### PR TITLE
Replace implicit Optional parameters with explicit T | None

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -638,7 +638,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514043850.19: *3* abbrev.dynamic abbreviation...
     # @+node:ekr.20150514043850.20: *4* abbrev.dynamicCompletion C-M-/
     @cmd('dabbrev-completion')
-    def dynamicCompletion(self, event: LeoKeyEvent = None) -> None:
+    def dynamicCompletion(self, event: LeoKeyEvent | None = None) -> None:
         """
         dabbrev-completion
         Insert the common prefix of all dynamic abbrev's matching the present word.
@@ -673,7 +673,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514043850.21: *4* abbrev.dynamicExpansion M-/ & helper
     @cmd('dabbrev-expands')
-    def dynamicExpansion(self, event: LeoKeyEvent = None) -> None:
+    def dynamicExpansion(self, event: LeoKeyEvent | None = None) -> None:
         """
         dabbrev-expands (M-/ in Emacs).
 
@@ -704,9 +704,9 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
     def dynamicExpandHelper(
         self,
         event: LeoKeyEvent,
-        prefix: str = None,
-        aList: list[str] = None,
-        w: QTextMixin = None,
+        prefix: str | None = None,
+        aList: list[str] | None = None,
+        w: QTextMixin | None = None,
     ) -> None:
         """State handler for dabbrev-expands command."""
         c, k = self.c, self.c.k
@@ -792,7 +792,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514043850.29: *4* abbrev.listAbbrevs
     @cmd('abbrev-list')
-    def listAbbrevs(self, event: LeoKeyEvent = None) -> None:
+    def listAbbrevs(self, event: LeoKeyEvent | None = None) -> None:
         """List all abbreviations."""
         d = self.abbrevs
         if d:
@@ -810,7 +810,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514043850.32: *4* abbrev.toggleAbbrevMode
     @cmd('toggle-abbrev-mode')
-    def toggleAbbrevMode(self, event: LeoKeyEvent = None) -> None:
+    def toggleAbbrevMode(self, event: LeoKeyEvent | None = None) -> None:
         """Toggle abbreviation mode."""
         k = self.c.k
         k.abbrevOn = not k.abbrevOn

--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -53,7 +53,7 @@ class BaseEditCommandsClass:
         return w
 
     # @+node:ekr.20150514043714.6: *4* BaseEdit.endCommand
-    def endCommand(self, label: str = None, changed: bool = True, setLabel: bool = True) -> None:
+    def endCommand(self, label: str | None = None, changed: bool = True, setLabel: bool = True) -> None:
         """
         Do the common processing at the end of each command.
         Handles undo only if we are in the body pane.
@@ -125,7 +125,7 @@ class BaseEditCommandsClass:
         return r1 + 1, r2, r3 + 1, r4
 
     # @+node:ekr.20150514043714.14: *4* BaseEdit.keyboardQuit
-    def keyboardQuit(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def keyboardQuit(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Clear the state and the minibuffer label."""
         self.c.k.keyboardQuit()
 

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -546,7 +546,7 @@ class PyflakesCommand:
     class LogStream:
         """A log stream for pyflakes."""
 
-        def __init__(self, fn_n: int = 0, roots: list[Position] = None) -> None:
+        def __init__(self, fn_n: int = 0, roots: list[Position] | None = None) -> None:
             self.fn_n = fn_n
             self.roots = roots
 
@@ -642,7 +642,7 @@ class PylintCommand:
 
     # @+others
     # @+node:ekr.20150514125218.11: *3* 1. pylint.run
-    def run(self, root: Position, *, last_path: str = None) -> Optional[tuple[str, Position]]:
+    def run(self, root: Position, *, last_path: str | None = None) -> Optional[tuple[str, Position]]:
         """Run Pylint on all Python @<file> nodes in root's tree."""
         c = self.c
         if not lint:

--- a/leo/commands/commanderEditCommands.py
+++ b/leo/commands/commanderEditCommands.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # @+others
 # @+node:ekr.20171123135625.34: ** c_ec.addComments
 @g.commander_command('add-comments')
-def addComments(self: Self, event: LeoKeyEvent = None) -> None:
+def addComments(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Undoably add comments to the selected text."""
     c, p, u, w = self, self.p, self.undoer, self.frame.body.wrapper
     # "Before" snapshot.
@@ -70,7 +70,7 @@ def addComments(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.16: ** c_ec.convertAllBlanks
 @g.commander_command('convert-all-blanks')
-def convertAllBlanks(self: Self, event: LeoKeyEvent = None) -> None:
+def convertAllBlanks(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Convert all blanks to tabs in the selected outline."""
     c, u = self, self.undoer
     undoType = 'Convert All Blanks'
@@ -111,7 +111,7 @@ def convertAllBlanks(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.17: ** c_ec.convertAllTabs
 @g.commander_command('convert-all-tabs')
-def convertAllTabs(self: Self, event: LeoKeyEvent = None) -> None:
+def convertAllTabs(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Convert all tabs to blanks in the selected outline."""
     c = self
     u = c.undoer
@@ -152,7 +152,7 @@ def convertAllTabs(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.18: ** c_ec.convertBlanks
 @g.commander_command('convert-blanks')
-def convertBlanks(self: Self, event: LeoKeyEvent = None) -> bool:
+def convertBlanks(self: Self, event: LeoKeyEvent | None = None) -> bool:
     """
     Convert *all* blanks to tabs in the selected node.
     Return True if the the p.b was changed.
@@ -187,7 +187,7 @@ def convertBlanks(self: Self, event: LeoKeyEvent = None) -> bool:
 
 # @+node:ekr.20171123135625.19: ** c_ec.convertTabs
 @g.commander_command('convert-tabs')
-def convertTabs(self: Self, event: LeoKeyEvent = None) -> bool:
+def convertTabs(self: Self, event: LeoKeyEvent | None = None) -> bool:
     """Convert all tabs to blanks in the selected node."""
     c, p, u, w = self, self.p, self.undoer, self.frame.body.wrapper
     #
@@ -228,7 +228,7 @@ def convertTabs(self: Self, event: LeoKeyEvent = None) -> bool:
 
 # @+node:ekr.20171123135625.21: ** c_ec.dedentBody (unindent-region)
 @g.commander_command('unindent-region')
-def dedentBody(self: Self, event: LeoKeyEvent = None) -> None:
+def dedentBody(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Remove one tab's worth of indentation from all presently selected lines."""
     c, p, u, w = self, self.p, self.undoer, self.frame.body.wrapper
     #
@@ -274,7 +274,7 @@ def dedentBody(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.36: ** c_ec.deleteComments
 @g.commander_command('delete-comments')
-def deleteComments(self: Self, event: LeoKeyEvent = None) -> None:
+def deleteComments(self: Self, event: LeoKeyEvent | None = None) -> None:
     # @+<< deleteComments docstring >>
     # @+node:ekr.20171123135625.37: *3* << deleteComments docstring >>
     # @@pagewidth 50
@@ -359,7 +359,7 @@ def deleteComments(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.54: ** c_ec.editHeadline (edit-headline)
 @g.commander_command('edit-headline')
-def editHeadline(self: Self, event: LeoKeyEvent = None) -> None:
+def editHeadline(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Begin editing the headline of the selected node.
     """
@@ -378,7 +378,7 @@ def editHeadline(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.23: ** c_ec.extract
 @g.commander_command('extract')
-def extract(self: Self, event: LeoKeyEvent = None) -> None:
+def extract(self: Self, event: LeoKeyEvent | None = None) -> None:
     # @+<< docstring for extract command >>
     # @+node:ekr.20201113130021.1: *3* << docstring for extract command >>
     r"""
@@ -544,7 +544,7 @@ def extractRef(c: Cmdr, s: str) -> str:
 
 # @+node:ekr.20171123135625.27: ** c_ec.extractSectionNames
 @g.commander_command('extract-names')
-def extractSectionNames(self: Self, event: LeoKeyEvent = None) -> None:
+def extractSectionNames(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Create child nodes for every section reference in the selected text.
     - The headline of each new child node is the section reference.
@@ -602,7 +602,7 @@ def findSectionName(self: Self, s: str) -> Optional[str]:
 # @+node:ekr.20171123135625.15: ** c_ec.findMatchingBracket
 @g.commander_command('match-brackets')
 @g.commander_command('select-to-matching-bracket')
-def findMatchingBracket(self: Self, event: LeoKeyEvent = None) -> None:
+def findMatchingBracket(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Select the text between matching brackets."""
     c, p = self, self.p
     if g.app.batchMode:
@@ -618,7 +618,7 @@ def findMatchingBracket(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.30: ** c_ec.alwaysIndentBody (always-indent-region)
 @g.commander_command('always-indent-region')
-def alwaysIndentBody(self: Self, event: LeoKeyEvent = None) -> None:
+def alwaysIndentBody(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     The always-indent-region command indents each line of the selected body
     text. The @tabwidth directive in effect determines amount of
@@ -681,7 +681,7 @@ def alwaysIndentBody(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20210104123442.1: ** c_ec.indentBody (indent-region)
 @g.commander_command('indent-region')
-def indentBody(self: Self, event: LeoKeyEvent = None) -> None:
+def indentBody(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     The indent-region command indents each line of the selected body text.
     Unlike the always-indent-region command, this command inserts a tab
@@ -707,7 +707,7 @@ def indentBody(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.38: ** c_ec.insertBodyTime
 @g.commander_command('insert-body-time')
-def insertBodyTime(self: Self, event: LeoKeyEvent = None) -> None:
+def insertBodyTime(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Insert a time/date stamp at the cursor."""
     c, p, u = self, self.p, self.undoer
     w = c.frame.body.wrapper
@@ -726,7 +726,7 @@ def insertBodyTime(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.52: ** c_ec.justify-toggle-auto
 @g.commander_command("justify-toggle-auto")
-def justify_toggle_auto(self: Self, event: LeoKeyEvent = None) -> None:
+def justify_toggle_auto(self: Self, event: LeoKeyEvent | None = None) -> None:
     c = self
     if c.editCommands.autojustify == 0:
         c.editCommands.autojustify = abs(c.config.getInt("autojustify") or 0)
@@ -741,7 +741,7 @@ def justify_toggle_auto(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20190210095609.1: ** c_ec.line_to_headline
 @g.commander_command('line-to-headline')
-def line_to_headline(self: Self, event: LeoKeyEvent = None) -> None:
+def line_to_headline(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Create child node from the selected line.
 
@@ -782,7 +782,7 @@ def line_to_headline(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.11: ** c_ec.preferences
 @g.commander_command('settings')
-def preferences(self: Self, event: LeoKeyEvent = None) -> None:
+def preferences(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Handle the preferences command."""
     c = self
     c.openLeoSettings()
@@ -790,7 +790,7 @@ def preferences(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.40: ** c_ec.reformatBody
 @g.commander_command('reformat-body')
-def reformatBody(self: Self, event: LeoKeyEvent = None) -> None:
+def reformatBody(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Reformat all paragraphs in the body."""
     c, p = self, self.p
     undoType = 'reformat-body'
@@ -812,7 +812,7 @@ def reformatBody(self: Self, event: LeoKeyEvent = None) -> None:
 @g.commander_command('reformat-paragraph')
 def reformatParagraph(
     self: Self,
-    event: LeoKeyEvent = None,
+    event: LeoKeyEvent | None = None,
     undoType: str = 'Reformat Paragraph',
 ) -> None:
     """
@@ -1057,7 +1057,7 @@ def startsParagraph(s: str) -> bool:
 # @+node:ekr.20201124191844.1: ** c_ec.reformatSelection
 @g.commander_command('reformat-selection')
 def reformatSelection(
-    self: Self, event: LeoKeyEvent = None, undoType: str = 'Reformat Selection'
+    self: Self, event: LeoKeyEvent | None = None, undoType: str = 'Reformat Selection'
 ) -> None:
     """
     Reformat the selected text, as in reformat-paragraph, but without
@@ -1095,21 +1095,21 @@ def reformatSelection(
 
 # @+node:ekr.20171123135625.12: ** c_ec.show/hide/toggleInvisibles
 @g.commander_command('hide-invisibles')
-def hideInvisibles(self: Self, event: LeoKeyEvent = None) -> None:
+def hideInvisibles(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Hide invisible (whitespace) characters."""
     c = self
     showInvisiblesHelper(c, False)
 
 
 @g.commander_command('show-invisibles')
-def showInvisibles(self: Self, event: LeoKeyEvent = None) -> None:
+def showInvisibles(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Show invisible (whitespace) characters."""
     c = self
     showInvisiblesHelper(c, True)
 
 
 @g.commander_command('toggle-invisibles')
-def toggleShowInvisibles(self: Self, event: LeoKeyEvent = None) -> None:
+def toggleShowInvisibles(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Toggle showing of invisible (whitespace) characters."""
     c = self
     colorizer = c.frame.body.getColorizer()
@@ -1137,7 +1137,7 @@ def showInvisiblesHelper(c: Cmdr, val: Value) -> None:
 
 # @+node:ekr.20171123135625.55: ** c_ec.toggleAngleBrackets
 @g.commander_command('toggle-angle-brackets')
-def toggleAngleBrackets(self: Self, event: LeoKeyEvent = None) -> None:
+def toggleAngleBrackets(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Add or remove double angle brackets from the headline of the selected node."""
     c, p, u = self, self.p, self.undoer
     if g.app.batchMode:
@@ -1167,7 +1167,7 @@ def toggleAngleBrackets(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20171123135625.49: ** c_ec.unformatParagraph & helper
 @g.commander_command('unformat-paragraph')
 def unformatParagraph(
-    self: Self, event: LeoKeyEvent = None, undoType: str = 'Unformat Paragraph'
+    self: Self, event: LeoKeyEvent | None = None, undoType: str = 'Unformat Paragraph'
 ) -> None:
     """
     Unformat a text paragraph. Removes all extra whitespace in a paragraph.
@@ -1232,7 +1232,7 @@ def unreformat(
 
 # @+node:ekr.20180410054716.1: ** c_ec: insert-jupyter-toc & insert-markdown-toc
 @g.commander_command('insert-jupyter-toc')
-def insertJupyterTOC(self: Self, event: LeoKeyEvent = None) -> None:
+def insertJupyterTOC(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Insert a Jupyter table of contents at the cursor,
     replacing any selected text.
@@ -1241,7 +1241,7 @@ def insertJupyterTOC(self: Self, event: LeoKeyEvent = None) -> None:
 
 
 @g.commander_command('insert-markdown-toc')
-def insertMarkdownTOC(self: Self, event: LeoKeyEvent = None) -> None:
+def insertMarkdownTOC(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Insert a Markdown table of contents at the cursor,
     replacing any selected text.

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -65,7 +65,7 @@ def set_name_and_title(c: Cmdr, fileName: str) -> str:
 
 # @+node:ekr.20170221033738.1: ** c_file.reloadSettings
 @g.commander_command('reload-settings')
-def reloadSettings(self: Self, event: LeoKeyEvent = None) -> None:
+def reloadSettings(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Reload settings in all commanders, saving all existing opened files first"""
     lm = g.app.loadManager
     # Save any changes so they can be seen, for existing files that are not new/untitled.
@@ -87,7 +87,7 @@ def reloadSettings(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20200422075655.1: ** c_file.restartLeo
 @g.commander_command('restart-leo')
-def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
+def restartLeo(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Restart Leo, reloading all presently open outlines."""
     verbose = False
     c = self
@@ -163,7 +163,7 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.2820: ** c_file.top level
 # @+node:ekr.20031218072017.2833: *3* c_file.close
 @g.commander_command('close-window')
-def close(self: Self, event: LeoKeyEvent = None, new_c: Cmdr = None) -> None:
+def close(self: Self, event: LeoKeyEvent | None = None, new_c: Cmdr | None = None) -> None:
     """Close the Leo window, prompting to save it if it has been changed."""
     g.app.closeLeoWindow(self.frame, new_c=new_c)
 
@@ -171,7 +171,7 @@ def close(self: Self, event: LeoKeyEvent = None, new_c: Cmdr = None) -> None:
 # @+node:ekr.20110530124245.18245: *3* c_file.importAnyFile
 @g.commander_command('import-any-file')
 @g.commander_command('import-file')
-def importAnyFile(self: Self, event: LeoKeyEvent = None) -> None:
+def importAnyFile(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Import one or more files."""
     c = self
     ic = c.importCommands
@@ -294,7 +294,7 @@ def import_txt_file(self: Self, fn: str) -> None:
 # @+node:ekr.20031218072017.1623: *3* c_file.new
 @g.commander_command('file-new')
 @g.commander_command('new')
-def new(self: Self, event: LeoKeyEvent = None, gui: LeoGui = None) -> Cmdr:
+def new(self: Self, event: LeoKeyEvent | None = None, gui: LeoGui | None = None) -> Cmdr:
     """Create a new Leo window."""
     t1 = time.process_time()
     from leo.core import leoApp
@@ -364,7 +364,7 @@ def new(self: Self, event: LeoKeyEvent = None, gui: LeoGui = None) -> Cmdr:
 # @+node:ekr.20031218072017.2821: *3* c_file.open_outline
 @g.commander_command('open-file')
 @g.commander_command('open-outline')
-def open_outline(self: Self, event: LeoKeyEvent = None) -> None:
+def open_outline(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open a Leo window containing the contents of a .leo file."""
     c = self
     filetypes = [
@@ -381,9 +381,9 @@ def open_outline(self: Self, event: LeoKeyEvent = None) -> None:
 @g.commander_command('refresh-from-disk')
 def refreshFromDisk(
     self: Self,
-    p: Position = None,  # For compatibility with existing scripts.
+    p: Position | None = None,  # For compatibility with existing scripts.
     *,
-    event: LeoKeyEvent = None,  # Required for all commands.
+    event: LeoKeyEvent | None = None,  # Required for all commands.
     silent: bool = True,  # No longer used.
 ) -> None:
     """
@@ -436,7 +436,7 @@ def refreshFromDisk(
 
 # @+node:ekr.20210610083257.1: *3* c_file.pwd
 @g.commander_command('pwd')
-def pwd_command(self: Self, event: LeoKeyEvent = None) -> None:
+def pwd_command(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Print the current working directory."""
     g.es_print('pwd:', os.getcwd())
 
@@ -445,7 +445,7 @@ def pwd_command(self: Self, event: LeoKeyEvent = None) -> None:
 @g.commander_command('save')
 @g.commander_command('file-save')
 @g.commander_command('save-file')
-def save(self: Self, event: LeoKeyEvent = None, fileName: str = None) -> None:
+def save(self: Self, event: LeoKeyEvent | None = None, fileName: str | None = None) -> None:
     """
     Save a Leo outline to a file, using the existing file name unless
     the fileName kwarg is given.
@@ -503,7 +503,7 @@ def save(self: Self, event: LeoKeyEvent = None, fileName: str = None) -> None:
 
 # @+node:ekr.20110228162720.13980: *3* c_file.saveAll
 @g.commander_command('save-all')
-def saveAll(self: Self, event: LeoKeyEvent = None) -> None:
+def saveAll(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Save all open tabs windows/tabs."""
     c = self
     c.save()  # Force a write of the present window.
@@ -520,7 +520,7 @@ def saveAll(self: Self, event: LeoKeyEvent = None) -> None:
 @g.commander_command('save-as')
 @g.commander_command('file-save-as')
 @g.commander_command('save-file-as')
-def saveAs(self: Self, event: LeoKeyEvent = None, fileName: str = None) -> None:
+def saveAs(self: Self, event: LeoKeyEvent | None = None, fileName: str | None = None) -> None:
     """
     Save a Leo outline to a file, prompting for a new filename unless the
     fileName kwarg is given.
@@ -575,7 +575,7 @@ def saveAs(self: Self, event: LeoKeyEvent = None, fileName: str = None) -> None:
 @g.commander_command('file-save-to')
 @g.commander_command('save-file-to')
 def saveTo(
-    self: Self, event: LeoKeyEvent = None, fileName: str = None, silent: bool = False
+    self: Self, event: LeoKeyEvent | None = None, fileName: str | None = None, silent: bool = False
 ) -> None:
     """
     Save a copy of the Leo outline to a file, prompting for a new file name.
@@ -620,7 +620,7 @@ def saveTo(
 
 # @+node:ekr.20031218072017.2837: *3* c_file.revert
 @g.commander_command('revert')
-def revert(self: Self, event: LeoKeyEvent = None) -> None:
+def revert(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Revert the contents of a Leo outline to last saved contents."""
     c = self
     u = c.undoer
@@ -642,7 +642,7 @@ def revert(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20210316075815.1: *3* c_file.save-as-leojs
 @g.commander_command('file-save-as-leojs')
 @g.commander_command('save-file-as-leojs')
-def save_as_leojs(self: Self, event: LeoKeyEvent = None) -> None:
+def save_as_leojs(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Save a copy of the Leo outline as a JSON (.leojs) file with a new file name.
     Leave the file name of the Leo outline unchanged.
@@ -667,7 +667,7 @@ def save_as_leojs(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20070413045221: *3* c_file.save-as-zipped
 @g.commander_command('file-save-as-db')
 @g.commander_command('save-file-as-db')
-def save_as_db(self: Self, event: LeoKeyEvent = None) -> None:
+def save_as_db(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Save a copy of the Leo outline as a SQLite (.db) file with a new file name.
     Leave the file name of the Leo outline unchanged.
@@ -692,7 +692,7 @@ def save_as_db(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20210316075357.1: *3* c_file.save-as-xml
 @g.commander_command('file-save-as-xml')
 @g.commander_command('save-file-as-xml')
-def save_as_xml(self: Self, event: LeoKeyEvent = None) -> None:
+def save_as_xml(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Save a copy of the Leo outline as an XML .leo file with a new file name.
     Leave the file name of the Leo outline unchanged.
@@ -717,7 +717,7 @@ def save_as_xml(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:tom.20220310092720.1: *3* c_file.save-node-as-xml
 @g.commander_command('save-node-as-xml')
-def save_node_as_xml_outline(self: Self, event: LeoKeyEvent = None) -> None:
+def save_node_as_xml_outline(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Save a node with its subtree as an XML .leo outline file.
     Leave the outline and the file name of the Leo outline unchanged.
@@ -740,7 +740,7 @@ def save_node_as_xml_outline(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.2849: ** Export
 # @+node:ekr.20031218072017.2850: *3* c_file.exportHeadlines
 @g.commander_command('export-headlines')
-def exportHeadlines(self: Self, event: LeoKeyEvent = None) -> None:
+def exportHeadlines(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Export headlines for c.p and its subtree to an external file."""
     c = self
     filetypes = [
@@ -757,7 +757,7 @@ def exportHeadlines(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2851: *3* c_file.flattenOutline
 @g.commander_command('flatten-outline')
-def flattenOutline(self: Self, event: LeoKeyEvent = None) -> None:
+def flattenOutline(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Export the selected outline to an external file.
     The outline is represented in MORE format.
@@ -777,7 +777,7 @@ def flattenOutline(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20141030120755.12: *3* c_file.flattenOutlineToNode
 @g.commander_command('flatten-outline-to-node')
-def flattenOutlineToNode(self: Self, event: LeoKeyEvent = None) -> None:
+def flattenOutlineToNode(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Append the body text of all descendants of the selected node to the
     body text of a new (last) top-level node.
@@ -805,7 +805,7 @@ def flattenOutlineToNode(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2857: *3* c_file.outlineToCWEB
 @g.commander_command('outline-to-cweb')
-def outlineToCWEB(self: Self, event: LeoKeyEvent = None) -> None:
+def outlineToCWEB(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Export the selected outline to an external file.
     The outline is represented in CWEB format.
@@ -826,7 +826,7 @@ def outlineToCWEB(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2858: *3* c_file.outlineToNoweb
 @g.commander_command('outline-to-noweb')
-def outlineToNoweb(self: Self, event: LeoKeyEvent = None) -> None:
+def outlineToNoweb(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Export the selected outline to an external file.
     The outline is represented in noweb format.
@@ -848,7 +848,7 @@ def outlineToNoweb(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2859: *3* c_file.removeSentinels
 @g.commander_command('remove-sentinels')
-def removeSentinels(self: Self, event: LeoKeyEvent = None) -> None:
+def removeSentinels(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Convert one or more files, replacing the original files
     while removing any sentinels they contain.
@@ -871,7 +871,7 @@ def removeSentinels(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2860: *3* c_file.weave
 @g.commander_command('weave')
-def weave(self: Self, event: LeoKeyEvent = None) -> None:
+def weave(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Simulate a literate-programming weave operation by writing the outline to a text file."""
     c = self
     fileName = g.app.gui.runSaveFileDialog(
@@ -892,7 +892,7 @@ def weave(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.2838: ** Read/Write
 # @+node:ekr.20070806105721.1: *3* c_file.readAtAutoNodes
 @g.commander_command('read-at-auto-nodes')
-def readAtAutoNodes(self: Self, event: LeoKeyEvent = None) -> None:
+def readAtAutoNodes(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Read all @auto nodes in the presently selected outline.
 
@@ -909,7 +909,7 @@ def readAtAutoNodes(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.1839: *3* c_file.readAtFileNodes
 @g.commander_command('read-at-file-nodes')
-def readAtFileNodes(self: Self, event: LeoKeyEvent = None) -> None:
+def readAtFileNodes(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Read all @file nodes in the presently selected outline.
 
@@ -927,7 +927,7 @@ def readAtFileNodes(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20080801071227.4: *3* c_file.readAtShadowNodes
 @g.commander_command('read-at-shadow-nodes')
-def readAtShadowNodes(self: Self, event: LeoKeyEvent = None) -> None:
+def readAtShadowNodes(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Read all @shadow nodes in the presently selected outline.
 
@@ -944,7 +944,7 @@ def readAtShadowNodes(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20070915134101: *3* c_file.readFileIntoNode
 @g.commander_command('read-file-into-node')
-def readFileIntoNode(self: Self, event: LeoKeyEvent = None) -> None:
+def readFileIntoNode(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Read a file into a single node."""
     c = self
     u = c.undoer
@@ -977,7 +977,7 @@ def readFileIntoNode(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20070915142635: *3* c_file.writeFileFromNode
 @g.commander_command('write-file-from-node')
-def writeFileFromNode(self: Self, event: LeoKeyEvent = None) -> None:
+def writeFileFromNode(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     If node starts with @read-file-into-node, use the full path name in the headline.
     Otherwise, prompt for a file name.
@@ -1016,7 +1016,7 @@ def writeFileFromNode(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:tom.20230201124905.1: *3* c_file.writeFileFromSubtree
 @g.commander_command('write-file-from-subtree')
-def writeFileFromSubtree(self: Self, event: LeoKeyEvent = None) -> None:
+def writeFileFromSubtree(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Write the entire tree from the selected node as text to a file.
 
     If node starts with @read-file-into-node, use the full path name in the headline.
@@ -1059,7 +1059,7 @@ def writeFileFromSubtree(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.2079: ** Recent Files
 # @+node:tbrown.20080509212202.6: *3* c_file.cleanRecentFiles
 @g.commander_command('clean-recent-files')
-def cleanRecentFiles(self: Self, event: LeoKeyEvent = None) -> None:
+def cleanRecentFiles(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Remove items from the recent files list that no longer exist.
 
@@ -1072,7 +1072,7 @@ def cleanRecentFiles(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2080: *3* c_file.clearRecentFiles
 @g.commander_command('clear-recent-files')
-def clearRecentFiles(self: Self, event: LeoKeyEvent = None) -> None:
+def clearRecentFiles(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Clear the recent files list, then add the present file."""
     c = self
     g.app.recentFilesManager.clearRecentFiles(c)
@@ -1080,7 +1080,7 @@ def clearRecentFiles(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:vitalije.20170703115710.1: *3* c_file.editRecentFiles
 @g.commander_command('edit-recent-files')
-def editRecentFiles(self: Self, event: LeoKeyEvent = None) -> None:
+def editRecentFiles(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Opens recent files list in a new node for editing."""
     c = self
     g.app.recentFilesManager.editRecentFiles(c)
@@ -1088,7 +1088,7 @@ def editRecentFiles(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:tbrown.20080509212202.8: *3* c_file.sortRecentFiles
 @g.commander_command('sort-recent-files')
-def sortRecentFiles(self: Self, event: LeoKeyEvent = None) -> None:
+def sortRecentFiles(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Sort the recent files list."""
     c = self
     g.app.recentFilesManager.sortRecentFiles(c)
@@ -1096,7 +1096,7 @@ def sortRecentFiles(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:vitalije.20170703115710.2: *3* c_file.writeEditedRecentFiles
 @g.commander_command('write-edited-recent-files')
-def writeEditedRecentFiles(self: Self, event: LeoKeyEvent = None) -> None:
+def writeEditedRecentFiles(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Write content of "edit_headline" node as recentFiles and recreates
     menus.

--- a/leo/commands/commanderHelpCommands.py
+++ b/leo/commands/commanderHelpCommands.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # @+others
 # @+node:ekr.20031218072017.2939: ** c_help.about (version number & date)
 @g.commander_command('about-leo')
-def about(self: Self, event: LeoKeyEvent = None) -> None:
+def about(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Bring up an About Leo Dialog."""
     c = self
     import datetime
@@ -42,7 +42,7 @@ def about(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:vitalije.20170713174950.1: ** c_help.editOneSetting
 @g.commander_command('edit-setting')
-def editOneSetting(self: Self, event: LeoKeyEvent = None) -> None:
+def editOneSetting(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Opens dialog for editing @button, @command, @color, @font, or @shortcuts nodes.
     """
@@ -65,7 +65,7 @@ def editOneSetting(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:vitalije.20170708172746.1: ** c_help.editShortcut
 @g.commander_command('edit-shortcut')
-def editShortcut(self: Self, event: LeoKeyEvent = None) -> None:
+def editShortcut(self: Self, event: LeoKeyEvent | None = None) -> None:
     k = self.k
     if k.isEditShortcutSensible():
         # k.setState('input-shortcut', 'input-shortcut')
@@ -80,7 +80,7 @@ def editShortcut(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.2940: *3* c_help.leoDocumentation
 @g.commander_command('open-leo-docs-leo')
 @g.commander_command('leo-docs-leo')
-def leoDocumentation(self: Self, event: LeoKeyEvent = None) -> None:
+def leoDocumentation(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open LeoDocs.leo in a new Leo window."""
     c = self
     name = "LeoDocs.leo"
@@ -95,7 +95,7 @@ def leoDocumentation(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20090628075121.5994: *3* c_help.leoQuickStart
 @g.commander_command('open-quickstart-leo')
 @g.commander_command('leo-quickstart-leo')
-def leoQuickStart(self: Self, event: LeoKeyEvent = None) -> None:
+def leoQuickStart(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open quickstart.leo in a new Leo window."""
     c = self
     name = "quickstart.leo"
@@ -111,7 +111,7 @@ def leoQuickStart(self: Self, event: LeoKeyEvent = None) -> None:
 @g.commander_command('open-cheat-sheet-leo')
 @g.commander_command('leo-cheat-sheet')
 @g.commander_command('cheat-sheet')
-def openCheatSheet(self: Self, event: LeoKeyEvent = None) -> None:
+def openCheatSheet(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open leo/doc/cheatSheet.leo"""
     c = self
     fn = g.finalize_join(g.app.loadDir, '..', 'doc', 'CheatSheet.leo')
@@ -129,7 +129,7 @@ def openCheatSheet(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:lkj.20190714022527.1: *3* c_help.openDesktopIntegration
 @g.commander_command('open-desktop-integration-leo')
 @g.commander_command('desktop-integration-leo')
-def openDesktopIntegration(self: Self, event: LeoKeyEvent = None) -> None:
+def openDesktopIntegration(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open Desktop-integration.leo."""
     c = self
     fileName = g.finalize_join(g.app.loadDir, '..', 'scripts', 'desktop-integration.leo')
@@ -143,7 +143,7 @@ def openDesktopIntegration(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20161025090405.1: *3* c_help.openLeoDist
 @g.commander_command('open-leo-dist-leo')
 @g.commander_command('leo-dist-leo')
-def openLeoDist(self: Self, event: LeoKeyEvent = None) -> None:
+def openLeoDist(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open leoDist.leo in a new Leo window."""
     c = self
     name = "leoDist.leo"
@@ -158,7 +158,7 @@ def openLeoDist(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20151225193723.1: *3* c_help.openLeoPy
 @g.commander_command('open-leo-py-leo')
 @g.commander_command('leo-py-leo')
-def openLeoPy(self: Self, event: LeoKeyEvent = None) -> Optional[Cmdr]:
+def openLeoPy(self: Self, event: LeoKeyEvent | None = None) -> Optional[Cmdr]:
     """Open leoPy.leo or LeoPyRef.leo in a new Leo window."""
     c = self
     names = (
@@ -179,7 +179,7 @@ def openLeoPy(self: Self, event: LeoKeyEvent = None) -> Optional[Cmdr]:
 # @+node:ekr.20201013105418.1: *3* c_help.openLeoPyRef
 @g.commander_command('open-leo-py-ref-leo')
 @g.commander_command('leo-py-ref-leo')
-def openLeoPyRef(self: Self, event: LeoKeyEvent = None) -> Optional[Cmdr]:
+def openLeoPyRef(self: Self, event: LeoKeyEvent | None = None) -> Optional[Cmdr]:
     """Open leoPyRef.leo in a new Leo window."""
     c = self
     path = g.finalize_join(g.app.loadDir, "..", "core", "LeoPyRef.leo")
@@ -194,7 +194,7 @@ def openLeoPyRef(self: Self, event: LeoKeyEvent = None) -> Optional[Cmdr]:
 # @+node:ekr.20061018094539: *3* c_help.openLeoScripts
 @g.commander_command('open-scripts-leo')
 @g.commander_command('leo-scripts-leo')
-def openLeoScripts(self: Self, event: LeoKeyEvent = None) -> None:
+def openLeoScripts(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open scripts.leo."""
     c = self
     fileName = g.finalize_join(g.app.loadDir, '..', 'scripts', 'scripts.leo')
@@ -209,7 +209,7 @@ def openLeoScripts(self: Self, event: LeoKeyEvent = None) -> None:
 @g.commander_command('open-leo-settings')
 @g.commander_command('open-leo-settings-leo')  # #1343.
 @g.commander_command('leo-settings')
-def openLeoSettings(self: Self, event: LeoKeyEvent = None) -> Optional[Cmdr]:
+def openLeoSettings(self: Self, event: LeoKeyEvent | None = None) -> Optional[Cmdr]:
     """Open leoSettings.leo in a new Leo window."""
     c, lm = self, g.app.loadManager
     path = lm.computeLeoSettingsPath()
@@ -223,7 +223,7 @@ def openLeoSettings(self: Self, event: LeoKeyEvent = None) -> Optional[Cmdr]:
 @g.commander_command('open-my-leo-settings')
 @g.commander_command('open-my-leo-settings-leo')  # #1343.
 @g.commander_command('my-leo-settings')
-def openMyLeoSettings(self: Self, event: LeoKeyEvent = None) -> Cmdr:
+def openMyLeoSettings(self: Self, event: LeoKeyEvent | None = None) -> Cmdr:
     """Open myLeoSettings.leo in a new Leo window."""
     c, lm = self, g.app.loadManager
     path = lm.computeMyLeoSettingsPath()
@@ -298,7 +298,7 @@ def createMyLeoSettings(c: Cmdr) -> Optional[Cmdr]:
 # @+node:ekr.20171124093507.1: ** c_help.Open Leo web pages
 # @+node:ekr.20031218072017.2941: *3* c_help.leoHome
 @g.commander_command('open-online-home')
-def leoHome(self: Self, event: LeoKeyEvent = None) -> None:
+def leoHome(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open Leo's Home page in a web browser."""
     import webbrowser
 
@@ -311,7 +311,7 @@ def leoHome(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20131213072223.19441: *3* c_help.openLeoTOC
 @g.commander_command('open-online-toc')
-def openLeoTOC(self: Self, event: LeoKeyEvent = None) -> None:
+def openLeoTOC(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open Leo's tutorials page in a web browser."""
     import webbrowser
 
@@ -324,7 +324,7 @@ def openLeoTOC(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20230104130712.1: *3* c_help.openLeoScriptingMiscellany
 @g.commander_command('open-online-scripting-miscellany')
-def openLeoScriptingMiscellany(self: Self, event: LeoKeyEvent = None) -> None:
+def openLeoScriptingMiscellany(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open Leo's scripting miscellany page in a web browser."""
     import webbrowser
 
@@ -337,7 +337,7 @@ def openLeoScriptingMiscellany(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20131213072223.19435: *3* c_help.openLeoTutorials
 @g.commander_command('open-online-tutorials')
-def openLeoTutorials(self: Self, event: LeoKeyEvent = None) -> None:
+def openLeoTutorials(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open Leo's tutorials page in a web browser."""
     import webbrowser
 
@@ -350,7 +350,7 @@ def openLeoTutorials(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20060613082924: *3* c_help.openLeoUsersGuide
 @g.commander_command('open-users-guide')
-def openLeoUsersGuide(self: Self, event: LeoKeyEvent = None) -> None:
+def openLeoUsersGuide(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open Leo's users guide in a web browser."""
     import webbrowser
 
@@ -363,7 +363,7 @@ def openLeoUsersGuide(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20131213072223.19437: *3* c_help.openLeoVideos
 @g.commander_command('open-online-videos')
-def openLeoVideos(self: Self, event: LeoKeyEvent = None) -> None:
+def openLeoVideos(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open Leo's videos page in a web browser."""
     import webbrowser
 
@@ -376,7 +376,7 @@ def openLeoVideos(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2932: ** c_help.openPythonWindow
 @g.commander_command('open-python-window')
-def openPythonWindow(self: Self, event: LeoKeyEvent = None) -> None:
+def openPythonWindow(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open Python's Idle debugger in a separate process."""
     m = g.import_module('idlelib')
     if not m:
@@ -393,7 +393,7 @@ def openPythonWindow(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20131213072223.19532: ** c_help.selectAtSettingsNode
 @g.commander_command('open-local-settings')
-def selectAtSettingsNode(self: Self, event: LeoKeyEvent = None) -> None:
+def selectAtSettingsNode(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Select the @settings node, if there is one."""
     c = self
     p = c.config.settingsRoot()

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # @+node:ekr.20031218072017.1548: ** c_oc.Cut & Paste Outlines
 # @+node:ekr.20031218072017.1550: *3* c_oc.copyOutline
 @g.commander_command('copy-node')
-def copyOutline(self: Cmdr, event: LeoKeyEvent = None) -> str:
+def copyOutline(self: Cmdr, event: LeoKeyEvent | None = None) -> str:
     """Copy the selected outline to the clipboard."""
     # Copying an outline has no undo consequences.
     c = self
@@ -41,7 +41,7 @@ def copyOutline(self: Cmdr, event: LeoKeyEvent = None) -> str:
 
 # @+node:ekr.20220314071523.1: *3* c_oc.copyOutlineAsJson & helpers
 @g.commander_command('copy-node-as-json')
-def copyOutlineAsJSON(self: Cmdr, event: LeoKeyEvent = None) -> Optional[str]:
+def copyOutlineAsJSON(self: Cmdr, event: LeoKeyEvent | None = None) -> Optional[str]:
     """Copy the selected outline as JSON to the clipboard"""
     # Copying an outline has no undo consequences.
     c = self
@@ -56,7 +56,7 @@ def copyOutlineAsJSON(self: Cmdr, event: LeoKeyEvent = None) -> Optional[str]:
 
 # @+node:ekr.20031218072017.1549: *3* c_oc.cutOutline
 @g.commander_command('cut-node')
-def cutOutline(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def cutOutline(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Delete the selected outline and send it to the clipboard."""
     c = self
     if c.canDeleteHeadline():
@@ -69,8 +69,8 @@ def cutOutline(self: Cmdr, event: LeoKeyEvent = None) -> None:
 @g.commander_command('paste-node')
 def pasteOutline(
     self: Cmdr,
-    event: LeoKeyEvent = None,
-    s: str = None,
+    event: LeoKeyEvent | None = None,
+    s: str | None = None,
     undoFlag: bool = True,  # A hack for abbrev.paste_tree.
 ) -> Optional[Position]:
     """
@@ -121,8 +121,8 @@ def pasteOutline(
 @g.commander_command('paste-retaining-clones')
 def pasteOutlineRetainingClones(
     self: Cmdr,
-    event: LeoKeyEvent = None,
-    s: str = None,
+    event: LeoKeyEvent | None = None,
+    s: str | None = None,
 ) -> Optional[Position]:
     """
     Paste an outline into the present outline from the clipboard.
@@ -205,7 +205,7 @@ def computeVnodeInfoDict(c: Cmdr) -> dict[VNode, g.Bunch]:
 
 # @+node:vitalije.20200529105105.1: *3* c_oc.pasteAsTemplate
 @g.commander_command('paste-as-template')
-def pasteAsTemplate(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def pasteAsTemplate(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Paste as template clones only nodes that were already clones"""
     c = self
     p = c.p
@@ -423,7 +423,7 @@ def pasteAsTemplate(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20040412060927: ** c_oc.dumpOutline
 @g.commander_command('dump-outline')
-def dumpOutline(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def dumpOutline(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Dump all nodes in the outline."""
     c = self
     seen = {}
@@ -441,7 +441,7 @@ def dumpOutline(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.2898: ** c_oc.Expand & contract commands
 # @+node:ekr.20031218072017.2900: *3* c_oc.contract-all
 @g.commander_command('contract-all')
-def contractAllHeadlinesCommand(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def contractAllHeadlinesCommand(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Contract all nodes in the outline."""
     # The helper does all the work.
     c = self
@@ -451,7 +451,7 @@ def contractAllHeadlinesCommand(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20080819075811.3: *3* c_oc.contractAllOtherNodes & helper
 @g.commander_command('contract-all-other-nodes')
-def contractAllOtherNodes(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def contractAllOtherNodes(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Contract all nodes except those needed to make the
     presently selected node visible.
@@ -477,7 +477,7 @@ def contractIfNotCurrent(c: Cmdr, p: Position, leaveOpen: Position) -> None:
 
 # @+node:ekr.20200824130837.1: *3* c_oc.contractAllSubheads (new)
 @g.commander_command('contract-all-subheads')
-def contractAllSubheads(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def contractAllSubheads(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Contract all children of the presently selected node."""
     c, p = self, self.p
     if not p:
@@ -492,7 +492,7 @@ def contractAllSubheads(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2901: *3* c_oc.contractNode
 @g.commander_command('contract-node')
-def contractNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def contractNode(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Contract the presently selected node."""
     c = self
     p = c.p
@@ -504,7 +504,7 @@ def contractNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20040930064232: *3* c_oc.contractNodeOrGoToParent
 @g.commander_command('contract-or-go-left')
-def contractNodeOrGoToParent(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def contractNodeOrGoToParent(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Simulate the left Arrow Key in folder of Windows Explorer."""
     c, cc, p = self, self.chapterController, self.p
     parent = p.parent()
@@ -531,7 +531,7 @@ def contractNodeOrGoToParent(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2902: *3* c_oc.contractParent
 @g.commander_command('contract-parent')
-def contractParent(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def contractParent(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Contract the parent of the presently selected node."""
     c = self
     c.endEditing()
@@ -546,7 +546,7 @@ def contractParent(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2903: *3* c_oc.expandAllHeadlines
 @g.commander_command('expand-all')
-def expandAllHeadlines(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandAllHeadlines(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand all headlines.
     Warning: this can take a long time for large outlines."""
     c = self
@@ -562,7 +562,7 @@ def expandAllHeadlines(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2904: *3* c_oc.expandAllSubheads
 @g.commander_command('expand-all-subheads')
-def expandAllSubheads(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandAllSubheads(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand all children of the presently selected node."""
     c, p = self, self.p
     if not p:
@@ -577,62 +577,62 @@ def expandAllSubheads(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2905: *3* c_oc.expandLevel1..9
 @g.commander_command('expand-to-level-1')
-def expandLevel1(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandLevel1(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the outline to level 1"""
     self.expandToLevel(1)
 
 
 @g.commander_command('expand-to-level-2')
-def expandLevel2(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandLevel2(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the outline to level 2"""
     self.expandToLevel(2)
 
 
 @g.commander_command('expand-to-level-3')
-def expandLevel3(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandLevel3(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the outline to level 3"""
     self.expandToLevel(3)
 
 
 @g.commander_command('expand-to-level-4')
-def expandLevel4(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandLevel4(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the outline to level 4"""
     self.expandToLevel(4)
 
 
 @g.commander_command('expand-to-level-5')
-def expandLevel5(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandLevel5(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the outline to level 5"""
     self.expandToLevel(5)
 
 
 @g.commander_command('expand-to-level-6')
-def expandLevel6(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandLevel6(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the outline to level 6"""
     self.expandToLevel(6)
 
 
 @g.commander_command('expand-to-level-7')
-def expandLevel7(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandLevel7(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the outline to level 7"""
     self.expandToLevel(7)
 
 
 @g.commander_command('expand-to-level-8')
-def expandLevel8(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandLevel8(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the outline to level 8"""
     self.expandToLevel(8)
 
 
 @g.commander_command('expand-to-level-9')
-def expandLevel9(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandLevel9(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the outline to level 9"""
     self.expandToLevel(9)
 
 
 # @+node:ekr.20031218072017.2906: *3* c_oc.expandNextLevel
 @g.commander_command('expand-next-level')
-def expandNextLevel(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandNextLevel(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Increase the expansion level of the outline and
     Expand all nodes at that level or lower.
@@ -647,7 +647,7 @@ def expandNextLevel(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2907: *3* c_oc.expandNode
 @g.commander_command('expand-node')
-def expandNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandNode(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the presently selected node."""
     c = self
     p = c.p
@@ -659,7 +659,7 @@ def expandNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20040930064232.1: *3* c_oc.expandNodeAndGoToFirstChild
 @g.commander_command('expand-and-go-right')
-def expandNodeAndGoToFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandNodeAndGoToFirstChild(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """If a node has children, expand it if needed and go to the first child."""
     c, p = self, self.p
     c.endEditing()
@@ -672,7 +672,7 @@ def expandNodeAndGoToFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171125082744.1: *3* c_oc.expandNodeOrGoToFirstChild
 @g.commander_command('expand-or-go-right')
-def expandNodeOrGoToFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandNodeOrGoToFirstChild(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Simulate the Right Arrow Key in folder of Windows Explorer.
     if c.p has no children, do nothing.
@@ -692,8 +692,8 @@ def expandNodeOrGoToFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
 @g.commander_command('expand-ancestors-only')
 def expandOnlyAncestorsOfNode(
     self: Cmdr,
-    event: LeoKeyEvent = None,
-    p: Position = None,
+    event: LeoKeyEvent | None = None,
+    p: Position | None = None,
 ) -> None:
     """Contract all nodes except ancestors of the selected node."""
     c = self
@@ -712,7 +712,7 @@ def expandOnlyAncestorsOfNode(
 
 # @+node:ekr.20031218072017.2908: *3* c_oc.expandPrevLevel
 @g.commander_command('expand-prev-level')
-def expandPrevLevel(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandPrevLevel(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Decrease the expansion level of the outline and
     Expand all nodes at that level or lower."""
     c = self
@@ -725,7 +725,7 @@ def expandPrevLevel(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171124081846.1: ** c_oc.fullCheckOutline
 @g.commander_command('check-outline')
-def fullCheckOutline(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def fullCheckOutline(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Do a full check of the consistency of a .leo file."""
     c = self
     t1 = time.process_time()
@@ -737,7 +737,7 @@ def fullCheckOutline(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.2913: ** c_oc.Goto commands
 # @+node:ekr.20071213123942: *3* c_oc.findNextClone
 @g.commander_command('find-next-clone')
-def findNextClone(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def findNextClone(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the next cloned node."""
     c, p = self, self.p
     cc = c.chapterController
@@ -764,7 +764,7 @@ def findNextClone(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.1628: *3* c_oc.goNextVisitedNode
 @g.commander_command('go-forward')
 @g.commander_command('goto-next-history-node')
-def goNextVisitedNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goNextVisitedNode(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the next visited node."""
     c = self
     c.nodeHistory.goNext()
@@ -773,7 +773,7 @@ def goNextVisitedNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.1627: *3* c_oc.goPrevVisitedNode
 @g.commander_command('go-back')
 @g.commander_command('goto-prev-history-node')
-def goPrevVisitedNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goPrevVisitedNode(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the previously visited node."""
     c = self
     c.nodeHistory.goPrev()
@@ -781,7 +781,7 @@ def goPrevVisitedNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2914: *3* c_oc.goToFirstNode
 @g.commander_command('goto-first-node')
-def goToFirstNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToFirstNode(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Select the first node of the entire outline.
     Or the first visible node if Leo is hoisted or within a chapter.
@@ -794,7 +794,7 @@ def goToFirstNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20051012092453: *3* c_oc.goToFirstSibling
 @g.commander_command('goto-first-sibling')
-def goToFirstSibling(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToFirstSibling(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the first sibling of the selected node."""
     c, p = self, self.p
     if p.hasBack():
@@ -805,7 +805,7 @@ def goToFirstSibling(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20070615070925: *3* c_oc.goToFirstVisibleNode
 @g.commander_command('goto-first-visible-node')
-def goToFirstVisibleNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToFirstVisibleNode(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the first visible node of the selected chapter or hoist."""
     c = self
     p = c.firstVisible()
@@ -819,7 +819,7 @@ def goToFirstVisibleNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2915: *3* c_oc.goToLastNode
 @g.commander_command('goto-last-node')
-def goToLastNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToLastNode(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the last node in the entire tree."""
     c = self
     p = c.rootPosition()
@@ -831,7 +831,7 @@ def goToLastNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20051012092847.1: *3* c_oc.goToLastSibling
 @g.commander_command('goto-last-sibling')
-def goToLastSibling(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToLastSibling(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the last sibling of the selected node."""
     c, p = self, self.p
     if p.hasNext():
@@ -842,7 +842,7 @@ def goToLastSibling(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20050711153537: *3* c_oc.goToLastVisibleNode
 @g.commander_command('goto-last-visible-node')
-def goToLastVisibleNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToLastVisibleNode(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the last visible node of selected chapter or hoist."""
     c = self
     p = c.lastVisible()
@@ -856,7 +856,7 @@ def goToLastVisibleNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2916: *3* c_oc.goToNextClone
 @g.commander_command('goto-next-clone')
-def goToNextClone(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToNextClone(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Select the next node that is a clone of the selected node.
     If the selected node is not a clone, do find-next-clone.
@@ -898,7 +898,7 @@ def goToNextClone(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2917: *3* c_oc.goToNextDirtyHeadline
 @g.commander_command('goto-next-changed')
-def goToNextDirtyHeadline(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToNextDirtyHeadline(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the node that is marked as changed."""
     c, p = self, self.p
     if not p:
@@ -922,7 +922,7 @@ def goToNextDirtyHeadline(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2918: *3* c_oc.goToNextMarkedHeadline
 @g.commander_command('goto-next-marked')
-def goToNextMarkedHeadline(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToNextMarkedHeadline(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the next marked node."""
     c, p = self, self.p
     if not p:
@@ -946,7 +946,7 @@ def goToNextMarkedHeadline(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2919: *3* c_oc.goToNextSibling
 @g.commander_command('goto-next-sibling')
-def goToNextSibling(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToNextSibling(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the next sibling of the selected node."""
     c, p = self, self.p
     c.treeSelectHelper(p and p.next())
@@ -954,7 +954,7 @@ def goToNextSibling(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2920: *3* c_oc.goToParent
 @g.commander_command('goto-parent')
-def goToParent(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToParent(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the parent of the selected node."""
     c, p = self, self.p
     c.treeSelectHelper(p and p.parent())
@@ -962,7 +962,7 @@ def goToParent(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20190211104913.1: *3* c_oc.goToPrevMarkedHeadline
 @g.commander_command('goto-prev-marked')
-def goToPrevMarkedHeadline(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToPrevMarkedHeadline(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the previous marked node."""
     c, p = self, self.p
     if not p:
@@ -986,7 +986,7 @@ def goToPrevMarkedHeadline(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2921: *3* c_oc.goToPrevSibling
 @g.commander_command('goto-prev-sibling')
-def goToPrevSibling(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToPrevSibling(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the previous sibling of the selected node."""
     c, p = self, self.p
     c.treeSelectHelper(p and p.back())
@@ -994,7 +994,7 @@ def goToPrevSibling(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2993: *3* c_oc.selectThreadBack
 @g.commander_command('goto-prev-node')
-def selectThreadBack(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def selectThreadBack(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the node preceding the selected node in outline order."""
     c, p = self, self.p
     if not p:
@@ -1005,7 +1005,7 @@ def selectThreadBack(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2994: *3* c_oc.selectThreadNext
 @g.commander_command('goto-next-node')
-def selectThreadNext(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def selectThreadNext(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the node following the selected node in outline order."""
     c, p = self, self.p
     if not p:
@@ -1016,7 +1016,7 @@ def selectThreadNext(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2995: *3* c_oc.selectVisBack
 @g.commander_command('goto-prev-visible')
-def selectVisBack(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def selectVisBack(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the visible node preceding the presently selected node."""
     # This has an up arrow for a control key.
     c, p = self, self.p
@@ -1031,7 +1031,7 @@ def selectVisBack(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2996: *3* c_oc.selectVisNext
 @g.commander_command('goto-next-visible')
-def selectVisNext(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def selectVisNext(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the visible node following the presently selected node."""
     c, p = self, self.p
     if not p:
@@ -1047,7 +1047,7 @@ def selectVisNext(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20120308061112.9865: *3* c_oc.deHoist
 @g.commander_command('de-hoist')
 @g.commander_command('dehoist')
-def dehoist(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def dehoist(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Undo a previous hoist of an outline."""
     c, cc, tag = self, self.chapterController, '@chapter '
     if not c.p or not c.hoistStack:
@@ -1073,7 +1073,7 @@ def dehoist(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20120308061112.9866: *3* c_oc.clearAllHoists
 @g.commander_command('clear-all-hoists')
-def clearAllHoists(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def clearAllHoists(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Undo a previous hoist of an outline."""
     c = self
     c.hoistStack = []
@@ -1083,7 +1083,7 @@ def clearAllHoists(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20120308061112.9867: *3* c_oc.hoist
 @g.commander_command('hoist')
-def hoist(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def hoist(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Make only the selected outline visible."""
     c, p = self, self.p
     if not p:
@@ -1106,7 +1106,7 @@ def hoist(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.1759: ** c_oc.Insert, Delete & Clone commands
 # @+node:ekr.20031218072017.1762: *3* c_oc.clone
 @g.commander_command('clone-node')
-def clone(self: Cmdr, event: LeoKeyEvent = None) -> Optional[Position]:
+def clone(self: Cmdr, event: LeoKeyEvent | None = None) -> Optional[Position]:
     """Create a clone of the selected outline."""
     c, p, u = self, self.p, self.undoer
     if not p:
@@ -1128,7 +1128,7 @@ def clone(self: Cmdr, event: LeoKeyEvent = None) -> Optional[Position]:
 
 # @+node:ekr.20150630152607.1: *3* c_oc.cloneToAtSpot
 @g.commander_command('clone-to-at-spot')
-def cloneToAtSpot(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def cloneToAtSpot(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Create a clone of the selected node and move it to the last @spot node
     of the outline. Create the @spot node if necessary.
@@ -1180,7 +1180,7 @@ def cloneToAtSpot(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20141023154408.5: *3* c_oc.cloneToLastNode
 @g.commander_command('clone-node-to-last-node')
-def cloneToLastNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def cloneToLastNode(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Clone the selected node and move it to the last node.
     Do *not* change the selected node.
@@ -1205,7 +1205,7 @@ def cloneToLastNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.1193: *3* c_oc.deleteOutline
 @g.commander_command('delete-node')
-def deleteOutline(self: Cmdr, event: LeoKeyEvent = None, op_name: str = "Delete Node") -> None:
+def deleteOutline(self: Cmdr, event: LeoKeyEvent | None = None, op_name: str = "Delete Node") -> None:
     """Deletes the selected outline."""
     c, u = self, self.undoer
     p = c.p
@@ -1239,7 +1239,7 @@ def deleteOutline(self: Cmdr, event: LeoKeyEvent = None, op_name: str = "Delete 
 
 # @+node:ekr.20071005173203.1: *3* c_oc.insertChild
 @g.commander_command('insert-child')
-def insertChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def insertChild(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Insert a node after the presently selected node."""
     c = self
     return c.insertHeadline(event=event, op_name='Insert Child', as_child=True)
@@ -1249,7 +1249,7 @@ def insertChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
 @g.commander_command('insert-node')
 def insertHeadline(
     self: Cmdr,
-    event: LeoKeyEvent = None,
+    event: LeoKeyEvent | None = None,
     op_name: str = "Insert Node",
     as_child: bool = False,
 ) -> Optional[Position]:
@@ -1265,14 +1265,14 @@ def insertHeadline(
 
 
 @g.commander_command('insert-as-first-child')
-def insertNodeAsFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> Optional[Position]:
+def insertNodeAsFirstChild(self: Cmdr, event: LeoKeyEvent | None = None) -> Optional[Position]:
     """Insert a node as the first child of the previous node."""
     c = self
     return insertHeadlineHelper(c, event=event, as_first_child=True)
 
 
 @g.commander_command('insert-as-last-child')
-def insertNodeAsLastChild(self: Cmdr, event: LeoKeyEvent = None) -> Optional[Position]:
+def insertNodeAsLastChild(self: Cmdr, event: LeoKeyEvent | None = None) -> Optional[Position]:
     """Insert a node as the last child of the previous node."""
     c = self
     return insertHeadlineHelper(c, event=event, as_last_child=True)
@@ -1281,7 +1281,7 @@ def insertNodeAsLastChild(self: Cmdr, event: LeoKeyEvent = None) -> Optional[Pos
 # @+node:ekr.20171124091846.1: *4* function: insertHeadlineHelper
 def insertHeadlineHelper(
     c: Cmdr,
-    event: LeoKeyEvent = None,
+    event: LeoKeyEvent | None = None,
     op_name: str = "Insert Node",
     as_child: bool = False,
     as_first_child: bool = False,
@@ -1320,7 +1320,7 @@ def insertHeadlineHelper(
 
 # @+node:ekr.20130922133218.11540: *3* c_oc.insertHeadlineBefore
 @g.commander_command('insert-node-before')
-def insertHeadlineBefore(self: Cmdr, event: LeoKeyEvent = None) -> Optional[Position]:
+def insertHeadlineBefore(self: Cmdr, event: LeoKeyEvent | None = None) -> Optional[Position]:
     """Insert a node before the presently selected node."""
     c, current, u = self, self.p, self.undoer
     op_name = 'Insert Node Before'
@@ -1344,7 +1344,7 @@ def insertHeadlineBefore(self: Cmdr, event: LeoKeyEvent = None) -> Optional[Posi
 # @+node:ekr.20031218072017.2922: ** c_oc.Mark commands
 # @+node:ekr.20090905110447.6098: *3* c_oc.cloneMarked
 @g.commander_command('clone-marked-nodes')
-def cloneMarked(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def cloneMarked(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Clone all marked nodes as children of a new node."""
     c, u = self, self.undoer
     p1 = c.p.copy()
@@ -1385,7 +1385,7 @@ def cloneMarked(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20160502090456.1: *3* c_oc.copyMarked
 @g.commander_command('copy-marked-nodes')
-def copyMarked(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def copyMarked(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Copy all marked nodes as children of a new node."""
     c, u = self, self.undoer
     p1 = c.p.copy()
@@ -1420,7 +1420,7 @@ def copyMarked(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20111005081134.15540: *3* c_oc.deleteMarked
 @g.commander_command('delete-marked-nodes')
-def deleteMarked(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def deleteMarked(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Delete all marked nodes."""
     c, u = self, self.undoer
     p1 = c.p.copy()
@@ -1445,7 +1445,7 @@ def deleteMarked(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20111005081134.15539: *3* c_oc.moveMarked & helper
 @g.commander_command('move-marked-nodes')
-def moveMarked(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def moveMarked(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Move all marked nodes as children of a new node.
     This command is not undoable.
@@ -1518,7 +1518,7 @@ def createMoveMarkedNode(c: Cmdr) -> Position:
 # @+node:ekr.20031218072017.2923: *3* c_oc.markChangedHeadlines
 @g.commander_command('mark-changed-items')
 @g.commander_command('mark-changed-nodes')
-def markChangedHeadlines(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def markChangedHeadlines(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Mark all nodes that have been changed."""
     c, current, u = self, self.p, self.undoer
     undoType = 'Mark Changed'
@@ -1542,7 +1542,7 @@ def markChangedHeadlines(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 
 # @+node:ekr.20031218072017.2924: *3* c_oc.markChangedRoots
-def markChangedRoots(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def markChangedRoots(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Mark all changed @root nodes."""
     c, current, u = self, self.p, self.undoer
     undoType = 'Mark Changed'
@@ -1570,7 +1570,7 @@ def markChangedRoots(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.2928: *3* c_oc.markHeadline
 @g.commander_command('mark')  # Compatibility
 @g.commander_command('toggle-mark')
-def markHeadline(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def markHeadline(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Toggle the mark of the selected node."""
     c, p, u = self, self.p, self.undoer
     if not p:
@@ -1590,7 +1590,7 @@ def markHeadline(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2929: *3* c_oc.markSubheads
 @g.commander_command('mark-subheads')
-def markSubheads(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def markSubheads(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Mark all children of the selected node as changed."""
     c, current, u = self, self.p, self.undoer
     undoType = 'Mark Subheads'
@@ -1614,7 +1614,7 @@ def markSubheads(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2930: *3* c_oc.unmarkAll
 @g.commander_command('unmark-all')
-def unmarkAll(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def unmarkAll(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Unmark all nodes in the entire outline."""
     c, current, u = self, self.p, self.undoer
     undoType = 'Unmark All'
@@ -1642,7 +1642,7 @@ def unmarkAll(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.1766: ** c_oc.Move commands
 # @+node:ekr.20031218072017.1767: *3* c_oc.demote
 @g.commander_command('demote')
-def demote(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def demote(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Make all following siblings children of the selected node."""
     c, p, u = self, self.p, self.undoer
     if not p or not p.hasNext():
@@ -1678,7 +1678,7 @@ def demote(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.1768: *3* c_oc.moveOutlineDown
 @g.commander_command('move-outline-down')
-def moveOutlineDown(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def moveOutlineDown(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Move the selected node down."""
     # Moving down is more tricky than moving up because we can't
     # move p to be a child of itself.
@@ -1738,7 +1738,7 @@ def moveOutlineDown(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.1770: *3* c_oc.moveOutlineLeft
 @g.commander_command('move-outline-left')
-def moveOutlineLeft(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def moveOutlineLeft(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Move the selected node left if possible."""
     c, p, u = self, self.p, self.undoer
     if not p:
@@ -1768,7 +1768,7 @@ def moveOutlineLeft(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.1771: *3* c_oc.moveOutlineRight
 @g.commander_command('move-outline-right')
-def moveOutlineRight(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def moveOutlineRight(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Move the selected node right if possible."""
     c, p, u = self, self.p, self.undoer
     if not p:
@@ -1799,7 +1799,7 @@ def moveOutlineRight(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.1772: *3* c_oc.moveOutlineUp
 @g.commander_command('move-outline-up')
-def moveOutlineUp(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def moveOutlineUp(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Move the selected node up if possible."""
     c, p, u = self, self.p, self.undoer
     if not p:
@@ -1864,7 +1864,7 @@ def moveOutlineUp(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20230902051130.1: *3* c_oc.moveOutlineToFirstChild
 @g.commander_command('move-outline-to-first-child')
-def moveOutlineToFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def moveOutlineToFirstChild(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Move the selected node so that it is the first child of its parent.
 
@@ -1892,7 +1892,7 @@ def moveOutlineToFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20230902051833.1: *3* c_oc.moveOutlineToLastChild
 @g.commander_command('move-outline-to-last-child')
-def moveOutlineToLastChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def moveOutlineToLastChild(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Move the selected node so that it is the last child of its parent.
 
@@ -1920,7 +1920,7 @@ def moveOutlineToLastChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.1774: *3* c_oc.promote
 @g.commander_command('promote')
-def promote(self: Cmdr, event: LeoKeyEvent = None, undoFlag: bool = True) -> None:
+def promote(self: Cmdr, event: LeoKeyEvent | None = None, undoFlag: bool = True) -> None:
     """Make all children of the selected nodes siblings of the selected node."""
     c, p, u = self, self.p, self.undoer
     if not p or not p.hasChildren():
@@ -1939,7 +1939,7 @@ def promote(self: Cmdr, event: LeoKeyEvent = None, undoFlag: bool = True) -> Non
 
 # @+node:ekr.20071213185710: *3* c_oc.toggleSparseMove
 @g.commander_command('toggle-sparse-move')
-def toggleSparseMove(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def toggleSparseMove(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Toggle whether moves collapse the outline."""
     c = self
     c.sparse_move = not c.sparse_move
@@ -1950,14 +1950,14 @@ def toggleSparseMove(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20080425060424.1: ** c_oc.Sort commands
 # @+node:felix.20230318172503.1: *3* c_oc.reverseSortChildren
 @g.commander_command('reverse-sort-children')
-def reverseSortChildren(self: Cmdr, event: LeoKeyEvent = None, key: str = None) -> None:
+def reverseSortChildren(self: Cmdr, event: LeoKeyEvent | None = None, key: str | None = None) -> None:
     """Sort the children of a node in reverse order."""
     self.sortChildren(key=key, reverse=True)  # as reverse, Fixes #3188
 
 
 # @+node:felix.20230318172511.1: *3* c_oc.reverseSortSiblings
 @g.commander_command('reverse-sort-siblings')
-def reverseSortSiblings(self: Cmdr, event: LeoKeyEvent = None, key: str = None) -> None:
+def reverseSortSiblings(self: Cmdr, event: LeoKeyEvent | None = None, key: str | None = None) -> None:
     """Sort the siblings of a node in reverse order."""
     self.sortSiblings(key=key, reverse=True)  # as reverse, Fixes #3188
 
@@ -1965,7 +1965,7 @@ def reverseSortSiblings(self: Cmdr, event: LeoKeyEvent = None, key: str = None) 
 # @+node:ekr.20050415134809: *3* c_oc.sortChildren
 @g.commander_command('sort-children')
 def sortChildren(
-    self: Cmdr, event: LeoKeyEvent = None, key: Callable = None, reverse: bool = False
+    self: Cmdr, event: LeoKeyEvent | None = None, key: Callable | None = None, reverse: bool = False
 ) -> None:
     """Sort the children of a node."""
     # This method no longer supports the 'cmp' keyword arg.
@@ -1978,9 +1978,9 @@ def sortChildren(
 @g.commander_command('sort-siblings')
 def sortSiblings(
     self: Cmdr,
-    event: LeoKeyEvent = None,  # cmp keyword is no longer supported.
-    key: Callable = None,
-    p: Position = None,
+    event: LeoKeyEvent | None = None,  # cmp keyword is no longer supported.
+    key: Callable | None = None,
+    p: Position | None = None,
     sortChildren: bool = False,
     reverse: bool = False,
 ) -> None:
@@ -2040,7 +2040,7 @@ def cantMoveMessage(c: Cmdr) -> None:
 
 # @+node:ekr.20180201040936.1: ** count-children
 @g.command('count-children')
-def count_children(event: LeoKeyEvent = None) -> None:
+def count_children(event: LeoKeyEvent | None = None) -> None:
     """Print out the number of children for the currently selected node"""
     c = event and event.get('c')
     if c:

--- a/leo/commands/controlCommands.py
+++ b/leo/commands/controlCommands.py
@@ -55,11 +55,11 @@ class ControlCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.92: *3* print plugins info...
     @cmd('show-plugin-handlers')
-    def printPluginHandlers(self, event: LeoKeyEvent = None) -> None:
+    def printPluginHandlers(self, event: LeoKeyEvent | None = None) -> None:
         """Print the handlers for each plugin."""
         g.app.pluginsController.printHandlers(self.c)
 
-    def printPlugins(self, event: LeoKeyEvent = None) -> None:
+    def printPlugins(self, event: LeoKeyEvent | None = None) -> None:
         """
         Print the file name responsible for loading a plugin.
 
@@ -69,7 +69,7 @@ class ControlCommandsClass(BaseEditCommandsClass):
         g.app.pluginsController.printPlugins(self.c)
 
     @cmd('show-plugins-info')
-    def printPluginsInfo(self, event: LeoKeyEvent = None) -> None:
+    def printPluginsInfo(self, event: LeoKeyEvent | None = None) -> None:
         """
         Print the file name responsible for loading a plugin.
 
@@ -80,7 +80,7 @@ class ControlCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.93: *3* setSilentMode
     @cmd('set-silent-mode')
-    def setSilentMode(self, event: LeoKeyEvent = None) -> None:
+    def setSilentMode(self, event: LeoKeyEvent | None = None) -> None:
         """
         Set the mode to be run silently, without the minibuffer.
         The only use for this command is to put the following in an @mode node::

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -1658,7 +1658,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
 
         # @+others
         # @+node:ekr.20231119103026.2: *5* py2rust.ctor
-        def __init__(self, c: Cmdr, alias: str = None) -> None:
+        def __init__(self, c: Cmdr, alias: str | None = None) -> None:
             self.c = c
             self.alias = alias  # For scripts. An alias for 'self'.
             data = c.config.getData('python-to-typescript-types') or []
@@ -2388,7 +2388,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
 
         # @+others
         # @+node:ekr.20211020162251.1: *5* py2ts.ctor
-        def __init__(self, c: Cmdr, alias: str = None) -> None:
+        def __init__(self, c: Cmdr, alias: str | None = None) -> None:
             self.c = c
             self.alias = alias  # For scripts. An alias for 'self'.
             data = c.config.getData('python-to-typescript-types') or []

--- a/leo/commands/debugCommands.py
+++ b/leo/commands/debugCommands.py
@@ -27,7 +27,7 @@ class DebugCommandsClass(BaseEditCommandsClass):
     # @+others
     # @+node:ekr.20150514063305.104: ** debug.debug & helper
     @cmd('debug')
-    def invoke_debugger(self, event: LeoKeyEvent = None) -> None:
+    def invoke_debugger(self, event: LeoKeyEvent | None = None) -> None:
         """
         Start an external debugger in another process to debug a script. The
         script is the presently selected text or then entire tree's script.
@@ -89,7 +89,7 @@ class DebugCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20170713112849.1: ** debug.dump-node
     @cmd('dump-node')
-    def dumpNode(self, event: LeoKeyEvent = None) -> None:
+    def dumpNode(self, event: LeoKeyEvent | None = None) -> None:
         """Dump c.p.v, including gnx, uA's, etc."""
         p = self.c.p
         if p:
@@ -102,7 +102,7 @@ class DebugCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.103: ** debug.gc-collect-garbage
     @cmd('gc-collect-garbage')
-    def collectGarbage(self, event: LeoKeyEvent = None) -> None:
+    def collectGarbage(self, event: LeoKeyEvent | None = None) -> None:
         """Run Python's Garbage Collector."""
         import gc
 
@@ -110,20 +110,20 @@ class DebugCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.106: ** debug.gc-dump-all-objects
     @cmd('gc-dump-all-objects')
-    def dumpAllObjects(self, event: LeoKeyEvent = None) -> None:
+    def dumpAllObjects(self, event: LeoKeyEvent | None = None) -> None:
         """Print a summary of all existing Python objects."""
         g.printGc()
 
     # @+node:ekr.20150514063305.111: ** debug.gc-show-summary
     @cmd('gc-show-summary')
-    def printGcSummary(self, event: LeoKeyEvent = None) -> None:
+    def printGcSummary(self, event: LeoKeyEvent | None = None) -> None:
         """Print a brief summary of all Python objects."""
         g.printGcSummary()
 
     # @+node:ekr.20170429154309.1: ** debug.kill-log-listener
     @cmd('kill-log-listener')
     @cmd('log-kill-listener')
-    def killLogListener(self, event: LeoKeyEvent = None) -> None:
+    def killLogListener(self, event: LeoKeyEvent | None = None) -> None:
         """Kill the listener started by listen-for-log."""
         if g.app.log_listener:
             try:
@@ -137,7 +137,7 @@ class DebugCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.110: ** debug.show-focus
     @cmd('show-focus')
-    def printFocus(self, event: LeoKeyEvent = None) -> None:
+    def printFocus(self, event: LeoKeyEvent | None = None) -> None:
         """
         Print information about the requested focus.
 

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -93,7 +93,7 @@ def lineScrollHelper(c: Cmdr, prefix1: str, prefix2: str, suffix: str) -> None:
 # @+node:ekr.20201129164455.1: **  Top-level commands
 # @+node:ekr.20180504180134.1: *3* @g.command('delete-trace-statements')
 @g.command('delete-trace-statements')
-def delete_trace_statements(event: LeoKeyEvent = None) -> None:
+def delete_trace_statements(event: LeoKeyEvent | None = None) -> None:
     """
     Delete all trace statements/blocks from c.p to the end of the outline.
 
@@ -203,7 +203,7 @@ def promote_section_definition(event: LeoKeyEvent) -> None:
 
 # @+node:ekr.20220515193048.1: *3* @g.command('merge-node-with-next-node')
 @g.command('merge-node-with-next-node')
-def merge_node_with_next_node(event: LeoKeyEvent = None) -> None:
+def merge_node_with_next_node(event: LeoKeyEvent | None = None) -> None:
     """
     Merge p.b into p.next().b and delete p, *provided* that p has no children.
     """
@@ -235,7 +235,7 @@ def merge_node_with_next_node(event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20220515193124.1: *3* @g.command('merge-node-with-prev-node')
 @g.command('merge-node-with-prev-node')
-def merge_node_with_prev_node(event: LeoKeyEvent = None) -> None:
+def merge_node_with_prev_node(event: LeoKeyEvent | None = None) -> None:
     """
     Merge p.b into p.back().b and delete p, *provided* that p has no children.
     """
@@ -332,7 +332,7 @@ def promoteHeadlines(event: LeoKeyEvent) -> None:
 
 # @+node:ekr.20180504180647.1: *3* @g.command('select-next-trace-statement')
 @g.command('select-next-trace-statement')
-def select_next_trace_statement(event: LeoKeyEvent = None) -> None:
+def select_next_trace_statement(event: LeoKeyEvent | None = None) -> None:
     """Select the next statement/block enabled by `if trace...:`"""
     c = event.get('c')
     if not c:
@@ -351,7 +351,7 @@ def select_next_trace_statement(event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20191010112910.1: *3* @g.command('show-clone-ancestors')
 @g.command('show-clone-ancestors')
-def show_clone_ancestors(event: LeoKeyEvent = None) -> None:
+def show_clone_ancestors(event: LeoKeyEvent | None = None) -> None:
     """Display links to all ancestor nodes of the node c.p."""
     c = event.get('c')
     if not c:
@@ -377,7 +377,7 @@ def show_clone_ancestors(event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20191007034723.1: *3* @g.command('show-clone-parents')
 @g.command('show-clone-parents')
-def show_clones(event: LeoKeyEvent = None) -> None:
+def show_clones(event: LeoKeyEvent | None = None) -> None:
     """Display links to all parent nodes of the node c.p."""
     c = event.get('c')
     if not c:
@@ -399,7 +399,7 @@ def show_clones(event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20180210161001.1: *3* @g.command('unmark-node-and-parents')
 @g.command('unmark-node-and-parents')
-def unmark_node_and_parents(event: LeoKeyEvent = None) -> list[Position]:
+def unmark_node_and_parents(event: LeoKeyEvent | None = None) -> list[Position]:
     """Unmark the node and all its parents."""
     c = event.get('c')
     changed: list[Position] = []
@@ -466,12 +466,12 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.190: *3* ec.cache
     @cmd('clear-all-caches')
     @cmd('clear-cache')
-    def clearAllCaches(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def clearAllCaches(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Clear all of Leo's file caches."""
         g.app.global_cacher.clear()
 
     @cmd('dump-caches')
-    def dumpCaches(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def dumpCaches(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Dump, all of Leo's file caches."""
         if hasattr(g.app.global_cacher, 'dump'):
             g.app.global_cacher.dump()
@@ -486,7 +486,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.278: *3* ec.insertFileName
     @cmd('insert-file-name')
-    def insertFileName(self, event: LeoKeyEvent = None) -> None:
+    def insertFileName(self, event: LeoKeyEvent | None = None) -> None:
         """
         Prompt for a file name, then insert it at the cursor position.
         This operation is undoable if done in the body pane.
@@ -532,7 +532,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.279: *3* ec.insertHeadlineTime
     @cmd('insert-headline-time')
-    def insertHeadlineTime(self, event: LeoKeyEvent = None) -> None:
+    def insertHeadlineTime(self, event: LeoKeyEvent | None = None) -> None:
         """Insert a date/time stamp in the headline of the selected node."""
         frame = self
         c, p = frame.c, self.c.p
@@ -574,7 +574,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:tom.20210922140250.1: *3* ec.capitalizeHeadline
     @cmd('capitalize-headline')
-    def capitalizeHeadline(self, event: LeoKeyEvent = None) -> None:
+    def capitalizeHeadline(self, event: LeoKeyEvent | None = None) -> None:
         """Capitalize all words in the headline of the selected node."""
         frame = self
         c, p, u = frame.c, self.c.p, self.c.undoer
@@ -707,7 +707,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:tom.20210922171731.1: *4* ec.capitalizeWords & selection
     @cmd('capitalize-words-or-selection')
-    def capitalizeWords(self, event: LeoKeyEvent = None) -> None:
+    def capitalizeWords(self, event: LeoKeyEvent | None = None) -> None:
         """Capitalize Entire Body Or Selection."""
         frame = self
         c, p, u = frame.c, self.c.p, self.c.undoer
@@ -747,37 +747,37 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.195: *3* ec: clicks and focus
     # @+node:ekr.20150514063305.196: *4* ec.activate-x-menu & activateMenu
     @cmd('activate-cmds-menu')
-    def activateCmdsMenu(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def activateCmdsMenu(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Activate Leo's Cmnds menu."""
         self.activateMenu('Cmds')
 
     @cmd('activate-edit-menu')
-    def activateEditMenu(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def activateEditMenu(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Activate Leo's Edit menu."""
         self.activateMenu('Edit')
 
     @cmd('activate-file-menu')
-    def activateFileMenu(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def activateFileMenu(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Activate Leo's File menu."""
         self.activateMenu('File')
 
     @cmd('activate-help-menu')
-    def activateHelpMenu(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def activateHelpMenu(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Activate Leo's Help menu."""
         self.activateMenu('Help')
 
     @cmd('activate-outline-menu')
-    def activateOutlineMenu(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def activateOutlineMenu(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Activate Leo's Outline menu."""
         self.activateMenu('Outline')
 
     @cmd('activate-plugins-menu')
-    def activatePluginsMenu(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def activatePluginsMenu(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Activate Leo's Plugins menu."""
         self.activateMenu('Plugins')
 
     @cmd('activate-window-menu')
-    def activateWindowMenu(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def activateWindowMenu(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Activate Leo's Window menu."""
         self.activateMenu('Window')
 
@@ -787,7 +787,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.199: *4* ec.focusTo...
     @cmd('focus-to-body')
-    def focusToBody(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def focusToBody(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Put the keyboard focus in Leo's body pane."""
         c, k = self.c, self.c.k
         c.bodyWantsFocus()
@@ -796,17 +796,17 @@ class EditCommandsClass(BaseEditCommandsClass):
             k.showStateAndMode()
 
     @cmd('focus-to-log')
-    def focusToLog(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def focusToLog(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Put the keyboard focus in Leo's log pane."""
         self.c.logWantsFocus()
 
     @cmd('focus-to-minibuffer')
-    def focusToMinibuffer(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def focusToMinibuffer(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Put the keyboard focus in Leo's minibuffer."""
         self.c.minibufferWantsFocus()
 
     @cmd('focus-to-tree')
-    def focusToTree(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def focusToTree(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Put the keyboard focus in Leo's outline pane."""
         self.c.treeWantsFocus()
 
@@ -814,32 +814,32 @@ class EditCommandsClass(BaseEditCommandsClass):
     # These call the actual event handlers so as to trigger hooks.
 
     @cmd('ctrl-click-icon')
-    def ctrlClickIconBox(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def ctrlClickIconBox(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Simulate a ctrl-click in the icon box of the presently selected node."""
         c = self.c
         c.frame.tree.OnIconCtrlClick(c.p)  # Calls the base LeoTree method.
 
     @cmd('click-icon-box')
-    def clickIconBox(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def clickIconBox(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Simulate a click in the icon box of the presently selected node."""
         c = self.c
         c.frame.tree.onIconBoxClick(event, p=c.p)
 
     @cmd('double-click-icon-box')
-    def doubleClickIconBox(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def doubleClickIconBox(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Simulate a double-click in the icon box of the presently selected node."""
         c = self.c
         c.frame.tree.onIconBoxDoubleClick(event, p=c.p)
 
     @cmd('right-click-icon')
-    def rightClickIconBox(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def rightClickIconBox(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Simulate a right click in the icon box of the presently selected node."""
         c = self.c
         c.frame.tree.onIconBoxRightClick(event, p=c.p)
 
     # @+node:ekr.20150514063305.202: *4* ec.clickClickBox
     @cmd('click-click-box')
-    def clickClickBox(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def clickClickBox(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """
         Simulate a click in the click box (+- box) of the presently selected node.
 
@@ -1105,7 +1105,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.225: *3* ec: goto node
     # @+node:ekr.20170411065920.1: *4* goto-any-clone
     @cmd('goto-any-clone')
-    def gotoAnyClone(self, event: LeoKeyEvent = None) -> None:
+    def gotoAnyClone(self, event: LeoKeyEvent | None = None) -> None:
         """Select then next cloned node, regardless of whether c.p is a clone."""
         c = self.c
         p = c.p.threadNext()
@@ -1200,7 +1200,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('hn-add-all')
     @cmd('headline-number-add-all')
     @cmd('add-all-headline-numbers')
-    def hn_add_all(self, event: LeoKeyEvent = None) -> None:
+    def hn_add_all(self, event: LeoKeyEvent | None = None) -> None:
         """
         Add headline numbers to all nodes of the outline *except*:
         -  @<file> nodes and their descendants.
@@ -1247,7 +1247,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('hn-add-subtree')
     @cmd('headline-number-add-subtree')
     @cmd('add-subtree-headline-numbers')
-    def hn_add_children(self, event: LeoKeyEvent = None) -> None:
+    def hn_add_children(self, event: LeoKeyEvent | None = None) -> None:
         """
         Add headline numbers to *all* children of c.p, *including*:
         -  @<file> nodes and their descendants.
@@ -1287,7 +1287,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('hn-delete-all')
     @cmd('headline-number-delete-all')
     @cmd('delete-all-headline-numbers')
-    def hn_delete_all(self, event: LeoKeyEvent = None) -> None:
+    def hn_delete_all(self, event: LeoKeyEvent | None = None) -> None:
         """Delete all headline numbers in the entire outline."""
         c, command = self.c, 'delete-all-headline-numbers'
         u = c.undoer
@@ -1302,7 +1302,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('hn-delete-subtree')
     @cmd('headline-number-delete-subtree')
     @cmd('delete-subtree-headline-numbers')
-    def hn_delete_tree(self, event: LeoKeyEvent = None) -> None:
+    def hn_delete_tree(self, event: LeoKeyEvent | None = None) -> None:
         """Delete all headline numbers in c.p's subtree."""
         c, command = self.c, 'delete-subtree-headline-numbers'
         u = c.undoer
@@ -1407,7 +1407,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.236: *4* ec.deleteFirstIcon
     @cmd('delete-first-icon')
-    def deleteFirstIcon(self, event: LeoKeyEvent = None) -> None:
+    def deleteFirstIcon(self, event: LeoKeyEvent | None = None) -> None:
         """Delete the first icon in the selected node's icon list."""
         c, p = self.c, self.c.p
         aList = self.getIconList(c.p.v)
@@ -1442,7 +1442,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.238: *4* ec.deleteLastIcon
     @cmd('delete-last-icon')
-    def deleteLastIcon(self, event: LeoKeyEvent = None) -> None:
+    def deleteLastIcon(self, event: LeoKeyEvent | None = None) -> None:
         """Delete the first icon in the selected node's icon list."""
         c, p = self.c, self.c.p
         aList = self.getIconList(p.v)
@@ -1453,7 +1453,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.239: *4* ec.deleteNodeIcons
     @cmd('delete-node-icons')
-    def deleteNodeIcons(self, event: LeoKeyEvent = None, p: Position = None) -> None:
+    def deleteNodeIcons(self, event: LeoKeyEvent | None = None, p: Position | None = None) -> None:
         """Delete all of the selected node's icons."""
         c = self.c
         p = p or c.p
@@ -1465,7 +1465,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.240: *4* ec.insertIcon
     @cmd('insert-icon')
-    def insertIcon(self, event: LeoKeyEvent = None) -> None:
+    def insertIcon(self, event: LeoKeyEvent | None = None) -> None:
         """Prompt for an icon, and insert it into the node's icon list."""
         c, p = self.c, self.c.p
         iconDir = g.finalize_join(g.app.loadDir, "..", "Icons")
@@ -1494,7 +1494,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.241: *4* ec.insertIconFromFile
     def insertIconFromFile(
-        self, path: str, p: Position = None, pos: int = None, **kargs: KWargs
+        self, path: str, p: Position | None = None, pos: int | None = None, **kargs: KWargs
     ) -> None:
         c = self.c
         if not p:
@@ -1701,7 +1701,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.253: *4* ec.backwardDeleteCharacter
     @cmd('backward-delete-char')
-    def backwardDeleteCharacter(self, event: LeoKeyEvent = None) -> None:
+    def backwardDeleteCharacter(self, event: LeoKeyEvent | None = None) -> None:
         """Delete the character to the left of the cursor."""
         c = self.c
         w = self.editWidget(event)
@@ -1839,24 +1839,24 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.258: *4* ec.delete-word & backward-delete-word
     @cmd('delete-word')
-    def deleteWord(self, event: LeoKeyEvent = None) -> None:
+    def deleteWord(self, event: LeoKeyEvent | None = None) -> None:
         """Delete the word at the cursor."""
         self.deleteWordHelper(event, forward=True)
 
     @cmd('backward-delete-word')
-    def backwardDeleteWord(self, event: LeoKeyEvent = None) -> None:
+    def backwardDeleteWord(self, event: LeoKeyEvent | None = None) -> None:
         """Delete the word in front of the cursor."""
         self.deleteWordHelper(event, forward=False)
 
     # Patch by NH2.
 
     @cmd('delete-word-smart')
-    def deleteWordSmart(self, event: LeoKeyEvent = None) -> None:
+    def deleteWordSmart(self, event: LeoKeyEvent | None = None) -> None:
         """Delete the word at the cursor, treating whitespace and symbols smartly."""
         self.deleteWordHelper(event, forward=True, smart=True)
 
     @cmd('backward-delete-word-smart')
-    def backwardDeleteWordSmart(self, event: LeoKeyEvent = None) -> None:
+    def backwardDeleteWordSmart(self, event: LeoKeyEvent | None = None) -> None:
         """Delete the word in front of the cursor, treating whitespace and symbols smartly."""
         self.deleteWordHelper(event, forward=False, smart=True)
 
@@ -3050,7 +3050,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self,
         event: LeoKeyEvent,
         select: bool = True,
-        w: QTextMixin = None,
+        w: QTextMixin | None = None,
     ) -> tuple[int, int]:
         """Compute the word at the cursor. Select it if select arg is True."""
         if not w:
@@ -3307,7 +3307,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20170707093335.1: *4* ec.pushCursor and popCursor
     @cmd('pop-cursor')
-    def popCursor(self, event: LeoKeyEvent = None) -> None:
+    def popCursor(self, event: LeoKeyEvent | None = None) -> None:
         """Restore the node, selection range and insert point from the stack."""
         c = self.c
         w = self.editWidget(event)
@@ -3324,7 +3324,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             g.es('no stacked cursor', color='blue')
 
     @cmd('push-cursor')
-    def pushCursor(self, event: LeoKeyEvent = None) -> None:
+    def pushCursor(self, event: LeoKeyEvent | None = None) -> None:
         """Push the selection range and insert point on the stack."""
         c = self.c
         w = self.editWidget(event)
@@ -3868,7 +3868,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.337: *4* ec.scrollOutlineUp/Down/Line/Page
     @cmd('scroll-outline-down-line')
-    def scrollOutlineDownLine(self, event: LeoKeyEvent = None) -> None:
+    def scrollOutlineDownLine(self, event: LeoKeyEvent | None = None) -> None:
         """Scroll the outline pane down one line."""
         tree = self.c.frame.tree
         if hasattr(tree, 'scrollDelegate'):
@@ -3879,7 +3879,7 @@ class EditCommandsClass(BaseEditCommandsClass):
                 tree.canvas.yview_scroll(1, "unit")
 
     @cmd('scroll-outline-down-page')
-    def scrollOutlineDownPage(self, event: LeoKeyEvent = None) -> None:
+    def scrollOutlineDownPage(self, event: LeoKeyEvent | None = None) -> None:
         """Scroll the outline pane down one page."""
         tree = self.c.frame.tree
         if hasattr(tree, 'scrollDelegate'):
@@ -3890,7 +3890,7 @@ class EditCommandsClass(BaseEditCommandsClass):
                 tree.canvas.yview_scroll(1, "page")
 
     @cmd('scroll-outline-up-line')
-    def scrollOutlineUpLine(self, event: LeoKeyEvent = None) -> None:
+    def scrollOutlineUpLine(self, event: LeoKeyEvent | None = None) -> None:
         """Scroll the outline pane up one line."""
         tree = self.c.frame.tree
         if hasattr(tree, 'scrollDelegate'):
@@ -3901,7 +3901,7 @@ class EditCommandsClass(BaseEditCommandsClass):
                 tree.canvas.yview_scroll(-1, "unit")
 
     @cmd('scroll-outline-up-page')
-    def scrollOutlineUpPage(self, event: LeoKeyEvent = None) -> None:
+    def scrollOutlineUpPage(self, event: LeoKeyEvent | None = None) -> None:
         """Scroll the outline pane up one page."""
         tree = self.c.frame.tree
         if hasattr(tree, 'scrollDelegate'):
@@ -3913,7 +3913,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.338: *4* ec.scrollOutlineLeftRight
     @cmd('scroll-outline-left')
-    def scrollOutlineLeft(self, event: LeoKeyEvent = None) -> None:
+    def scrollOutlineLeft(self, event: LeoKeyEvent | None = None) -> None:
         """Scroll the outline left."""
         tree = self.c.frame.tree
         if hasattr(tree, 'scrollDelegate'):
@@ -3922,7 +3922,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             tree.canvas.xview_scroll(1, "unit")
 
     @cmd('scroll-outline-right')
-    def scrollOutlineRight(self, event: LeoKeyEvent = None) -> None:
+    def scrollOutlineRight(self, event: LeoKeyEvent | None = None) -> None:
         """Scroll the outline left."""
         tree = self.c.frame.tree
         if hasattr(tree, 'scrollDelegate'):
@@ -4104,7 +4104,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.348: *3* ec: uA's
     # @+node:ekr.20150514063305.349: *4* ec.clearNodeUas & clearAllUas
     @cmd('clear-node-uas')
-    def clearNodeUas(self, event: LeoKeyEvent = None) -> None:
+    def clearNodeUas(self, event: LeoKeyEvent | None = None) -> None:
         """Clear the uA's in the selected VNode."""
         c = self.c
         p = c and c.p
@@ -4119,7 +4119,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             c.redraw()
 
     @cmd('clear-all-uas')
-    def clearAllUas(self, event: LeoKeyEvent = None) -> None:
+    def clearAllUas(self, event: LeoKeyEvent | None = None) -> None:
         """Clear all uAs in the entire outline."""
         c, u, undoType = self.c, self.c.undoer, 'clear-all-uas'
         # #1276.
@@ -4141,7 +4141,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.350: *4* ec.showUas & showAllUas
     @cmd('show-all-uas')
-    def showAllUas(self, event: LeoKeyEvent = None) -> None:
+    def showAllUas(self, event: LeoKeyEvent | None = None) -> None:
         """Print all uA's in the outline."""
         g.es_print('Dump of uAs...')
         for v in self.c.all_unique_nodes():
@@ -4149,7 +4149,7 @@ class EditCommandsClass(BaseEditCommandsClass):
                 self.showNodeUas(v=v)
 
     @cmd('show-node-uas')
-    def showNodeUas(self, event: LeoKeyEvent = None, v: VNode = None) -> None:
+    def showNodeUas(self, event: LeoKeyEvent | None = None, v: VNode | None = None) -> None:
         """Print the uA's in the selected node."""
         c = self.c
         if v:

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -172,7 +172,7 @@ class EditFileCommandsClass(BaseEditCommandsClass):
     # @+others
     # @+node:ekr.20210308051724.1: *3* efc.convert-at-root
     @cmd('convert-at-root')
-    def convert_at_root(self, event: LeoKeyEvent = None) -> None:
+    def convert_at_root(self, event: LeoKeyEvent | None = None) -> None:
         # @+<< convert-at-root docstring >>
         # @+node:ekr.20210309035627.1: *4* << convert-at-root docstring >>
         # @@wrap
@@ -508,7 +508,7 @@ class EditFileCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20170806094318.3: *3* efc.diff (file-diff-files)
     @cmd('file-diff-files')
-    def diff(self, event: LeoKeyEvent = None) -> None:
+    def diff(self, event: LeoKeyEvent | None = None) -> None:
         """Creates a node and puts the diff between 2 files into it."""
         c, u = self.c, self.c.undoer
         fn = self.getReadableTextFile()
@@ -551,14 +551,14 @@ class EditFileCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20170819035801.90: *3* efc.gitDiff (gd & git-diff)
     @cmd('git-diff')
     @cmd('gd')
-    def gitDiff(self, event: LeoKeyEvent = None) -> None:
+    def gitDiff(self, event: LeoKeyEvent | None = None) -> None:
         """Produce a Leonine git diff."""
         GitDiffController(c=self.c).git_diff(rev1='HEAD')
 
     # @+node:ekr.20201215093414.1: *3* efc.gitDiffPR (git-diff-pr & git-diff-pull-request)
     @cmd('git-diff-pull-request')
     @cmd('git-diff-pr')
-    def gitDiffPullRequest(self, event: LeoKeyEvent = None) -> None:
+    def gitDiffPullRequest(self, event: LeoKeyEvent | None = None) -> None:
         """
         Produce a Leonine diff of pull request in the current branch.
         """
@@ -813,7 +813,7 @@ class GitDiffController:
         self.finish()
 
     # @+node:ekr.20180507212821.1: *4* gdc.diff_two_revs
-    def diff_two_revs(self, rev1: str = 'HEAD', rev2: str = '', path: str = None) -> None:
+    def diff_two_revs(self, rev1: str = 'HEAD', rev2: str = '', path: str | None = None) -> None:
         """
         Create an outline describing the git diffs for all files changed
         between rev1 and rev2.
@@ -895,7 +895,7 @@ class GitDiffController:
         return True
 
     # @+node:ekr.20230705082614.1: *4* gdc.node_history & helpers
-    def node_history(self, path: str, gnxs: list[str], limit: int = None) -> None:
+    def node_history(self, path: str, gnxs: list[str], limit: int | None = None) -> None:
         """Produce a Leonine history of the node whose file name and gnx are given."""
         c = self.c
         # The path must be absolute.
@@ -1203,7 +1203,7 @@ class GitDiffController:
             g.trace('Unknown kind', repr(b.kind))
 
     # @+node:ekr.20260112115313.1: *4* gdc.summary_diff_two_revs
-    def summary_diff_two_revs(self, rev1: str = 'HEAD', rev2: str = '', path: str = None) -> None:
+    def summary_diff_two_revs(self, rev1: str = 'HEAD', rev2: str = '', path: str | None = None) -> None:
         """
         Create an outline describing the git diffs for all files changed
         between rev1 and rev2.
@@ -1517,7 +1517,7 @@ class GitDiffController:
             return ''
 
     # @+node:ekr.20170806094320.9: *4* gdc.get_files
-    def get_files(self, rev1: str, rev2: str, path: str = None) -> list[str]:
+    def get_files(self, rev1: str, rev2: str, path: str | None = None) -> list[str]:
         """Return a list of changed files."""
         # #2143
         git_directory = self.get_parent_of_git_directory()

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -27,7 +27,7 @@ class GoToCommands:
 
     # @+others
     # @+node:ekr.20100216141722.5622: *3* goto.find_file_line & helper
-    def find_file_line(self, n: int, p: Position = None) -> tuple[Position, int]:
+    def find_file_line(self, n: int, p: Position | None = None) -> tuple[Position, int]:
         """
         Helper for goto-global-line command.
 
@@ -48,7 +48,7 @@ class GoToCommands:
         return p, offset
 
     # @+node:ekr.20230727074847.1: *4* goto.find_file_line_helper
-    def find_file_line_helper(self, n: int, p: Position = None) -> tuple[Position, int]:
+    def find_file_line_helper(self, n: int, p: Position | None = None) -> tuple[Position, int]:
         c = self.c
         if n < 0:
             return None, -1
@@ -97,7 +97,7 @@ class GoToCommands:
         return None, -1
 
     # @+node:ekr.20160921210529.1: *3* goto.find_node_start & helper
-    def find_node_start(self, p: Position, s: str = None) -> Optional[int]:
+    def find_node_start(self, p: Position, s: str | None = None) -> Optional[int]:
         """
         Helper for show-file-line command.
 

--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -32,7 +32,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
     # @+others
     # @+node:ekr.20150514063305.373: *3* help
     @cmd('help')
-    def help_command(self, event: LeoKeyEvent = None) -> None:
+    def help_command(self, event: LeoKeyEvent | None = None) -> None:
         """Prints an introduction to Leo's help system."""
         # @+<< define rst_s >>
         # @+node:ekr.20150514063305.374: *4* << define rst_s >> (F1)
@@ -72,7 +72,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.375: *3* helpForAbbreviations
     @cmd('help-for-abbreviations')
-    def helpForAbbreviations(self, event: LeoKeyEvent = None) -> None:
+    def helpForAbbreviations(self, event: LeoKeyEvent | None = None) -> None:
         """Explains Leo's abbreviations."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.376: *4* << define s >> (helpForAbbreviations)
@@ -136,7 +136,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.377: *3* helpForAutocompletion
     @cmd('help-for-autocompletion')
-    def helpForAutocompletion(self, event: LeoKeyEvent = None) -> None:
+    def helpForAutocompletion(self, event: LeoKeyEvent | None = None) -> None:
         """Explains how to use autocompletion."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.378: *4* << define s >> (helpForAutocompletion)
@@ -254,7 +254,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.379: *3* helpForBindings
     @cmd('help-for-bindings')
-    def helpForBindings(self, event: LeoKeyEvent = None) -> None:
+    def helpForBindings(self, event: LeoKeyEvent | None = None) -> None:
         """Explains Leo's keyboard bindings."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.380: *4* << define s >> (helpForBindings)
@@ -464,7 +464,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.386: *3* helpForCreatingExternalFiles
     @cmd('help-for-creating-external-files')
-    def helpForCreatingExternalFiles(self, event: LeoKeyEvent = None) -> None:
+    def helpForCreatingExternalFiles(self, event: LeoKeyEvent | None = None) -> None:
         """Explains how to create external files."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.387: *4* << define s >> (helpForCreatingExternalFiles)
@@ -600,7 +600,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.388: *3* helpForDebuggingCommands
     @cmd('help-for-debugging-commands')
-    def helpForDebuggingCommands(self, event: LeoKeyEvent = None) -> None:
+    def helpForDebuggingCommands(self, event: LeoKeyEvent | None = None) -> None:
         """Explains Leo's debugging commands."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.389: *4* << define s >> (helpForDebuggingCommands)
@@ -633,7 +633,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.390: *3* helpForDragAndDrop
     @cmd('help-for-drag-and-drop')
-    def helpForDragAndDrop(self, event: LeoKeyEvent = None) -> None:
+    def helpForDragAndDrop(self, event: LeoKeyEvent | None = None) -> None:
         """Explains Leo's drag-and-drop commands."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.391: *4* << define s >> (helpForDragAndDrop
@@ -674,7 +674,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.392: *3* helpForDynamicAbbreviations
     @cmd('help-for-dynamic-abbreviations')
-    def helpForDynamicAbbreviations(self, event: LeoKeyEvent = None) -> None:
+    def helpForDynamicAbbreviations(self, event: LeoKeyEvent | None = None) -> None:
         """Explains Leo's abbreviations."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.393: *4* << define s >> (helpForDynamicAbbreviations)
@@ -721,7 +721,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.394: *3* helpForFindCommands
     @cmd('help-for-find-commands')
-    def helpForFindCommands(self, event: LeoKeyEvent = None) -> None:
+    def helpForFindCommands(self, event: LeoKeyEvent | None = None) -> None:
         """Explains Leo's find commands."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.395: *4* << define s >> (help-for-find-commands)
@@ -804,7 +804,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20240822071015.1: *3* helpForLayouts
     @cmd('help-for-layouts')
-    def helpForLayouts(self, event: LeoKeyEvent = None) -> None:
+    def helpForLayouts(self, event: LeoKeyEvent | None = None) -> None:
         """Print a message telling you how to use Leo's layouts."""
         c = self.c
         # @+<< create listing list>>
@@ -861,7 +861,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.396: *3* helpForMinibuffer
     @cmd('help-for-minibuffer')
-    def helpForMinibuffer(self, event: LeoKeyEvent = None) -> None:
+    def helpForMinibuffer(self, event: LeoKeyEvent | None = None) -> None:
         """Print a messages telling you how to get started with Leo."""
         # A bug in Leo: triple quotes puts indentation before each line.
         c = self.c
@@ -899,7 +899,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.398: *3* helpForRegularExpressions
     @cmd('help-for-regular-expressions')
-    def helpForRegularExpressions(self, event: LeoKeyEvent = None) -> None:
+    def helpForRegularExpressions(self, event: LeoKeyEvent | None = None) -> None:
         """Explains the regular expressions used by Leo's find commands."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.399: *4* << define s >> (helpForRegularExpressions)
@@ -971,7 +971,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.400: *3* helpForScripting
     @cmd('help-for-scripting')
-    def helpForScripting(self, event: LeoKeyEvent = None) -> None:
+    def helpForScripting(self, event: LeoKeyEvent | None = None) -> None:
         """Shows a tutorial about scripting Leo."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.401: *4* << define s >> (helpForScripting)
@@ -1188,7 +1188,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20170823084423.1: *3* helpForSettings
     @cmd('help-for-settings')
-    def helpForSettings(self, event: LeoKeyEvent = None) -> None:
+    def helpForSettings(self, event: LeoKeyEvent | None = None) -> None:
         """Explains Leo's settings."""
         # @+<< define s >>
         # @+node:ekr.20170823084456.1: *4* << define s >> (helpForSettings)
@@ -1218,7 +1218,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20230306104232.1: *3* help.showColorSettings
     @cmd('show-color-settings')
-    def showColorSettings(self, event: LeoKeyEvent = None) -> None:
+    def showColorSettings(self, event: LeoKeyEvent | None = None) -> None:
         """
         Print the value of all @color settings.
 
@@ -1235,7 +1235,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20230306104131.1: *3* help.showFontSettings
     @cmd('show-font-settings')
-    def showFontSettings(self, event: LeoKeyEvent = None) -> None:
+    def showFontSettings(self, event: LeoKeyEvent | None = None) -> None:
         """
         Print the value of every @font setting.
 
@@ -1252,7 +1252,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.402: *3* help.showSettings
     @cmd('show-settings')
-    def showSettings(self, event: LeoKeyEvent = None) -> None:
+    def showSettings(self, event: LeoKeyEvent | None = None) -> None:
         """
         Print the value of every setting, except key bindings, commands, and
         open-with tables.
@@ -1270,7 +1270,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20190831025811.1: *3* help.showSettingsOutline
     @cmd('show-settings-outline')
-    def showSettingsOutline(self, event: LeoKeyEvent = None) -> None:
+    def showSettingsOutline(self, event: LeoKeyEvent | None = None) -> None:
         """
         Create and open an outline, summarizing all presently active settings.
 
@@ -1283,7 +1283,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.403: *3* pythonHelp
     @cmd('help-for-python')
-    def pythonHelp(self, event: LeoKeyEvent = None) -> None:
+    def pythonHelp(self, event: LeoKeyEvent | None = None) -> None:
         """Prompt for a arg for Python's help function, and put it to the VR pane."""
         c, k = self.c, self.c.k
         c.minibufferWantsFocus()

--- a/leo/commands/keyCommands.py
+++ b/leo/commands/keyCommands.py
@@ -23,7 +23,7 @@ class KeyHandlerCommandsClass(BaseEditCommandsClass):
     # @+others
     # @+node:ekr.20150514063305.406: *3* menuShortcutPlaceHolder
     @g.command('menu-shortcut')
-    def menuShortcutPlaceHolder(self, event: LeoKeyEvent = None) -> None:
+    def menuShortcutPlaceHolder(self, event: LeoKeyEvent | None = None) -> None:
         """
         This will never be called.
         A placeholder for the show-bindings command.

--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -118,7 +118,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.414: *3* clearKillRing
     @cmd('clear-kill-ring')
-    def clearKillRing(self, event: LeoKeyEvent = None) -> None:
+    def clearKillRing(self, event: LeoKeyEvent | None = None) -> None:
         """Clear the kill ring."""
         g.app.globalKillBuffer = []
 
@@ -179,7 +179,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         frm: int,
         to: int,
         w: QTextMixin,
-        undoType: str = None,
+        undoType: str | None = None,
     ) -> None:
         """
         A helper method for all kill commands except kill-paragraph commands.
@@ -210,7 +210,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         event: LeoKeyEvent,
         frm: int,
         to: int,
-        undoType: str = None,
+        undoType: str | None = None,
     ) -> None:
         """A helper method for kill-paragraph commands."""
         w = self.editWidget(event)
@@ -348,12 +348,12 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.425: *3* yank & yankPop
     @cmd('yank')
-    def yank(self, event: LeoKeyEvent = None) -> None:
+    def yank(self, event: LeoKeyEvent | None = None) -> None:
         """Insert the next entry of the kill ring."""
         self.yankHelper(event, pop=False)
 
     @cmd('yank-pop')
-    def yankPop(self, event: LeoKeyEvent = None) -> None:
+    def yankPop(self, event: LeoKeyEvent | None = None) -> None:
         """Insert the first entry of the kill ring."""
         self.yankHelper(event, pop=True)
 

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -116,7 +116,7 @@ class BaseSpellWrapper:
 class DefaultDict:
     """A class with the same interface as the enchant dict class."""
 
-    def __init__(self, words: list[str] = None) -> None:
+    def __init__(self, words: list[str] | None = None) -> None:
         self.added_words: set[str] = set()
         self.ignored_words: set[str] = set()
         self.words: set[str] = set() if words is None else set(words)
@@ -466,7 +466,7 @@ class SpellCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.484: *3* openSpellTab
     @cmd('spell-tab-open')
-    def openSpellTab(self, event: LeoKeyEvent = None) -> None:
+    def openSpellTab(self, event: LeoKeyEvent | None = None) -> None:
         """Open the Spell Checker tab in the log pane."""
         if g.unitTesting:
             return
@@ -655,7 +655,7 @@ class SpellTabHandler:
 
     # @+node:ekr.20150514063305.502: *3* Commands
     # @+node:ekr.20150514063305.503: *4* SpellTabHandler.add
-    def add(self, event: LeoKeyEvent = None) -> None:
+    def add(self, event: LeoKeyEvent | None = None) -> None:
         """Add the selected suggestion to the dictionary."""
         if self.loaded:
             w = self.currentWord
@@ -664,7 +664,7 @@ class SpellTabHandler:
                 self.tab.onFindButton()
 
     # @+node:ekr.20150514063305.504: *4* SpellTabHandler.change
-    def change(self, event: LeoKeyEvent = None) -> bool:
+    def change(self, event: LeoKeyEvent | None = None) -> bool:
         """Make the selected change to the text"""
         if not self.loaded:
             return False
@@ -706,7 +706,7 @@ class SpellTabHandler:
     re_part = re.compile(r'[a-zA-z]+')
     re_http = re.compile(r'.*?(http|https)://(.*?)$')
 
-    def find(self, event: LeoKeyEvent = None) -> Optional[str]:
+    def find(self, event: LeoKeyEvent | None = None) -> Optional[str]:
         """
         Find the next unknown word.
 
@@ -869,11 +869,11 @@ class SpellTabHandler:
             c.selectPosition(p)
 
     # @+node:ekr.20150514063305.508: *4* SpellTabHandler.hide
-    def hide(self, event: LeoKeyEvent = None) -> None:
+    def hide(self, event: LeoKeyEvent | None = None) -> None:
         self.c.frame.log.selectTab('Log')
 
     # @+node:ekr.20150514063305.509: *4* SpellTabHandler.ignore
-    def ignore(self, event: LeoKeyEvent = None) -> None:
+    def ignore(self, event: LeoKeyEvent | None = None) -> None:
         """Ignore the incorrect word for the duration of this spell check session."""
         if self.loaded:
             w = self.currentWord
@@ -886,7 +886,7 @@ class SpellTabHandler:
 
 # @+node:ekr.20180209141207.1: ** @g.command('show-spell-info')
 @g.command('show-spell-info')
-def show_spell_info(event: LeoKeyEvent = None) -> None:
+def show_spell_info(event: LeoKeyEvent | None = None) -> None:
     c = event.get('c')
     if c:
         c.spellCommands.handler.spellController.show_info()

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -33,7 +33,7 @@ class IconBarAPI:
     def add(self, *args: str, **keys: str) -> None:
         pass
 
-    def addRow(self, height: str = None) -> None:
+    def addRow(self, height: str | None = None) -> None:
         pass
 
     def addRowIfNeeded(self) -> None:
@@ -76,7 +76,7 @@ class StatusLineAPI:
     def clear(self) -> None:
         pass
 
-    def disable(self, background: str = None) -> None:
+    def disable(self, background: str | None = None) -> None:
         pass
 
     def enable(self, background: str = "white") -> None:
@@ -88,7 +88,7 @@ class StatusLineAPI:
     def isEnabled(self) -> bool:
         return False
 
-    def put(self, s: str, bg: str = None, fg: str = None) -> None:
+    def put(self, s: str, bg: str | None = None, fg: str | None = None) -> None:
         pass
 
     def setFocus(self) -> None:
@@ -158,13 +158,13 @@ class TreeAPI:
     # Must be defined in subclasses.
 
     # Leo 6.8.9: return None.
-    def editLabel(self, v: VNode, selectAll: bool = False, selection: tuple = None) -> None:
+    def editLabel(self, v: VNode, selectAll: bool = False, selection: tuple | None = None) -> None:
         pass
 
     def edit_widget(self, p: Position) -> None:
         return None
 
-    def redraw(self, p: Position = None) -> None:
+    def redraw(self, p: Position | None = None) -> None:
         pass
 
     redraw_now = redraw
@@ -185,7 +185,7 @@ class TreeAPI:
     def redraw_after_head_changed(self) -> None:
         pass
 
-    def redraw_after_select(self, p: Position = None) -> None:
+    def redraw_after_select(self, p: Position | None = None) -> None:
         pass
 
     # Must be defined in the LeoTree class...

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1054,7 +1054,7 @@ class LeoApp:
             sys.exit(message)
 
     # @+node:ekr.20031218072017.1938: *5* app.createNullGuiWithScript
-    def createNullGuiWithScript(self, script: str = None) -> None:
+    def createNullGuiWithScript(self, script: str | None = None) -> None:
         app = self
         app.batchMode = True
         app.gui = g.app.nullGui
@@ -1320,7 +1320,7 @@ class LeoApp:
 
     # @+node:ekr.20171127111053.1: *3* app.Closing
     # @+node:ekr.20031218072017.2609: *4* app.closeLeoWindow
-    def closeLeoWindow(self, frame: LeoFrame, new_c: Cmdr = None, finish_quit: bool = True) -> bool:
+    def closeLeoWindow(self, frame: LeoFrame, new_c: Cmdr | None = None, finish_quit: bool = True) -> bool:
         """
         Attempt to close a Leo window.
 
@@ -1438,7 +1438,7 @@ class LeoApp:
     # @+node:ekr.20031218072017.2617: *4* app.onQuit
     @cmd('exit-leo')
     @cmd('quit-leo')
-    def onQuit(self, event: LeoKeyEvent = None) -> None:
+    def onQuit(self, event: LeoKeyEvent | None = None) -> None:
         """Exit Leo, prompting to save unsaved outlines first."""
         if 'shutdown' in g.app.debug:
             g.trace()
@@ -1546,7 +1546,7 @@ class LeoApp:
     # @+node:ekr.20170429152049.1: *3* app.listenToLog
     @cmd('listen-to-log')
     @cmd('log-listen')
-    def listenToLog(self, event: LeoKeyEvent = None) -> None:
+    def listenToLog(self, event: LeoKeyEvent | None = None) -> None:
         """
         A socket listener, listening on localhost. See:
         https://docs.python.org/2/howto/logging-cookbook.html#sending-and-receiving-logging-events-across-a-network
@@ -1588,10 +1588,10 @@ class LeoApp:
     def newCommander(
         self,
         fileName: str,
-        gui: LeoGui = None,
-        parentFrame: Any = None,
-        previousSettings: "PreviousSettings" = None,
-        relativeFileName: str = None,
+        gui: LeoGui | None = None,
+        parentFrame: Any | None = None,
+        previousSettings: "PreviousSettings" | None = None,
+        relativeFileName: str | None = None,
     ) -> Cmdr:
         """Create a commander and its view frame for the Leo main window."""
         # Create the commander and its subcommanders.
@@ -2326,7 +2326,7 @@ class LoadManager:
             print(d)
 
     # @+node:ekr.20120219154958.10452: *3* LM.load & helpers
-    def load(self, fileName: str = None, pymacs: bool = None) -> None:
+    def load(self, fileName: str | None = None, pymacs: bool | None = None) -> None:
         """This is Leo's main startup method."""
         lm = self
         #
@@ -3212,7 +3212,7 @@ class LoadManager:
     loadLocalFile = openWithFileName  # Compatibility.
 
     # @+node:ekr.20120223062418.10405: *5* LM.createMenu
-    def createMenu(self, c: Cmdr, fn: str = None) -> None:
+    def createMenu(self, c: Cmdr, fn: str | None = None) -> None:
         # lm = self
         # Create the menu as late as possible so it can use user commands.
         if not g.doHook("menu1", c=c, p=c.p, v=c.p):
@@ -3669,7 +3669,7 @@ class RecentFilesManager:
                 continue  # happens with empty list/new file
 
             def recentFilesCallback(
-                event: LeoKeyEvent = None, c: Cmdr = c, name: str = name
+                event: LeoKeyEvent | None = None, c: Cmdr = c, name: str = name
             ) -> None:
                 c.openRecentFile(fn=name)
 
@@ -4006,7 +4006,7 @@ def toggle_idle_time_events(event: LeoKeyEvent) -> None:
 
 # @+node:ekr.20150514125218.5: *3* open-url
 @g.command('open-url')
-def openUrl(event: LeoKeyEvent = None) -> None:
+def openUrl(event: LeoKeyEvent | None = None) -> None:
     """
     Open the url in the headline or body text of the selected node.
 
@@ -4020,7 +4020,7 @@ def openUrl(event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20150514125218.6: *3* open-url-under-cursor
 @g.command('open-url-under-cursor')
-def openUrlUnderCursor(event: LeoKeyEvent = None) -> Optional[str]:
+def openUrlUnderCursor(event: LeoKeyEvent | None = None) -> Optional[str]:
     """Open the url under the cursor."""
     return g.openUrlOnClick(event)
 

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -314,7 +314,7 @@ class AtFile:
     # @+node:ekr.20041005105605.18: *4* at.Reading (top level)
     # @+node:ekr.20070919133659: *5* at.checkExternalFile
     @cmd('check-external-file')
-    def checkExternalFile(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def checkExternalFile(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Make sure an external file written by Leo may be read properly."""
         c, p = self.c, self.c.p
         if not p.isAtFileNode() and not p.isAtThinFileNode():
@@ -336,7 +336,7 @@ class AtFile:
 
     # @+node:ekr.20250724123631.1: *5* at.openAtLeoFile
     @cmd('open-at-leo-file')
-    def openAtLeoFile(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def openAtLeoFile(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """
         Open the outline given by the @leo node at c.p.
         If the outline has already been loaded, switch to its tab.
@@ -354,7 +354,7 @@ class AtFile:
             g.red(f"file not found: {path}")
 
     # @+node:ekr.20041005105605.19: *5* at.openFileForReading & helper
-    def openFileForReading(self, fromString: str = None) -> tuple[Optional[str], Optional[str]]:
+    def openFileForReading(self, fromString: str | None = None) -> tuple[Optional[str], Optional[str]]:
         """
         Open the file given by at.root.
         This will be the private file for @shadow nodes.
@@ -408,7 +408,7 @@ class AtFile:
         return shadow_fn
 
     # @+node:ekr.20041005105605.21: *5* at.read & helpers
-    def read(self, root: Position, fromString: str = None) -> bool:
+    def read(self, root: Position, fromString: str | None = None) -> bool:
         """Read an @thin or @file tree."""
         at, c = self, self.c
         fileName = c.fullPath(root)
@@ -723,7 +723,7 @@ class AtFile:
         return p  # For #451: return p.
 
     # @+node:ekr.20150204165040.5: *5* at.readOneAtCleanNode & helpers
-    def readOneAtCleanNode(self, root: Position, *, new_contents: str = None) -> None:
+    def readOneAtCleanNode(self, root: Position, *, new_contents: str | None = None) -> None:
         """Update the @clean/@nosent node at root."""
         at, c, x = self, self.c, self.c.shadowController
 
@@ -1196,7 +1196,7 @@ class AtFile:
     # @+node:ekr.20190111153551.1: *5* at.commands
     # @+node:ekr.20070806105859: *6* at.writeAtAutoNodes
     @cmd('write-at-auto-nodes')
-    def writeAtAutoNodes(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def writeAtAutoNodes(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Write all @auto nodes in the selected outline."""
         at, c, p = self, self.c, self.c.p
         c.init_error_dialogs()
@@ -1221,7 +1221,7 @@ class AtFile:
 
     # @+node:ekr.20220120072251.1: *6* at.writeDirtyAtAutoNodes
     @cmd('write-dirty-at-auto-nodes')  # pragma: no cover
-    def writeDirtyAtAutoNodes(self, event: LeoKeyEvent = None) -> None:
+    def writeDirtyAtAutoNodes(self, event: LeoKeyEvent | None = None) -> None:
         """Write all dirty @auto nodes in the selected outline."""
         at, c, p = self, self.c, self.c.p
         c.init_error_dialogs()
@@ -1246,7 +1246,7 @@ class AtFile:
 
     # @+node:ekr.20080711093251.3: *6* at.writeAtShadowNodes
     @cmd('write-at-shadow-nodes')
-    def writeAtShadowNodes(self, event: LeoKeyEvent = None) -> bool:  # pragma: no cover
+    def writeAtShadowNodes(self, event: LeoKeyEvent | None = None) -> bool:  # pragma: no cover
         """Write all @shadow nodes in the selected outline."""
         at, c, p = self, self.c, self.c.p
         c.init_error_dialogs()
@@ -1273,7 +1273,7 @@ class AtFile:
 
     # @+node:ekr.20220120072917.1: *6* at.writeDirtyAtShadowNodes
     @cmd('write-dirty-at-shadow-nodes')
-    def writeDirtyAtShadowNodes(self, event: LeoKeyEvent = None) -> bool:  # pragma: no cover
+    def writeDirtyAtShadowNodes(self, event: LeoKeyEvent | None = None) -> bool:  # pragma: no cover
         """Write all @shadow nodes in the selected outline."""
         at, c, p = self, self.c, self.c.p
         c.init_error_dialogs()
@@ -3355,7 +3355,7 @@ class AtFile:
 
     # @+node:ekr.20090712050729.6017: *4* at.promptForDangerousWrite
     def promptForDangerousWrite(
-        self, fileName: str, message: str = None
+        self, fileName: str, message: str | None = None
     ) -> bool:  # pragma: no cover
         """Raise a dialog asking the user whether to overwrite an existing file."""
         at, c, root = self, self.c, self.root

--- a/leo/core/leoBackground.py
+++ b/leo/core/leoBackground.py
@@ -141,7 +141,7 @@ class BackgroundProcessManager:
         self.pid = None
 
     # @+node:ekr.20161026193609.3: *3* bpm.kill
-    def kill(self, kind: str = None) -> None:
+    def kill(self, kind: str | None = None) -> None:
         """Kill the presently running process, if any."""
         if kind is None:
             kind = 'all'
@@ -240,7 +240,7 @@ class BackgroundProcessManager:
             self.timer.stop()
 
     # @+node:ekr.20161026193609.5: *3* bpm.start_process (creates callback)
-    def start_process(self, c: Cmdr, command: str, kind: str, fn: str = None) -> None:
+    def start_process(self, c: Cmdr, command: str, kind: str, fn: str | None = None) -> None:
         """
         Start or queue a process described by command and fn.
         """

--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -49,7 +49,7 @@ class CommanderWrapper:
         self.db = g.app.db
         self.user_keys: set[str] = set()
 
-    def get(self, key: str, default: Value = None) -> Value:
+    def get(self, key: str, default: Value | None = None) -> Value:
         value = self.db.get(f"{self.c.mFileName}:::{key}")
         return default if value is None else value
 
@@ -255,7 +255,7 @@ class SqlitePickleShare:
         os.makedirs(fn, mode)
 
     # @+node:vitalije.20170716201700.12: *3* _walkfiles & helpers
-    def _walkfiles(self, s: str, pattern: str = None) -> None:
+    def _walkfiles(self, s: str, pattern: str | None = None) -> None:
         """D.walkfiles() -> iterator over files in D, recursively.
 
         The optional argument, pattern, limits the results to files
@@ -265,7 +265,7 @@ class SqlitePickleShare:
         """
 
     # @+node:vitalije.20170716201700.13: *4* _listdir
-    def _listdir(self, s: str, pattern: str = None) -> list[str]:
+    def _listdir(self, s: str, pattern: str | None = None) -> list[str]:
         """D.listdir() -> List of items in this directory.
 
         Use D.files() or D.dirs() instead if you want a listing
@@ -300,7 +300,7 @@ class SqlitePickleShare:
         self.conn.execute('delete from cachevalues;')
 
     # @+node:vitalije.20170716201700.16: *3* get  (SqlitePickleShare)
-    def get(self, key: str, default: Value = None) -> Value:
+    def get(self, key: str, default: Value | None = None) -> Value:
         if not self.has_key(key):  # noqa
             return default
         try:
@@ -328,7 +328,7 @@ class SqlitePickleShare:
     # @+node:vitalije.20170716201700.19: *3* keys (SqlitePickleShare)
     # Called by clear, and during unit testing.
 
-    def keys(self, globpat: str = None) -> Generator:
+    def keys(self, globpat: str | None = None) -> Generator:
         """Return all keys in DB, or all keys matching a glob"""
         args: tuple
         if globpat is None:

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -75,7 +75,7 @@ class ChapterController:
         c.redraw()
 
     # @+node:ekr.20160411145155.1: *4* cc.makeCommand
-    def makeCommand(self, chapterName: str, binding: str = None) -> None:
+    def makeCommand(self, chapterName: str, binding: str | None = None) -> None:
         """Make chapter-select-<chapterName> command."""
         c, cc = self.c, self
         commandName = f"chapter-select-{chapterName}"
@@ -122,7 +122,7 @@ class ChapterController:
 
     # @+node:ekr.20070604165126: *3* cc: chapter-select
     @cmd('chapter-select')
-    def selectChapter(self, event: LeoKeyEvent = None) -> None:
+    def selectChapter(self, event: LeoKeyEvent | None = None) -> None:
         """Prompt for a chapter name and select the given chapter."""
         cc, k = self, self.c.k
         names = cc.setAllChapterNames()
@@ -139,7 +139,7 @@ class ChapterController:
 
     # @+node:ekr.20170202061705.1: *3* cc: chapter-back/next
     @cmd('chapter-back')
-    def backChapter(self, event: LeoKeyEvent = None) -> None:
+    def backChapter(self, event: LeoKeyEvent | None = None) -> None:
         """Select the previous chapter."""
         cc = self
         names = cc.setAllChapterNames()
@@ -149,7 +149,7 @@ class ChapterController:
         cc.selectChapterByName(new_name)
 
     @cmd('chapter-next')
-    def nextChapter(self, event: LeoKeyEvent = None) -> None:
+    def nextChapter(self, event: LeoKeyEvent | None = None) -> None:
         """Select the next chapter."""
         cc = self
         names = cc.setAllChapterNames()
@@ -309,7 +309,7 @@ class ChapterController:
         return s[:128]
 
     # @+node:ekr.20070615075643: *4* cc.selectChapterForPosition (calls c.redraw_later)
-    def selectChapterForPosition(self, p: Position, chapter: "Chapter" = None) -> None:
+    def selectChapterForPosition(self, p: Position, chapter: "Chapter" | None = None) -> None:
         """
         Select a chapter containing position p.
         New in Leo 4.11: prefer the given chapter if possible.

--- a/leo/core/leoColor.py
+++ b/leo/core/leoColor.py
@@ -734,7 +734,7 @@ for key in leo_color_database:
 # @+others
 # @+node:bob.20080115070511.3: ** color database functions
 # @+node:bob.20071231111744.2: *3* function: leoColor.get / getColor
-def getColor(name: str, default: str = None) -> str:
+def getColor(name: str, default: str | None = None) -> str:
     """Translate a named color into #rrggbb' format.
 
     if 'name' is not a string it is returned unchanged.
@@ -761,7 +761,7 @@ get = getColor
 
 
 # @+node:bob.20080115070511.4: *3* function: leoColor.getRGB / getColorRGB
-def getColorRGB(name: str, default: str = None) -> tuple[int, int, int]:
+def getColorRGB(name: str, default: str | None = None) -> tuple[int, int, int]:
     """Convert a named color into an (r, g, b) tuple."""
     s = getColor(name, default)
     try:
@@ -775,7 +775,7 @@ getRGB = getColorRGB
 
 
 # @+node:bob.20080115072302: *3* function: leoColor.getCairo / getColorCairo
-def getColorCairo(name: str, default: str = None) -> tuple[float, float, float]:
+def getColorCairo(name: str, default: str | None = None) -> tuple[float, float, float]:
     """Convert a named color into a cairo color tuple."""
     color = getColorRGB(name, default)
     if color is None:

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -2016,7 +2016,7 @@ class JEditColorizer(BaseColorizer):
         s: str,
         i: int,
         *,
-        kind: str = None,
+        kind: str | None = None,
         seq: str = '',
         at_line_start: bool = False,
         at_whitespace_end: bool = False,
@@ -2239,7 +2239,7 @@ class JEditColorizer(BaseColorizer):
         return -len(word)  # An important new optimization.
 
     # @+node:ekr.20110605121601.18615: *4* jedit.match_line
-    def match_line(self, s: str, i: int, *, kind: str = None) -> int:
+    def match_line(self, s: str, i: int, *, kind: str | None = None) -> int:
         """Match the rest of the line."""
         j = g.skip_to_end_of_line(s, i)
         self.colorRangeWithTag(s, i, j, kind)
@@ -3303,7 +3303,7 @@ if Qsci:
     class NullScintillaLexer(Qsci.QsciLexerCustom):
         """A do-nothing colorizer for Scintilla."""
 
-        def __init__(self, c: Cmdr, parent: QWidget = None) -> None:
+        def __init__(self, c: Cmdr, parent: QWidget | None = None) -> None:
             super().__init__(parent)  # Init the pase class
             self.leo_c = c
             self.configure_lexer()

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -111,10 +111,10 @@ class Commands:
     def __init__(
         self,
         fileName: str,
-        gui: LeoGui = None,
-        parentFrame: Any = None,
-        previousSettings: "PreviousSettings" = None,
-        relativeFileName: str = None,
+        gui: LeoGui | None = None,
+        parentFrame: Any | None = None,
+        previousSettings: "PreviousSettings" | None = None,
+        relativeFileName: str | None = None,
     ) -> None:
         t1 = time.process_time()
         c = self
@@ -201,7 +201,7 @@ class Commands:
         return title
 
     # @+node:ekr.20120217070122.10475: *5* c.computeWindowTitle
-    def computeWindowTitle(self, fileName: str = None) -> str:
+    def computeWindowTitle(self, fileName: str | None = None) -> str:
         """
         Return the title for the top-level window.
         """
@@ -637,14 +637,14 @@ class Commands:
 
     # @+node:ekr.20250508044308.1: *3* @cmd beautify-tree
     @cmd('beautify-tree')
-    def beautify_tree_command(self, event: LeoKeyEvent = None) -> None:
+    def beautify_tree_command(self, event: LeoKeyEvent | None = None) -> None:
         """Undoably beautify c.p and its subtree."""
         c = self
         c.beautify_script_tree(c.p)
 
     # @+node:ekr.20210530065748.1: *3* @cmd c.execute-general-script
     @cmd('execute-general-script')
-    def execute_general_script_command(self, event: LeoKeyEvent = None) -> None:
+    def execute_general_script_command(self, event: LeoKeyEvent | None = None) -> None:
         """
         Execute c.p and all its descendants as a script.
 
@@ -694,7 +694,7 @@ class Commands:
     # @+node:tom.20241014154415.1: *3* @cmd c.execute-external-file
     # @@language python
     @cmd('execute-external-file')
-    def execute_external_file(self, event: LeoKeyEvent = None) -> None:
+    def execute_external_file(self, event: LeoKeyEvent | None = None) -> None:
         r"""
         # @+<< docstring >>
         # @+node:tom.20241014154415.2: *4* << docstring >>
@@ -1157,7 +1157,7 @@ class Commands:
 
     # @+node:vitalije.20190924191405.1: *3* @cmd execute-pytest
     @cmd('execute-pytest')
-    def execute_pytest(self, event: LeoKeyEvent = None) -> None:
+    def execute_pytest(self, event: LeoKeyEvent | None = None) -> None:
         """Using pytest, execute all @test nodes for p, p's parents and p's subtree."""
         c = self
 
@@ -1224,15 +1224,15 @@ class Commands:
     def executeScript(
         self,
         *,
-        event: LeoKeyEvent = None,
-        args: Args = None,
-        p: Position = None,
-        script: str = None,
+        event: LeoKeyEvent | None = None,
+        args: Args | None = None,
+        p: Position | None = None,
+        script: str | None = None,
         useSelectedText: bool = True,
         define_g: bool = True,
         define_name: str = '__main__',
         silent: bool = False,
-        namespace: dict = None,
+        namespace: dict | None = None,
         raiseFlag: bool = False,
         runPyflakes: bool = True,
     ) -> Value:
@@ -1409,7 +1409,7 @@ class Commands:
 
     # @+node:ekr.20080514131122.12: *3* @cmd recolor
     @cmd('recolor')
-    def recolorCommand(self, event: LeoKeyEvent = None) -> None:
+    def recolorCommand(self, event: LeoKeyEvent | None = None) -> None:
         """Force a full recolor."""
         c = self
         # Call colorer.force_recolor for pygments.
@@ -1460,7 +1460,7 @@ class Commands:
     safe_all_positions = all_positions
 
     # @+node:ekr.20191014093239.1: *5* c.all_positions_for_v
-    def all_positions_for_v(self, v: VNode, stack: list[tuple] = None) -> Generator:
+    def all_positions_for_v(self, v: VNode, stack: list[tuple] | None = None) -> Generator:
         """
         Generates all positions p in this outline where p.v is v.
 
@@ -1500,7 +1500,7 @@ class Commands:
                 stack.pop(0)
 
     # @+node:ekr.20161120121226.1: *5* c.all_roots
-    def all_roots(self, copy: bool = True, predicate: Callable = None) -> Generator:
+    def all_roots(self, copy: bool = True, predicate: Callable | None = None) -> Generator:
         """
         A generator yielding *all* the root positions in the outline that
         satisfy the given predicate. p.isAnyAtFileNode is the default
@@ -1543,7 +1543,7 @@ class Commands:
     all_positions_with_unique_vnodes_iter = all_unique_positions
 
     # @+node:ekr.20161120125322.1: *5* c.all_unique_roots
-    def all_unique_roots(self, copy: bool = True, predicate: Callable = None) -> Generator:
+    def all_unique_roots(self, copy: bool = True, predicate: Callable | None = None) -> Generator:
         """
         A generator yielding all unique root positions in the outline that
         satisfy the given predicate. p.isAnyAtFileNode is the default
@@ -1989,7 +1989,7 @@ class Commands:
         return p
 
     # @+node:ekr.20040307104131.3: *5* c.positionExists
-    def positionExists(self, p: Position, root: Position = None, trace: bool = False) -> bool:
+    def positionExists(self, p: Position, root: Position | None = None, trace: bool = False) -> bool:
         """Return True if a position exists in c's tree"""
         if not p or not p.v:
             return False
@@ -2296,7 +2296,7 @@ class Commands:
         g.doHook("set-mark", c=c, p=p)
 
     # @+node:ekr.20040803140033.3: *5* c.setRootPosition (A do-nothing)
-    def setRootPosition(self, unused_p: Position = None) -> None:
+    def setRootPosition(self, unused_p: Position | None = None) -> None:
         """Set c._rootPosition."""
         # 2011/03/03: No longer used.
 
@@ -2674,7 +2674,7 @@ class Commands:
     # @+node:ekr.20031218072017.1765: *4* c.validateOutline (compatibility only)
     # Makes sure all nodes are valid.
 
-    def validateOutline(self, event: LeoKeyEvent = None) -> bool:
+    def validateOutline(self, event: LeoKeyEvent | None = None) -> bool:
         """
         A legacy outline checker, retained only for compatibility.
 
@@ -2720,7 +2720,7 @@ class Commands:
     # This code is no longer used by any Leo command,
     # but it will be retained for use of scripts.
     # @+node:ekr.20040723094220.1: *4* c.checkAllPythonCode
-    def checkAllPythonCode(self, event: LeoKeyEvent = None, ignoreAtIgnore: bool = True) -> str:
+    def checkAllPythonCode(self, event: LeoKeyEvent | None = None, ignoreAtIgnore: bool = True) -> str:
         """Check all nodes in the selected tree for syntax and tab errors."""
         c = self
         count = 0
@@ -2755,7 +2755,7 @@ class Commands:
     # @+node:ekr.20040723094220.3: *4* c.checkPythonCode
     def checkPythonCode(
         self,
-        event: LeoKeyEvent = None,
+        event: LeoKeyEvent | None = None,
         ignoreAtIgnore: bool = True,
         checkOnSave: bool = False,
     ) -> str:
@@ -3235,7 +3235,7 @@ class Commands:
         return return_value
 
     # @+node:ekr.20200522075411.1: *4* c.doCommandByName
-    def doCommandByName(self, command_name: str, event: LeoKeyEvent = None) -> Value:
+    def doCommandByName(self, command_name: str, event: LeoKeyEvent | None = None) -> Value:
         """
         Execute one command, given the name of the command.
 
@@ -3277,8 +3277,8 @@ class Commands:
         ext: str,
         language: str,
         root: Position,
-        directory: str = None,
-        regex: str = None,
+        directory: str | None = None,
+        regex: str | None = None,
     ) -> None:
         """
         The official helper for the execute-general-script command.
@@ -3642,8 +3642,8 @@ class Commands:
     # @+node:ekr.20150422080541.1: *4* c.backup
     def backup(
         self,
-        fileName: str = None,
-        prefix: str = None,
+        fileName: str | None = None,
+        prefix: str | None = None,
         silent: bool = False,
         useTimeStamp: bool = True,
     ) -> Optional[str]:
@@ -3675,9 +3675,9 @@ class Commands:
     # @+node:ekr.20180210092235.1: *4* c.backup_helper
     def backup_helper(
         self,
-        base_dir: str = None,
+        base_dir: str | None = None,
         env_key: str = 'LEO_BACKUP',
-        sub_dir: str = None,
+        sub_dir: str | None = None,
         use_git_prefix: bool = True,
     ) -> None:
         """
@@ -3752,8 +3752,8 @@ class Commands:
         top_directory: str,
         kind: str = '@clean',  # Any @<file> type. @clean is recommended.
         report_changed_at_clean_nodes: bool = True,  # Recommended.
-        sub_directories: list[str] = None,
-        top_outline_name: str = None,
+        sub_directories: list[str] | None = None,
+        top_outline_name: str | None = None,
     ) -> None:
         # @+<< c.makeLinkLeoFiles: docstring >>
         # @+node:ekr.20250717132150.1: *5* << c.makeLinkLeoFiles: docstring >>
@@ -3935,7 +3935,7 @@ class Commands:
         c2.close()
 
     # @+node:ekr.20031218072017.2925: *4* c.markAllAtFileNodesDirty
-    def markAllAtFileNodesDirty(self, event: LeoKeyEvent = None) -> None:
+    def markAllAtFileNodesDirty(self, event: LeoKeyEvent | None = None) -> None:
         """Mark all @file nodes as changed."""
         c = self
         c.endEditing()
@@ -3949,7 +3949,7 @@ class Commands:
                 p.moveToThreadNext()
 
     # @+node:ekr.20031218072017.2926: *4* c.markAtFileNodesDirty
-    def markAtFileNodesDirty(self, event: LeoKeyEvent = None) -> None:
+    def markAtFileNodesDirty(self, event: LeoKeyEvent | None = None) -> None:
         """Mark all @file nodes in the selected tree as changed."""
         c = self
         p = c.p
@@ -3966,7 +3966,7 @@ class Commands:
                 p.moveToThreadNext()
 
     # @+node:ekr.20250717080554.1: *4* c.openAllLinkedFiles (transitive closure)
-    def openAllLinkedFiles(self, gui: LeoGui = None) -> list[Commands]:
+    def openAllLinkedFiles(self, gui: LeoGui | None = None) -> list[Commands]:
         """
         Open the transitive closure of all outlines reachable from any @leo
         node in this outline.
@@ -4023,7 +4023,7 @@ class Commands:
         return result
 
     # @+node:ekr.20031218072017.2081: *4* c.openRecentFile
-    def openRecentFile(self, event: LeoKeyEvent = None, fn: str = None) -> None:
+    def openRecentFile(self, event: LeoKeyEvent | None = None, fn: str | None = None) -> None:
         """
         c.openRecentFile: This is not a command!
 
@@ -4039,7 +4039,7 @@ class Commands:
             g.doHook("recentfiles2", c=c2, p=c2.p, v=c2.p, fileName=fn)
 
     # @+node:ekr.20031218072017.2823: *4* c.openWith
-    def openWith(self, event: LeoKeyEvent = None, d: dict[str, Any] = None) -> None:
+    def openWith(self, event: LeoKeyEvent | None = None, d: dict[str, Any] | None = None) -> None:
         """
         This is *not* a command.
 
@@ -4093,7 +4093,7 @@ class Commands:
         x.diff_file(fn=fn, rev1=rev1, rev2=rev2)
 
     # @+node:ekr.20180508110755.1: *4* c.diff_two_revs
-    def diff_two_revs(self, directory: str = None, rev1: str = '', rev2: str = '') -> None:
+    def diff_two_revs(self, directory: str | None = None, rev1: str = '', rev2: str = '') -> None:
         """
         Create an outline describing the git diffs for all files changed
         between rev1 and rev2.
@@ -4315,7 +4315,7 @@ class Commands:
 
     # @+node:ekr.20031218072017.2949: *4* c.Drawing
     # @+node:ekr.20080514131122.8: *5* c.bringToFront
-    def bringToFront(self, c2: "Commands" = None) -> None:
+    def bringToFront(self, c2: "Commands" | None = None) -> None:
         c = self
         c2 = c2 or c
         g.app.gui.ensure_commander_visible(c2)
@@ -4377,7 +4377,7 @@ class Commands:
                 mods.clear()
 
     # @+node:ekr.20080514131122.13: *5* c.recolor
-    def recolor(self, p: Position = None) -> None:
+    def recolor(self, p: Position | None = None) -> None:
         c = self
         colorizer = c.frame.body.colorizer
         if colorizer and hasattr(colorizer, 'colorize'):
@@ -4410,7 +4410,7 @@ class Commands:
                 colorizer.old_v = None  # #4146
             c.recolor(p)
 
-    def redraw(self, p: Position = None) -> None:
+    def redraw(self, p: Position | None = None) -> None:
         """
         Redraw the screen immediately.
         If p is given, set c.p to p.
@@ -4588,7 +4588,7 @@ class Commands:
 
     # @+node:ekr.20031218072017.2909: *4* c.Expand/contract
     # @+node:ekr.20171124091426.1: *5* c.contractAllHeadlines
-    def contractAllHeadlines(self, event: LeoKeyEvent = None) -> None:
+    def contractAllHeadlines(self, event: LeoKeyEvent | None = None) -> None:
         """Contract all nodes in the outline."""
         c = self
         for v in c.all_nodes():
@@ -4758,9 +4758,9 @@ class Commands:
         self,
         menu: LeoQtMenu,
         accelerator: str = '',  # Not used.
-        command: Callable = None,
-        commandName: str = None,  # Not used.
-        label: str = None,  # Not used.
+        command: Callable | None = None,
+        commandName: str | None = None,  # Not used.
+        label: str | None = None,  # Not used.
         underline: int = 0,
     ) -> None:
         c = self
@@ -4962,7 +4962,7 @@ class Commands:
         return current != c.rootPosition()
 
     # @+node:ekr.20031218072017.2974: *6* c.canPasteOutline
-    def canPasteOutline(self, s: str = None) -> bool:
+    def canPasteOutline(self, s: str | None = None) -> bool:
         # c = self
         if not s:
             s = g.app.gui.getTextFromClipboard()
@@ -5091,7 +5091,7 @@ class Commands:
         self,
         p: Position,
         selectAll: bool = False,
-        selection: tuple = None,
+        selection: tuple | None = None,
         keepMinibuffer: bool = False,
     ) -> None:
         """Redraw the screen and edit p's headline."""
@@ -5174,12 +5174,12 @@ class Commands:
     def recursiveImport(
         self,
         *,  # All arguments are kwargs.
-        dir_: str = None,  # A directory or file name.
-        ignore_pattern: re.Pattern = None,  # Ignore files matching this regex pattern.
+        dir_: str | None = None,  # A directory or file name.
+        ignore_pattern: re.Pattern | None = None,  # Ignore files matching this regex pattern.
         kind: str = '@file',
         recursive: bool = True,
         safe_at_file: bool = True,
-        theTypes: list[str] = None,
+        theTypes: list[str] | None = None,
         verbose: bool = True,
     ) -> None:
         # @+<< docstring >>
@@ -5303,10 +5303,10 @@ class Commands:
         self,
         generator: Callable,
         predicate: Callable,
-        failMsg: str = None,
+        failMsg: str | None = None,
         flatten: bool = False,
-        iconPath: str = None,
-        undoType: str = None,
+        iconPath: str | None = None,
+        undoType: str | None = None,
     ) -> Position:
         """
         Traverse the tree given using the generator, cloning all positions for
@@ -5387,7 +5387,7 @@ class Commands:
     def createNodeHierarchy(
         self,
         heads: list[str],
-        parent: Position = None,
+        parent: Position | None = None,
         forcecreate: bool = False,
     ) -> Position:
         """
@@ -5490,7 +5490,7 @@ class Commands:
     undoableDeletePositions = deletePositionsInList
 
     # @+node:ekr.20091211111443.6265: *4* c.doBatchOperations & helpers
-    def doBatchOperations(self, aList: list = None) -> None:
+    def doBatchOperations(self, aList: list | None = None) -> None:
         # Validate aList and create the parents dict
         if aList is None:
             aList = []
@@ -5532,7 +5532,7 @@ class Commands:
         self,
         regex: re.Pattern,
         flags: re.RegexFlag = re.IGNORECASE,
-        it: Iterable[Position] = None,
+        it: Iterable[Position] | None = None,
     ) -> list[Position]:
         """
         Return list of all Positions whose body matches the regex at least once.
@@ -5553,7 +5553,7 @@ class Commands:
         self,
         regex: re.Pattern,
         flags: re.RegexFlag = re.IGNORECASE,
-        it: Iterable[Position] = None,
+        it: Iterable[Position] | None = None,
     ) -> list[Position]:
         """
         Return list of all Positions whose headline matches the regex.

--- a/leo/core/leoCompare.py
+++ b/leo/core/leoCompare.py
@@ -30,7 +30,7 @@ class BaseLeoCompare:
 
     def __init__(
         self,  # Keyword arguments are much convenient and more clear for scripts.
-        commands: Cmdr = None,
+        commands: Cmdr | None = None,
         appendOutput: bool = False,
         ignoreBlankLines: bool = True,
         ignoreFirstLine1: bool = False,
@@ -45,7 +45,7 @@ class BaseLeoCompare:
         printMatches: bool = False,
         printMismatches: bool = True,
         printTrailingMismatches: bool = False,
-        outputFileName: str = None,
+        outputFileName: str | None = None,
     ) -> None:
         # It is more convenient for the LeoComparePanel to set these directly.
         self.c = commands

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -464,7 +464,7 @@ class ParserBaseClass:
             g.es_print("ERROR: @menuat found but no menu tree to patch")
 
     # @+node:tbrown.20080514180046.9: *5* pbc.getName
-    def getName(self, val: str, val2: str = None) -> str:
+    def getName(self, val: str, val2: str | None = None) -> str:
         if val2 and val2.strip():
             val = val2
         val = val.split('\n', 1)[0]
@@ -679,7 +679,7 @@ class ParserBaseClass:
 
     # @+node:ekr.20041120105609: *4* pbc.doShortcuts
     def doShortcuts(
-        self, p: Position, kind: str, junk_name: str, junk_val: Any, s: str = None
+        self, p: Position, kind: str, junk_name: str, junk_val: Any, s: str | None = None
     ) -> None:
         """Handle an @shortcut or @shortcuts node."""
         c, d = self.c, self.shortcutsDict
@@ -1196,7 +1196,7 @@ class ActiveSettingsOutline:
                 self.add(p)
 
     # @+node:ekr.20190905091614.12: *3* aso.add
-    def add(self, p: Position, h: str = None) -> None:
+    def add(self, p: Position, h: str | None = None) -> None:
         """
         Add a node for p.
 
@@ -1443,7 +1443,7 @@ class GlobalConfigManager:
         return d or {}
 
     # @+node:ekr.20041117081009.3: *4* gcm.getBool
-    def getBool(self, setting: str, default: bool = None) -> bool:
+    def getBool(self, setting: str, default: bool | None = None) -> bool:
         """Return the value of @bool setting, or the default if the setting is not found."""
         val = self.get(setting, "bool")
         if val in (True, False):
@@ -1616,7 +1616,7 @@ class LocalConfigManager:
 
     # @+others
     # @+node:ekr.20041118104831.2: *3*  c.config.ctor
-    def __init__(self, c: Cmdr, previousSettings: PreviousSettings = None) -> None:
+    def __init__(self, c: Cmdr, previousSettings: PreviousSettings | None = None) -> None:
         self.c = c
         lm = g.app.loadManager
         if previousSettings:
@@ -1811,7 +1811,7 @@ class LocalConfigManager:
         return d or {}
 
     # @+node:ekr.20120215072959.12523: *5* c.config.getBool
-    def getBool(self, setting: str, default: bool = None) -> bool:
+    def getBool(self, setting: str, default: bool | None = None) -> bool:
         """Return the value of @bool setting, or the default if the setting is not found."""
         val = self.get(setting, "bool")
         if val in (True, False):

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -72,7 +72,7 @@ class ExternalFilesController:
 
     # @+others
     # @+node:ekr.20150404083533.1: *3* efc.ctor
-    def __init__(self, c: Cmdr = None) -> None:
+    def __init__(self, c: Cmdr | None = None) -> None:
         """Ctor for ExternalFiles class."""
         self.checksum_d: dict[str, str] = {}  # Keys are full paths, values are file checksums.
         # For efc.on_idle.
@@ -550,7 +550,7 @@ class ExternalFilesController:
     # @+node:ekr.20150405110219.1: *3* efc.utilities
 
     # @+node:ekr.20150405200212.1: *4* efc.ask
-    def ask(self, c: Cmdr, path: str, p: Position = None) -> str:
+    def ask(self, c: Cmdr, path: str, p: Position | None = None) -> str:
         """
         Ask user whether to overwrite an @<file> tree.
 
@@ -682,7 +682,7 @@ class ExternalFilesController:
         return f"{s1} {s2}"
 
     # @+node:tbrown.20150904102518.1: *4* efc.set_time
-    def set_time(self, path: str, new_time: float = None) -> None:
+    def set_time(self, path: str, new_time: float | None = None) -> None:
         """
         Implements c.setTimeStamp.
 

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -219,7 +219,7 @@ class FastRead:
         fc.descendentMarksList = marked
 
     # @+node:ekr.20180606041211.1: *4* fast.resolveUa
-    def resolveUa(self, attr: str, val: Value, kind: str = None) -> Value:
+    def resolveUa(self, attr: str, val: Value, kind: str | None = None) -> Value:
         # Kind is for unit testing.
         """Parse an unknown attribute in a <v> or <t> element."""
         try:
@@ -657,7 +657,7 @@ class FileCommands:
     # @+node:ekr.20210316042224.1: *3* fc: Commands
     # @+node:ekr.20031218072017.2012: *4* write-at-file-nodes
     @cmd('write-at-file-nodes')
-    def writeAtFileNodes(self, event: LeoKeyEvent = None) -> None:
+    def writeAtFileNodes(self, event: LeoKeyEvent | None = None) -> None:
         """Write all @file nodes in the selected outline."""
         c = self.c
         c.endEditing()
@@ -667,7 +667,7 @@ class FileCommands:
 
     # @+node:ekr.20031218072017.1666: *4* write-dirty-at-file-nodes
     @cmd('write-dirty-at-file-nodes')
-    def writeDirtyAtFileNodes(self, event: LeoKeyEvent = None) -> None:
+    def writeDirtyAtFileNodes(self, event: LeoKeyEvent | None = None) -> None:
         """Write all changed @file Nodes."""
         c = self.c
         c.endEditing()
@@ -677,7 +677,7 @@ class FileCommands:
 
     # @+node:ekr.20031218072017.2013: *4* write-missing-at-file-nodes
     @cmd('write-missing-at-file-nodes')
-    def writeMissingAtFileNodes(self, event: LeoKeyEvent = None) -> None:
+    def writeMissingAtFileNodes(self, event: LeoKeyEvent | None = None) -> None:
         """Write all @file nodes for which the corresponding external file does not exist."""
         c = self.c
         c.endEditing()
@@ -685,7 +685,7 @@ class FileCommands:
 
     # @+node:ekr.20031218072017.3050: *4* write-outline-only
     @cmd('write-outline-only')
-    def writeOutlineOnly(self, event: LeoKeyEvent = None) -> None:
+    def writeOutlineOnly(self, event: LeoKeyEvent | None = None) -> None:
         """Write the entire outline without writing any derived files."""
         c = self.c
         c.endEditing()
@@ -693,7 +693,7 @@ class FileCommands:
 
     # @+node:ekr.20230406053535.1: *4* write-zip-archive
     @cmd('write-zip-archive')
-    def writeZipArchive(self, event: LeoKeyEvent = None) -> None:
+    def writeZipArchive(self, event: LeoKeyEvent | None = None) -> None:
         """
         Write a .zip file containing this .leo file and all external files.
 
@@ -1195,7 +1195,7 @@ class FileCommands:
         return rootChildren[0]
 
     # @+node:vitalije.20170815162307.1: *6* fc.initNewDb
-    def initNewDb(self, conn: Conn, path: str = None) -> VNode:
+    def initNewDb(self, conn: Conn, path: str | None = None) -> VNode:
         """Initializes tables and returns None"""
         c, fc = self.c, self
         v = leoNodes.VNode(context=c)
@@ -1254,7 +1254,7 @@ class FileCommands:
     # Pre Leo 4.5 Only @thin vnodes had the descendentTnodeUnknownAttributes field.
     # New in Leo 4.5: @thin & @shadow vnodes have descendentVnodeUnknownAttributes field.
 
-    def getDescendentUnknownAttributes(self, s: str, v: VNode = None) -> Value:
+    def getDescendentUnknownAttributes(self, s: str, v: VNode | None = None) -> Value:
         """Unhexlify and unpickle t/v.descendentUnknownAttribute field."""
         try:
             # Changed in version 3.2: Accept only bytestring or bytearray objects as input.
@@ -1608,7 +1608,7 @@ class FileCommands:
         )
 
     # @+node:ekr.20031218072017.1573: *5* fc.outline_to_clipboard_string
-    def outline_to_clipboard_string(self, p: Position = None) -> str:
+    def outline_to_clipboard_string(self, p: Position | None = None) -> str:
         """
         Return a string suitable for pasting to the clipboard.
         """
@@ -1640,7 +1640,7 @@ class FileCommands:
         return s
 
     # @+node:felix.20230326001957.1: *5* fc.outline_to_clipboard_json_string
-    def outline_to_clipboard_json_string(self, p: Position = None) -> str:
+    def outline_to_clipboard_json_string(self, p: Position | None = None) -> str:
         """
         Return a JSON string suitable for pasting to the clipboard.
         """
@@ -1719,7 +1719,7 @@ class FileCommands:
             return False
 
     # @+node:ekr.20210316095706.1: *6* fc.leojs_outline_dict
-    def leojs_outline_dict(self, p: Position = None) -> dict[str, Value]:
+    def leojs_outline_dict(self, p: Position | None = None) -> dict[str, Value]:
         """Return a dict representing the outline."""
         c = self.c
         uas = {}
@@ -2219,7 +2219,7 @@ class FileCommands:
         return ''.join(attrs)
 
     # @+node:ekr.20031218072017.1579: *5* fc.put_v_elements & helper
-    def put_v_elements(self, p: Position = None) -> None:
+    def put_v_elements(self, p: Position | None = None) -> None:
         """Puts all <v> elements in the order in which they appear in the outline."""
         c = self.c
         c.clearAllVisited()

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -242,7 +242,7 @@ class LeoFind:
         self,
         root: Position,
         replacements: list[tuple[str, str]],
-        settings: Settings = None,
+        settings: Settings | None = None,
     ) -> int:
         # @+<< docstring: find.batch_change >>
         # @+node:ekr.20210925161347.1: *4* << docstring: find.batch_change >>
@@ -364,8 +364,8 @@ class LeoFind:
     # @+node:ekr.20210925161148.1: *3* find.interactive_search_helper
     def interactive_search_helper(
         self,
-        root: Position = None,
-        settings: Settings = None,
+        root: Position | None = None,
+        settings: Settings | None = None,
     ) -> None:  # pragma: no cover
         # @+<< docstring: find.interactive_search >>
         # @+node:ekr.20210925161451.1: *4* << docstring: find.interactive_search >>
@@ -423,7 +423,7 @@ class LeoFind:
     # @+node:ekr.20031218072017.3062: *4* find.change-then-find & helper
     @cmd('replace-then-find')
     @cmd('change-then-find')
-    def change_then_find(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (cmd)
+    def change_then_find(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover (cmd)
         """Handle the replace-then-find command."""
         # Settings...
         self.init_in_headline()
@@ -449,7 +449,7 @@ class LeoFind:
     # @+node:ekr.20160224175312.1: *4* find.clone-find_marked & helper
     @cmd('clone-find-all-marked')
     @cmd('cfam')
-    def cloneFindAllMarked(self, event: LeoKeyEvent = None) -> None:
+    def cloneFindAllMarked(self, event: LeoKeyEvent | None = None) -> None:
         """
         clone-find-all-marked, aka cfam.
 
@@ -461,7 +461,7 @@ class LeoFind:
 
     @cmd('clone-find-all-flattened-marked')
     @cmd('cffm')
-    def cloneFindAllFlattenedMarked(self, event: LeoKeyEvent = None) -> None:
+    def cloneFindAllFlattenedMarked(self, event: LeoKeyEvent | None = None) -> None:
         """
         clone-find-all-flattened-marked, aka cffm.
 
@@ -519,7 +519,7 @@ class LeoFind:
 
     # @+node:ekr.20140828080010.18532: *4* find.clone-find-parents
     @cmd('clone-find-parents')
-    def cloneFindParents(self, event: LeoKeyEvent = None) -> bool:
+    def cloneFindParents(self, event: LeoKeyEvent | None = None) -> bool:
         """
         Create an organizer node whose direct children are clones of all
         parents of the selected node, which must be a clone.
@@ -563,7 +563,7 @@ class LeoFind:
     # @+node:ekr.20150629084204.1: *4* find.find-def/var & helper
     @cmd('find-def')
     @cmd('find-var')
-    def find_def(self, event: LeoKeyEvent = None) -> list[tuple[int, Position, str]]:
+    def find_def(self, event: LeoKeyEvent | None = None) -> list[tuple[int, Position, str]]:
         """
         Find the class, def or assignment to var of the word under the cursor.
         """
@@ -850,7 +850,7 @@ class LeoFind:
 
     # @+node:ekr.20031218072017.3063: *4* find.find-next, find-prev & do_find_*
     @cmd('find-next')
-    def find_next(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (cmd)
+    def find_next(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover (cmd)
         """The find-next command."""
         # Settings...
         self.reverse = False
@@ -860,7 +860,7 @@ class LeoFind:
         self.do_find_next(settings)
 
     @cmd('find-prev')
-    def find_prev(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (cmd)
+    def find_prev(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover (cmd)
         """Handle F2 (find-previous)"""
         # Settings...
         self.init_in_headline()  # Do this *before* creating the settings.
@@ -965,7 +965,7 @@ class LeoFind:
 
     # @+node:ekr.20131117164142.17015: *4* find.find-tab-hide
     @cmd('find-tab-hide')
-    def hide_find_tab(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (cmd)
+    def hide_find_tab(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover (cmd)
         """Hide the Find tab."""
         c = self.c
         if self.minibuffer_mode:
@@ -976,7 +976,7 @@ class LeoFind:
     # @+node:ekr.20131117164142.16916: *4* find.find-tab-open
     @cmd('find-tab-open')
     def open_find_tab(
-        self, event: LeoKeyEvent = None, show: bool = True
+        self, event: LeoKeyEvent | None = None, show: bool = True
     ) -> None:  # pragma: no cover (cmd)
         """Open the Find tab in the log pane."""
         c = self.c
@@ -987,7 +987,7 @@ class LeoFind:
 
     # @+node:ekr.20141113094129.6: *4* find.focus-to-find
     @cmd('focus-to-find')
-    def focus_to_find(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (cmd)
+    def focus_to_find(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover (cmd)
         c = self.c
         if c.config.getBool('use-find-dialog', default=True):
             g.app.gui.openFindDialog(c)
@@ -997,7 +997,7 @@ class LeoFind:
     # @+node:ekr.20031218072017.3068: *4* find.replace (replace)
     @cmd('replace')
     @cmd('change')
-    def change(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (cmd)
+    def change(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover (cmd)
         """Replace the selected text with the replacement text."""
         p = self.c.p
         settings = self.ftm.get_settings()
@@ -1011,23 +1011,23 @@ class LeoFind:
     # @+node:ekr.20131117164142.17019: *4* find.set-find-*
     @cmd('set-find-everywhere')
     def set_find_scope_every_where(
-        self, event: LeoKeyEvent = None
+        self, event: LeoKeyEvent | None = None
     ) -> None:  # pragma: no cover (cmd)
         """Set the 'Entire Outline' radio button in the Find tab."""
         self.set_find_scope('entire-outline')
 
     @cmd('set-find-node-only')
-    def set_find_scope_node_only(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (cmd)
+    def set_find_scope_node_only(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover (cmd)
         """Set the 'Node Only' radio button in the Find tab."""
         self.set_find_scope('node-only')
 
     @cmd('set-find-file-only')
-    def set_find_scope_file_only(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (cmd)
+    def set_find_scope_file_only(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover (cmd)
         """Set the 'File Only' radio button in the Find tab."""
         self.set_find_scope('file-only')
 
     @cmd('set-find-suboutline-only')
-    def set_find_scope_suboutline_only(self, event: LeoKeyEvent = None) -> None:
+    def set_find_scope_suboutline_only(self, event: LeoKeyEvent | None = None) -> None:
         """Set the 'Suboutline Only' radio button in the Find tab."""
         self.set_find_scope('suboutline-only')
 
@@ -1040,7 +1040,7 @@ class LeoFind:
 
     # @+node:ekr.20131117164142.16989: *4* find.show-find-options
     @cmd('show-find-options')
-    def show_find_options(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (cmd)
+    def show_find_options(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover (cmd)
         """
         Show the present find options in the status line.
         This is useful for commands like search-forward that do not show the Find Panel.
@@ -1149,7 +1149,7 @@ class LeoFind:
     @cmd('change-all')
     @cmd('replace-all')
     def interactive_change_all(
-        self, event: LeoKeyEvent = None
+        self, event: LeoKeyEvent | None = None
     ) -> None:  # pragma: no cover (interactive)
         """Replace all instances of the search string with the replacement string."""
         self.ftm.clear_focus()
@@ -1400,7 +1400,7 @@ class LeoFind:
     @cmd('cfa')
     def interactive_clone_find_all(
         self,
-        event: LeoKeyEvent = None,
+        event: LeoKeyEvent | None = None,
         preloaded: bool = False,
     ) -> None:  # pragma: no cover (interactive)
         """
@@ -1463,7 +1463,7 @@ class LeoFind:
     @cmd('cff')
     def interactive_cff(
         self,
-        event: LeoKeyEvent = None,
+        event: LeoKeyEvent | None = None,
         preloaded: bool = False,
     ) -> None:  # pragma: no cover (interactive)
         """
@@ -1524,7 +1524,7 @@ class LeoFind:
     @cmd('find-clone-tag')
     @cmd('cft')
     def interactive_clone_find_tag(
-        self, event: LeoKeyEvent = None
+        self, event: LeoKeyEvent | None = None
     ) -> None:  # pragma: no cover (interactive)
         """
         clone-find-tag (aka find-clone-tag and cft).
@@ -1609,7 +1609,7 @@ class LeoFind:
     # @+node:ekr.20131117164142.16998: *4* find.find-all & helper
     @cmd('find-all')
     def interactive_find_all(
-        self, event: LeoKeyEvent = None
+        self, event: LeoKeyEvent | None = None
     ) -> None:  # pragma: no cover (interactive)
         """
         Create a summary node containing descriptions of all matches of the
@@ -1627,7 +1627,7 @@ class LeoFind:
         )
 
     def interactive_find_all1(
-        self, event: LeoKeyEvent = None
+        self, event: LeoKeyEvent | None = None
     ) -> None:  # pragma: no cover (interactive)
         k = self.k
         # Settings.
@@ -1909,7 +1909,7 @@ class LeoFind:
     # @+node:ekr.20250206055338.1: *4* find.find-source-for-command & helpers
     @cmd('find-source-for-command')
     def find_source_for_command(
-        self, event: LeoKeyEvent = None
+        self, event: LeoKeyEvent | None = None
     ) -> None:  # pragma: no cover (interactive)
         """
         Create a summary node containing descriptions of all matches of the
@@ -1924,7 +1924,7 @@ class LeoFind:
         self.start_state_machine(event, 'Command Name: ', handler=self.find_source_for_command1)
 
     def find_source_for_command1(
-        self, event: LeoKeyEvent = None
+        self, event: LeoKeyEvent | None = None
     ) -> None:  # pragma: no cover (interactive)
         k = self.k
         # Settings.
@@ -2121,7 +2121,7 @@ class LeoFind:
     startSearch = start_search  # Compatibility. Do not delete.
 
     # @+node:ekr.20210117143611.1: *5* find.start_search1
-    def start_search1(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def start_search1(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Common handler for use by vim commands and other find commands."""
         c, k, w = self.c, self.k, self.c.frame.body.wrapper
         # Settings...
@@ -2140,7 +2140,7 @@ class LeoFind:
         self.do_find_next(settings)  # Handles reverse.
 
     # @+node:ekr.20210117143614.1: *5* find._start_search_escape1
-    def start_search_escape1(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def start_search_escape1(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """
         Common escape handler for use by find commands.
 
@@ -2230,7 +2230,7 @@ class LeoFind:
     # @+node:ekr.20160920164418.2: *4* find.tag-children & helper
     @cmd('tag-children')
     def interactive_tag_children(
-        self, event: LeoKeyEvent = None
+        self, event: LeoKeyEvent | None = None
     ) -> None:  # pragma: no cover (interactive)
         """Prompt for a tag and add it to all children of c.p."""
         w = self.c.frame.body.wrapper
@@ -2271,7 +2271,7 @@ class LeoFind:
     # @+node:ekr.20230124043210.1: *4* find.tag-node & helper
     @cmd('tag-node')
     def interactive_tag_node(
-        self, event: LeoKeyEvent = None
+        self, event: LeoKeyEvent | None = None
     ) -> None:  # pragma: no cover (interactive)
         """Prompt for a tag and add it to c.p."""
         w = self.c.frame.body.wrapper
@@ -3331,7 +3331,7 @@ class LeoFind:
         return f" ({', '.join(status)})" if status else ''
 
     # @+node:ekr.20131119204029.16479: *4* find.help_for_find_commands
-    def help_for_find_commands(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (cmd)
+    def help_for_find_commands(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover (cmd)
         """Called from Find panel.  Redirect."""
         self.c.helpCommands.help_for_find_commands(event)
 
@@ -3423,7 +3423,7 @@ class LeoFind:
         event: LeoKeyEvent,
         prefix: str,
         handler: Callable,
-        escape_handler: Callable = None,
+        escape_handler: Callable | None = None,
     ) -> None:  # pragma: no cover (cmd)
         """
         Initialize and start the state machine used to get user arguments.

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -434,7 +434,7 @@ class LeoFrame:
             return self.statusLine.computeStatusUnl(p)
         return ''
 
-    def disableStatusLine(self, background: str = None) -> None:
+    def disableStatusLine(self, background: str | None = None) -> None:
         if self.statusLine:
             self.statusLine.disable(background)
 
@@ -447,7 +447,7 @@ class LeoFrame:
 
     getStatusObject = getStatusLine
 
-    def putStatusLine(self, s: str, bg: str = None, fg: str = None) -> None:
+    def putStatusLine(self, s: str, bg: str | None = None, fg: str | None = None) -> None:
         if self.statusLine:
             self.statusLine.put(s, bg, fg)
 
@@ -466,13 +466,13 @@ class LeoFrame:
 
     # @+node:felix.20250313154127.1: *4* LeoFrame.Window Layouts
     @frame_cmd('horizontal-window-layout')
-    def horizontalWindowLayout(self, event: LeoKeyEvent = None) -> None:
+    def horizontalWindowLayout(self, event: LeoKeyEvent | None = None) -> None:
         c = self.c
         c.inCommand = False  # Allow inner command
         c.doCommandByName('layout-legacy')
 
     @frame_cmd('vertical-window-layout')
-    def verticalWindowLayout(self, event: LeoKeyEvent = None) -> None:
+    def verticalWindowLayout(self, event: LeoKeyEvent | None = None) -> None:
         c = self.c
         c.inCommand = False  # Allow inner command
         c.doCommandByName('layout-vertical-thirds')
@@ -480,7 +480,7 @@ class LeoFrame:
     # @+node:ekr.20070130115927.4: *4* LeoFrame.Cut/Copy/Paste
     # @+node:ekr.20070130115927.5: *5* LeoFrame.copyText
     @frame_cmd('copy-text')
-    def copyText(self, event: LeoKeyEvent = None) -> None:
+    def copyText(self, event: LeoKeyEvent | None = None) -> None:
         """Copy the selected text from the widget to the clipboard."""
         # f = self
         w = event and event.widget
@@ -503,7 +503,7 @@ class LeoFrame:
 
     # @+node:ekr.20070130115927.6: *5* LeoFrame.cutText
     @frame_cmd('cut-text')
-    def cutText(self, event: LeoKeyEvent = None) -> None:
+    def cutText(self, event: LeoKeyEvent | None = None) -> None:
         """Invoked from the mini-buffer and from shortcuts."""
         c, p, u = self.c, self.c.p, self.c.undoer
         w = event and event.widget
@@ -532,7 +532,7 @@ class LeoFrame:
 
     # @+node:ekr.20070130115927.7: *5* LeoFrame.pasteText
     @frame_cmd('paste-text')
-    def pasteText(self, event: LeoKeyEvent = None, middleButton: bool = False) -> None:
+    def pasteText(self, event: LeoKeyEvent | None = None, middleButton: bool = False) -> None:
         """
         Paste the clipboard into a widget.
         If middleButton is True, support x-windows middle-mouse-button easter-egg.
@@ -599,13 +599,13 @@ class LeoFrame:
     OnPasteFromMenu = pasteText
 
     # @+node:ekr.20061016071937: *5* LeoFrame.OnPaste (support middle-button paste)
-    def OnPaste(self, event: LeoKeyEvent = None) -> None:
+    def OnPaste(self, event: LeoKeyEvent | None = None) -> None:
         return self.pasteText(event=event, middleButton=True)
 
     # @+node:ekr.20031218072017.3980: *4* LeoFrame.Edit Menu
     # @+node:ekr.20031218072017.3982: *5* LeoFrame.endEditLabelCommand
     @frame_cmd('end-edit-headline')
-    def endEditLabelCommand(self, event: LeoKeyEvent = None, p: Position = None) -> None:
+    def endEditLabelCommand(self, event: LeoKeyEvent | None = None, p: Position | None = None) -> None:
         """End editing of a headline and move focus to the body pane."""
         frame = self
         c = frame.c
@@ -628,82 +628,82 @@ class LeoFrame:
     def bringToFront(self) -> None:
         raise NotImplementedError
 
-    def cascade(self, event: LeoKeyEvent = None) -> None:
+    def cascade(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
-    def contractBodyPane(self, event: LeoKeyEvent = None) -> None:
+    def contractBodyPane(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
-    def contractLogPane(self, event: LeoKeyEvent = None) -> None:
+    def contractLogPane(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
-    def contractOutlinePane(self, event: LeoKeyEvent = None) -> None:
+    def contractOutlinePane(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
-    def contractPane(self, event: LeoKeyEvent = None) -> None:
+    def contractPane(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
     def deiconify(self) -> None:
         raise NotImplementedError
 
-    def equalSizedPanes(self, event: LeoKeyEvent = None) -> None:
+    def equalSizedPanes(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
-    def expandBodyPane(self, event: LeoKeyEvent = None) -> None:
+    def expandBodyPane(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
-    def expandLogPane(self, event: LeoKeyEvent = None) -> None:
+    def expandLogPane(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
-    def expandOutlinePane(self, event: LeoKeyEvent = None) -> None:
+    def expandOutlinePane(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
-    def expandPane(self, event: LeoKeyEvent = None) -> None:
+    def expandPane(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
-    def fullyExpandBodyPane(self, event: LeoKeyEvent = None) -> None:
+    def fullyExpandBodyPane(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
-    def fullyExpandLogPane(self, event: LeoKeyEvent = None) -> None:
+    def fullyExpandLogPane(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
-    def fullyExpandOutlinePane(self, event: LeoKeyEvent = None) -> None:
+    def fullyExpandOutlinePane(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
-    def fullyExpandPane(self, event: LeoKeyEvent = None) -> None:
+    def fullyExpandPane(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
     def get_window_info(self) -> tuple[int, int, int, int]:
         raise NotImplementedError
 
-    def hideBodyPane(self, event: LeoKeyEvent = None) -> None:
+    def hideBodyPane(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
-    def hideLogPane(self, event: LeoKeyEvent = None) -> None:
+    def hideLogPane(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
-    def hideLogWindow(self, event: LeoKeyEvent = None) -> None:
+    def hideLogWindow(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
-    def hideOutlinePane(self, event: LeoKeyEvent = None) -> None:
+    def hideOutlinePane(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
-    def hidePane(self, event: LeoKeyEvent = None) -> None:
+    def hidePane(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
-    def leoHelp(self, event: LeoKeyEvent = None) -> None:
+    def leoHelp(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
     def lift(self) -> None:
         raise NotImplementedError
 
-    def minimizeAll(self, event: LeoKeyEvent = None) -> None:
+    def minimizeAll(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
     def resizePanesToRatio(self, ratio: float, secondary_ratio: float) -> None:
         raise NotImplementedError
 
-    def resizeToScreen(self, event: LeoKeyEvent = None) -> None:
+    def resizeToScreen(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
     def setInitialWindowGeometry(self) -> None:
@@ -712,10 +712,10 @@ class LeoFrame:
     def setTopGeometry(self, w: int, h: int, x: int, y: int) -> None:
         raise NotImplementedError
 
-    def toggleActivePane(self, event: LeoKeyEvent = None) -> None:
+    def toggleActivePane(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
-    def toggleSplitDirection(self, event: LeoKeyEvent = None) -> None:
+    def toggleSplitDirection(self, event: LeoKeyEvent | None = None) -> None:
         raise NotImplementedError
 
     # @-others
@@ -760,7 +760,7 @@ class LeoLog:
         self,
         tabName: str,
         createText: bool = True,
-        widget: Widget = None,
+        widget: Widget | None = None,
         wrap: str = 'none',
     ) -> Widget:
         # Do not change the signature above.
@@ -808,7 +808,7 @@ class LeoLog:
         self.c.bodyWantsFocus()
 
     # @+node:ekr.20111122080923.10184: *3* LeoLog.orderedTabNames
-    def orderedTabNames(self, LeoLog: str = None) -> list:
+    def orderedTabNames(self, LeoLog: str | None = None) -> list:
         return list(self.frameDict.values())
 
     # @+node:ekr.20070302094848.9: *3* LeoLog.numberOfVisibleTabs
@@ -821,10 +821,10 @@ class LeoLog:
     def put(
         self,
         s: str,
-        color: str = None,
+        color: str | None = None,
         tabName: str = 'Log',
         from_redirect: bool = False,
-        nodeLink: str = None,
+        nodeLink: str | None = None,
     ) -> None:
         print(s)
 
@@ -976,7 +976,7 @@ class LeoTree:
     def redraw_after_head_changed(self) -> None:
         self.c.redraw()
 
-    def redraw_after_select(self, p: Position = None) -> None:
+    def redraw_after_select(self, p: Position | None = None) -> None:
         self.c.redraw()
 
     # @+node:ekr.20040803072955.91: *4* LeoTree.onHeadChanged
@@ -1115,7 +1115,7 @@ class LeoTree:
     # @+node:ekr.20031218072017.3706: *3* LeoTree.Must be defined in subclasses
     # Drawing & scrolling.
 
-    def redraw(self, p: Position = None) -> None:
+    def redraw(self, p: Position | None = None) -> None:
         raise NotImplementedError
 
     redraw_now = redraw
@@ -1129,7 +1129,7 @@ class LeoTree:
         self,
         p: Position,
         selectAll: bool = False,
-        selection: tuple = None,
+        selection: tuple | None = None,
     ) -> tuple[Widget, Any]:  # Any is the best possible annotation.
         raise NotImplementedError
 
@@ -1372,7 +1372,7 @@ class NullFrame(LeoFrame):
     def bringToFront(self) -> None:
         pass
 
-    def cascade(self, event: LeoKeyEvent = None) -> None:
+    def cascade(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
     def compute_ratio(self) -> float:
@@ -1381,16 +1381,16 @@ class NullFrame(LeoFrame):
     def compute_secondary_ratio(self) -> float:
         return 0.5
 
-    def contractBodyPane(self, event: LeoKeyEvent = None) -> None:
+    def contractBodyPane(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
-    def contractLogPane(self, event: LeoKeyEvent = None) -> None:
+    def contractLogPane(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
-    def contractOutlinePane(self, event: LeoKeyEvent = None) -> None:
+    def contractOutlinePane(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
-    def contractPane(self, event: LeoKeyEvent = None) -> None:
+    def contractPane(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
     def deiconify(self) -> None:
@@ -1399,34 +1399,34 @@ class NullFrame(LeoFrame):
     def destroySelf(self) -> None:
         pass
 
-    def equalSizedPanes(self, event: LeoKeyEvent = None) -> None:
+    def equalSizedPanes(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
-    def expandBodyPane(self, event: LeoKeyEvent = None) -> None:
+    def expandBodyPane(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
-    def expandLogPane(self, event: LeoKeyEvent = None) -> None:
+    def expandLogPane(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
-    def expandOutlinePane(self, event: LeoKeyEvent = None) -> None:
+    def expandOutlinePane(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
-    def expandPane(self, event: LeoKeyEvent = None) -> None:
+    def expandPane(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
     def forceWrap(self, p: Position) -> None:
         pass
 
-    def fullyExpandBodyPane(self, event: LeoKeyEvent = None) -> None:
+    def fullyExpandBodyPane(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
-    def fullyExpandLogPane(self, event: LeoKeyEvent = None) -> None:
+    def fullyExpandLogPane(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
-    def fullyExpandOutlinePane(self, event: LeoKeyEvent = None) -> None:
+    def fullyExpandOutlinePane(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
-    def fullyExpandPane(self, event: LeoKeyEvent = None) -> None:
+    def fullyExpandPane(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
     def getIconBar(self) -> NullIconBarClass | QtIconBarClass:
@@ -1437,34 +1437,34 @@ class NullFrame(LeoFrame):
     def get_window_info(self) -> tuple[int, int, int, int]:
         return 600, 500, 20, 20
 
-    def hideBodyPane(self, event: LeoKeyEvent = None) -> None:
+    def hideBodyPane(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
-    def hideLogPane(self, event: LeoKeyEvent = None) -> None:
+    def hideLogPane(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
-    def hideLogWindow(self, event: LeoKeyEvent = None) -> None:
+    def hideLogWindow(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
-    def hideOutlinePane(self, event: LeoKeyEvent = None) -> None:
+    def hideOutlinePane(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
-    def hidePane(self, event: LeoKeyEvent = None) -> None:
+    def hidePane(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
-    def leoHelp(self, event: LeoKeyEvent = None) -> None:
+    def leoHelp(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
     def lift(self) -> None:
         pass
 
-    def minimizeAll(self, event: LeoKeyEvent = None) -> None:
+    def minimizeAll(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
     def resizePanesToRatio(self, ratio: float, secondary_ratio: float) -> None:
         pass
 
-    def resizeToScreen(self, event: LeoKeyEvent = None) -> None:
+    def resizeToScreen(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
     def setInitialWindowGeometry(self) -> None:
@@ -1476,10 +1476,10 @@ class NullFrame(LeoFrame):
     def setWrap(self, flag: str, force: bool = False) -> None:
         pass
 
-    def toggleActivePane(self, event: LeoKeyEvent = None) -> None:
+    def toggleActivePane(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
-    def toggleSplitDirection(self, event: LeoKeyEvent = None) -> None:
+    def toggleSplitDirection(self, event: LeoKeyEvent | None = None) -> None:
         pass
 
     def update(self) -> None:
@@ -1504,7 +1504,7 @@ class NullIconBarClass:
         self.c = c
 
     # @+node:ekr.20070301165343: *3*  NullIconBarClass.Do nothing
-    def addRow(self, height: str = None) -> None:
+    def addRow(self, height: str | None = None) -> None:
         pass
 
     def addRowIfNeeded(self) -> None:
@@ -1585,7 +1585,7 @@ class NullIconBarClass:
 class NullLog(LeoLog):
     """A do-nothing log class."""
 
-    def __init__(self, *, frame: NullFrame = None) -> None:
+    def __init__(self, *, frame: NullFrame | None = None) -> None:
         super().__init__(frame)
         c = self.c
         self.isNull = True
@@ -1608,10 +1608,10 @@ class NullLog(LeoLog):
     def put(
         self,
         s: str,
-        color: str = None,
+        color: str | None = None,
         tabName: str = 'Log',
         from_redirect: bool = False,
-        nodeLink: str = None,
+        nodeLink: str | None = None,
     ) -> None:
         if self.enabled and not g.unitTesting:
             try:
@@ -1635,7 +1635,7 @@ class NullLog(LeoLog):
         self,
         tabName: str,
         createText: bool = True,
-        widget: Widget = None,
+        widget: Widget | None = None,
         wrap: str = 'none',
     ) -> None:
         pass
@@ -1676,7 +1676,7 @@ class NullStatusLineClass:
     def computeStatusUnl(self, p: Position) -> str:
         return ''
 
-    def disable(self, background: str = None) -> None:
+    def disable(self, background: str | None = None) -> None:
         self.enabled = False
 
     def enable(self, background: str = "white") -> None:
@@ -1693,7 +1693,7 @@ class NullStatusLineClass:
     def isEnabled(self) -> bool:
         return self.enabled
 
-    def put(self, s: str, bg: str = None, fg: str = None) -> None:
+    def put(self, s: str, bg: str | None = None, fg: str | None = None) -> None:
         w = self.textWidget
         w.insert(w.getLastIndex(), s)
 
@@ -1734,7 +1734,7 @@ class NullTree(LeoTree):
         self,
         p: Position,
         selectAll: bool = False,
-        selection: tuple = None,
+        selection: tuple | None = None,
     ) -> tuple[Widget, StringTextWrapper]:
         """Start editing p's headline."""
         self.endEditLabel()
@@ -1753,7 +1753,7 @@ class NullTree(LeoTree):
             g.pr('w', w, 'v.h:', key.headString, 's:', repr(w.s))
 
     # @+node:ekr.20070228163350.1: *3* NullTree.Drawing & scrolling
-    def redraw(self, p: Position = None) -> None:
+    def redraw(self, p: Position | None = None) -> None:
         self.redrawCount += 1
 
     redraw_after_contract = redraw

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -469,10 +469,10 @@ class BindingInfo:
         self,
         kind: str,
         commandName: str = '',
-        func: Callable = None,
-        nextMode: str = None,
-        pane: str = None,
-        stroke: KeyStroke = None,
+        func: Callable | None = None,
+        nextMode: str | None = None,
+        pane: str | None = None,
+        stroke: KeyStroke | None = None,
     ) -> None:
         if not g.isStrokeOrNone(stroke):
             g.trace('***** (BindingInfo) oops', repr(stroke))
@@ -574,7 +574,7 @@ class Bunch:
         """Support aBunch[key]"""
         return operator.getitem(self.__dict__, key)
 
-    def get(self, key: str, theDefault: Value = None) -> Value:
+    def get(self, key: str, theDefault: Value | None = None) -> Value:
         return self.__dict__.get(key, theDefault)
 
     def __contains__(self, key: str) -> bool:
@@ -692,13 +692,13 @@ class GeneralSetting:
     def __init__(
         self,
         kind: str,
-        encoding: str = None,
-        ivar: str = None,
-        source: str = None,
-        val: Value = None,
-        path: str = None,
+        encoding: str | None = None,
+        ivar: str | None = None,
+        source: str | None = None,
+        val: Value | None = None,
+        path: str | None = None,
         tag: str = 'setting',
-        unl: str = None,
+        unl: str | None = None,
     ) -> None:
         self.encoding = encoding
         self.ivar = ivar
@@ -1571,7 +1571,7 @@ class OptionsUtils:
     This class *calculates* valid options from the usage message.
     """
 
-    def __init__(self, usage: str, obsolete_options: list[str] = None) -> None:
+    def __init__(self, usage: str, obsolete_options: list[str] | None = None) -> None:
         # This class is essentially stateless because these ivars never change.
         self.usage = usage
         self.obsolete_options = obsolete_options
@@ -1805,7 +1805,7 @@ class SettingsDict(dict):
 
     # @+others
     # @+node:ekr.20120223062418.10422: *4* td.copy
-    def copy(self, name: str = None) -> Value:
+    def copy(self, name: str | None = None) -> Value:
         """Return a new dict with the same contents."""
         # The result is a g.SettingsDict.
         return copy.deepcopy(self)
@@ -2033,7 +2033,7 @@ tracing_tags: dict[int, str] = {}  # Keys are id's, values are tags.
 class NullObject:
     """An object that does nothing, and does it very well."""
 
-    def __init__(self, ivars: list[str] = None, *args: Args, **kwargs: KWargs) -> None:
+    def __init__(self, ivars: list[str] | None = None, *args: Args, **kwargs: KWargs) -> None:
         pass
 
     def __call__(self, *args: Args, **kwargs: KWargs) -> "NullObject":
@@ -2082,7 +2082,7 @@ class NullObject:
 class TracingNullObject:
     """Tracing NullObject."""
 
-    def __init__(self, tag: str, ivars: list[str] = None, *args: Args, **kwargs: KWargs) -> None:
+    def __init__(self, tag: str, ivars: list[str] | None = None, *args: Args, **kwargs: KWargs) -> None:
         tracing_tags[id(self)] = tag  # noqa  # conflict between flake8 and black.
 
     def __call__(self, *args: Args, **kwargs: KWargs) -> "TracingNullObject":
@@ -2365,7 +2365,7 @@ qt_text_classes = [
 ]
 
 
-def checkQtTextWidget(obj: Any, *, other_classes: list[str] = None) -> None:
+def checkQtTextWidget(obj: Any, *, other_classes: list[str] | None = None) -> None:
     """
     Check that an object has the appropriate class.
     """
@@ -2467,7 +2467,7 @@ def oldDump(s: str) -> str:
 
 
 # @+node:ekr.20210904114446.1: *4* g.dump_tree & g.tree_to_string
-def dump_tree(c: Cmdr, dump_body: bool = False, msg: str = None) -> None:
+def dump_tree(c: Cmdr, dump_body: bool = False, msg: str | None = None) -> None:
     if msg:
         print(msg.rstrip())
     else:
@@ -2479,7 +2479,7 @@ def dump_tree(c: Cmdr, dump_body: bool = False, msg: str = None) -> None:
                 print(z.rstrip())
 
 
-def tree_to_string(c: Cmdr, dump_body: bool = False, msg: str = None) -> str:
+def tree_to_string(c: Cmdr, dump_body: bool = False, msg: str | None = None) -> str:
     result = ['\n']
     if msg:
         result.append(msg)
@@ -2509,19 +2509,19 @@ def dump_encoded_string(encoding: str, s: str) -> None:
 
 
 # @+node:ekr.20031218072017.1317: *4* g.file/module/plugin_date
-def module_date(mod: ModuleType, format: str = None) -> str:
+def module_date(mod: ModuleType, format: str | None = None) -> str:
     theFile = g.os_path_join(app.loadDir, mod.__file__)
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=format)
 
 
-def plugin_date(plugin_mod: ModuleType, format: str = None) -> str:
+def plugin_date(plugin_mod: ModuleType, format: str | None = None) -> str:
     theFile = g.os_path_join(app.loadDir, "..", "plugins", plugin_mod.__file__)
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=str)
 
 
-def file_date(theFile: IO, format: str = None) -> str:
+def file_date(theFile: IO, format: str | None = None) -> str:
     if theFile and g.os_path_exists(theFile):
         try:
             n = g.os_path_getmtime(theFile)
@@ -2579,7 +2579,7 @@ def getIvarsDict(obj: object) -> dict[str, Value]:
 def checkUnchangedIvars(
     obj: object,
     d: dict[str, Value],
-    exceptions: Sequence[str] = None,
+    exceptions: Sequence[str] | None = None,
 ) -> bool:
     if not exceptions:
         exceptions = []
@@ -2625,7 +2625,7 @@ def objToString(
     obj: object,
     *,
     indent: int = 0,
-    tag: str = None,
+    tag: str | None = None,
     width: int = 120,
     offset: int = 0,  # Offset into array-like objects.
 ) -> str:
@@ -2682,7 +2682,7 @@ def sleep(n: float) -> None:
 
 
 # @+node:ekr.20171023140544.1: *4* g.printObj & aliases
-def printObj(obj: object, *, tag: str = None, indent: int = 0, offset: int = 0) -> None:
+def printObj(obj: object, *, tag: str | None = None, indent: int = 0, offset: int = 0) -> None:
     """Pretty print any Python object using g.pr."""
     g.pr(objToString(obj, indent=indent, tag=tag, offset=offset))
 
@@ -2795,7 +2795,7 @@ def clearStats() -> None:
 
 # @+node:ekr.20031218072017.3135: *4* g.printStats
 @command('show-stats')
-def printStats(event: LeoKeyEvent = None) -> None:
+def printStats(event: LeoKeyEvent | None = None) -> None:
     """
     Print all stats created by g.stat(), counts first.
     """
@@ -2824,7 +2824,7 @@ def printStats(event: LeoKeyEvent = None) -> None:
 _int_stat_prefix = 'stat_count: '
 
 
-def stat(obj: Any = None) -> None:
+def stat(obj: Any | None = None) -> None:
     """
     Add another count stat to g.app.statsDict.
     g.printStats() prints all such stats.
@@ -3073,7 +3073,7 @@ def getLanguageAtPosition(c: Cmdr, p: Position) -> str:
 
 
 # @+node:ekr.20031218072017.1386: *3* g.getOutputNewline
-def getOutputNewline(c: Cmdr = None, name: str = None) -> str:
+def getOutputNewline(c: Cmdr | None = None, name: str | None = None) -> str:
     """Convert the name of a line ending to the line ending itself.
 
     Priority:
@@ -3505,7 +3505,7 @@ def createHiddenCommander(fn: str) -> Cmdr:
 
 
 # @+node:vitalije.20170714085545.1: *3* g.defaultLeoFileExtension
-def defaultLeoFileExtension(c: Cmdr = None) -> str:
+def defaultLeoFileExtension(c: Cmdr | None = None) -> str:
     conf = c.config if c else g.app.config
     return conf.getString('default-leo-extension') or '.leo'
 
@@ -3536,7 +3536,7 @@ def fullPath(c: Cmdr, p: Position) -> str:
 
 
 # @+node:ekr.20190327192721.1: *3* g.get_files_in_directory
-def get_files_in_directory(directory: str, kinds: list = None, recursive: bool = True) -> list[str]:
+def get_files_in_directory(directory: str, kinds: list | None = None, recursive: bool = True) -> list[str]:
     """
     Return a list of all files of the given file extensions in the directory.
     Default kinds: ['*.py'].
@@ -3578,7 +3578,7 @@ def getBaseDirectory(c: Cmdr) -> str:
 
 
 # @+node:ekr.20170223093758.1: *3* g.getEncodingAt (deprecated)
-def getEncodingAt(p: Position, b: bytes = None) -> str:
+def getEncodingAt(p: Position, b: bytes | None = None) -> str:
     """
     Return the encoding in effect at p and/or for string s.
 
@@ -3599,7 +3599,7 @@ def getEncodingAt(p: Position, b: bytes = None) -> str:
 
 
 # @+node:ville.20090701144325.14942: *3* g.guessExternalEditor
-def guessExternalEditor(c: Cmdr = None) -> Optional[str]:
+def guessExternalEditor(c: Cmdr | None = None) -> Optional[str]:
     """Return a 'sensible' external editor"""
     editor = (
         c
@@ -3700,7 +3700,7 @@ def makePathRelativeTo(fullPath: str, basePath: str) -> str:
 
 
 # @+node:ekr.20090520055433.5945: *3* g.openWithFileName
-def openWithFileName(fileName: str, old_c: Cmdr = None, gui: LeoGui = None) -> Optional[Cmdr]:
+def openWithFileName(fileName: str, old_c: Cmdr | None = None, gui: LeoGui | None = None) -> Optional[Cmdr]:
     """
     Load any kind of file in the appropriate way:
 
@@ -3748,7 +3748,7 @@ def readFileIntoEncodedString(fn: str, silent: bool = False) -> bytes:
 def readFileIntoString(
     fileName: str,
     encoding: str = 'utf-8',  # BOM may override this.
-    kind: str = None,  # @file, @edit, ...
+    kind: str | None = None,  # @file, @edit, ...
     verbose: bool = True,
 ) -> tuple[str, str]:
     """
@@ -3914,7 +3914,7 @@ def setGlobalOpenDir(fileName: str) -> None:
 
 
 # @+node:ekr.20031218072017.3125: *3* g.shortFileName & shortFilename
-def shortFileName(fileName: str, n: int = None) -> str:
+def shortFileName(fileName: str, n: int | None = None) -> str:
     """Return the base name of a path."""
     if n is not None:
         g.trace('"n" keyword argument is no longer used')
@@ -4041,7 +4041,7 @@ def findAncestorVnodeByPredicate(p: Position, v_predicate: Optional[Callable]) -
 
 
 # @+node:ekr.20170220103251.1: *3* g.findRootsWithPredicate
-def findRootsWithPredicate(c: Cmdr, root: Position, predicate: Callable = None) -> list[Position]:
+def findRootsWithPredicate(c: Cmdr, root: Position, predicate: Callable | None = None) -> list[Position]:
     """
     Commands often want to find one or more **roots**, given a position p.
     A root is the position of any node matching a predicate.
@@ -4610,7 +4610,7 @@ def skip_c_id(s: str, i: int) -> int:
 
 
 # @+node:ekr.20040705195048: *4* g.skip_id
-def skip_id(s: str, i: int, chars: str = None) -> int:
+def skip_id(s: str, i: int, chars: str | None = None) -> int:
     chars = g.toUnicode(chars) if chars else ''
     n = len(s)
     while i < n and (g.isWordChar(s[i]) or s[i] in chars):
@@ -4771,7 +4771,7 @@ def skip_ws_and_nl(s: str, i: int) -> int:
 
 # @+node:ekr.20170414034616.1: ** g.Git
 # @+node:ekr.20180325025502.1: *3* g.backupGitIssues
-def backupGitIssues(c: Cmdr, base_url: str = None) -> None:
+def backupGitIssues(c: Cmdr, base_url: str | None = None) -> None:
     """Get a list of issues from Leo's GitHub site."""
     if base_url is None:
         base_url = 'https://api.github.com/repos/leo-editor/leo-editor/issues'
@@ -4823,9 +4823,9 @@ def execGitCommand(command: str, directory: str) -> list[str]:
 # @+node:ekr.20180126043905.1: *3* g.getGitIssues
 def getGitIssues(
     c: Cmdr,
-    base_url: str = None,
-    label_list: list = None,
-    milestone: str = None,
+    base_url: str | None = None,
+    label_list: list | None = None,
+    milestone: str | None = None,
     state: Optional[str] = None,  # in (None, 'closed', 'open')
 ) -> None:
     """Get a list of issues from Leo's GitHub site."""
@@ -4859,7 +4859,7 @@ class GitIssueController:
         c: Cmdr,
         label_list: list[str],
         root: Position,
-        state: str = None,
+        state: str | None = None,
     ) -> None:
         self.base_url = base_url
         self.root = root
@@ -5015,7 +5015,7 @@ class GitIssueController:
 
 
 # @+node:ekr.20190428173354.1: *3* g.getGitVersion
-def getGitVersion(directory: str = None) -> tuple[str, str, str]:
+def getGitVersion(directory: str | None = None) -> tuple[str, str, str]:
     """Return a tuple (author, build, date) from the git log, or None."""
     #
     # -n: Get only the last log.
@@ -5080,7 +5080,7 @@ def getModifiedFiles(repo_path: str) -> list[str]:
 
 
 # @+node:ekr.20170414034616.2: *3* g.gitBranchName
-def gitBranchName(path: str = None) -> str:
+def gitBranchName(path: str | None = None) -> str:
     """
     Return the git branch name associated with path/.git, or the empty
     string if path/.git does not exist. If path is None, use the leo-editor
@@ -5091,7 +5091,7 @@ def gitBranchName(path: str = None) -> str:
 
 
 # @+node:ekr.20170414034616.4: *3* g.gitCommitNumber
-def gitCommitNumber(path: str = None) -> str:
+def gitCommitNumber(path: str | None = None) -> str:
     """
     Return the git commit number associated with path/.git, or the empty
     string if path/.git does not exist. If path is None, use the leo-editor
@@ -5102,7 +5102,7 @@ def gitCommitNumber(path: str = None) -> str:
 
 
 # @+node:maphew.20171112205129.1: *3* g.gitDescribe
-def gitDescribe(path: str = None) -> tuple[str, str, str]:
+def gitDescribe(path: str | None = None) -> tuple[str, str, str]:
     """
     Return the Git tag, distance-from-tag, and commit hash for the
     associated path. If path is None, use the leo-editor directory.
@@ -5138,7 +5138,7 @@ def gitHeadPath(path_s: str) -> Optional[str]:
 
 
 # @+node:ekr.20170414034616.3: *3* g.gitInfo
-def gitInfo(path: str = None) -> tuple[str, str]:
+def gitInfo(path: str | None = None) -> tuple[str, str]:
     """
     Path may be a directory or file.
 
@@ -5332,7 +5332,7 @@ def enableIdleTimeHook(*args: Args, **kwargs: KWargs) -> None:
 
 
 # @+node:ekr.20140825042850.18410: *3* g.IdleTime
-def IdleTime(handler: Callable, delay: int = 500, tag: str = None) -> QtIdleTime:
+def IdleTime(handler: Callable, delay: int = 500, tag: str | None = None) -> QtIdleTime:
     """
     A thin wrapper for the LeoQtGui.IdleTime class.
 
@@ -5388,7 +5388,7 @@ def idleTimeHookHandler(timer: Callable) -> None:
 
 # @+node:ekr.20041219095213: ** g.Importing
 # @+node:ekr.20040917061619: *3* g.cantImport
-def cantImport(moduleName: str, pluginName: str = None, verbose: bool = True) -> None:
+def cantImport(moduleName: str, pluginName: str | None = None, verbose: bool = True) -> None:
     """Print a "Can't Import" message and return None."""
     s = f"Can not import {moduleName}"
     if pluginName:
@@ -5402,7 +5402,7 @@ def cantImport(moduleName: str, pluginName: str = None, verbose: bool = True) ->
 
 
 # @+node:ekr.20191220044128.1: *3* g.import_module
-def import_module(name: str, package: str = None) -> Optional[ModuleType]:
+def import_module(name: str, package: str | None = None) -> Optional[ModuleType]:
     """
     A thin wrapper over importlib.import_module.
     """
@@ -5440,7 +5440,7 @@ def convertPythonIndexToRowCol(s: str, i: int) -> tuple[int, int]:
 
 
 # @+node:ekr.20050315071727: *4* g.convertRowColToPythonIndex
-def convertRowColToPythonIndex(s: str, row: int, col: int, lines: list[str] = None) -> int:
+def convertRowColToPythonIndex(s: str, row: int, col: int, lines: list[str] | None = None) -> int:
     """Convert zero-based row/col indices into a python index into string s."""
     if row < 0:
         return 0
@@ -5666,7 +5666,7 @@ def bytesToStr(b: bytes, reportErrors: bool = False) -> str:
 
 
 # @+node:ekr.20190505052756.1: *4* g.checkUnicode
-def checkUnicode(s: str, encoding: str = None) -> str:
+def checkUnicode(s: str, encoding: str | None = None) -> str:
     """
     Warn when converting bytes. Report *all* errors.
 
@@ -5824,7 +5824,7 @@ def toEncodedString(s: str, encoding: str = 'utf-8', reportErrors: bool = False)
 
 
 # @+node:ekr.20050208093800.1: *4* g.toUnicode
-def toUnicode(s: object, encoding: str = None, reportErrors: bool = False) -> str:
+def toUnicode(s: object, encoding: str | None = None, reportErrors: bool = False) -> str:
     """Convert bytes to unicode if necessary."""
     if isinstance(s, str):
         return s
@@ -5920,7 +5920,7 @@ def computeWidth(s: str, tab_width: int) -> int:
 # @@language python
 
 
-def wrap_lines(lines: list[str], pageWidth: int, firstLineWidth: int = None) -> list[str]:
+def wrap_lines(lines: list[str], pageWidth: int, firstLineWidth: int | None = None) -> list[str]:
     """Returns a list of lines, consisting of the input lines wrapped to the given pageWidth."""
     if pageWidth < 10:
         pageWidth = 10
@@ -6136,7 +6136,7 @@ def stripBlankLines(s: str) -> str:
 # g.pr prints to the console.
 # g.es_print and related print to both the Log window and the console.
 # @+node:ekr.20080821073134.2: *3* g.doKeywordArgs
-def doKeywordArgs(keys: dict, d: dict = None) -> dict:
+def doKeywordArgs(keys: dict, d: dict | None = None) -> dict:
     """
     Return a result dict that is a copy of the keys dict
     with missing items replaced by defaults in d dict.
@@ -6254,7 +6254,7 @@ log = es
 
 
 # @+node:ekr.20060917120951: *3* g.es_dump
-def es_dump(s: str, n: int = 30, title: str = None) -> None:
+def es_dump(s: str, n: int = 30, title: str | None = None) -> None:
     if title:
         g.es_print('', title)
     i = 0
@@ -6303,7 +6303,7 @@ def es_exception(*args: Sequence, **kwargs: Sequence) -> None:
 
 
 # @+node:ekr.20061015090538: *3* g.es_exception_type
-def es_exception_type(c: Cmdr = None, color: str = "red") -> None:
+def es_exception_type(c: Cmdr | None = None, color: str = "red") -> None:
     # exctype is a Exception class object; value is the error message.
     exctype, value = sys.exc_info()[:2]
     g.es_print('', f"{exctype.__name__}, {value}", color=color)
@@ -6439,7 +6439,7 @@ is_unique_class = isUniqueClass
 
 
 # @+node:ekr.20150127060254.5: *3* g.log_to_file
-def log_to_file(s: str, fn: str = None) -> None:
+def log_to_file(s: str, fn: str | None = None) -> None:
     """Write a message to ~/test/leo_log.txt."""
     if fn is None:
         fn = g.finalize('~/test/leo_log.txt')
@@ -6515,7 +6515,7 @@ def prettyPrintType(obj: object) -> str:
 # @+node:ekr.20111107181638.9741: *3* g.print_exception
 def print_exception(
     full: bool = True,
-    c: Cmdr = None,
+    c: Cmdr | None = None,
     flush: bool = False,
     color: str = "red",
 ) -> tuple[str, int]:
@@ -6551,7 +6551,7 @@ def printEntireTree(c: Cmdr, tag: str = '') -> None:
 
 
 # @+node:ekr.20031218072017.3114: *3* g.printGlobals
-def printGlobals(message: str = None) -> None:
+def printGlobals(message: str | None = None) -> None:
     # Get the list of globals.
     globs = list(globals())
     globs.sort()
@@ -6564,7 +6564,7 @@ def printGlobals(message: str = None) -> None:
 
 
 # @+node:ekr.20031218072017.3115: *3* g.printLeoModules
-def printLeoModules(message: str = None) -> None:
+def printLeoModules(message: str | None = None) -> None:
     # Create the list.
     mods = []
     for name in sys.modules:
@@ -6776,7 +6776,7 @@ def CheckVersion(
     s1: str,
     s2: str,
     condition: str = ">=",
-    stringCompare: bool = None,
+    stringCompare: bool | None = None,
     delimiter: str = '.',
     trace: bool = False,
 ) -> bool:
@@ -6828,7 +6828,7 @@ def CheckVersionToInt(s: str) -> int:
 
 # @+node:ekr.20111103205308.9657: *3* g.cls
 @command('cls')
-def cls(event: LeoKeyEvent = None) -> None:
+def cls(event: LeoKeyEvent | None = None) -> None:
     """Clear the screen."""
     if g.isWindows:
         # Leo 6.7.5: Two calls seem to be required!
@@ -6839,7 +6839,7 @@ def cls(event: LeoKeyEvent = None) -> None:
 
 
 # @+node:ekr.20131114124839.16665: *3* g.createScratchCommander
-def createScratchCommander(fileName: str = None) -> None:
+def createScratchCommander(fileName: str | None = None) -> None:
     c = g.app.newCommander(fileName)
     frame = c.frame
     frame.createFirstTreeNode()
@@ -6860,7 +6860,7 @@ def deprecated() -> None:
 
 
 # @+node:ekr.20031218072017.3126: *3* g.funcToMethod (Python Cookbook)
-def funcToMethod(f: Callable, theClass: object, name: str = None) -> None:
+def funcToMethod(f: Callable, theClass: object, name: str | None = None) -> None:
     """
     From the Python Cookbook...
 
@@ -6920,7 +6920,7 @@ def init_zodb(pathToZodbStorage: str, verbose: bool = True) -> Value:
 
 
 # @+node:ekr.20170206080908.1: *3* g.input_
-def input_(message: str = '', c: Cmdr = None) -> str:
+def input_(message: str = '', c: Cmdr | None = None) -> str:
     """
     Safely execute python's input statement.
 
@@ -7337,7 +7337,7 @@ def os_startfile(fname: str) -> None:
 
 # @+node:ekr.20111115155710.9859: ** g.Parsing & Tokenizing
 # @+node:ekr.20031218072017.822: *3* g.createTopologyList
-def createTopologyList(c: Cmdr, root: Position = None, useHeadlines: bool = False) -> list:
+def createTopologyList(c: Cmdr, root: Position | None = None, useHeadlines: bool = False) -> list:
     """Creates a list describing a node and all its descendants"""
     if not root:
         root = c.rootPosition()
@@ -7444,7 +7444,7 @@ def python_tokenize(s: str) -> list:
 
 # @+node:ekr.20040327103735.2: ** g.Scripting
 # @+node:ekr.20161223090721.1: *3* g.exec_file
-def exec_file(path: str, d: dict[str, Value], script: str = None) -> None:
+def exec_file(path: str, d: dict[str, Value], script: str | None = None) -> None:
     """Simulate python's execfile statement for python 3."""
     if script is None:
         with open(path) as f:
@@ -7473,13 +7473,13 @@ def execute_shell_commands(commands: str | list[str], trace: bool = False) -> No
 
 # @+node:ekr.20180217113719.1: *3* g.execute_shell_commands_with_options & helpers
 def execute_shell_commands_with_options(
-    base_dir: str = None,
-    c: Cmdr = None,
-    command_setting: str = None,
-    commands: list = None,
-    path_setting: str = None,
+    base_dir: str | None = None,
+    c: Cmdr | None = None,
+    command_setting: str | None = None,
+    commands: list | None = None,
+    path_setting: str | None = None,
     trace: bool = False,
-    warning: str = None,
+    warning: str | None = None,
 ) -> None:
     """
     A helper for prototype commands or any other code that
@@ -7763,8 +7763,8 @@ def extractExecutableString(c: Cmdr, p: Position, s: str) -> str:
 def handleScriptException(
     c: Cmdr,
     p: Position,
-    script: str = None,  # No longer used.
-    script1: str = None,  # No longer used.
+    script: str | None = None,  # No longer used.
+    script1: str | None = None,  # No longer used.
 ) -> None:
     g.warning("exception executing script")
     g.es_exception()
@@ -7881,7 +7881,7 @@ def run_coverage_tests(module: str = '', filename: str = '') -> None:
 
 
 # @+node:ekr.20210901065224.1: *3* g.run_unit_tests
-def run_unit_tests(tests: str = None, verbose: bool = False) -> None:
+def run_unit_tests(tests: str | None = None, verbose: bool = False) -> None:
     """
     Run the unit tests given by the "tests" string.
 
@@ -7969,7 +7969,7 @@ def run_unit_tests(tests: str = None, verbose: bool = False) -> None:
 #    For example, Leo's forum: https://leo-editor.github.io/leo-editor/
 # @-<< About clickable links >>
 # @+node:ekr.20120320053907.9776: *3* g.computeFileUrl
-def computeFileUrl(fn: str, c: Cmdr = None, p: Position = None) -> str:
+def computeFileUrl(fn: str, c: Cmdr | None = None, p: Position | None = None) -> str:
     """
     Compute finalized url for filename fn.
     """
@@ -8285,7 +8285,7 @@ def handleUnl(unl_s: str, c: Cmdr) -> Optional[Cmdr]:
 
 
 # @+node:tbrown.20090219095555.63: *3* g.handleUrl & helpers
-def handleUrl(url: str, c: Cmdr = None, p: Position = None) -> Optional[str]:
+def handleUrl(url: str, c: Cmdr | None = None, p: Position | None = None) -> Optional[str]:
     """Open a url or a unl."""
     if c and not p:
         p = c.p
@@ -8434,7 +8434,7 @@ def openUrl(p: Position) -> None:  # pragma: no cover
 
 
 # @+node:ekr.20110605121601.18135: *3* g.openUrlOnClick (open-url-under-cursor)
-def openUrlOnClick(event: QMouseEvent, url: str = None) -> Optional[str]:  # pragma: no cover
+def openUrlOnClick(event: QMouseEvent, url: str | None = None) -> Optional[str]:  # pragma: no cover
     """Open the URL under the cursor.  Return it for unit testing."""
     # QTextEditWrapper.mouseReleaseEvent calls this outside Leo's command logic.
     # Make sure to catch all exceptions!
@@ -8446,7 +8446,7 @@ def openUrlOnClick(event: QMouseEvent, url: str = None) -> Optional[str]:  # pra
 
 
 # @+node:ekr.20170216091704.1: *4* g.openUrlHelper
-def openUrlHelper(event: LeoKeyEvent, url: str = None) -> Optional[str]:
+def openUrlHelper(event: LeoKeyEvent, url: str | None = None) -> Optional[str]:
     """Open the unl, url or gnx under the cursor.  Return it for unit testing."""
     c = getattr(event, 'c', None)
     if not c:

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -109,7 +109,7 @@ class LeoGui:
         """Create and run Leo's About Leo dialog."""
         raise NotImplementedError
 
-    def runAskOkDialog(self, c: Cmdr, title: str, message: str = None, text: str = "Ok") -> Any:
+    def runAskOkDialog(self, c: Cmdr, title: str, message: str | None = None, text: str = "Ok") -> Any:
         """Create and run an askOK dialog ."""
         raise NotImplementedError
 
@@ -118,8 +118,8 @@ class LeoGui:
         c: Cmdr,
         title: str,
         message: str,
-        cancelButtonText: str = None,
-        okButtonText: str = None,
+        cancelButtonText: str | None = None,
+        okButtonText: str | None = None,
     ) -> Any:
         """Create and run askOkCancelNumber dialog ."""
         raise NotImplementedError
@@ -129,8 +129,8 @@ class LeoGui:
         c: Cmdr,
         title: str,
         message: str,
-        cancelButtonText: str = None,
-        okButtonText: str = None,
+        cancelButtonText: str | None = None,
+        okButtonText: str | None = None,
         default: str = "",
         wide: bool = False,
     ) -> Any:
@@ -141,7 +141,7 @@ class LeoGui:
         self,
         c: Cmdr,
         title: str,
-        message: str = None,
+        message: str | None = None,
         yes_all: bool = False,
         no_all: bool = False,
     ) -> Any:
@@ -152,12 +152,12 @@ class LeoGui:
         self,
         c: Cmdr,
         title: str,
-        message: str = None,
+        message: str | None = None,
         yesMessage: str = "Yes",
         noMessage: str = "No",
-        yesToAllMessage: str = None,
+        yesToAllMessage: str | None = None,
         defaultButton: str = "Yes",
-        cancelMessage: str = None,
+        cancelMessage: str | None = None,
     ) -> Any:
         """Create and run an askYesNoCancel dialog ."""
         raise NotImplementedError
@@ -165,9 +165,9 @@ class LeoGui:
     def runPropertiesDialog(
         self,
         title: str = 'Properties',
-        data: Any = None,
-        callback: Callable = None,
-        buttons: list[str] = None,
+        data: Any | None = None,
+        callback: Callable | None = None,
+        buttons: list[str] | None = None,
     ) -> Any:
         """Display a modal TkPropertiesDialog"""
         raise NotImplementedError
@@ -180,7 +180,7 @@ class LeoGui:
         *,
         filetypes: list[tuple[str, str]],
         defaultextension: str = '',  # Not used
-        startpath: str = None,
+        startpath: str | None = None,
     ) -> str:
         """Create and run an open file dialog ."""
         raise NotImplementedError
@@ -192,7 +192,7 @@ class LeoGui:
         *,
         filetypes: list[tuple[str, str]],
         defaultextension: str = '',  # Not used
-        startpath: str = None,
+        startpath: str | None = None,
     ) -> list[str]:
         """Create and run an open files dialog ."""
         raise NotImplementedError
@@ -256,7 +256,7 @@ class LeoGui:
     def create_labeled_frame(
         self,
         parent: str,
-        caption: str = None,
+        caption: str | None = None,
         relief: str = "groove",
         bd: int = 2,
         padx: int = 0,
@@ -282,19 +282,19 @@ class LeoGui:
         raise NotImplementedError
 
     # @+node:ekr.20070212145124: *5* LeoGui.getFullVersion
-    def getFullVersion(self, c: Cmdr = None) -> str:
+    def getFullVersion(self, c: Cmdr | None = None) -> str:
         return 'LeoGui: dummy version'
 
     # @+node:ekr.20070212070820: *5* LeoGui.makeScriptButton
     def makeScriptButton(
         self,
         c: Cmdr,
-        args: str = None,
-        p: Position = None,
-        script: str = None,
-        buttonText: str = None,
+        args: str | None = None,
+        p: Position | None = None,
+        script: str | None = None,
+        buttonText: str | None = None,
         balloonText: str = 'Script Button',
-        shortcut: str = None,
+        shortcut: str | None = None,
         bg: str = 'LightSteelBlue1',
         define_g: bool = True,
         define_name: str = '__main__',
@@ -308,14 +308,14 @@ class LeoGui:
         self,
         c: Cmdr,
         *,
-        binding: str = None,
-        char: str = None,
-        event: LeoKeyEvent = None,
-        w: QTextMixin = None,
-        x: int = None,
-        x_root: int = None,
-        y: int = None,
-        y_root: int = None,
+        binding: str | None = None,
+        char: str | None = None,
+        event: LeoKeyEvent | None = None,
+        w: QTextMixin | None = None,
+        x: int | None = None,
+        x_root: int | None = None,
+        y: int | None = None,
+        y_root: int | None = None,
     ) -> LeoKeyEvent:
         # Do not call strokeFromSetting here!
         # For example, this would wrongly convert Ctrl-C to Ctrl-c,
@@ -330,7 +330,7 @@ class LeoGui:
             return "invalid gui name"
 
     # @+node:ekr.20031218072017.2231: *4* LeoGui.setScript
-    def setScript(self, script: str = None, scriptFileName: str = None) -> None:
+    def setScript(self, script: str | None = None, scriptFileName: str | None = None) -> None:
         self.script = script
         self.scriptFileName = scriptFileName
 
@@ -356,10 +356,10 @@ class LeoKeyEvent:
         event: LeoKeyEvent,
         binding: Any,
         w: Any,
-        x: int = None,
-        y: int = None,
-        x_root: int = None,
-        y_root: int = None,
+        x: int | None = None,
+        y: int | None = None,
+        x_root: int | None = None,
+        y_root: int | None = None,
     ) -> None:
         """Ctor for LeoKeyEvent class."""
         stroke: Any
@@ -432,7 +432,7 @@ class NullGui(LeoGui):
     ) -> str:
         return None
 
-    def runAskOkDialog(self, c: Cmdr, title: str, message: str = None, text: str = "Ok") -> str:
+    def runAskOkDialog(self, c: Cmdr, title: str, message: str | None = None, text: str = "Ok") -> str:
         return 'Ok'
 
     def runAskOkCancelNumberDialog(
@@ -440,8 +440,8 @@ class NullGui(LeoGui):
         c: Cmdr,
         title: str,
         message: str,
-        cancelButtonText: str = None,
-        okButtonText: str = None,
+        cancelButtonText: str | None = None,
+        okButtonText: str | None = None,
     ) -> str:
         return 'no'
 
@@ -450,8 +450,8 @@ class NullGui(LeoGui):
         c: Cmdr,
         title: str,
         message: str,
-        cancelButtonText: str = None,
-        okButtonText: str = None,
+        cancelButtonText: str | None = None,
+        okButtonText: str | None = None,
         default: str = "",
         wide: bool = False,
     ) -> str:
@@ -465,9 +465,9 @@ class NullGui(LeoGui):
         c: Cmdr,
         title: str,
         *,
-        filetypes: list[tuple[str, str]] = None,
+        filetypes: list[tuple[str, str]] | None = None,
         defaultextension: str = '',  # Not used
-        startpath: str = None,
+        startpath: str | None = None,
     ) -> str:
         return ''
 
@@ -476,7 +476,7 @@ class NullGui(LeoGui):
         c: Cmdr,
         title: str,
         *,
-        filetypes: list[tuple[str, str]] = None,
+        filetypes: list[tuple[str, str]] | None = None,
         defaultextension: str = '',  # Not used
     ) -> str:
         return ''
@@ -486,9 +486,9 @@ class NullGui(LeoGui):
         c: Cmdr,
         title: str,
         *,
-        filetypes: list[tuple[str, str]] = None,
+        filetypes: list[tuple[str, str]] | None = None,
         defaultextension: str = '',  # Not used
-        startpath: str = None,
+        startpath: str | None = None,
     ) -> list[str]:
         return []
 
@@ -496,7 +496,7 @@ class NullGui(LeoGui):
         self,
         c: Cmdr,
         title: str,
-        message: str = None,
+        message: str | None = None,
         yes_all: bool = False,
         no_all: bool = False,
     ) -> str:
@@ -506,12 +506,12 @@ class NullGui(LeoGui):
         self,
         c: Cmdr,
         title: str,
-        message: str = None,
+        message: str | None = None,
         yesMessage: str = "Yes",
         noMessage: str = "No",
-        yesToAllMessage: str = None,
+        yesToAllMessage: str | None = None,
         defaultButton: str = "Yes",
-        cancelMessage: str = None,
+        cancelMessage: str | None = None,
     ) -> str:
         return 'cancel'
 
@@ -624,7 +624,7 @@ class NullScriptingControllerClass:
 
     This keeps pylint happy."""
 
-    def __init__(self, c: Cmdr, iconBar: NullIconBarClass = None) -> None:
+    def __init__(self, c: Cmdr, iconBar: NullIconBarClass | None = None) -> None:
         self.c = c
         self.iconBar = iconBar
 
@@ -636,7 +636,7 @@ class NullScriptingControllerClass:
 class StringCheckBox:
     """Simulate a QCheckBox."""
 
-    def __init__(self, name: str, label: str = None) -> None:
+    def __init__(self, name: str, label: str | None = None) -> None:
         self.label = label
         self.name = name
         self.value = True
@@ -884,7 +884,7 @@ class StringLineEdit:
 class StringRadioButton:
     """Simulate a QRadioButton."""
 
-    def __init__(self, name: str, label: str = None) -> None:
+    def __init__(self, name: str, label: str | None = None) -> None:
         self.label = label
         self.name = name
         self.value = True
@@ -906,7 +906,7 @@ class UnitTestGui(NullGui):
     # Presently used only by the import/export unit tests.
     # @+others
     # @+node:ekr.20031218072017.3743: *3* UnitTestGui.__init__
-    def __init__(self, theDict: dict = None) -> None:
+    def __init__(self, theDict: dict | None = None) -> None:
         """ctor for the UnitTestGui class."""
         self.oldGui = g.app.gui
         super().__init__("UnitTestGui")

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -585,8 +585,8 @@ class LeoImportCommands:
     def createOutline(
         self,
         parent: Position,
-        ext: str = None,
-        s: str = None,
+        ext: str | None = None,
+        s: str | None = None,
         treeType: str = '@file',
     ) -> Position:
         """
@@ -735,8 +735,8 @@ class LeoImportCommands:
     # @+node:ekr.20031218072017.1810: *4* ic.importDerivedFiles
     def importDerivedFiles(
         self,
-        parent: Position = None,
-        paths: list[str] = None,
+        parent: Position | None = None,
+        paths: list[str] | None = None,
         command: str = 'Import',
     ) -> Optional[Position]:
         """
@@ -779,8 +779,8 @@ class LeoImportCommands:
     # @+node:ekr.20031218072017.3212: *4* ic.importFilesCommand
     def importFilesCommand(
         self,
-        files: list[str] = None,
-        parent: Position = None,
+        files: list[str] | None = None,
+        parent: Position | None = None,
         shortFn: bool = False,
         treeType: str = '@file',
         verbose: bool = True,  # Legacy value.
@@ -824,7 +824,7 @@ class LeoImportCommands:
         FreeMindImporter(self.c).import_files(files)
 
     # @+node:ekr.20241027003435.1: *4* ic.importJupytextFiles
-    def importJupytextFiles(self, paths: list[str] = None) -> Optional[Position]:
+    def importJupytextFiles(self, paths: list[str] | None = None) -> Optional[Position]:
         """
         Import one or more .ipynb files.
         This is not a command.  It must *not* have an event arg.
@@ -1395,7 +1395,7 @@ class LeoImportCommands:
         return s
 
     # @+node:ekr.20031218072017.1463: *4* ic.setEncoding (deprecated)
-    def setEncoding(self, p: Position = None, default: str = None) -> None:
+    def setEncoding(self, p: Position | None = None, default: str | None = None) -> None:
         g.deprecated()
         c = self.c
         self.encoding = c.getEncoding(p)
@@ -1734,11 +1734,11 @@ class RecursiveImportController:
         c: Cmdr,
         *,  # All other args are kwargs.
         dir_: Optional[str],
-        ignore_pattern: re.Pattern = None,
+        ignore_pattern: re.Pattern | None = None,
         kind: str,
         recursive: bool = True,
         safe_at_file: bool = True,
-        theTypes: list[str] = None,
+        theTypes: list[str] | None = None,
         verbose: bool = True,  # legacy value.
     ) -> None:
         """Ctor for RecursiveImportController class."""
@@ -2139,7 +2139,7 @@ class TabImporter:
             self.import_files(names)
 
     # @+node:ekr.20161006071801.5: *3* tabbed.scan
-    def scan(self, s1: str, fn: str = None, root: Position = None) -> Position:
+    def scan(self, s1: str, fn: str | None = None, root: Position | None = None) -> Position:
         """Create the outline corresponding to s1."""
         c = self.c
         # self.root can be None if we are called from a script or unit test.

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -217,7 +217,7 @@ class AutoCompleterClass:
     # @+node:ekr.20061031131434.8: *3* ac.Top level
     # @+node:ekr.20061031131434.9: *4* ac.autoComplete
     @ac_cmd('auto-complete')
-    def autoComplete(self, event: LeoKeyEvent = None) -> None:
+    def autoComplete(self, event: LeoKeyEvent | None = None) -> None:
         """An event handler for autocompletion."""
         c, k = self.c, self.k
         # pylint: disable=consider-using-ternary
@@ -237,7 +237,7 @@ class AutoCompleterClass:
 
     # @+node:ekr.20061031131434.10: *4* ac.autoCompleteForce
     @ac_cmd('auto-complete-force')
-    def autoCompleteForce(self, event: LeoKeyEvent = None) -> None:
+    def autoCompleteForce(self, event: LeoKeyEvent | None = None) -> None:
         """Show autocompletion, even if autocompletion is not presently enabled."""
         c, k = self.c, self.k
         # pylint: disable=consider-using-ternary
@@ -256,44 +256,44 @@ class AutoCompleterClass:
 
     # @+node:ekr.20061031131434.12: *4* ac.enable/disable/toggleAutocompleter/Calltips
     @ac_cmd('disable-autocompleter')
-    def disableAutocompleter(self, event: LeoKeyEvent = None) -> None:
+    def disableAutocompleter(self, event: LeoKeyEvent | None = None) -> None:
         """Disable the autocompleter."""
         self.k.enable_autocompleter = False
         self.showAutocompleterStatus()
 
     @ac_cmd('disable-calltips')
-    def disableCalltips(self, event: LeoKeyEvent = None) -> None:
+    def disableCalltips(self, event: LeoKeyEvent | None = None) -> None:
         """Disable calltips."""
         self.k.enable_calltips = False
         self.showCalltipsStatus()
 
     @ac_cmd('enable-autocompleter')
-    def enableAutocompleter(self, event: LeoKeyEvent = None) -> None:
+    def enableAutocompleter(self, event: LeoKeyEvent | None = None) -> None:
         """Enable the autocompleter."""
         self.k.enable_autocompleter = True
         self.showAutocompleterStatus()
 
     @ac_cmd('enable-calltips')
-    def enableCalltips(self, event: LeoKeyEvent = None) -> None:
+    def enableCalltips(self, event: LeoKeyEvent | None = None) -> None:
         """Enable calltips."""
         self.k.enable_calltips = True
         self.showCalltipsStatus()
 
     @ac_cmd('toggle-autocompleter')
-    def toggleAutocompleter(self, event: LeoKeyEvent = None) -> None:
+    def toggleAutocompleter(self, event: LeoKeyEvent | None = None) -> None:
         """Toggle whether the autocompleter is enabled."""
         self.k.enable_autocompleter = not self.k.enable_autocompleter
         self.showAutocompleterStatus()
 
     @ac_cmd('toggle-calltips')
-    def toggleCalltips(self, event: LeoKeyEvent = None) -> None:
+    def toggleCalltips(self, event: LeoKeyEvent | None = None) -> None:
         """Toggle whether calltips are enabled."""
         self.k.enable_calltips = not self.k.enable_calltips
         self.showCalltipsStatus()
 
     # @+node:ekr.20061031131434.13: *4* ac.showCalltips
     @ac_cmd('show-calltips')
-    def showCalltips(self, event: LeoKeyEvent = None) -> None:
+    def showCalltips(self, event: LeoKeyEvent | None = None) -> None:
         """Show the calltips at the cursor."""
         c, k, w = self.c, self.c.k, event and event.w
         if not w:
@@ -307,7 +307,7 @@ class AutoCompleterClass:
 
     # @+node:ekr.20061031131434.14: *4* ac.showCalltipsForce
     @ac_cmd('show-calltips-force')
-    def showCalltipsForce(self, event: LeoKeyEvent = None) -> None:
+    def showCalltipsForce(self, event: LeoKeyEvent | None = None) -> None:
         """Show the calltips at the cursor, even if calltips are not presently enabled."""
         c, w = self.c, event and event.w
         if not w:
@@ -865,7 +865,7 @@ class AutoCompleterClass:
             put(str(doc))
 
     # @+node:ekr.20110510071925.14586: *4* ac.init_qcompleter
-    def init_qcompleter(self, event: LeoKeyEvent = None) -> None:
+    def init_qcompleter(self, event: LeoKeyEvent | None = None) -> None:
         # Compute the prefix and the list of options.
         prefix = self.get_autocompleter_prefix()
         options = self.get_completions(prefix)
@@ -880,7 +880,7 @@ class AutoCompleterClass:
             self.exit()
 
     # @+node:ekr.20110511133940.14552: *4* ac.init_tabcompleter
-    def init_tabcompleter(self, event: LeoKeyEvent = None) -> None:
+    def init_tabcompleter(self, event: LeoKeyEvent | None = None) -> None:
         # Compute the prefix and the list of options.
         prefix = self.get_autocompleter_prefix()
         options = self.get_completions(prefix)
@@ -1499,13 +1499,13 @@ class GetArg:
     def get_arg(
         self,
         event: LeoKeyEvent,
-        returnKind: str = None,
-        returnState: int = None,
-        handler: Callable = None,
-        tabList: list[str] = None,
+        returnKind: str | None = None,
+        returnState: int | None = None,
+        handler: Callable | None = None,
+        tabList: list[str] | None = None,
         completion: bool = True,
         oneCharacter: bool = False,
-        stroke: Stroke = None,
+        stroke: Stroke | None = None,
         useMinibuffer: bool = True,
     ) -> None:
         # @+<< ga.get_arg docstring >>
@@ -2127,7 +2127,7 @@ class KeyHandlerClass:
         callback: Callable,
         commandName: str,
         modeFlag: bool = False,
-        tag: str = None,
+        tag: str | None = None,
     ) -> bool:
         """
         Bind the indicated shortcut (a Tk keystroke) to the callback.
@@ -2255,7 +2255,7 @@ class KeyHandlerClass:
         name = d.get('name')
         # The first parameter must be event, and it must default to None.
 
-        def openWithCallback(event: LeoKeyEvent = None, c: Cmdr = c, d: dict = d) -> None:
+        def openWithCallback(event: LeoKeyEvent | None = None, c: Cmdr = c, d: dict = d) -> None:
             return c.openWith(d=d)
 
         # Use k.registerCommand to set the shortcuts in the various binding dicts.
@@ -2287,7 +2287,7 @@ class KeyHandlerClass:
                     g.trace(f"No shortcut for {name} = {key}")
 
     # @+node:ekr.20061031131434.97: *4* k.completeAllBindings
-    def completeAllBindings(self, w: QTextMixin = None) -> None:
+    def completeAllBindings(self, w: QTextMixin | None = None) -> None:
         """
         Make an actual binding in *all* the standard places.
 
@@ -2409,7 +2409,7 @@ class KeyHandlerClass:
                     k.bindKey(pane, stroke, command, commandName, tag=tag)  # type:ignore
 
     # @+node:ekr.20061031131434.103: *4* k.makeMasterGuiBinding
-    def makeMasterGuiBinding(self, stroke: Stroke, w: QTextMixin = None) -> None:
+    def makeMasterGuiBinding(self, stroke: Stroke, w: QTextMixin | None = None) -> None:
         """Make a master gui binding for stroke in pane w, or in all the standard widgets."""
         c, k = self.c, self
         f = c.frame
@@ -2509,10 +2509,10 @@ class KeyHandlerClass:
     def fullCommand(
         self,
         event: LeoKeyEvent,
-        specialStroke: Stroke = None,
-        specialFunc: Callable = None,
+        specialStroke: Stroke | None = None,
+        specialFunc: Callable | None = None,
         help: bool = False,
-        helpHandler: Callable = None,
+        helpHandler: Callable | None = None,
     ) -> None:
         """Handle 'full-command' (alt-x) mode."""
         try:
@@ -2591,7 +2591,7 @@ class KeyHandlerClass:
         if commandName and commandName.isdigit():
             # The line number Easter Egg.
 
-            def func(event: LeoKeyEvent = None) -> None:
+            def func(event: LeoKeyEvent | None = None) -> None:
                 c.gotoCommands.find_file_line(n=int(commandName))
 
         else:
@@ -2622,13 +2622,13 @@ class KeyHandlerClass:
 
     # @+node:ekr.20061031131434.114: *3* k.Externally visible commands
     # @+node:ekr.20070613133500: *4* k.menuCommandKey
-    def menuCommandKey(self, event: LeoKeyEvent = None) -> None:
+    def menuCommandKey(self, event: LeoKeyEvent | None = None) -> None:
         # This method must exist, but it never gets called.
         pass
 
     # @+node:ekr.20061031131434.119: *4* 'show-bindings' & helper
     @cmd('show-bindings')
-    def showBindings(self, event: LeoKeyEvent = None) -> list[str]:
+    def showBindings(self, event: LeoKeyEvent | None = None) -> list[str]:
         """Print all the bindings presently in effect."""
         c, k = self.c, self
         d = k.masterBindingsDict
@@ -2722,7 +2722,7 @@ class KeyHandlerClass:
 
     # @+node:ekr.20120520174745.9867: *4* 'show-buttons'
     @cmd('show-buttons')
-    def printButtons(self, event: LeoKeyEvent = None) -> None:
+    def printButtons(self, event: LeoKeyEvent | None = None) -> None:
         """Print all @button and @command commands, their bindings and their source."""
         c = self.c
         tabName = '@buttons && @commands'
@@ -2765,7 +2765,7 @@ class KeyHandlerClass:
 
     # @+node:ekr.20241211005649.1: *4* 'show-buttons-and-at-commands'
     @cmd('show-buttons-and-at-commands')
-    def showButtonsAndAtCommands(self, event: LeoKeyEvent = None) -> None:
+    def showButtonsAndAtCommands(self, event: LeoKeyEvent | None = None) -> None:
         '''For each @button and @command node, show its file and gnx.'''
 
         class ShowCommands:
@@ -2898,7 +2898,7 @@ class KeyHandlerClass:
 
     # @+node:ekr.20061031131434.121: *4* 'show-commands'
     @cmd('show-commands')
-    def printCommands(self, event: LeoKeyEvent = None) -> None:
+    def printCommands(self, event: LeoKeyEvent | None = None) -> None:
         """Print all the known commands and their bindings, if any."""
         c, k = self.c, self
         tabName = 'Commands'
@@ -2928,7 +2928,7 @@ class KeyHandlerClass:
 
     # @+node:tom.20220320235059.1: *4* 'show-commands-with-docs'
     @cmd('show-commands-with-docs')
-    def printCommandsWithDocs(self, event: LeoKeyEvent = None) -> None:
+    def printCommandsWithDocs(self, event: LeoKeyEvent | None = None) -> None:
         """Show all the known commands and their bindings, if any."""
         c, k = self.c, self
         tabName = 'List'
@@ -3015,7 +3015,7 @@ class KeyHandlerClass:
 
     # @+node:ekr.20061031131434.124: *4* 'toggle-input-state'
     @cmd('toggle-input-state')
-    def toggleInputState(self, event: LeoKeyEvent = None) -> None:
+    def toggleInputState(self, event: LeoKeyEvent | None = None) -> None:
         """The toggle-input-state command."""
         c, k = self.c, self
         default = c.config.getString('top-level-unbound-key-action') or 'insert'
@@ -3048,11 +3048,11 @@ class KeyHandlerClass:
         self,
         event: LeoKeyEvent,
         handler: Callable,
-        prefix: str = None,
-        tabList: list[str] = None,
+        prefix: str | None = None,
+        tabList: list[str] | None = None,
         completion: bool = True,
         oneCharacter: bool = False,
-        stroke: Stroke = None,
+        stroke: Stroke | None = None,
         useMinibuffer: bool = True,
     ) -> None:
         # @+<< docstring for k.get1arg >>
@@ -3158,14 +3158,14 @@ class KeyHandlerClass:
     def getArg(
         self,
         event: LeoKeyEvent,
-        returnKind: str = None,
-        returnState: int = None,
-        handler: Callable = None,
-        prefix: str = None,
-        tabList: list[str] = None,
+        returnKind: str | None = None,
+        returnState: int | None = None,
+        handler: Callable | None = None,
+        prefix: str | None = None,
+        tabList: list[str] | None = None,
         completion: bool = True,
         oneCharacter: bool = False,
-        stroke: Stroke = None,
+        stroke: Stroke | None = None,
         useMinibuffer: bool = True,
     ) -> None:
         """Convenience method mapping k.getArg to ga.get_arg."""
@@ -3198,7 +3198,7 @@ class KeyHandlerClass:
 
     # @+node:ekr.20061031131434.130: *4* k.keyboardQuit
     @cmd('keyboard-quit')
-    def keyboardQuit(self, event: LeoKeyEvent = None, setFocus: bool = True) -> None:
+    def keyboardQuit(self, event: LeoKeyEvent | None = None, setFocus: bool = True) -> None:
         """Clears the state and the minibuffer label."""
         c, k = self.c, self
         ac = k.autoCompleter
@@ -3288,9 +3288,9 @@ class KeyHandlerClass:
         func: Callable,
         *,
         allowBinding: bool = False,
-        fileName: str = None,
+        fileName: str | None = None,
         pane: str = 'all',
-        shortcut: str = None,  # Must be None unless allowBindings is True.
+        shortcut: str | None = None,  # Must be None unless allowBindings is True.
         **kwargs: KWargs,  # Used only to warn about deprecated kwargs.
     ) -> None:
         """
@@ -3382,7 +3382,7 @@ class KeyHandlerClass:
                         break
 
     # @+node:ekr.20061031131434.127: *4* k.simulateCommand
-    def simulateCommand(self, commandName: str, event: LeoKeyEvent = None) -> Value:
+    def simulateCommand(self, commandName: str, event: LeoKeyEvent | None = None) -> Value:
         """
         Execute a Leo command by name.
 
@@ -3397,8 +3397,8 @@ class KeyHandlerClass:
     def getFileName(
         self,
         event: LeoKeyEvent,
-        callback: Callable = None,
-        filterExt: list[str] = None,
+        callback: Callable | None = None,
+        filterExt: list[str] | None = None,
         prompt: str = 'Enter File Name: ',
         tabName: str = 'Dired',
     ) -> None:
@@ -4072,7 +4072,7 @@ class KeyHandlerClass:
                 k.setLabel(label, protect=protect)
 
     # @+node:ekr.20061031170011.11: *4* k.setLabelGrey
-    def setLabelGrey(self, label: str = None) -> None:
+    def setLabelGrey(self, label: str | None = None) -> None:
         k, w = self, self.w
         if not w:
             return
@@ -4083,7 +4083,7 @@ class KeyHandlerClass:
     setLabelGray = setLabelGrey
 
     # @+node:ekr.20080510153327.2: *4* k.setLabelRed
-    def setLabelRed(self, label: str = None, protect: bool = False) -> None:
+    def setLabelRed(self, label: str | None = None, protect: bool = False) -> None:
         k, w = self, self.w
         if not w:
             return
@@ -4140,7 +4140,7 @@ class KeyHandlerClass:
         # Create the callback functions and update c.commandsDict.
         for key in d.keys():
 
-            def enterModeCallback(event: LeoKeyEvent = None, name: str = key) -> None:
+            def enterModeCallback(event: LeoKeyEvent | None = None, name: str = key) -> None:
                 k.enterNamedMode(event, name)
 
             c.commandsDict[key] = enterModeCallback
@@ -4209,7 +4209,7 @@ class KeyHandlerClass:
 
     # @+node:ekr.20061031131434.161: *4* k.exitNamedMode
     @cmd('exit-named-mode')
-    def exitNamedMode(self, event: LeoKeyEvent = None) -> None:
+    def exitNamedMode(self, event: LeoKeyEvent | None = None) -> None:
         """Exit an input mode."""
         k = self
         if k.inState():
@@ -4220,11 +4220,11 @@ class KeyHandlerClass:
     def generalModeHandler(
         self,
         event: LeoKeyEvent,
-        commandName: str = None,
-        func: Callable = None,
-        modeName: str = None,
-        nextMode: str = None,
-        prompt: str = None,
+        commandName: str | None = None,
+        func: Callable | None = None,
+        modeName: str | None = None,
+        nextMode: str | None = None,
+        prompt: str | None = None,
     ) -> None:
         """Handle a mode defined by an @mode node in leoSettings.leo."""
         c, k = self.c, self
@@ -4473,7 +4473,7 @@ class KeyHandlerClass:
         return self.state.kind
 
     # @+node:ekr.20061031131434.198: *4* k.inState
-    def inState(self, kind: str = None) -> bool:
+    def inState(self, kind: str | None = None) -> bool:
         k = self
         if kind:
             return k.state.kind == kind and k.state.n is not None
@@ -4497,7 +4497,7 @@ class KeyHandlerClass:
         k.unboundKeyAction = state
 
     # @+node:ekr.20061031131434.199: *4* k.setState
-    def setState(self, kind: str, n: int, handler: Callable = None) -> None:
+    def setState(self, kind: str, n: int, handler: Callable | None = None) -> None:
         k = self
         if kind and n is not None:
             k.state.kind = kind
@@ -4511,8 +4511,8 @@ class KeyHandlerClass:
     # @+node:ekr.20061031131434.192: *4* k.showStateAndMode
     def showStateAndMode(
         self,
-        w: QTextMixin = None,
-        prompt: str = None,
+        w: QTextMixin | None = None,
+        prompt: str | None = None,
         setFocus: bool = True,
     ) -> None:
         """Show the state and mode at the start of the minibuffer."""
@@ -4653,7 +4653,7 @@ class ModeInfo:
         c = self.c
         key = 'enter-' + self.name.replace(' ', '-')
 
-        def enterModeCallback(event: LeoKeyEvent = None, self: ModeInfo = self) -> None:
+        def enterModeCallback(event: LeoKeyEvent | None = None, self: ModeInfo = self) -> None:
             self.enterMode()
 
         c.commandsDict[key] = f = enterModeCallback

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -46,7 +46,7 @@ sphinx_build = which('sphinx-build')
 # @+node:ekr.20191006153522.1: ** adoc, pandoc & sphinx commands
 # @+node:ekr.20190515070742.22: *3* @g.command: 'adoc' & 'adoc-with-preview')
 @g.command('adoc')
-def adoc_command(event: LeoKeyEvent = None, verbose: bool = True) -> File_List:
+def adoc_command(event: LeoKeyEvent | None = None, verbose: bool = True) -> File_List:
     # @+<< adoc command docstring >>
     # @+node:ekr.20190515115100.1: *4* << adoc command docstring >>
     """
@@ -107,7 +107,7 @@ def adoc_command(event: LeoKeyEvent = None, verbose: bool = True) -> File_List:
 
 
 @g.command('adoc-with-preview')
-def adoc_with_preview_command(event: LeoKeyEvent = None, verbose: bool = True) -> File_List:
+def adoc_with_preview_command(event: LeoKeyEvent | None = None, verbose: bool = True) -> File_List:
     """Run the adoc command, then show the result in the browser."""
     c = event and event.get('c')
     if not c:
@@ -169,7 +169,7 @@ def pandoc_command(event: LeoKeyEvent, verbose: bool = True) -> File_List:
 
 @g.command('pandoc-with-preview')
 def pandoc_with_preview_command(
-    event: LeoKeyEvent = None,
+    event: LeoKeyEvent | None = None,
     verbose: bool = True,
 ) -> File_List:
     """Run the pandoc command, then show the result in the browser."""
@@ -233,7 +233,7 @@ def sphinx_command(event: LeoKeyEvent, verbose: bool = True) -> File_List:
 
 @g.command('sphinx-with-preview')
 def sphinx_with_preview_command(
-    event: LeoKeyEvent = None,
+    event: LeoKeyEvent | None = None,
     verbose: bool = True,
 ) -> File_List:
     """Run the sphinx command, then show the result in the browser."""
@@ -542,7 +542,7 @@ class MarkupCommands:
     # @+node:ekr.20191006155051.1: *3* markup.commands
     def adoc_command(
         self,
-        event: LeoKeyEvent = None,
+        event: LeoKeyEvent | None = None,
         preview: bool = False,
         verbose: bool = True,
     ) -> File_List:
@@ -555,7 +555,7 @@ class MarkupCommands:
 
     def pandoc_command(
         self,
-        event: LeoKeyEvent = None,
+        event: LeoKeyEvent | None = None,
         preview: bool = False,
         verbose: bool = True,
     ) -> File_List:
@@ -568,7 +568,7 @@ class MarkupCommands:
 
     def sphinx_command(
         self,
-        event: LeoKeyEvent = None,
+        event: LeoKeyEvent | None = None,
         preview: bool = False,
         verbose: bool = True,
     ) -> File_List:

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -240,7 +240,7 @@ class LeoMenu:
 
     # @+node:ekr.20070927172712: *6* LeoMenu.handleSpecialMenus
     def handleSpecialMenus(
-        self, name: str, parentName: str, alt_name: str = None, table: list = None
+        self, name: str, parentName: str, alt_name: str | None = None, table: list | None = None
     ) -> bool:
         """
         Handle a special menu if name is the name of a special menu.
@@ -355,7 +355,7 @@ class LeoMenu:
         # The command must be a callable.
         if not callable(command):
 
-            def dummy_menu_callback(event: LeoKeyEvent = None) -> None:
+            def dummy_menu_callback(event: LeoKeyEvent | None = None) -> None:
                 pass
 
             g.trace(f"bad command: {command!r}", color='red')
@@ -459,7 +459,7 @@ class LeoMenu:
 
     # @+node:ekr.20031218072017.3804: *4* LeoMenu.createNewMenu
     def createNewMenu(
-        self, menuName: str, parentName: str = "top", before: str = None
+        self, menuName: str, parentName: str = "top", before: str | None = None
     ) -> QtMenuWrapper:
         try:
             parent = self.getMenu(parentName)  # parent may be None.
@@ -574,11 +574,11 @@ class LeoMenu:
                 )
 
     # @+node:ekr.20031218072017.4118: *6* LeoMenu.defineOpenWithMenuCallback
-    def defineOpenWithMenuCallback(self, d: dict[str, Any] = None) -> Callable:
+    def defineOpenWithMenuCallback(self, d: dict[str, Any] | None = None) -> Callable:
         # The first parameter must be a LeoKeyEvent, and it must default to None.
 
         def openWithMenuCallback(
-            event: LeoKeyEvent = None,
+            event: LeoKeyEvent | None = None,
             self: LeoMenu = self,
             d: dict[str, Any] = d,
         ) -> Any:
@@ -669,9 +669,9 @@ class LeoMenu:
         self,
         menu: QtMenuWrapper,
         accelerator: str = '',
-        command: Callable = None,
-        commandName: str = None,
-        label: str = None,
+        command: Callable | None = None,
+        commandName: str | None = None,
+        label: str | None = None,
         underline: int = 0,
     ) -> None:
         pass
@@ -694,7 +694,7 @@ class LeoMenu:
         position: int,
         label: str,
         command: Callable,
-        underline: int = None,
+        underline: int | None = None,
     ) -> None:
         pass
 

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -560,7 +560,7 @@ class Position:
                 p.moveToThreadNext()
 
     # @+node:ekr.20161120163203.1: *4* p.nearest_unique_roots (aka p.nearest)
-    def nearest_unique_roots(self, copy: bool = True, predicate: Callable = None) -> Generator:
+    def nearest_unique_roots(self, copy: bool = True, predicate: Callable | None = None) -> Generator:
         """
         A generator yielding all unique root positions "near" p1 = self that
         satisfy the given predicate. p.isAnyAtFileNode is the default
@@ -2724,7 +2724,7 @@ class VNode:
             pass
 
     # @+node:ekr.20191213161023.1: *4* v.setAllAncestorAtFileNodesDirty
-    def setAllAncestorAtFileNodesDirty(self, *, to_do_set: set[VNode] = None) -> None:
+    def setAllAncestorAtFileNodesDirty(self, *, to_do_set: set[VNode] | None = None) -> None:
         """
         Original idea by Виталије Милошевић (Vitalije Milosevic).
 

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -67,7 +67,7 @@ class CommandChainDispatcher:
 
     """
 
-    def __init__(self, commands: list = None) -> None:
+    def __init__(self, commands: list | None = None) -> None:
         if commands is None:
             self.chain = []
         else:
@@ -255,7 +255,7 @@ class BaseLeoPlugin:
 
     # @+node:ekr.20100908125007.6014: *3* BaseLeoPlugin.setMenuItem
     def setMenuItem(
-        self, menu: LeoQtMenu, commandName: str = None, handler: Callable = None
+        self, menu: LeoQtMenu, commandName: str | None = None, handler: Callable | None = None
     ) -> None:
         """Create a menu item in 'menu' using text 'commandName' calling handler 'handler'
         if commandName and handler are none, use the most recently defined values
@@ -273,7 +273,7 @@ class BaseLeoPlugin:
         self.c.frame.menu.createMenuItemsFromTable(menu, table)
 
     # @+node:ekr.20100908125007.6015: *3* BaseLeoPlugin.setButton
-    def setButton(self, buttonText: str = None, commandName: str = None, color: str = None) -> None:
+    def setButton(self, buttonText: str | None = None, commandName: str | None = None, color: str | None = None) -> None:
         """Associate an existing command with a 'button'"""
         if buttonText is None:
             buttonText = self.commandName

--- a/leo/core/leoPrinting.py
+++ b/leo/core/leoPrinting.py
@@ -78,7 +78,7 @@ class PrintingController:
         return doc
 
     # @+node:ekr.20150419124739.9: *4* pr.document
-    def document(self, text: str, head: str = None) -> QtGui.QTextDocument:
+    def document(self, text: str, head: str | None = None) -> QtGui.QTextDocument:
         """Create a Qt document."""
         doc = QtGui.QTextDocument()
         doc.setDefaultStyleSheet(self.stylesheet)
@@ -127,14 +127,14 @@ class PrintingController:
     # @+node:ekr.20150420081215.1: *3* pr.Preview
     # @+node:ekr.20150419124739.21: *4* pr.preview_body
     @cmd('preview-body')
-    def preview_body(self, event: LeoKeyEvent = None) -> None:
+    def preview_body(self, event: LeoKeyEvent | None = None) -> None:
         """Preview the body of the selected node."""
         doc = self.document(self.c.p.b)
         self.preview_doc(doc)
 
     # @+node:ekr.20150419124739.19: *4* pr.preview_html
     @cmd('preview-html')
-    def preview_html(self, event: LeoKeyEvent = None) -> None:
+    def preview_html(self, event: LeoKeyEvent | None = None) -> None:
         """
         Preview the body of the selected text as html. The body must be valid
         html, including <html> and <body> elements.
@@ -144,14 +144,14 @@ class PrintingController:
 
     # @+node:peckj.20150421084706.1: *4* pr.preview_expanded_body
     @cmd('preview-expanded-body')
-    def preview_expanded_body(self, event: LeoKeyEvent = None) -> None:
+    def preview_expanded_body(self, event: LeoKeyEvent | None = None) -> None:
         """Preview the selected node's body, expanded"""
         doc = self.document(self.expand(self.c.p))
         self.preview_doc(doc)
 
     # @+node:peckj.20150421084719.1: *4* pr.preview_expanded_html
     @cmd('preview-expanded-html')
-    def preview_expanded_html(self, event: LeoKeyEvent = None) -> None:
+    def preview_expanded_html(self, event: LeoKeyEvent | None = None) -> None:
         """
         Preview all the expanded bodies of the selected node as html. The
         expanded text must be valid html, including <html> and <body> elements.
@@ -161,7 +161,7 @@ class PrintingController:
 
     # @+node:ekr.20150419124739.31: *4* pr.preview_marked_bodies
     @cmd('preview-marked-bodies')
-    def preview_marked_bodies(self, event: LeoKeyEvent = None) -> None:
+    def preview_marked_bodies(self, event: LeoKeyEvent | None = None) -> None:
         """Preview the bodies of the marked nodes."""
         nodes = [p.v for p in self.c.all_positions() if p.isMarked()]
         doc = self.complex_document(nodes)
@@ -169,7 +169,7 @@ class PrintingController:
 
     # @+node:ekr.20150420081906.1: *4* pr.preview_marked_html
     @cmd('preview-marked-html')
-    def preview_marked_html(self, event: LeoKeyEvent = None) -> None:
+    def preview_marked_html(self, event: LeoKeyEvent | None = None) -> None:
         """
         Preview the concatenated bodies of the marked nodes. The concatenated
         bodies must be valid html, including <html> and <body> elements.
@@ -181,7 +181,7 @@ class PrintingController:
 
     # @+node:ekr.20150419124739.33: *4* pr.preview_marked_nodes
     @cmd('preview-marked-nodes')
-    def preview_marked_nodes(self, event: LeoKeyEvent = None) -> None:
+    def preview_marked_nodes(self, event: LeoKeyEvent | None = None) -> None:
         """Preview the marked nodes."""
         nodes = [p.v for p in self.c.all_positions() if p.isMarked()]
         doc = self.complex_document(nodes, heads=True)
@@ -189,7 +189,7 @@ class PrintingController:
 
     # @+node:ekr.20150419124739.23: *4* pr.preview_node
     @cmd('preview-node')
-    def preview_node(self, event: LeoKeyEvent = None) -> None:
+    def preview_node(self, event: LeoKeyEvent | None = None) -> None:
         """Preview the selected node."""
         p = self.c.p
         doc = self.document(p.b, head=p.h)
@@ -197,14 +197,14 @@ class PrintingController:
 
     # @+node:ekr.20150419124739.26: *4* pr.preview_tree_bodies
     @cmd('preview-tree-bodies')
-    def preview_tree_bodies(self, event: LeoKeyEvent = None) -> None:
+    def preview_tree_bodies(self, event: LeoKeyEvent | None = None) -> None:
         """Preview the bodies in the selected tree."""
         doc = self.document(self.getBodies(self.c.p))
         self.preview_doc(doc)
 
     # @+node:ekr.20150419124739.28: *4* pr.preview_tree_nodes
     @cmd('preview-tree-nodes')
-    def preview_tree_nodes(self, event: LeoKeyEvent = None) -> None:
+    def preview_tree_nodes(self, event: LeoKeyEvent | None = None) -> None:
         """Preview the entire tree."""
         p = self.c.p
         doc = self.document(self.getNodes(p), head=p.h)
@@ -212,7 +212,7 @@ class PrintingController:
 
     # @+node:ekr.20150420081923.1: *4* pr_preview_tree_html
     @cmd('preview-tree-html')
-    def preview_tree_html(self, event: LeoKeyEvent = None) -> None:
+    def preview_tree_html(self, event: LeoKeyEvent | None = None) -> None:
         """
         Preview all the bodies of the selected node as html. The concatenated
         bodies must valid html, including <html> and <body> elements.
@@ -223,14 +223,14 @@ class PrintingController:
     # @+node:ekr.20150420073128.1: *3* pr.Print
     # @+node:ekr.20150419124739.20: *4* pr.print_body
     @cmd('print-body')
-    def print_body(self, event: LeoKeyEvent = None) -> None:
+    def print_body(self, event: LeoKeyEvent | None = None) -> None:
         """Print the selected node's body"""
         doc = self.document(self.c.p.b)
         self.print_doc(doc)
 
     # @+node:ekr.20150419124739.18: *4* pr.print_html
     @cmd('print-html')
-    def print_html(self, event: LeoKeyEvent = None) -> None:
+    def print_html(self, event: LeoKeyEvent | None = None) -> None:
         """
         Print the body of the selected text as html. The body must be valid
         html, including <html> and <body> elements.
@@ -240,14 +240,14 @@ class PrintingController:
 
     # @+node:peckj.20150421084548.1: *4* pr.print_expanded_body
     @cmd('print-expanded-body')
-    def print_expanded_body(self, event: LeoKeyEvent = None) -> None:
+    def print_expanded_body(self, event: LeoKeyEvent | None = None) -> None:
         """Print the selected node's body, expanded"""
         doc = self.document(self.expand(self.c.p))
         self.print_doc(doc)
 
     # @+node:peckj.20150421084636.1: *4* pr.print_expanded_html
     @cmd('print-expanded-html')
-    def print_expanded_html(self, event: LeoKeyEvent = None) -> None:
+    def print_expanded_html(self, event: LeoKeyEvent | None = None) -> None:
         """
         Preview all the expanded bodies of the selected node as html. The
         expanded text must be valid html, including <html> and <body> elements.
@@ -257,7 +257,7 @@ class PrintingController:
 
     # @+node:ekr.20150419124739.30: *4* pr.print_marked_bodies
     @cmd('print-marked-bodies')
-    def print_marked_bodies(self, event: LeoKeyEvent = None) -> None:
+    def print_marked_bodies(self, event: LeoKeyEvent | None = None) -> None:
         """Print the body text of marked nodes."""
         nodes = [p.v for p in self.c.all_positions() if p.isMarked()]
         doc = self.complex_document(nodes)
@@ -265,7 +265,7 @@ class PrintingController:
 
     # @+node:ekr.20150420085054.1: *4* pr.print_marked_html
     @cmd('print-marked-html')
-    def print_marked_html(self, event: LeoKeyEvent = None) -> None:
+    def print_marked_html(self, event: LeoKeyEvent | None = None) -> None:
         """
         Print the concatenated bodies of the marked nodes. The concatenated
         bodies must be valid html, including <html> and <body> elements.
@@ -277,7 +277,7 @@ class PrintingController:
 
     # @+node:ekr.20150419124739.32: *4* pr.print_marked_nodes
     @cmd('print-marked-nodes')
-    def print_marked_nodes(self, event: LeoKeyEvent = None) -> None:
+    def print_marked_nodes(self, event: LeoKeyEvent | None = None) -> None:
         """Print all the marked nodes"""
         nodes = [p.v for p in self.c.all_positions() if p.isMarked()]
         doc = self.complex_document(nodes, heads=True)
@@ -285,21 +285,21 @@ class PrintingController:
 
     # @+node:ekr.20150419124739.22: *4* pr.print_node
     @cmd('print-node')
-    def print_node(self, event: LeoKeyEvent = None) -> None:
+    def print_node(self, event: LeoKeyEvent | None = None) -> None:
         """Print the selected node"""
         doc = self.document(self.c.p.b, head=self.c.p.h)
         self.print_doc(doc)
 
     # @+node:ekr.20150419124739.25: *4* pr.print_tree_bodies
     @cmd('print-tree-bodies')
-    def print_tree_bodies(self, event: LeoKeyEvent = None) -> None:
+    def print_tree_bodies(self, event: LeoKeyEvent | None = None) -> None:
         """Print all the bodies in the selected tree."""
         doc = self.document(self.getBodies(self.c.p))
         self.print_doc(doc)
 
     # @+node:ekr.20150420084948.1: *4* pr.print_tree_html
     @cmd('print-tree-html')
-    def print_tree_html(self, event: LeoKeyEvent = None) -> None:
+    def print_tree_html(self, event: LeoKeyEvent | None = None) -> None:
         """
         Print all the bodies of the selected node as html. The concatenated
         bodies must valid html, including <html> and <body> elements.
@@ -309,7 +309,7 @@ class PrintingController:
 
     # @+node:ekr.20150419124739.27: *4* pr.print_tree_nodes
     @cmd('print-tree-nodes')
-    def print_tree_nodes(self, event: LeoKeyEvent = None) -> None:
+    def print_tree_nodes(self, event: LeoKeyEvent | None = None) -> None:
         """Print all the nodes of the selected tree."""
         doc = self.document(self.getNodes(self.c.p), head=self.c.p.h)
         self.print_doc(doc)

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -140,7 +140,7 @@ class RstCommands:
     # @+node:ekr.20210403150303.1: *4* rst.rst-convert-legacy-outline
     @cmd('rst-convert-legacy-outline')
     @cmd('convert-legacy-rst-outline')
-    def convert_legacy_outline(self, event: LeoKeyEvent = None) -> None:
+    def convert_legacy_outline(self, event: LeoKeyEvent | None = None) -> None:
         """
         Convert @rst-preformat nodes and `@ @rst-options` doc parts.
         """
@@ -179,7 +179,7 @@ class RstCommands:
 
     # @+node:ekr.20090511055302.5793: *4* rst.rst3 command & helpers
     @cmd('rst3')
-    def rst3(self, event: LeoKeyEvent = None) -> int:
+    def rst3(self, event: LeoKeyEvent | None = None) -> int:
         """Write all @rst nodes."""
         t1 = time.time()
         self.n_intermediate = self.n_docutils = 0
@@ -559,7 +559,7 @@ class RstCommands:
         return result
 
     # @+node:ekr.20090502071837.66: *6* rst.handleMissingStyleSheetArgs
-    def handleMissingStyleSheetArgs(self, s: str = None) -> dict[str, str]:
+    def handleMissingStyleSheetArgs(self, s: str | None = None) -> dict[str, str]:
         """
         Parse the publish_argv_for_missing_stylesheets option,
         returning a dict containing the parsed args.

--- a/leo/core/leoSessions.py
+++ b/leo/core/leoSessions.py
@@ -61,7 +61,7 @@ class SessionManager:
         return None
 
     # @+node:ekr.20120420054855.14247: *3* SessionManager.load_session
-    def load_session(self, c: Cmdr = None, unls: list[str] = None) -> None:
+    def load_session(self, c: Cmdr | None = None, unls: list[str] | None = None) -> None:
         """
         Open a tab for each item in UNLs & select the indicated node in each.
 

--- a/leo/core/leoShadow.py
+++ b/leo/core/leoShadow.py
@@ -211,7 +211,7 @@ class ShadowController:
         new_public_lines: list[str],
         old_private_lines: list[str],
         marker: Marker,
-        p: Position = None,
+        p: Position | None = None,
     ) -> list[str]:
         # @+<< docstring >>
         # @+node:ekr.20150207044400.9: *5*  << docstring >>

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -172,7 +172,7 @@ class LeoUnitTest(unittest.TestCase):
             print(f"{p.gnx:<28} {head_s:<20} body: {p.b!r}")
 
     # @+node:ekr.20230720210931.1: *4* LeoUnitTest.dump_clone_info
-    def dump_clone_info(self, c: Cmdr, tag: str = None) -> None:
+    def dump_clone_info(self, c: Cmdr, tag: str | None = None) -> None:
         """Dump all clone info."""
         print('')
         g.trace(f"{tag or ''} {c.fileName()}")
@@ -184,7 +184,7 @@ class LeoUnitTest(unittest.TestCase):
             )
 
     # @+node:ekr.20220805071838.1: *4* LeoUnitTest.dump_headlines
-    def dump_headlines(self, c: Cmdr, tag: str = None) -> None:  # pragma: no cover
+    def dump_headlines(self, c: Cmdr, tag: str | None = None) -> None:  # pragma: no cover
         """Dump all headlines."""
         print('')
         g.trace(f"{tag or ''} {c.fileName()}")
@@ -193,13 +193,13 @@ class LeoUnitTest(unittest.TestCase):
             print(f"{p.gnx:25}: {' ' * p.level()}{p.h}")
 
     # @+node:ekr.20220806170537.1: *4* LeoUnitTest.dump_string
-    def dump_string(self, s: str, tag: str = None) -> None:
+    def dump_string(self, s: str, tag: str | None = None) -> None:
         if tag:
             print(tag)
         g.printObj([f"{i:2} {z.rstrip()}" for i, z in enumerate(g.splitLines(s))])
 
     # @+node:ekr.20211129062220.1: *4* LeoUnitTest.dump_tree
-    def dump_tree(self, root: Position = None, tag: str = None) -> None:  # pragma: no cover
+    def dump_tree(self, root: Position | None = None, tag: str | None = None) -> None:  # pragma: no cover
         """
         Dump root's tree, or the entire tree if root is None.
         """

--- a/leo/core/leoTips.py
+++ b/leo/core/leoTips.py
@@ -59,7 +59,7 @@ class TipManager:
 class UserTip:
     """A User Tip."""
 
-    def __init__(self, n: int = 0, tags: list[str] = None, text: str = '', title: str = '') -> None:
+    def __init__(self, n: int = 0, tags: list[str] | None = None, text: str = '', title: str = '') -> None:
         self.n = n  # Not used.
         self.tags: list[str] = tags or []  # Not used.
         self.title = title.strip()

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -867,7 +867,7 @@ class Undoer:
         self,
         p: Position,
         pasteAsClone: bool = False,
-        copiedBunchList: list[g.Bunch] = None,
+        copiedBunchList: list[g.Bunch] | None = None,
     ) -> g.Bunch:
         u = self
         if copiedBunchList is None:
@@ -978,10 +978,10 @@ class Undoer:
         undo_type: str,
         oldText: str,
         newText: str,
-        newInsert: int = None,
-        oldSel: tuple[int, int] = None,
-        newSel: tuple[int, int] = None,
-        oldYview: int = None,
+        newInsert: int | None = None,
+        oldSel: tuple[int, int] | None = None,
+        newSel: tuple[int, int] | None = None,
+        oldYview: int | None = None,
     ) -> None:
         """
         Save enough information to undo or redo a typing operation efficiently,
@@ -1400,7 +1400,7 @@ class Undoer:
 
     # @+node:ekr.20031218072017.2030: *3* u.redo
     @cmd('redo')
-    def redo(self, event: LeoKeyEvent = None) -> None:
+    def redo(self, event: LeoKeyEvent | None = None) -> None:
         """Redo the operation undone by the last undo."""
         c, u = self.c, self
         if not c.p:
@@ -1797,7 +1797,7 @@ class Undoer:
 
     # @+node:ekr.20031218072017.2039: *3* u.undo
     @cmd('undo')
-    def undo(self, event: LeoKeyEvent = None) -> None:
+    def undo(self, event: LeoKeyEvent | None = None) -> None:
         """Undo the operation described by the undo parameters."""
         c, u = self.c, self
         if not c.p:
@@ -2190,7 +2190,7 @@ class Undoer:
         oldNewlines: list[str],
         newNewlines: list[str],  # Number of trailing newlines.
         tag: str = "undo",  # "undo" or "redo"
-        undoType: str = None,
+        undoType: str | None = None,
     ) -> None:
         """Handle text undo and redo: converts _new_ text into _old_ text."""
         # newNewlines is unused, but it has symmetry.

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -502,7 +502,7 @@ class VimCommands:
 
     # @+node:ekr.20140803220119.18097: *4* direct acceptance methods
     # @+node:ekr.20140802225657.18031: *5* vc.accept
-    def accept(self, add_to_dot: bool = True, handler: Callable = None) -> None:
+    def accept(self, add_to_dot: bool = True, handler: Callable | None = None) -> None:
         """
         Accept the present stroke.
         Optionally, this can set the dot or change self.handler.
@@ -535,7 +535,7 @@ class VimCommands:
         add_to_dot: bool = True,
         return_value: bool = True,
         set_dot: bool = True,
-        stroke: Stroke = None,
+        stroke: Stroke | None = None,
     ) -> None:
         """Complete a command, preserving text and optionally updating the dot."""
         self.do_trace()
@@ -627,7 +627,7 @@ class VimCommands:
 
     # @+node:ekr.20140802225657.18034: *4* indirect acceptance methods
     # @+node:ekr.20140222064735.16709: *5* vc.begin_insert_mode
-    def begin_insert_mode(self, i: int = None, w: QTextMixin = None) -> None:
+    def begin_insert_mode(self, i: int | None = None, w: QTextMixin | None = None) -> None:
         """Common code for beginning insert mode."""
         self.do_trace()
         # c = self.c
@@ -2043,7 +2043,7 @@ class VimCommands:
 
         # @+others
         # @+node:ekr.20140820034724.18316: *5* :r.__call__
-        def __call__(self, event: QEvent = None) -> None:
+        def __call__(self, event: QEvent | None = None) -> None:
             """Prompt for a file name, then load it at the cursor."""
             self.vc.c.k.getFileName(event, callback=self.load_file_at_cursor)
 
@@ -2083,7 +2083,7 @@ class VimCommands:
 
         # @+others
         # @+node:ekr.20140820063930.18321: *5* Substitution.__call__ (:%s & :s)
-        def __call__(self, event: QEvent = None) -> None:
+        def __call__(self, event: QEvent | None = None) -> None:
             """Handle the :s and :%s commands. Neither command affects the dot."""
             vc = self.vc
             c, w = vc.c, vc.w
@@ -2121,7 +2121,7 @@ class VimCommands:
 
         # @+others
         # @+node:ekr.20140820034724.18313: *5* :tabnew.__call__
-        def __call__(self, event: QEvent = None) -> None:
+        def __call__(self, event: QEvent | None = None) -> None:
             """Prompt for a file name, the open a new Leo tab."""
             self.vc.c.k.getFileName(event, callback=self.open_file_by_name)
 
@@ -2154,16 +2154,16 @@ class VimCommands:
 
     # @+node:ekr.20150509050905.1: *4* vc.e_command & tabnew_command
     @cmd(':e')
-    def e_command(self, event: LeoKeyEvent = None) -> None:
+    def e_command(self, event: LeoKeyEvent | None = None) -> None:
         self.Tabnew(self)
 
     @cmd(':tabnew')
-    def tabnew_command(self, event: LeoKeyEvent = None) -> None:
+    def tabnew_command(self, event: LeoKeyEvent | None = None) -> None:
         self.Tabnew(self)
 
     # @+node:ekr.20140815160132.18824: *4* vc.print_dot (:print-dot)
     @cmd(':print-dot')
-    def print_dot(self, event: LeoKeyEvent = None) -> None:
+    def print_dot(self, event: LeoKeyEvent | None = None) -> None:
         """Print the dot."""
         aList = [z.stroke if isinstance(z, VimEvent) else z for z in self.dot_list]
         aList = [show_stroke(self.c.k.stroke2char(z)) for z in aList]
@@ -2177,12 +2177,12 @@ class VimCommands:
 
     # @+node:ekr.20140815160132.18825: *4* vc.q/qa_command & quit_now (:q & q! & :qa)
     @cmd(':q')
-    def q_command(self, event: LeoKeyEvent = None) -> None:
+    def q_command(self, event: LeoKeyEvent | None = None) -> None:
         """Quit the present Leo outline, prompting for saves."""
         g.app.closeLeoWindow(self.c.frame, new_c=None)
 
     @cmd(':qa')
-    def qa_command(self, event: LeoKeyEvent = None) -> None:
+    def qa_command(self, event: LeoKeyEvent | None = None) -> None:
         """Quit only if there are no unsaved changes."""
         for c in g.app.commanders():
             if c.isChanged():
@@ -2190,33 +2190,33 @@ class VimCommands:
         g.app.onQuit(event)
 
     @cmd(':q!')
-    def quit_now(self, event: LeoKeyEvent = None) -> None:
+    def quit_now(self, event: LeoKeyEvent | None = None) -> None:
         """Quit immediately."""
         g.app.forceShutdown()
 
     # @+node:ekr.20150509050918.1: *4* vc.r_command
     @cmd(':r')
-    def r_command(self, event: LeoKeyEvent = None) -> None:
+    def r_command(self, event: LeoKeyEvent | None = None) -> None:
         self.LoadFileAtCursor(self)
 
     # @+node:ekr.20140815160132.18826: *4* vc.revert (:e!)
     @cmd(':e!')
-    def revert(self, event: LeoKeyEvent = None) -> None:
+    def revert(self, event: LeoKeyEvent | None = None) -> None:
         """Revert all changes to a .leo file, prompting if there have been changes."""
         self.c.revert()
 
     # @+node:ekr.20150509050755.1: *4* vc.s_command & percent_s_command
     @cmd(':%s')
-    def percent_s_command(self, event: LeoKeyEvent = None) -> None:
+    def percent_s_command(self, event: LeoKeyEvent | None = None) -> None:
         self.Substitution(self, all_lines=True)
 
     @cmd(':s')
-    def s_command(self, event: LeoKeyEvent = None) -> None:
+    def s_command(self, event: LeoKeyEvent | None = None) -> None:
         self.Substitution(self, all_lines=False)
 
     # @+node:ekr.20140815160132.18827: *4* vc.shell_command (:!)
     @cmd(':!')
-    def shell_command(self, event: LeoKeyEvent = None) -> None:
+    def shell_command(self, event: LeoKeyEvent | None = None) -> None:
         """Execute a shell command."""
         c, k = self.c, self.c.k
         if k.functionTail:
@@ -2229,7 +2229,7 @@ class VimCommands:
 
     # @+node:ekr.20140815160132.18830: *4* vc.toggle_vim_mode
     @cmd(':toggle-vim-mode')
-    def toggle_vim_mode(self, event: LeoKeyEvent = None) -> None:
+    def toggle_vim_mode(self, event: LeoKeyEvent | None = None) -> None:
         """toggle vim-mode."""
         c = self.c
         c.vim_mode = not c.vim_mode
@@ -2249,7 +2249,7 @@ class VimCommands:
 
     # @+node:ekr.20140909140052.18128: *4* vc.toggle_vim_trace
     @cmd(':toggle-vim-trace')
-    def toggle_vim_trace(self, event: LeoKeyEvent = None) -> None:
+    def toggle_vim_trace(self, event: LeoKeyEvent | None = None) -> None:
         """toggle vim tracing."""
         self.trace_flag = not self.trace_flag
         val = 'On' if self.trace_flag else 'Off'
@@ -2257,7 +2257,7 @@ class VimCommands:
 
     # @+node:ekr.20140815160132.18831: *4* vc.toggle_vim_trainer_mode
     @cmd(':toggle-vim-trainer-mode')
-    def toggle_vim_trainer_mode(self, event: LeoKeyEvent = None) -> None:
+    def toggle_vim_trainer_mode(self, event: LeoKeyEvent | None = None) -> None:
         """toggle vim-trainer mode."""
         self.trainer = not self.trainer
         val = 'on' if self.trainer else 'off'
@@ -2265,19 +2265,19 @@ class VimCommands:
 
     # @+node:ekr.20140815160132.18832: *4* w/xa/wq_command (:w & :xa & wq)
     @cmd(':w')
-    def w_command(self, event: LeoKeyEvent = None) -> None:
+    def w_command(self, event: LeoKeyEvent | None = None) -> None:
         """Save the .leo file."""
         self.c.save()
 
     @cmd(':xa')
-    def xa_command(self, event: LeoKeyEvent = None) -> None:  # same as :xa
+    def xa_command(self, event: LeoKeyEvent | None = None) -> None:  # same as :xa
         """Save all open files and keep working."""
         for c in g.app.commanders():
             if c.isChanged():
                 c.save()
 
     @cmd(':wq')
-    def wq_command(self, event: LeoKeyEvent = None) -> None:
+    def wq_command(self, event: LeoKeyEvent | None = None) -> None:
         """Save all open files and exit."""
         for c in g.app.commanders():
             c.save()
@@ -2390,7 +2390,7 @@ class VimCommands:
 
     # @+node:ekr.20140222064735.16682: *3* vc.Utilities
     # @+node:ekr.20140802183521.17998: *4* vc.add_to_dot
-    def add_to_dot(self, stroke: Stroke = None) -> None:
+    def add_to_dot(self, stroke: Stroke | None = None) -> None:
         """
         Add a new VimEvent to self.command_list.
         Never change self.command_list if self.in_dot is True
@@ -2412,7 +2412,7 @@ class VimCommands:
             self.dot_list = self.command_list[:]
 
     # @+node:ekr.20140810214537.18241: *4* vc.do
-    def do(self, o: Any, event: LeoKeyEvent = None) -> None:
+    def do(self, o: Any, event: LeoKeyEvent | None = None) -> None:
         """Do one or more Leo commands by name."""
         if not event:
             event = self.event
@@ -2453,7 +2453,7 @@ class VimCommands:
         """Return True if stroke is a plain key."""
         return self.k.isPlainKey(stroke)
 
-    def is_text_wrapper(self, w: QTextMixin = None) -> bool:
+    def is_text_wrapper(self, w: QTextMixin | None = None) -> bool:
         """Return True if w is a text widget."""
         return self.is_body(w) or self.is_head(w) or g.isTextWrapper(w)
 
@@ -2517,9 +2517,9 @@ class VimCommands:
     # @+node:ekr.20140804123147.18929: *4* vc.set_border & helper
     def set_border(
         self,
-        kind: str = None,
-        w: QTextMixin = None,
-        activeFlag: bool = None,
+        kind: str | None = None,
+        w: QTextMixin | None = None,
+        activeFlag: bool | None = None,
     ) -> None:
         """
         Set the border color of self.w, depending on state.

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -355,7 +355,7 @@ class ServerExternalFilesController(ExternalFilesController):
     # @+node:felix.20210626222905.7: *3* sefc.utilities
     # @+node:felix.20210626222905.8: *4* sefc.ask
     # The base class returns str.
-    def ask(self, c: Cmdr, path: str, p: Position = None) -> bool:  # type:ignore
+    def ask(self, c: Cmdr, path: str, p: Position | None = None) -> bool:  # type:ignore
         """
         Ask user whether to overwrite an @<file> tree.
         Return True if the user agrees by default, or skips and asks
@@ -898,7 +898,7 @@ class QuickSearchController:
 
     # @+node:felix.20220225003906.20: *4* QSC.onSelectItem (from quicksearch.py)
     def onSelectItem(
-        self, it: Any, it_prev: Any = None
+        self, it: Any, it_prev: Any | None = None
     ) -> None:  # it_prev not used. Hard to annotate.
         c = self.c
         tgt = self.its.get(it)
@@ -1060,7 +1060,7 @@ class LeoServer:
         self.c.frame.tree.onHeadChanged(self.c.p)
 
     # @+node:felix.20210711194729.1: *4* LeoServer._runAskOkDialog
-    def _runAskOkDialog(self, c: Cmdr, title: str, message: str = None, text: str = "Ok") -> None:
+    def _runAskOkDialog(self, c: Cmdr, title: str, message: str | None = None, text: str = "Ok") -> None:
         """Create and run an askOK dialog ."""
         # Called by many commands in Leo
         if message:
@@ -1075,7 +1075,7 @@ class LeoServer:
         self,
         c: Cmdr,
         title: str,
-        message: str = None,
+        message: str | None = None,
         yes_all: bool = False,
         no_all: bool = False,
     ) -> str:
@@ -1102,12 +1102,12 @@ class LeoServer:
         self,
         c: Cmdr,
         title: str,
-        message: str = None,
+        message: str | None = None,
         yesMessage: str = "Yes",
         noMessage: str = "No",
-        yesToAllMessage: str = None,
+        yesToAllMessage: str | None = None,
         defaultButton: str = "Yes",
-        cancelMessage: str = None,
+        cancelMessage: str | None = None,
     ) -> str:
         """Create and run an askYesNoCancel dialog ."""
         # used in dangerous write with title: 'Overwrite existing file?'
@@ -4883,7 +4883,7 @@ class LeoServer:
         return p
 
     # @+node:felix.20210621233316.80: *4* server._check_c
-    def _check_c(self, param: Param = None) -> Cmdr:
+    def _check_c(self, param: Param | None = None) -> Cmdr:
         """
         Return self.c, or a specific commander chosen by id,
         or raise ServerError no commander found.
@@ -5320,7 +5320,7 @@ class LeoServer:
             return False
 
     # @+node:felix.20210621233316.94: *4* server._make_minimal_response
-    def _make_minimal_response(self, package: Package = None) -> str:
+    def _make_minimal_response(self, package: Package | None = None) -> str:
         """
         Return a json string representing a response dict.
 
@@ -5347,7 +5347,7 @@ class LeoServer:
         return json.dumps(package, separators=(',', ':'), cls=SetEncoder)
 
     # @+node:felix.20210621233316.93: *4* server._make_response
-    def _make_response(self, package: Package = None) -> str:
+    def _make_response(self, package: Package | None = None) -> str:
         """
         Return a json string representing a response dict.
 
@@ -5573,12 +5573,12 @@ def main() -> None:  # pragma: no cover (tested in client)
     def general_yes_no_dialog(
         c: Cmdr,
         title: str,  # Not used.
-        message: str = None,  # Must exist.
+        message: str | None = None,  # Must exist.
         yesMessage: str = "&Yes",  # Not used.
         noMessage: str = "&No",  # Not used.
-        yesToAllMessage: str = None,  # Not used.
+        yesToAllMessage: str | None = None,  # Not used.
         defaultButton: str = "Yes",  # Not used
-        cancelMessage: str = None,  # Not used.
+        cancelMessage: str | None = None,  # Not used.
     ) -> str:
         """
         Monkey-patched implementation of LeoQtGui.runAskYesNoCancelDialog
@@ -5616,14 +5616,14 @@ def main() -> None:  # pragma: no cover (tested in client)
                 b.pack(side="left", padx=5, pady=10)
 
             # @+node:ekr.20210801180311.5: *5* function: callbacks
-            def noButton(event: Event = None) -> None:
+            def noButton(event: Event | None = None) -> None:
                 """Do default click action in ok button."""
                 nonlocal val
                 print(f"Not saved: {c.fileName()}")
                 val = "no"
                 top.destroy()
 
-            def yesButton(event: Event = None) -> None:
+            def yesButton(event: Event | None = None) -> None:
                 """Do default click action in ok button."""
                 nonlocal val
                 print(f"Saved: {c.fileName()}")
@@ -5838,7 +5838,7 @@ def main() -> None:  # pragma: no cover (tested in client)
             wsLimit = 1
 
     # @+node:felix.20210803174312.1: *3* function: notify_clients
-    async def notify_clients(action: str, excludedConn: Any = None) -> None:
+    async def notify_clients(action: str, excludedConn: Any | None = None) -> None:
         if connectionsPool:  # asyncio.wait doesn't accept an empty list
             opened = bool(controller.c)  # c can be none if no files opened
             m = json.dumps(
@@ -5882,7 +5882,7 @@ def main() -> None:  # pragma: no cover (tested in client)
         await notify_clients("unregister")
 
     # @+node:felix.20210621233316.106: *3* function: ws_handler (server)
-    async def ws_handler(websocket: Any, path: Any = None) -> None:
+    async def ws_handler(websocket: Any, path: Any | None = None) -> None:
         """
         The web socket handler: server.ws_server.
 

--- a/leo/core/runLeo.py
+++ b/leo/core/runLeo.py
@@ -103,7 +103,7 @@ prof = profile_leo
 
 
 # @+node:ekr.20120219154958.10499: ** run (runLeo.py)
-def run(fileName=None, pymacs: bool = None, *args, **keywords):
+def run(fileName=None, pymacs: bool | None = None, *args, **keywords):
     """Initialize and run Leo"""
     # #1403: sys.excepthook doesn't help.
     # sys.excepthook = leo_excepthook

--- a/leo/core/tracing_utils.py
+++ b/leo/core/tracing_utils.py
@@ -113,7 +113,7 @@ def plural(obj: Any) -> str:
 
 
 # @+node:ekr.20230203163544.8: ** tracing_utils.print_obj
-def print_obj(obj: Any, tag: str = None, indent: int = 0) -> None:
+def print_obj(obj: Any, tag: str | None = None, indent: int = 0) -> None:
     """Pretty print any Python object."""
     print(to_string(obj, indent=indent, tag=tag))
 
@@ -149,7 +149,7 @@ def to_encoded_string(s: Any, encoding: str = 'utf-8') -> bytes:
 
 
 # @+node:ekr.20230203163544.11: ** tracing_utils.to_string
-def to_string(obj: Any, indent: int = 0, tag: str = None, width: int = 120) -> str:
+def to_string(obj: Any, indent: int = 0, tag: str | None = None, width: int = 120) -> str:
     """
     Pretty print any Python object to a string.
     """

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -419,9 +419,9 @@ class textLeoMenu(leoMenu.LeoMenu):
         self,
         menu: Any,
         accelerator: str = '',
-        command: Callable = None,
-        commandName: str = None,
-        label: str = None,
+        command: Callable | None = None,
+        commandName: str | None = None,
+        label: str | None = None,
         underline: int = 0,
     ) -> None:
         # ?
@@ -555,7 +555,7 @@ class textTree(leoFrame.LeoTree):
         # and something to do with undo?
 
     # @+node:ekr.20150107090324.66: *3* editLabel & edit_widget (cursesGui)
-    def editLabel(self, v, selectAll: bool = False, selection: tuple = None) -> tuple[None, None]:
+    def editLabel(self, v, selectAll: bool = False, selection: tuple | None = None) -> tuple[None, None]:
         return None, None
 
     def edit_widget(self, p):

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -506,8 +506,8 @@ class LeoTreeData(npyscreen.TreeData):
             self,
             only_expanded: bool = True,
             ignore_root: bool = True,
-            sort: bool = None,  # not used here.
-            sort_function: Callable = None,
+            sort: bool | None = None,  # not used here.
+            sort_function: Callable | None = None,
         ) -> Generator:
             # Never change the stored position!
             # LeoTreeData(p) makes a copy of p.
@@ -1161,10 +1161,10 @@ class KeyEvent:
         event: Event,
         shortcut: str,
         w: Any,
-        x: int = None,
-        y: int = None,
-        x_root: Position = None,
-        y_root: Position = None,
+        x: int | None = None,
+        y: int | None = None,
+        x_root: Position | None = None,
+        y_root: Position | None = None,
     ) -> None:
         """Ctor for KeyEvent class."""
         assert not g.isStroke(shortcut), g.callers()
@@ -1654,7 +1654,7 @@ class LeoCursesGui(leoGui.LeoGui):
         sys.exit(0)
 
     # @+node:ekr.20220618070256.1: *5* CGui.getFullVersion
-    def getFullVersion(self, c: Cmdr = None) -> str:
+    def getFullVersion(self, c: Cmdr | None = None) -> str:
         return 'Leo Console Gui (npyscreen)'
 
     # @+node:ekr.20170501032447.1: *5* CGui.init_logger
@@ -1769,8 +1769,8 @@ class LeoCursesGui(leoGui.LeoGui):
         c: Cmdr,
         title: str,
         message: str,
-        cancelButtonText: str = None,
-        okButtonText: str = None,
+        cancelButtonText: str | None = None,
+        okButtonText: str | None = None,
     ) -> str:
         """Create and run askOkCancelNumber dialog ."""
         if g.unitTesting:
@@ -1788,8 +1788,8 @@ class LeoCursesGui(leoGui.LeoGui):
         c: Cmdr,
         title: str,
         message: str,
-        cancelButtonText: str = None,
-        okButtonText: str = None,
+        cancelButtonText: str | None = None,
+        okButtonText: str | None = None,
         default: str = "",
         wide: bool = False,
     ) -> str:
@@ -1806,7 +1806,7 @@ class LeoCursesGui(leoGui.LeoGui):
         self,
         c: Cmdr,
         title: str,
-        message: str = None,
+        message: str | None = None,
         text: str = "Ok",
     ) -> bool:
         """Create and run an askOK dialog ."""
@@ -1824,12 +1824,12 @@ class LeoCursesGui(leoGui.LeoGui):
         self,
         c: Cmdr,
         title: str,
-        message: str = None,
+        message: str | None = None,
         yesMessage: str = "Yes",
         noMessage: str = "No",
-        yesToAllMessage: str = None,
+        yesToAllMessage: str | None = None,
         defaultButton: str = "Yes",
-        cancelMessage: str = None,
+        cancelMessage: str | None = None,
     ) -> str:
         """Create and run an askYesNoCancel dialog ."""
         if g.unitTesting:
@@ -1845,7 +1845,7 @@ class LeoCursesGui(leoGui.LeoGui):
         self,
         c: Cmdr,
         title: str,
-        message: str = None,
+        message: str | None = None,
         yes_all: bool = False,
         no_all: bool = False,
     ) -> str:
@@ -1865,7 +1865,7 @@ class LeoCursesGui(leoGui.LeoGui):
         *,
         filetypes: list[tuple[str, str]],
         defaultextension: str = '',  # Not used.
-        startpath: str = None,
+        startpath: str | None = None,
     ) -> str:
         if not g.unitTesting:
             g.trace('not ready yet', title)
@@ -1878,7 +1878,7 @@ class LeoCursesGui(leoGui.LeoGui):
         *,
         filetypes: list[tuple[str, str]],
         defaultextension: str = '',  # Not used.
-        startpath: str = None,
+        startpath: str | None = None,
     ) -> list[str]:
         if not g.unitTesting:
             g.trace('not ready yet', title)
@@ -1888,9 +1888,9 @@ class LeoCursesGui(leoGui.LeoGui):
     def runPropertiesDialog(
         self,
         title: str = 'Properties',
-        data: Any = None,
-        callback: Callable = None,
-        buttons: list[str] = None,
+        data: Any | None = None,
+        callback: Callable | None = None,
+        buttons: list[str] | None = None,
     ) -> None:
         """Dispay a modal TkPropertiesDialog"""
         if not g.unitTesting:
@@ -1975,7 +1975,7 @@ class LeoCursesGui(leoGui.LeoGui):
         self.set_focus(c, c.frame.miniBufferWidget)
 
     # @+node:ekr.20170502101347.1: *5* CGui.get_focus
-    def get_focus(self, c: Cmdr = None, raw: bool = False, at_idle: bool = False) -> Optional[Any]:
+    def get_focus(self, c: Cmdr | None = None, raw: bool = False, at_idle: bool = False) -> Optional[Any]:
         """
         Return the Leo wrapper for the npyscreen widget that is being edited.
         """
@@ -2422,7 +2422,7 @@ class CoreFrame(leoFrame.LeoFrame):
     def bringToFront(self) -> None:
         pass
 
-    def contractPane(self, event: Event = None) -> None:
+    def contractPane(self, event: Event | None = None) -> None:
         pass
 
     def deiconify(self) -> None:
@@ -2450,13 +2450,13 @@ class CoreFrame(leoFrame.LeoFrame):
     def getTitle(self) -> str:
         return self.title
 
-    def minimizeAll(self, event: Event = None) -> None:
+    def minimizeAll(self, event: Event | None = None) -> None:
         pass
 
     def resizePanesToRatio(self, ratio: float, secondary_ratio: float) -> None:
         """Resize splitter1 and splitter2 using the given ratios."""
 
-    def resizeToScreen(self, event: Event = None) -> None:
+    def resizeToScreen(self, event: Event | None = None) -> None:
         pass
 
     def setInitialWindowGeometry(self) -> None:
@@ -2480,7 +2480,7 @@ class CoreFrame(leoFrame.LeoFrame):
 
     # @+node:ekr.20170522015906.1: *4* CFrame.pasteText (cursesGui2)
     @frame_cmd('paste-text')
-    def pasteText(self, event: Event = None, middleButton: bool = False) -> None:
+    def pasteText(self, event: Event | None = None, middleButton: bool = False) -> None:
         """
         Paste the clipboard into a widget.
         If middleButton is True, support x-windows middle-mouse-button easter-egg.
@@ -2541,7 +2541,7 @@ class CoreLog(leoFrame.LeoLog):
 
     # @+node:ekr.20170419143731.7: *4* CLog.clearLog
     @log_cmd('clear-log')
-    def clearLog(self, event: Event = None) -> None:
+    def clearLog(self, event: Event | None = None) -> None:
         """Clear the log pane."""
 
     # @+node:ekr.20170420035717.1: *4* CLog.enable/disable
@@ -2560,7 +2560,7 @@ class CoreLog(leoFrame.LeoLog):
         return w == self or w in list(self.contentsDict.values())
 
     # @+node:ekr.20170513184115.1: *4* CLog.orderedTabNames
-    def orderedTabNames(self, LeoLog: Any = None) -> list[str]:  # Unused: LeoLog
+    def orderedTabNames(self, LeoLog: Any | None = None) -> list[str]:  # Unused: LeoLog
         """Return a list of tab names in the order in which they appear in the QTabbedWidget."""
         return []
         # w = self.tabWidget
@@ -2571,7 +2571,7 @@ class CoreLog(leoFrame.LeoLog):
 
     # fmt: off
 
-    def put(self, s: str, color: str = None, tabName: str = 'Log', from_redirect: bool = False) -> None:  # type:ignore
+    def put(self, s: str, color: str | None = None, tabName: str = 'Log', from_redirect: bool = False) -> None:  # type:ignore
         """All output to the log stream eventually comes here."""
         c, w = self.c, self.widget
         if not c or not c.exists or not w:
@@ -2635,7 +2635,7 @@ class CoreTree(leoFrame.LeoTree):
 
     # @+node:ekr.20170511094217.1: *4* CTree.Drawing
     # @+node:ekr.20170511094217.3: *5* CTree.redraw
-    def redraw(self, p: Position = None) -> None:
+    def redraw(self, p: Position | None = None) -> None:
         """
         Redraw all visible nodes of the tree.
         Preserve the vertical scrolling unless scroll is True.
@@ -2659,7 +2659,7 @@ class CoreTree(leoFrame.LeoTree):
     def redraw_after_head_changed(self) -> None:
         self.redraw()
 
-    def redraw_after_select(self, p: Position = None) -> None:
+    def redraw_after_select(self, p: Position | None = None) -> None:
         """Redraw the entire tree when an invisible node is selected."""
         if not self.redrawing:
             self.redraw(p=p)
@@ -2673,7 +2673,7 @@ class CoreTree(leoFrame.LeoTree):
     # @+node:ekr.20170511104533.12: *5* CTree.onHeadChanged (cursesGui2)
     # Tricky code: do not change without careful thought and testing.
 
-    def onHeadChanged(self, p: Position, s: str = None, undoType: str = 'Typing') -> None:  # type:ignore
+    def onHeadChanged(self, p: Position, s: str | None = None, undoType: str = 'Typing') -> None:  # type:ignore
         """
         Officially change a headline.
         This is c.frame.tree.onHeadChanged.
@@ -2762,7 +2762,7 @@ class CoreTree(leoFrame.LeoTree):
 
     # @+node:ekr.20170511095353.1: *5* CTree.editLabel (cursesGui2) (not used)
     def editLabel(
-        self, p: Position, selectAll: bool = False, selection: tuple = None
+        self, p: Position, selectAll: bool = False, selection: tuple | None = None
     ) -> tuple[None, None]:
         """Start editing p's headline."""
         return None, None
@@ -2950,7 +2950,7 @@ class LeoBody(npyscreen.MultiLineEditable):
             self._continue_editing()
 
     # @+node:ekr.20170604185028.1: *4* LeoBody.delete_line_value
-    def delete_line_value(self, ch_i: int = None) -> None:
+    def delete_line_value(self, ch_i: int | None = None) -> None:
         c = self.leo_c
         if self.values:
             del self.values[self.cursor_line]
@@ -3088,7 +3088,7 @@ class LeoLog(npyscreen.MultiLineEditable):
 
     # @+others
     # @+node:ekr.20170604184928.2: *4* LeoLog.delete_line_value
-    def delete_line_value(self, ch_i: int = None) -> None:
+    def delete_line_value(self, ch_i: int | None = None) -> None:
         if self.values:
             del self.values[self.cursor_line]
             self.display()
@@ -4198,7 +4198,7 @@ class TextMixin:
 
     # @+others
     # @+node:ekr.20170511053143.2: *4* tm.ctor & helper
-    def __init__(self, c: Cmdr = None) -> None:
+    def __init__(self, c: Cmdr | None = None) -> None:
         """Ctor for TextMixin class"""
         self.c = c
         self.enabled = True
@@ -4238,7 +4238,7 @@ class TextMixin:
         g.app.gui.replaceClipboardWith('')
 
     # @+node:ekr.20170511053143.14: *5* tm.delete
-    def delete(self, i: int, j: int = None) -> None:
+    def delete(self, i: int, j: int | None = None) -> None:
         """TextMixin"""
         s = self.getAllText()
         if j is None:
@@ -4264,7 +4264,7 @@ class TextMixin:
         self.enabled = enabled
 
     # @+node:ekr.20170511053143.16: *5* tm.get
-    def get(self, i: int, j: int = None) -> str:
+    def get(self, i: int, j: int | None = None) -> str:
         """TextMixin"""
         # 2012/04/12: fix the following two bugs by using the vanilla code:
         # https://bugs.launchpad.net/leo-editor/+bug/979142
@@ -4362,7 +4362,7 @@ class BodyWrapper(StringTextWrapper):
         self.leo_frame = None
 
     # @+node:ekr.20170504034655.6: *4* bw.onCursorPositionChanged
-    def onCursorPositionChanged(self, event: Event = None) -> None:
+    def onCursorPositionChanged(self, event: Event | None = None) -> None:
         if 0:
             g.trace('=====', event)
 

--- a/leo/plugins/demo.py
+++ b/leo/plugins/demo.py
@@ -358,7 +358,7 @@ class Demo:
         return aList
 
     # @+node:ekr.20170128213103.43: *4* demo.wait & key_wait
-    def key_wait(self, speed: float = None, n1=None, n2=None):
+    def key_wait(self, speed: float | None = None, n1=None, n2=None):
         """Wait for an interval between n1 and n2, in seconds."""
         if n1 is None:
             n1 = self.n1
@@ -538,7 +538,7 @@ class Demo:
         return p
 
     # @+node:ekr.20170211045602.1: *4* demo.insert_node
-    def insert_node(self, headline, end=True, keys=False, speed: float = None):
+    def insert_node(self, headline, end=True, keys=False, speed: float | None = None):
         """Helper for inserting a node."""
         c = self.c
         p = c.insertHeadline()

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -198,7 +198,7 @@ class FreeLayoutController:
         c.redraw()
 
     # @+node:ekr.20160424035257.1: *3* flc.get_main_splitter
-    def get_main_splitter(self, w: QTextMixin = None) -> Optional[NestedSplitter]:
+    def get_main_splitter(self, w: QTextMixin | None = None) -> Optional[NestedSplitter]:
         """
         Return the main splitter.
 

--- a/leo/plugins/importers/leo_rst.py
+++ b/leo/plugins/importers/leo_rst.py
@@ -119,7 +119,7 @@ class Rst_Importer(Importer):
         )
 
     # @+node:ekr.20230529072922.5: *4* rst_i.is_underline
-    def is_underline(self, line: str, extra: str = None) -> bool:
+    def is_underline(self, line: str, extra: str | None = None) -> bool:
         """True if the line consists of nothing but the same underlining characters."""
         if line.isspace():
             return False

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -170,7 +170,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # @+node:ekr.20180328085010.1: ** Top level (mod_scripting)
 # @+node:tbrown.20140819100840.37719: *3* mod_scripting.build_rclick_tree
 def build_rclick_tree(
-    command_p: Position, rclicks: RClicks = None, top_level: bool = False
+    command_p: Position, rclicks: RClicks | None = None, top_level: bool = False
 ) -> list:
     """
     Return a list of top level RClicks for the button at command_p, which can be
@@ -290,7 +290,7 @@ class AtButtonCallback:
         self.__doc__ = docstring  # The docstring for this callback for g.getDocStringForFunction.
 
     # @+node:ekr.20141031053508.10: *3* __call__ (AtButtonCallback)
-    def __call__(self, event: Event = None) -> Value:
+    def __call__(self, event: Event | None = None) -> Value:
         """AtButtonCallbgack.__call__. The callback for @button nodes."""
         return self.execute_script()
 
@@ -353,7 +353,7 @@ class ScriptingController:
 
     # @+others
     # @+node:ekr.20060328125248.7: *3*  sc.ctor
-    def __init__(self, c: Cmdr, iconBar: QtWidgets.QWidget = None) -> None:
+    def __init__(self, c: Cmdr, iconBar: QtWidgets.QWidget | None = None) -> None:
         self.c = c
         self.gui = c.frame.gui
         getBool = c.config.getBool
@@ -399,7 +399,7 @@ class ScriptingController:
 
     # @+node:ekr.20150401113822.1: *3* sc.Callbacks
     # @+node:ekr.20060328125248.23: *4* sc.addScriptButtonCommand
-    def addScriptButtonCommand(self, event: Event = None) -> None:
+    def addScriptButtonCommand(self, event: Event | None = None) -> None:
         """Called when the user presses the 'script-button' button or executes the script-button command."""
         c = self.c
         p = c.p
@@ -413,7 +413,7 @@ class ScriptingController:
         c.bodyWantsFocus()
 
     # @+node:ekr.20060522105937.1: *4* sc.runDebugScriptCommand
-    def runDebugScriptCommand(self, event: Event = None) -> None:
+    def runDebugScriptCommand(self, event: Event | None = None) -> None:
         """Called when user presses the 'debug-script' button or executes the debug-script command."""
         c = self.c
         p = c.p
@@ -476,7 +476,7 @@ class ScriptingController:
         c.bodyWantsFocus()
 
     # @+node:ekr.20060328125248.21: *4* sc.runScriptCommand
-    def runScriptCommand(self, event: Event = None) -> None:
+    def runScriptCommand(self, event: Event | None = None) -> None:
         """Called when user presses the 'run-script' button or executes the run-script command."""
         c, p = self.c, self.c.p
         args = self.getArgs(p)
@@ -601,8 +601,8 @@ class ScriptingController:
         text: str,
         command: Callable,
         statusLine: str,
-        bg: str = None,
-        kind: str = None,
+        bg: str | None = None,
+        kind: str | None = None,
     ) -> QtWidgets.QButton:
         """
         Create one icon button.
@@ -636,7 +636,7 @@ class ScriptingController:
             )
 
         def deleteButtonCallback(
-            event: Event = None, self: Any = self, b: QtWidgets.QButton = b
+            event: Event | None = None, self: Any = self, b: QtWidgets.QButton = b
         ) -> None:
             self.deleteButton(b, event=event)
 
@@ -665,7 +665,7 @@ class ScriptingController:
         buttonText: str,
         p: Position,
         script: str,
-        script_gnx: str = None,
+        script_gnx: str | None = None,
     ) -> Value:
         """Execute an @button script in p.b or script."""
         c = self.c
@@ -732,7 +732,7 @@ class ScriptingController:
                 self.createCommonButton(p, script, rclicks)
 
     # @+node:ekr.20070926084600: *4* sc.createCommonButton (common @button)
-    def createCommonButton(self, p: Position, script: str, rclicks: RClicks = None) -> None:
+    def createCommonButton(self, p: Position, script: str, rclicks: RClicks | None = None) -> None:
         """
         Create a button in the icon area for a common @button node in an
         @buttons node in an @setting tree. Binds button presses to a callback
@@ -872,7 +872,7 @@ class ScriptingController:
         args = self.getArgs(p)
 
         def atCommandCallback(
-            event: Event = None,
+            event: Event | None = None,
             args: Args = args,
             c: Cmdr = c,
             p: Position = p.copy(),
@@ -919,7 +919,7 @@ class ScriptingController:
         args = self.getArgs(p)
 
         def atCommandCallback(
-            event: Event = None,
+            event: Event | None = None,
             args: Args = args,
             c: Cmdr = c,
             p: Position = p.copy(),
@@ -1147,8 +1147,8 @@ class ScriptingController:
         func: Callable,
         h: str,
         pane: str,
-        source_c: Cmdr = None,
-        tag: str = None,
+        source_c: Cmdr | None = None,
+        tag: str | None = None,
     ) -> None:
         """Register @button <name> and @rclick <name> and <name>"""
         c, k = self.c, self.c.k
@@ -1178,7 +1178,7 @@ class ScriptingController:
                 # Create a *second* func, to avoid collision in c.commandsDict.
 
                 def registerAllCommandsCallback(
-                    event: Event = None, func: Callable = func
+                    event: Event | None = None, func: Callable = func
                 ) -> Callable:
                     return func()
 

--- a/leo/plugins/nodetags.py
+++ b/leo/plugins/nodetags.py
@@ -285,7 +285,7 @@ if QtWidgets:
     class LeoTagWidget(QtWidgets.QWidget):  # type:ignore
         # @+others
         # @+node:peckj.20140804114520.15200: *3* tag_w.__init__
-        def __init__(self, c: Cmdr, parent: QtWidgets.QWidget = None) -> None:
+        def __init__(self, c: Cmdr, parent: QtWidgets.QWidget | None = None) -> None:
             super().__init__(parent)
             self.c = c
             self.tc = self.c.theTagController
@@ -494,7 +494,7 @@ if QtWidgets:
             self.update_current_tags(self.c.p)
 
         # @+node:peckj.20140806145948.6579: *4* tag_w.add_tag
-        def add_tag(self, event: Event = None) -> None:
+        def add_tag(self, event: Event | None = None) -> None:
             p = self.c.p
             tag = str(self.comboBox.currentText()).strip()
             if not tag:

--- a/leo/plugins/pane_commands.py
+++ b/leo/plugins/pane_commands.py
@@ -31,7 +31,7 @@ def init() -> bool:
 
 # @+node:ekr.20221020063528.1: ** bottom of-pane
 @g.command('bottom-of-pane')
-def bottomOfPane(event: LeoKeyEvent = None) -> None:
+def bottomOfPane(event: LeoKeyEvent | None = None) -> None:
     """move the text cursor to the last character visible in the body pane"""
     c: Cmdr = event.c if event else None
     if not c:
@@ -62,7 +62,7 @@ def bottomOfPane(event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20221020063441.1: ** top-of-pane
 @g.command('top-of-pane')
-def topOfPane(event: LeoKeyEvent = None) -> None:
+def topOfPane(event: LeoKeyEvent | None = None) -> None:
     """move the text cursor to the first character visible in the body pane"""
     c: Cmdr = event.c if event else None
     if not c:

--- a/leo/plugins/plugins_menu.py
+++ b/leo/plugins/plugins_menu.py
@@ -250,7 +250,7 @@ class PlugIn:
 
     # @+others
     # @+node:EKR.20040517080555.4: *3* PlugIn.__init__ & helper
-    def __init__(self, plgMod: ModuleType, c: Cmdr = None) -> None:
+    def __init__(self, plgMod: ModuleType, c: Cmdr | None = None) -> None:
         """
         @param plgMod: Module object for the plugin represented by this instance.
         @param c:  Leo-editor "commander" for the current .leo file
@@ -300,7 +300,7 @@ class PlugIn:
                 self.othercmds[func.command_name] = func
 
     # @+node:EKR.20040517080555.8: *3* PlugIn.about
-    def about(self, event: Event = None) -> None:
+    def about(self, event: Event | None = None) -> None:
         """Put information about this plugin in a scrolledMessage dialog."""
         c = self.c
         msg = self.doc.strip() + '\n' if self.doc else ''
@@ -324,7 +324,7 @@ class PlugIn:
         return name.capitalize()
 
     # @+node:EKR.20040517080555.9: *3* PlugIn.properties
-    def properties(self, event: Event = None) -> None:
+    def properties(self, event: Event | None = None) -> None:
         """Display a modal properties dialog for this plugin"""
         if self.hasapply:
 

--- a/leo/plugins/qt_commands.py
+++ b/leo/plugins/qt_commands.py
@@ -135,7 +135,7 @@ def showColorNames(event: LeoKeyEvent) -> None:
 
 # @+node:ekr.20170324142416.1: ** qt: show-color-wheel
 @g.command('show-color-wheel')
-def showColorWheel(self: Any, event: LeoKeyEvent = None) -> None:
+def showColorWheel(self: Any, event: LeoKeyEvent | None = None) -> None:
     """Show a Qt color dialog."""
     c, p = self.c, self.c.p
     picker = QtWidgets.QColorDialog()
@@ -164,7 +164,7 @@ def showColorWheel(self: Any, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20170324143944.3: ** qt: show-fonts
 @g.command('show-fonts')
-def showFonts(self: Any, event: LeoKeyEvent = None) -> None:
+def showFonts(self: Any, event: LeoKeyEvent | None = None) -> None:
     """Open a tab in the log pane showing a font picker."""
     c, p = self.c, self.c.p
     picker = QtWidgets.QFontDialog()
@@ -207,7 +207,7 @@ def showFonts(self: Any, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20140918124632.17893: ** qt: show-style-sheet
 @g.command('show-style-sheet')
-def print_style_sheet(event: LeoKeyEvent = None) -> None:
+def print_style_sheet(event: LeoKeyEvent | None = None) -> None:
     """show-style-sheet command."""
     c: Cmdr = event.get('c')
     if c:

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -139,7 +139,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
     # @+others
     # @+node:ekr.20240730052903.1: *3*  dw: Birth
     # @+node:ekr.20110605121601.18138: *4* dw.ctor
-    def __init__(self, c: Cmdr, parent: QWidget = None) -> None:
+    def __init__(self, c: Cmdr, parent: QWidget | None = None) -> None:
         """Ctor for the DynamicWindow class.  The main window is c.frame.top"""
         # Called from LeoQtFrame.finishCreate.
         # parent is a LeoTabbedTopLevel.
@@ -194,7 +194,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
                 self.iconBar.hide()
 
     # @+node:ekr.20110605121601.18139: *3* dw.construct & helpers
-    def construct(self, master: LeoTabbedTopLevel = None) -> None:
+    def construct(self, master: LeoTabbedTopLevel | None = None) -> None:
         """Factor 'heavy duty' code out from the DynamicWindow ctor"""
         c = self.leo_c
         self.leo_master = master
@@ -635,11 +635,11 @@ class DynamicWindow(QtWidgets.QMainWindow):
         self,
         parent: QWidget,
         name: str,
-        hPolicy: Policy = None,
-        vPolicy: Policy = None,
+        hPolicy: Policy | None = None,
+        vPolicy: Policy | None = None,
         lineWidth: int = 1,
-        shadow: Shadow = None,
-        shape: Shape = None,
+        shadow: Shadow | None = None,
+        shape: Shape | None = None,
     ) -> QWidget:
         """Create a Qt Frame."""
         if shadow is None:
@@ -717,8 +717,8 @@ class DynamicWindow(QtWidgets.QMainWindow):
         parent: QWidget,
         name: str,
         lineWidth: int = 1,
-        hPolicy: Policy = None,
-        vPolicy: Policy = None,
+        hPolicy: Policy | None = None,
+        vPolicy: Policy | None = None,
     ) -> QWidget:  # QtWidgets.QStackedWidget
         w = QtWidgets.QStackedWidget(parent)
         self.set_widget_size_policy(w, kind1=hPolicy, kind2=vPolicy)
@@ -732,8 +732,8 @@ class DynamicWindow(QtWidgets.QMainWindow):
         self,
         parent: QWidget,
         name: str,
-        hPolicy: Policy = None,
-        vPolicy: Policy = None,
+        hPolicy: Policy | None = None,
+        vPolicy: Policy | None = None,
     ) -> QWidget:
         w = QtWidgets.QTabWidget(parent)
         # tb = w.tabBar()
@@ -748,8 +748,8 @@ class DynamicWindow(QtWidgets.QMainWindow):
         parent: QWidget,
         name: str,
         lineWidth: int = 0,
-        shadow: Shadow = None,
-        shape: Shape = None,
+        shadow: Shadow | None = None,
+        shape: Shape | None = None,
     ) -> QWidget:
         # Create a text widget.
         c = self.leo_c
@@ -1132,7 +1132,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         return panes
 
     # @+node:ekr.20110605121601.18212: *4* dw.packLabel
-    def packLabel(self, w: QWidget, n: int = None) -> None:
+    def packLabel(self, w: QWidget, n: int | None = None) -> None:
         """
         Pack w into the body frame's QVGridLayout.
 
@@ -1181,7 +1181,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
 
     # @+node:ekr.20110605121601.18170: *4* dw.set_widget_size_policy
     def set_widget_size_policy(
-        self, widget: QWidget, kind1: Policy = None, kind2: Policy = None
+        self, widget: QWidget, kind1: Policy | None = None, kind2: Policy | None = None
     ) -> None:
         if kind1 is None:
             kind1 = Policy.Ignored
@@ -1655,7 +1655,7 @@ class LeoBaseTabWidget(QtWidgets.QTabWidget):
                     self.setTabText(i, title)
 
     # @+node:ekr.20131115120119.17396: *3* qt_base_tab.setTabName
-    def setTabName(self, c: Cmdr, fileName: str, tooltip: str = None) -> None:
+    def setTabName(self, c: Cmdr, fileName: str, tooltip: str | None = None) -> None:
         """Set the tab name and optional tooltip for c's tab to fileName."""
         # Find the tab corresponding to c.
         dw = c.frame.top  # A DynamicWindow
@@ -1997,10 +1997,10 @@ class LeoQtFrame(leoFrame.LeoFrame):
         pass
 
     # @+node:ekr.20110605121601.18280: *4* LeoQtFrame.forceWrap & setWrap
-    def forceWrap(self, p: Position = None) -> None:
+    def forceWrap(self, p: Position | None = None) -> None:
         self.c.frame.body.forceWrap(p)
 
-    def setWrap(self, p: Position = None) -> None:
+    def setWrap(self, p: Position | None = None) -> None:
         self.c.frame.body.setWrap(p)
 
     # @+node:ekr.20110605121601.18281: *4* LeoQtFrame.reconfigurePanes
@@ -2078,21 +2078,21 @@ class LeoQtFrame(leoFrame.LeoFrame):
             g.app.closeLeoWindow(self)
 
     # @+node:ekr.20110605121601.18287: *4* LeoQtFrame.OnControlKeyUp/Down
-    def OnControlKeyDown(self, event: QEvent = None) -> None:
+    def OnControlKeyDown(self, event: QEvent | None = None) -> None:
         self.controlKeyIsDown = True
 
-    def OnControlKeyUp(self, event: QEvent = None) -> None:
+    def OnControlKeyUp(self, event: QEvent | None = None) -> None:
         self.controlKeyIsDown = False
 
     # @+node:ekr.20110605121601.18290: *4* LeoQtFrame.OnActivateTree
-    def OnActivateTree(self, event: QEvent = None) -> None:
+    def OnActivateTree(self, event: QEvent | None = None) -> None:
         pass
 
     # @+node:ekr.20110605121601.18293: *3* LeoQtFrame.Gui-dependent commands
     # @+node:ekr.20110605121601.18301: *4* LeoQtFrame.Window Menu...
     # @+node:ekr.20110605121601.18302: *5* LeoQtFrame.toggleActivePane
     @frame_cmd('toggle-active-pane')
-    def toggleActivePane(self, event: LeoKeyEvent = None) -> None:
+    def toggleActivePane(self, event: LeoKeyEvent | None = None) -> None:
         """Toggle the focus between the outline and body panes."""
         frame = self
         c = frame.c
@@ -2106,20 +2106,20 @@ class LeoQtFrame(leoFrame.LeoFrame):
 
     # @+node:ekr.20110605121601.18304: *5* LeoQtFrame.equalSizedPanes
     @frame_cmd('equal-sized-panes')
-    def equalSizedPanes(self, event: LeoKeyEvent = None) -> None:
+    def equalSizedPanes(self, event: LeoKeyEvent | None = None) -> None:
         """Make the outline and body panes have the same size."""
         self.resizePanesToRatio(0.5, self.compute_secondary_ratio())
 
     # @+node:ekr.20250422154709.1: *5* LeoQtFrame.contract/expandMainSplitter
     @frame_cmd('contract-main-splitter')
-    def contractMainSplitter(self, event: LeoKeyEvent = None) -> None:
+    def contractMainSplitter(self, event: LeoKeyEvent | None = None) -> None:
         """
         Contract the main splitter's first widget, expanding the main splitter's second widget.
         """
         self.resize_main_splitter(-40)
 
     @frame_cmd('expand-main-splitter')
-    def expandMainSplitter(self, event: LeoKeyEvent = None) -> None:
+    def expandMainSplitter(self, event: LeoKeyEvent | None = None) -> None:
         """
         Expand the main splitter's first widget, contracting the main splitter's second widget.
         """
@@ -2140,13 +2140,13 @@ class LeoQtFrame(leoFrame.LeoFrame):
             splitter.setSizes(sizes)
 
     # @+node:ekr.20110605121601.18305: *5* LeoQtFrame.hideLogWindow
-    def hideLogWindow(self, event: LeoKeyEvent = None) -> None:
+    def hideLogWindow(self, event: LeoKeyEvent | None = None) -> None:
         """Hide the log pane."""
         self.divideLeoSplitter2(0.99)
 
     # @+node:ekr.20110605121601.18306: *5* LeoQtFrame.minimizeAll
     @frame_cmd('minimize-all')
-    def minimizeAll(self, event: LeoKeyEvent = None) -> None:
+    def minimizeAll(self, event: LeoKeyEvent | None = None) -> None:
         """Minimize all Leo's windows."""
         for frame in g.app.windowList:
             self.minimize(frame)
@@ -2162,7 +2162,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
 
     # @+node:ekr.20110605121601.18307: *5* LeoQtFrame.toggleSplitDirection
     @frame_cmd('toggle-split-direction')
-    def toggleSplitDirection(self, event: LeoKeyEvent = None) -> None:
+    def toggleSplitDirection(self, event: LeoKeyEvent | None = None) -> None:
         """
         Toggle the split direction in the present Leo window.
         """
@@ -2178,7 +2178,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
 
     # @+node:ekr.20110605121601.18308: *5* LeoQtFrame.resizeToScreen
     @frame_cmd('resize-to-screen')
-    def resizeToScreen(self, event: LeoKeyEvent = None) -> None:
+    def resizeToScreen(self, event: LeoKeyEvent | None = None) -> None:
         """Resize the Leo window so it fill the entire screen."""
         frame = self
         # This unit test will fail when run externally.
@@ -2352,7 +2352,7 @@ class LeoQtLog(leoFrame.LeoLog):
     # @+node:ekr.20150717102728.1: *3* LeoQtLog: clear-log & dump-log
     @log_cmd('clear-log')
     @log_cmd('log-clear')
-    def clearLog(self, event: LeoKeyEvent = None) -> None:
+    def clearLog(self, event: LeoKeyEvent | None = None) -> None:
         """Clear the log pane."""
         w = self.qtLogCtrl.widget
         if w:
@@ -2360,7 +2360,7 @@ class LeoQtLog(leoFrame.LeoLog):
 
     @log_cmd('dump-log')
     @log_cmd('log-dump')
-    def dumpLog(self, event: LeoKeyEvent = None) -> None:
+    def dumpLog(self, event: LeoKeyEvent | None = None) -> None:
         """Clear the log pane."""
         w = self.qtLogCtrl.widget
         if not w:
@@ -2421,7 +2421,7 @@ class LeoQtLog(leoFrame.LeoLog):
                 g.es(key3, val3, tabName='Fonts')
 
     # @+node:ekr.20110605121601.18339: *4* LeoQtLog.hideFontTab
-    def hideFontTab(self, event: LeoKeyEvent = None) -> None:
+    def hideFontTab(self, event: LeoKeyEvent | None = None) -> None:
         c = self.c
         c.frame.log.selectTab('Log')
         c.bodyWantsFocus()
@@ -2465,10 +2465,10 @@ class LeoQtLog(leoFrame.LeoLog):
     def put(
         self,
         s: str,
-        color: str = None,
+        color: str | None = None,
         tabName: str = 'Log',
         from_redirect: bool = False,
-        nodeLink: str = None,
+        nodeLink: str | None = None,
     ) -> None:
         """
         Put s to the Qt Log widget, converting to html.
@@ -2589,7 +2589,7 @@ class LeoQtLog(leoFrame.LeoLog):
         self,
         tabName: str,
         createText: bool = True,
-        widget: QWidget = None,
+        widget: QWidget | None = None,
         wrap: str = 'none',
     ) -> QTextMixin:
         """
@@ -2658,7 +2658,7 @@ class LeoQtLog(leoFrame.LeoLog):
         self.selectTab('Log')
 
     # @+node:ekr.20111122080923.10185: *4* LeoQtLog.orderedTabNames
-    def orderedTabNames(self, LeoLog: str = None) -> list[str]:  # Unused: LeoLog
+    def orderedTabNames(self, LeoLog: str | None = None) -> list[str]:  # Unused: LeoLog
         """Return a list of tab names in the order in which they appear in the QTabbedWidget."""
         w = self.qtTabWidget
         return [w.tabText(i) for i in range(w.count())]
@@ -2815,9 +2815,9 @@ class LeoQtMenu(leoMenu.LeoMenu):
         self,
         menu: QMenu,
         accelerator: str = '',
-        command: Callable = None,
-        commandName: str = None,
-        label: str = None,
+        command: Callable | None = None,
+        commandName: str | None = None,
+        label: str | None = None,
         underline: int = 0,
     ) -> None:
         """Wrapper for the Tkinter add_command menu method."""
@@ -2878,7 +2878,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
         position: int,
         label: str,
         command: Callable,
-        underline: int = None,
+        underline: int | None = None,
     ) -> None:
         menu = self.getMenu(menuName)
         if menu and label:
@@ -3583,14 +3583,14 @@ class LeoQtSpellTab:
         self.handler.add()
 
     # @+node:ekr.20110605121601.18391: *4* onChangeButton & onChangeThenFindButton
-    def onChangeButton(self, event: QEvent = None) -> None:
+    def onChangeButton(self, event: QEvent | None = None) -> None:
         """Handle a click in the Change button in the Spell tab."""
         state = self.updateButtons()
         if state:
             self.handler.change()
         self.updateButtons()
 
-    def onChangeThenFindButton(self, event: QEvent = None) -> None:
+    def onChangeThenFindButton(self, event: QEvent | None = None) -> None:
         """Handle a click in the "Change, Find" button in the Spell tab."""
         state = self.updateButtons()
         if state:
@@ -3614,17 +3614,17 @@ class LeoQtSpellTab:
         self.handler.hide()
 
     # @+node:ekr.20110605121601.18394: *4* onIgnoreButton
-    def onIgnoreButton(self, event: QEvent = None) -> None:
+    def onIgnoreButton(self, event: QEvent | None = None) -> None:
         """Handle a click in the Ignore button in the Check Spelling dialog."""
         self.handler.ignore()
 
     # @+node:ekr.20110605121601.18395: *4* onMap
-    def onMap(self, event: QEvent = None) -> None:
+    def onMap(self, event: QEvent | None = None) -> None:
         """Respond to a Tk <Map> event."""
         self.update(show=False, fill=False)
 
     # @+node:ekr.20110605121601.18396: *4* onSelectListBox
-    def onSelectListBox(self, event: QEvent = None) -> None:
+    def onSelectListBox(self, event: QEvent | None = None) -> None:
         """Respond to a click in the selection listBox."""
         c = self.c
         self.updateButtons()
@@ -3636,7 +3636,7 @@ class LeoQtSpellTab:
         self.c.frame.log.selectTab('Spell')
 
     # @+node:ekr.20110605121601.18399: *4* fillbox (LeoQtSpellTab)
-    def fillbox(self, alts: list[str], word: str = None) -> None:
+    def fillbox(self, alts: list[str], word: str | None = None) -> None:
         """Update the suggestions listBox in the Check Spelling dialog."""
         self.suggestions = alts
         if not word:
@@ -3847,7 +3847,7 @@ class QtIconBarClass:
     # @+node:ekr.20110605121601.18264: *3*  QtIconBar.do-nothings
     # These *are* called from Leo's core.
 
-    def addRow(self, height: int = None) -> None:
+    def addRow(self, height: int | None = None) -> None:
         pass
 
     def getNewFrame(self) -> None:
@@ -4025,8 +4025,8 @@ class QtIconBarClass:
         rclicks: RClicks,
         controller: ScriptingController,
         top_level: bool = True,
-        button: QWidget = None,
-        script: str = None,
+        button: QWidget | None = None,
+        script: str | None = None,
     ) -> None:
         c = controller.c
         top_offset = -2  # insert before the remove button and goto script items
@@ -4219,11 +4219,11 @@ class QtStatusLineClass:
     def get(self) -> str:
         return self.textWidget2.text()
 
-    def put(self, s: str, bg: str = None, fg: str = None) -> None:
+    def put(self, s: str, bg: str | None = None, fg: str | None = None) -> None:
         """Put the UNL area."""
         self.put_helper(s, self.textWidget2, bg, fg)
 
-    def put1(self, s: str, bg: str = None, fg: str = None) -> None:
+    def put1(self, s: str, bg: str | None = None, fg: str | None = None) -> None:
         """Put the status area"""
         self.put_helper(s, self.textWidget1, bg, fg)
 
@@ -4231,7 +4231,7 @@ class QtStatusLineClass:
     # Keys are widgets, values are stylesheets.
     styleSheetCache: dict[QWidget, str] = {}
 
-    def put_helper(self, s: str, w: QWidget, bg: str = None, fg: str = None) -> None:
+    def put_helper(self, s: str, w: QWidget, bg: str | None = None, fg: str | None = None) -> None:
         """Put string s in the indicated widget, with proper colors."""
         c = self.c
         bg = bg or c.config.getColor('status-bg') or 'white'
@@ -4358,7 +4358,7 @@ class QtStatusLineClass:
             self.put1(f"fline: {fline:2} line: {row:2d} col: {col:2} fcol: {fcol:2}")
 
     # @+node:ekr.20220911120019.1: *3* QtStatusLineClass: do-nothings
-    def disable(self, background: str = None) -> None:
+    def disable(self, background: str | None = None) -> None:
         pass
 
     def enable(self, background: str = "white") -> None:
@@ -4379,7 +4379,7 @@ class QtTabBarWrapper(QtWidgets.QTabBar):
 
     # @+others
     # @+node:peckj.20140516114832.10108: *3* __init__
-    def __init__(self, parent: QWidget = None) -> None:
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setMovable(True)
 

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -414,8 +414,8 @@ class LeoQtGui(leoGui.LeoGui):
         c: Cmdr,
         title: str,
         message: str = 'Select Date/Time',
-        init: datetime.datetime = None,
-        step_min: dict = None,
+        init: datetime.datetime | None = None,
+        step_min: dict | None = None,
     ) -> Optional[datetime.datetime]:
         """Create and run a qt date/time selection dialog.
 
@@ -444,9 +444,9 @@ class LeoQtGui(leoGui.LeoGui):
 
             def __init__(
                 self,
-                parent: QWidget = None,
-                init: datetime.datetime = None,
-                step_min: dict = None,
+                parent: QWidget | None = None,
+                init: datetime.datetime | None = None,
+                step_min: dict | None = None,
             ) -> None:
                 if step_min is None:
                     step_min = {}
@@ -465,10 +465,10 @@ class LeoQtGui(leoGui.LeoGui):
         class Calendar(QtWidgets.QDialog):
             def __init__(
                 self,
-                parent: QWidget = None,
+                parent: QWidget | None = None,
                 message: str = 'Select Date/Time',
-                init: datetime.datetime = None,
-                step_min: dict = None,
+                init: datetime.datetime | None = None,
+                step_min: dict | None = None,
             ) -> None:
                 if step_min is None:
                     step_min = {}
@@ -521,8 +521,8 @@ class LeoQtGui(leoGui.LeoGui):
         c: Cmdr,
         title: str,
         message: str,
-        cancelButtonText: str = None,
-        okButtonText: str = None,
+        cancelButtonText: str | None = None,
+        okButtonText: str | None = None,
     ) -> Optional[int]:
         """Create and run askOkCancelNumber dialog ."""
         if g.unitTesting:
@@ -559,8 +559,8 @@ class LeoQtGui(leoGui.LeoGui):
         c: Cmdr,
         title: str,
         message: str,
-        cancelButtonText: str = None,
-        okButtonText: str = None,
+        cancelButtonText: str | None = None,
+        okButtonText: str | None = None,
         default: str = "",
         wide: bool = False,
     ) -> Optional[str]:
@@ -594,7 +594,7 @@ class LeoQtGui(leoGui.LeoGui):
         return str(dialog.textValue()) if ok else None
 
     # @+node:ekr.20110605121601.18495: *4* LeoQtGui.runAskOkDialog
-    def runAskOkDialog(self, c: Cmdr, title: str, message: str = None, text: str = "Ok") -> None:
+    def runAskOkDialog(self, c: Cmdr, title: str, message: str | None = None, text: str = "Ok") -> None:
         """Create and run a qt askOK dialog ."""
         if g.unitTesting:
             return
@@ -624,12 +624,12 @@ class LeoQtGui(leoGui.LeoGui):
         self,
         c: Cmdr,
         title: str,
-        message: str = None,
+        message: str | None = None,
         yesMessage: str = "&Yes",
         noMessage: str = "&No",
-        yesToAllMessage: str = None,
+        yesToAllMessage: str | None = None,
         defaultButton: str = "Yes",
-        cancelMessage: str = None,
+        cancelMessage: str | None = None,
     ) -> str:
         """
         Create and run an askYesNo dialog.
@@ -685,7 +685,7 @@ class LeoQtGui(leoGui.LeoGui):
         self,
         c: Cmdr,
         title: str,
-        message: str = None,
+        message: str | None = None,
         yes_all: bool = False,
         no_all: bool = False,
     ) -> str:
@@ -767,7 +767,7 @@ class LeoQtGui(leoGui.LeoGui):
         *,
         filetypes: list[tuple[str, str]],
         defaultextension: str = '',  # Not used
-        startpath: str = None,
+        startpath: str | None = None,
     ) -> str:
         """
         Create and run an Qt open file dialog.
@@ -813,7 +813,7 @@ class LeoQtGui(leoGui.LeoGui):
         *,
         filetypes: list[tuple[str, str]],
         defaultextension: str = '',  # Not used.
-        startpath: str = None,
+        startpath: str | None = None,
     ) -> list[str]:
         """
         Create and run an Qt open file dialog.
@@ -856,9 +856,9 @@ class LeoQtGui(leoGui.LeoGui):
     def runPropertiesDialog(
         self,
         title: str = 'Properties',
-        data: Value = None,
-        callback: Callable = None,
-        buttons: list[str] = None,
+        data: Value | None = None,
+        callback: Callable | None = None,
+        buttons: list[str] | None = None,
     ) -> tuple[str, dict]:
         """Display a modal TkPropertiesDialog"""
         if not g.unitTesting:
@@ -871,7 +871,7 @@ class LeoQtGui(leoGui.LeoGui):
         c: Cmdr,
         title: str = 'Save',
         *,
-        filetypes: list[tuple[str, str]] = None,
+        filetypes: list[tuple[str, str]] | None = None,
         defaultextension: str = '',  # Not used.
     ) -> str:
         """Create and run an Qt save file dialog ."""
@@ -917,7 +917,7 @@ class LeoQtGui(leoGui.LeoGui):
         title: str = 'Message',
         label: str = '',
         msg: str = '',
-        c: Cmdr = None,
+        c: Cmdr | None = None,
         **keys: KWargs,
     ) -> None:
         if g.unitTesting:
@@ -1098,7 +1098,7 @@ class LeoQtGui(leoGui.LeoGui):
                 c.bodyWantsFocusNow()
 
     # @+node:ekr.20190601054958.1: *4* LeoQtGui.get_focus
-    def get_focus(self, c: Cmdr = None, raw: bool = False, at_idle: bool = False) -> QWidget:
+    def get_focus(self, c: Cmdr | None = None, raw: bool = False, at_idle: bool = False) -> QWidget:
         """Returns the widget that has focus."""
         trace = 'focus' in g.app.debug and not at_idle
         w = QtWidgets.QApplication.focusWidget()
@@ -1175,7 +1175,7 @@ class LeoQtGui(leoGui.LeoGui):
             return None
 
     # @+node:ekr.20110605121601.18511: *3* LeoQtGui.getFullVersion
-    def getFullVersion(self, c: Cmdr = None) -> str:
+    def getFullVersion(self, c: Cmdr | None = None) -> str:
         """Return the PyQt version (for signon)"""
         try:
             qtLevel = f"version {QtCore.qVersion()}"
@@ -1317,12 +1317,12 @@ class LeoQtGui(leoGui.LeoGui):
     def makeScriptButton(
         self,
         c: Cmdr,
-        args: Args = None,
-        p: Position = None,  # A node containing the script.
-        script: str = None,  # The script itself.
-        buttonText: str = None,
+        args: Args | None = None,
+        p: Position | None = None,  # A node containing the script.
+        script: str | None = None,  # The script itself.
+        buttonText: str | None = None,
         balloonText: str = 'Script Button',
-        shortcut: str = None,
+        shortcut: str | None = None,
         bg: str = 'LightSteelBlue1',
         define_g: bool = True,
         define_name: str = '__main__',
@@ -1346,14 +1346,14 @@ class LeoQtGui(leoGui.LeoGui):
         # @+<< define the callbacks for b >>
         # @+node:ekr.20110605121601.18530: *4* << define the callbacks for b >>
         def deleteButtonCallback(
-            event: LeoKeyEvent = None, b: QPushButton = b, c: Cmdr = c
+            event: LeoKeyEvent | None = None, b: QPushButton = b, c: Cmdr = c
         ) -> None:
             if b:
                 b.pack_forget()
             c.bodyWantsFocus()
 
         def executeScriptCallback(
-            event: LeoKeyEvent = None,
+            event: LeoKeyEvent | None = None,
             b: QPushButton = b,
             c: Cmdr = c,
             buttonText: str = buttonText,
@@ -1493,7 +1493,7 @@ class LeoQtGui(leoGui.LeoGui):
 
     # @+node:ekr.20180117053546.1: *3* LeoQtGui.show_tips & helpers
     @g.command('show-tips')
-    def show_next_tip(self, event: LeoKeyEvent = None) -> None:
+    def show_next_tip(self, event: LeoKeyEvent | None = None) -> None:
         c = g.app.log and g.app.log.c
         if c:
             g.app.gui.show_tips(c)
@@ -1728,11 +1728,11 @@ class LeoQtGui(leoGui.LeoGui):
         self,
         parent: QWidget,
         name: str,
-        hPolicy: Policy = None,
-        vPolicy: Policy = None,
+        hPolicy: Policy | None = None,
+        vPolicy: Policy | None = None,
         lineWidth: int = 1,
-        shadow: Shadow = None,
-        shape: Shape = None,
+        shadow: Shadow | None = None,
+        shape: Shape | None = None,
     ) -> QFrame:
         """Create a Qt Frame."""
         if shadow is None:
@@ -1789,8 +1789,8 @@ class LeoQtGui(leoGui.LeoGui):
         self,
         parent: QWidget,
         name: str,
-        hPolicy: Policy = None,
-        vPolicy: Policy = None,
+        hPolicy: Policy | None = None,
+        vPolicy: Policy | None = None,
     ) -> QTabWidget:
         w = QtWidgets.QTabWidget(parent)
         self.setSizePolicy(w, kind1=hPolicy, kind2=vPolicy)
@@ -1798,7 +1798,7 @@ class LeoQtGui(leoGui.LeoGui):
         return w
 
     # @+node:ekr.20190819091214.1: *4* LeoQtGui.setSizePolicy
-    def setSizePolicy(self, widget: QWidget, kind1: Policy = None, kind2: Policy = None) -> None:
+    def setSizePolicy(self, widget: QWidget, kind1: Policy | None = None, kind2: Policy | None = None) -> None:
         if kind1 is None:
             kind1 = Policy.Ignored
         if kind2 is None:
@@ -1898,7 +1898,7 @@ class StyleSheetManager:
         # g.es("https://leo-editor.github.io/leo-editor/tutorial-basics.html#configuring-leo")
 
     # @+node:ekr.20170222051716.1: *4* ssm.reload_settings
-    def reload_settings(self, sheet: str = None) -> None:
+    def reload_settings(self, sheet: str | None = None) -> None:
         """
         Recompute and apply the stylesheet.
         Called automatically by the reload-settings commands.
@@ -2019,7 +2019,7 @@ class StyleSheetManager:
         print(f"style sheet for: {w}...\n\n{sheet}")
 
     # @+node:ekr.20110605121601.18175: *4* ssm.set_style_sheets
-    def set_style_sheets(self, all: bool = True, top: QWidget = None, w: QWidget = None) -> None:
+    def set_style_sheets(self, all: bool = True, top: QWidget | None = None, w: QWidget | None = None) -> None:
         """Set the master style sheet for all widgets using config settings."""
         c = self.c
         if top is None:
@@ -2057,7 +2057,7 @@ class StyleSheetManager:
     # @+node:ekr.20140915062551.19510: *4* ssm.expand_css_constants & helpers
     css_warning_given = False  # For do_pass.
 
-    def expand_css_constants(self, sheet: str, settingsDict: g.SettingsDict = None) -> str:
+    def expand_css_constants(self, sheet: str, settingsDict: g.SettingsDict | None = None) -> str:
         """Expand @ settings into their corresponding constants."""
         c = self.c
         trace = 'zoom' in g.app.debug
@@ -2329,7 +2329,7 @@ class StyleSheetManager:
 
     # @+node:ekr.20180316092116.1: *3* ssm.Widgets
     # @+node:ekr.20140913054442.19390: *4* ssm.get_master_widget
-    def get_master_widget(self, top: QWidget = None) -> QWidget:
+    def get_master_widget(self, top: QWidget | None = None) -> QWidget:
         """
         Carefully return the master widget.
         c.frame.top is a DynamicWindow.

--- a/leo/plugins/qt_idle_time.py
+++ b/leo/plugins/qt_idle_time.py
@@ -52,7 +52,7 @@ class IdleTime:
 
     # @+others
     # @+node:ekr.20140825042850.18406: *3* IdleTime.__init__
-    def __init__(self, handler: Callable, delay: int = 500, tag: str = None) -> None:
+    def __init__(self, handler: Callable, delay: int = 500, tag: str | None = None) -> None:
         """ctor for IdleTime class."""
         # For use by handlers...
         self.count = 0  # The number of times handler has been called.

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -664,7 +664,7 @@ class LayoutCacheWidget(QWidget):
         g.trace('Fail 2')
 
     # @+node:tom.20240923194438.6: *4* LCW.restoreFromLayout
-    def restoreFromLayout(self, layout: Dict = None) -> None:
+    def restoreFromLayout(self, layout: Dict | None = None) -> None:
         self.layout_dict = layout
         if layout is None:
             layout = FALLBACK_LAYOUT

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -44,7 +44,7 @@ QFontMetrics = QtGui.QFontMetrics
 # @+node:ekr.20191001084541.1: **  zoom commands
 # @+node:tbrown.20130411145310.18857: *3* @g.command('zoom-in')
 @g.command("zoom-in")
-def zoom_in(event: LeoKeyEvent = None, delta: int = 1) -> None:
+def zoom_in(event: LeoKeyEvent | None = None, delta: int = 1) -> None:
     """increase body font size by one
 
     @font-size-body must be present in the stylesheet
@@ -54,7 +54,7 @@ def zoom_in(event: LeoKeyEvent = None, delta: int = 1) -> None:
 
 # @+node:ekr.20191001084646.1: *3* @g.command('zoom-out')
 @g.command("zoom-out")
-def zoom_out(event: LeoKeyEvent = None) -> None:
+def zoom_out(event: LeoKeyEvent | None = None) -> None:
     """decrease body font size by one
 
     @font-size-body must be present in the stylesheet
@@ -117,7 +117,7 @@ Valid values are standard css color names like `lightgrey`, and css rgb values l
 
 
 @g.command('help-for-highlight-current-line')
-def helpForLineHighlight(self: Value, event: LeoKeyEvent = None) -> None:
+def helpForLineHighlight(self: Value, event: LeoKeyEvent | None = None) -> None:
     """Displays Settings used by current line highlighter."""
     self.c.putHelpFor(hilite_doc)
 
@@ -156,7 +156,7 @@ class QTextMixin:
     This is also the annotation for all text-related wrappers.
     """
 
-    def __init__(self, c: Cmdr = None) -> None:
+    def __init__(self, c: Cmdr | None = None) -> None:
         self.c = c
         self.changingText = False  # A lockout for onTextChanged.
         self.enabled = True
@@ -217,7 +217,7 @@ class QTextMixin:
     # @+node:ekr.20140901122110.18733: *3* QTextMixin: Event handlers
     # These are independent of the kind of Qt widget.
     # @+node:ekr.20140901062324.18716: *4* QTextMixin.onCursorPositionChanged
-    def onCursorPositionChanged(self, event: QEvent = None) -> None:
+    def onCursorPositionChanged(self, event: QEvent | None = None) -> None:
         c = self.c
         name = c.widget_name(self)
         # Apparently, this does not cause problems
@@ -322,7 +322,7 @@ class QTextMixin:
         self.setInsertPoint(len(s2))
 
     # @+node:ekr.20140901141402.18706: *5* QTextMixin.delete
-    def delete(self, i: int, j: int = None) -> None:
+    def delete(self, i: int, j: int | None = None) -> None:
         if j is None:
             j = i + 1
         # This allows subclasses to use this base class method.
@@ -338,7 +338,7 @@ class QTextMixin:
         self.delete(i, j)
 
     # @+node:ekr.20110605121601.18102: *5* QTextMixin.get
-    def get(self, i: int, j: int = None) -> str:
+    def get(self, i: int, j: int | None = None) -> str:
         # 2012/04/12: fix the following two bugs by using the vanilla code:
         # https://bugs.launchpad.net/leo-editor/+bug/979142
         # https://bugs.launchpad.net/leo-editor/+bug/971166
@@ -410,13 +410,13 @@ class QTextMixin:
         self.setSelectionRange(0, self.getLength())
 
     # @+node:ekr.20260406043726.1: *5* QTextMixin.setInsertPoint
-    def setInsertPoint(self, i: int, s: str = None) -> None:
+    def setInsertPoint(self, i: int, s: str | None = None) -> None:
         self.virtualInsertPoint = i
         self.ins = i
         self.sel = i, i
 
     # @+node:ekr.20260406043803.1: *5* QTextMixin.setSelectionRange (NEW)
-    def setSelectionRange(self, i: int, j: int, insert: int = None) -> None:
+    def setSelectionRange(self, i: int, j: int, insert: int | None = None) -> None:
         self.sel = i, j
         self.ins = j if insert is None else insert
 
@@ -440,7 +440,7 @@ class QLineEditWrapper(QTextMixin):
 
     # @+others
     # @+node:ekr.20110605121601.18060: *3* qlew.Birth
-    def __init__(self, widget: QLineEdit, name: str, c: Cmdr = None) -> None:
+    def __init__(self, widget: QLineEdit, name: str, c: Cmdr | None = None) -> None:
         """Ctor for QLineEditWrapper class."""
         super().__init__(c)
         self.widget = widget
@@ -535,7 +535,7 @@ class QLineEditWrapper(QTextMixin):
             g.app.gui.set_focus(self.c, self.widget)
 
     # @+node:ekr.20110605121601.18129: *4* qlew.setInsertPoint
-    def setInsertPoint(self, i: int, s: str = None) -> None:
+    def setInsertPoint(self, i: int, s: str | None = None) -> None:
         """QHeadlineWrapper."""
         if not self.check():
             return
@@ -547,7 +547,7 @@ class QLineEditWrapper(QTextMixin):
 
     # @+node:ekr.20110605121601.18130: *4* qlew.setSelectionRange
     def setSelectionRange(
-        self, i: int, j: int, insert: Optional[int] = None, s: str = None
+        self, i: int, j: int, insert: Optional[int] = None, s: str | None = None
     ) -> None:
         """QHeadlineWrapper."""
         if not self.check():
@@ -1442,7 +1442,7 @@ class QMinibufferWrapper(QLineEditWrapper):
         # level sheet will get pushed down quite frequently.
         self.widget.setStyleSheet(self.c.frame.top.styleSheet())
 
-    def setSelectionRange(self, i: int, j: int, insert: int = None, s: str = None) -> None:
+    def setSelectionRange(self, i: int, j: int, insert: int | None = None, s: str | None = None) -> None:
         QLineEditWrapper.setSelectionRange(self, i, j, insert, s)
         insert = j if insert is None else insert
         if self.widget:
@@ -1462,7 +1462,7 @@ class QScintillaWrapper(QTextMixin):
 
     # @+others
     # @+node:ekr.20110605121601.18105: *3* qsciw.ctor
-    def __init__(self, widget: QWidget, c: Cmdr, name: str = None) -> None:
+    def __init__(self, widget: QWidget, c: Cmdr, name: str | None = None) -> None:
         """Ctor for the QScintillaWrapper class."""
         super().__init__(c)
         self.baseClassName = 'QScintillaWrapper'
@@ -1493,7 +1493,7 @@ class QScintillaWrapper(QTextMixin):
 
     # @+node:ekr.20110605121601.18107: *3* qsciw.WidgetAPI
     # @+node:ekr.20140901062324.18593: *4* qsciw.delete
-    def delete(self, i: int, j: int = None) -> None:
+    def delete(self, i: int, j: int | None = None) -> None:
         """Delete s[i:j]"""
         w = self.widget
         if j is None:
@@ -1566,7 +1566,7 @@ class QScintillaWrapper(QTextMixin):
             addFlashCallback()
 
     # @+node:ekr.20140901062324.18595: *4* qsciw.get
-    def get(self, i: int, j: int = None) -> str:
+    def get(self, i: int, j: int | None = None) -> str:
         # Fix the following two bugs by using vanilla code:
         # https://bugs.launchpad.net/leo-editor/+bug/979142
         # https://bugs.launchpad.net/leo-editor/+bug/971166
@@ -1679,7 +1679,7 @@ class QScintillaWrapper(QTextMixin):
         # w.update()
 
     # @+node:ekr.20110605121601.18114: *4* qsciw.setInsertPoint
-    def setInsertPoint(self, i: int, s: str = None) -> None:
+    def setInsertPoint(self, i: int, s: str | None = None) -> None:
         """Set the insertion point in a QsciScintilla widget."""
         w = self.widget
         # w.SendScintilla(w.SCI_SETCURRENTPOS,i)
@@ -1687,7 +1687,7 @@ class QScintillaWrapper(QTextMixin):
         w.SendScintilla(w.SCI_SETSEL, i, i)
 
     # @+node:ekr.20110605121601.18115: *4* qsciw.setSelectionRange
-    def setSelectionRange(self, i: int, j: int, insert: int = None, s: str = None) -> None:
+    def setSelectionRange(self, i: int, j: int, insert: int | None = None, s: str | None = None) -> None:
         """Set the selection range in a QsciScintilla widget."""
         w = self.widget
         if insert is None:
@@ -1715,7 +1715,7 @@ class QTextEditWrapper(QTextMixin):
 
     # @+others
     # @+node:ekr.20110605121601.18073: *3* QTextEditWrapper.ctor & helpers
-    def __init__(self, widget: QWidget, name: str = 'TestWrapper', c: Cmdr = None) -> None:
+    def __init__(self, widget: QWidget, name: str = 'TestWrapper', c: Cmdr | None = None) -> None:
         """Ctor for QTextEditWrapper class. widget is a QTextEdit/QTextBrowser."""
         super().__init__(c)
         # Make sure all ivars are set.
@@ -1786,7 +1786,7 @@ class QTextEditWrapper(QTextMixin):
     # @+node:ekr.20110605121601.18078: *3* QTextEditWrapper.High-level interface
     # These are all widget-dependent
     # @+node:ekr.20110605121601.18079: *4* qtew.delete (avoid call to setAllText)
-    def delete(self, i: int, j: int = None) -> None:
+    def delete(self, i: int, j: int | None = None) -> None:
         """QTextEditWrapper."""
         w = self.widget
         if j is None:
@@ -2091,7 +2091,7 @@ class QTextEditWrapper(QTextMixin):
             self.changingText = False
 
     # @+node:ekr.20110605121601.18095: *4* qtew.setInsertPoint
-    def setInsertPoint(self, i: int, s: str = None) -> None:
+    def setInsertPoint(self, i: int, s: str | None = None) -> None:
         # Fix bug 981849: incorrect body content shown.
         # Use the more careful code in setSelectionRange.
         self.setSelectionRange(i=i, j=i, insert=i, s=s)

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -166,7 +166,7 @@ class LeoQtTree(leoFrame.LeoTree):
         w.clear()
 
     # @+node:ekr.20110605121601.17873: *4* qtree.full_redraw & helpers
-    def full_redraw(self, p: Position = None) -> Position:
+    def full_redraw(self, p: Position | None = None) -> Position:
         """
         Redraw all visible nodes of the tree.
         Preserve the vertical scrolling unless scroll is True.
@@ -522,7 +522,7 @@ class LeoQtTree(leoFrame.LeoTree):
             g.trace(f"{t2 - t1:5.2f} sec.", g.callers(3))
 
     # @+node:ekr.20110605121601.17877: *5* qtree.drawTree
-    def drawTree(self, p: Position, parent_item: QTreeWidgetItem = None) -> None:
+    def drawTree(self, p: Position, parent_item: QTreeWidgetItem | None = None) -> None:
         if g.app.gui.isNullGui:
             return
         # Draw the (visible) parent node.
@@ -554,7 +554,7 @@ class LeoQtTree(leoFrame.LeoTree):
                         item.setIcon(0, icon)  # 0 is the column number.
 
     # @+node:ekr.20110605121601.17884: *4* qtree.redraw_after_select
-    def redraw_after_select(self, p: Position = None) -> None:
+    def redraw_after_select(self, p: Position | None = None) -> None:
         """Redraw the entire tree when an invisible node is selected."""
         if self.busy:
             if 'drawing' in g.app.debug:
@@ -574,7 +574,7 @@ class LeoQtTree(leoFrame.LeoTree):
     # @+node:ekr.20110605121601.17885: *3* qtree.Event handlers
     # @+node:ekr.20110605121601.17887: *4*  qtree.Click Box
     # @+node:ekr.20110605121601.17888: *5* qtree.onClickBoxClick
-    def onClickBoxClick(self, event: LeoKeyEvent, p: Position = None) -> None:
+    def onClickBoxClick(self, event: LeoKeyEvent, p: Position | None = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -583,7 +583,7 @@ class LeoQtTree(leoFrame.LeoTree):
         c.outerUpdate()
 
     # @+node:ekr.20110605121601.17889: *5* qtree.onClickBoxRightClick
-    def onClickBoxRightClick(self, event: LeoKeyEvent, p: Position = None) -> None:
+    def onClickBoxRightClick(self, event: LeoKeyEvent, p: Position | None = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -592,7 +592,7 @@ class LeoQtTree(leoFrame.LeoTree):
         c.outerUpdate()
 
     # @+node:ekr.20110605121601.17890: *5* qtree.onPlusBoxRightClick
-    def onPlusBoxRightClick(self, event: LeoKeyEvent, p: Position = None) -> None:
+    def onPlusBoxRightClick(self, event: LeoKeyEvent, p: Position | None = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -602,7 +602,7 @@ class LeoQtTree(leoFrame.LeoTree):
     # @+node:ekr.20110605121601.17891: *4*  qtree.Icon Box
     # For Qt, there seems to be no way to trigger these events.
     # @+node:ekr.20110605121601.17892: *5* qtree.onIconBoxClick
-    def onIconBoxClick(self, event: LeoKeyEvent, p: Position = None) -> None:
+    def onIconBoxClick(self, event: LeoKeyEvent, p: Position | None = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -611,7 +611,7 @@ class LeoQtTree(leoFrame.LeoTree):
         c.outerUpdate()
 
     # @+node:ekr.20110605121601.17893: *5* qtree.onIconBoxRightClick
-    def onIconBoxRightClick(self, event: LeoKeyEvent, p: Position = None) -> None:
+    def onIconBoxRightClick(self, event: LeoKeyEvent, p: Position | None = None) -> None:
         """Handle a right click in any outline widget."""
         if self.busy:
             return
@@ -621,7 +621,7 @@ class LeoQtTree(leoFrame.LeoTree):
         c.outerUpdate()
 
     # @+node:ekr.20110605121601.17894: *5* qtree.onIconBoxDoubleClick
-    def onIconBoxDoubleClick(self, event: LeoKeyEvent, p: Position = None) -> None:
+    def onIconBoxDoubleClick(self, event: LeoKeyEvent, p: Position | None = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -1167,7 +1167,7 @@ class LeoQtTree(leoFrame.LeoTree):
         self,
         p: Position,
         selectAll: bool = False,
-        selection: tuple = None,
+        selection: tuple | None = None,
     ) -> tuple[QLineEdit, QHeadlineWrapper]:
         """Start editing p's headline."""
         if self.busy:
@@ -1195,7 +1195,7 @@ class LeoQtTree(leoFrame.LeoTree):
         self,
         item: QTreeWidgetItem,
         selectAll: bool = False,
-        selection: tuple = None,
+        selection: tuple | None = None,
     ) -> tuple[QLineEdit, QHeadlineWrapper]:
         """Helper for qtree.editLabel."""
         c, vc = self.c, self.c.vimCommands

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -312,7 +312,7 @@ class LeoQuickSearchWidget(QtWidgets.QWidget):  # type:ignore
 
     # @+others
     # @+node:ekr.20111015194452.15695: *3* quick_w.ctor
-    def __init__(self, c: Cmdr, mode: str = "nav", parent: QWidget = None) -> None:
+    def __init__(self, c: Cmdr, mode: str = "nav", parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.ui: Any = qt_quicksearch.Ui_LeoQuickSearchWidget()
         self.ui.setupUi(self)
@@ -734,7 +734,7 @@ class QuickSearchController:
 
     # @+node:ekr.20111015194452.15700: *3* Event handlers
     # @+node:ekr.20111015194452.15686: *4* onSelectItem (quicksearch.py)
-    def onSelectItem(self, it: Iterable, it_prev: Iterable = None) -> None:
+    def onSelectItem(self, it: Iterable, it_prev: Iterable | None = None) -> None:
         c = self.c
         if not it:
             return

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -609,7 +609,7 @@ class todoController:
 
     # @+node:tbrown.20090119215428.15: *3* todoController.loadAllIcons
     @redrawer
-    def loadAllIcons(self, tag: str = None, k: int = None, clear: bool = None) -> None:
+    def loadAllIcons(self, tag: str | None = None, k: int | None = None, clear: bool | None = None) -> None:
         """Load icons to represent cleo state"""
         for p in self.c.all_positions():
             self.loadIcons(p, clear=clear)
@@ -847,13 +847,13 @@ class todoController:
     # @+node:tbrown.20090119215428.31: *4* todoController.progress_clear
     @redrawer
     @projectChanger
-    def progress_clear(self, v: VNode = None) -> None:
+    def progress_clear(self, v: VNode | None = None) -> None:
         self.setat(self.c.currentPosition().v, 'progress', '')
 
     # @+node:tbrown.20090119215428.32: *4* todoController.set_progress
     @redrawer
     @projectChanger
-    def set_progress(self, p: Position = None, val: Any = None) -> None:  # Hard to annotate.
+    def set_progress(self, p: Position | None = None, val: Any | None = None) -> None:  # Hard to annotate.
         if p is None:
             p = self.c.currentPosition()
         v = p.v
@@ -866,7 +866,7 @@ class todoController:
     # @+node:tbrown.20090119215428.33: *4* todoController.set_time_req
     @redrawer
     @projectChanger
-    def set_time_req(self, p: Position = None, val: Any = None) -> None:  # Hard to annotate.
+    def set_time_req(self, p: Position | None = None, val: Any | None = None) -> None:  # Hard to annotate.
         if p is None:
             p = self.c.currentPosition()
         v = p.v
@@ -878,7 +878,7 @@ class todoController:
 
     # @+node:tbrown.20090119215428.34: *4* todoController.show_times
     @redrawer
-    def show_times(self, p: Position = None, show: bool = False) -> None:
+    def show_times(self, p: Position | None = None, show: bool = False) -> None:
         def rnd(x: float) -> str:
             return re.sub('.0$', '', '%.1f' % x)
 
@@ -916,7 +916,7 @@ class todoController:
                 self.loadIcons(nd)  # update progress icon
 
     # @+node:tbrown.20090119215428.35: *4* todoController.recalc_time
-    def recalc_time(self, p: Position = None, clear: bool = False) -> tuple[str, str]:
+    def recalc_time(self, p: Position | None = None, clear: bool = False) -> tuple[str, str]:
         if p is None:
             p = self.c.currentPosition()
         v = p.v
@@ -969,7 +969,7 @@ class todoController:
     # @+node:tbrown.20090119215428.36: *4* todoController.clear_time_req
     @redrawer
     @projectChanger
-    def clear_time_req(self, p: Position = None) -> None:
+    def clear_time_req(self, p: Position | None = None) -> None:
         if p is None:
             p = self.c.currentPosition()
         v = p.v
@@ -977,7 +977,7 @@ class todoController:
 
     # @+node:tbrown.20090119215428.37: *4* todoController.update_project
     @redrawer
-    def update_project(self, p: Position = None) -> None:
+    def update_project(self, p: Position | None = None) -> None:
         """Find highest parent with '@project' in headline and run recalc_time
         and maybe show_times (if headline has '@project time')"""
 
@@ -1000,19 +1000,19 @@ class todoController:
 
     # @+node:tbrown.20090119215428.38: *4* todoController.local_recalc
     @redrawer
-    def local_recalc(self, p: Position = None) -> None:
+    def local_recalc(self, p: Position | None = None) -> None:
         self.recalc_time(p)
 
     # @+node:tbrown.20090119215428.39: *4* todoController.local_clear
     @redrawer
-    def local_clear(self, p: Position = None) -> None:
+    def local_clear(self, p: Position | None = None) -> None:
         self.recalc_time(p, clear=True)
 
     # @+node:tbrown.20110213091328.16233: *4* todoController.set_due_date
     def set_due_date(
         self,
-        p: Position = None,
-        val: Any = None,  # Hard to annotate.
+        p: Position | None = None,
+        val: Any | None = None,  # Hard to annotate.
         mode: str = 'adjust',
         field: str = 'duedate',
     ) -> None:
@@ -1041,8 +1041,8 @@ class todoController:
     # @+node:tbrown.20110213091328.16235: *4* todoController.set_due_time
     def set_due_time(
         self,
-        p: Position = None,
-        val: Any = None,  # Hard to annotate.
+        p: Position | None = None,
+        val: Any | None = None,  # Hard to annotate.
         mode: str = 'adjust',
         field: str = 'duetime',
     ) -> None:
@@ -1101,7 +1101,7 @@ class todoController:
     # @+node:tbrown.20090119215428.40: *3* todoController:ToDo icon related...
     # @+node:tbrown.20090119215428.41: *4* todoController.childrenTodo
     @redrawer
-    def childrenTodo(self, p: Position = None) -> None:
+    def childrenTodo(self, p: Position | None = None) -> None:
         if p is None:
             p = self.c.currentPosition()
         for p in p.children():
@@ -1112,7 +1112,7 @@ class todoController:
 
     # @+node:tbrown.20130207095125.20463: *4* todoController.dueClear
     @redrawer
-    def dueClear(self, p: Position = None) -> None:
+    def dueClear(self, p: Position | None = None) -> None:
         """clear due date on descendants, useful for creating a master todo
         item with sub items which previously had their own dates"""
         if p is None:
@@ -1122,7 +1122,7 @@ class todoController:
 
     # @+node:tbrown.20130207103126.28498: *4* todoController.needs_doing
     def needs_doing(
-        self, v: VNode = None, pri: Any = None, due: Any = None
+        self, v: VNode | None = None, pri: Any | None = None, due: Any | None = None
     ) -> bool:  # Hard to annotate.
         """needs_doing - Return true if the node is a todo node that needs doing
 
@@ -1138,7 +1138,7 @@ class todoController:
 
     # @+node:tbrown.20090119215428.42: *4* todoController.find_todo
     @redrawer
-    def find_todo(self, p: Position = None, stage: int = 0) -> bool:
+    def find_todo(self, p: Position | None = None, stage: int = 0) -> bool:
         """Recursively find the next todo"""
 
         # search is like XPath 'following' axis, all nodes after p in document order.
@@ -1201,7 +1201,7 @@ class todoController:
 
     # @+node:tbrown.20110213153425.16377: *4* todoController.dueSort
     @redrawer
-    def dueSort(self, p: Position = None, field: str = 'due') -> None:
+    def dueSort(self, p: Position | None = None, field: str = 'due') -> None:
         if p is None:
             p = self.c.currentPosition()
         self.c.selectPosition(p)
@@ -1209,7 +1209,7 @@ class todoController:
 
     # @+node:tbrown.20090119215428.44: *4* todoController.priority_clear
     @redrawer
-    def priority_clear(self, v: VNode = None) -> None:
+    def priority_clear(self, v: VNode | None = None) -> None:
         if v is None:
             v = self.c.currentPosition().v
         self.setat(v, 'priority', 9999)
@@ -1217,7 +1217,7 @@ class todoController:
 
     # @+node:tbrown.20090119215428.45: *4* todoController.priSort
     @redrawer
-    def priSort(self, p: Position = None) -> None:
+    def priSort(self, p: Position | None = None) -> None:
         if p is None:
             p = self.c.currentPosition()
         self.c.selectPosition(p)
@@ -1225,7 +1225,7 @@ class todoController:
 
     # @+node:tbrown.20090119215428.46: *4* todoController.reclassify
     @redrawer
-    def reclassify(self, p: Position = None) -> None:
+    def reclassify(self, p: Position | None = None) -> None:
         """change priority codes"""
 
         if p is None:
@@ -1298,7 +1298,7 @@ class todoController:
         self.loadIcons(p)
 
     # @+node:tbrown.20090119215428.48: *4* todoController.showDist
-    def showDist(self, p: Position = None) -> None:
+    def showDist(self, p: Position | None = None) -> None:
         """show distribution of priority levels in subtree"""
         if p is None:
             p = self.c.currentPosition()
@@ -1323,7 +1323,7 @@ class todoController:
                 )
 
     # @+node:tbrown.20150605111428.1: *3* todoController.updateStyle
-    def updateStyle(self, tag: str = None, k: int = None) -> None:
+    def updateStyle(self, tag: str | None = None, k: int | None = None) -> None:
         """
         updateStyle - calling widget.setStyleSheet("/* */") is a trick to get Qt to
         update appearance on a widget styled depending on changes in attributes.
@@ -1351,7 +1351,7 @@ class todoController:
                 self._widget_to_style = None
 
     # @+node:tbrown.20090119215428.49: *3* todoController.updateUI
-    def updateUI(self, tag: str = None, k: dict = None) -> None:
+    def updateUI(self, tag: str | None = None, k: dict | None = None) -> None:
         if k and k['c'] != self.c:
             return  # wrong number
 

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -317,7 +317,7 @@ def init() -> bool:
 
 # @+node:ekr.20240727091022.1: *3* vr function: getVR
 def getVr(
-    *, c: Any = None, event: Any = None, parent: QtWidgets.QWidget = None
+    *, c: Any | None = None, event: Any | None = None, parent: QtWidgets.QWidget | None = None
 ) -> Optional[QtWidgets.QWidget]:
     """Return the ViewRenderedController instance or None."""
     if g.app.gui.guiName() != 'qt':
@@ -645,7 +645,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     # @-<< vr: default templates >>
     # @+others
     # @+node:ekr.20110317080650.14380: *3*  vr.ctor & helpers
-    def __init__(self, c: Cmdr, parent: QWidget = None) -> None:
+    def __init__(self, c: Cmdr, parent: QWidget | None = None) -> None:
         """Ctor for ViewRenderedController class."""
         self.c = c
         # Create the widget.

--- a/leo/plugins/zenity_file_dialogs.py
+++ b/leo/plugins/zenity_file_dialogs.py
@@ -74,7 +74,7 @@ def callZenity(title: str, save: bool = False, test: bool = False) -> Optional[b
 def runOpenFileDialog(
     title,
     *,
-    filetypes: list[tuple[str, str]] = None,
+    filetypes: list[tuple[str, str]] | None = None,
     defaultextension='',  # Not used.
 ):
     """Call zenity's open file(s) dialog."""
@@ -86,7 +86,7 @@ def runOpenFileDialog(
 def runSaveFileDialog(
     title=None,
     *,
-    filetypes: list[tuple[str, str]] = None,
+    filetypes: list[tuple[str, str]] | None = None,
     defaultextension='',  # Not used.
 ) -> bytes:
     """Call zenity's save file dialog."""


### PR DESCRIPTION
## Summary
Applies the [`no_implicit_optional`](https://pypi.org/project/no-implicit-optional/) codemod (`--use-union-or`) to `leo/core`, `leo/commands`, and `leo/plugins`. Rewrites **71 files**, purely mechanically:

\`\`\`python
# before
def foo(x: str = None, y: Callable = None) -> None: ...

# after
def foo(x: str | None = None, y: Callable | None = None) -> None: ...
\`\`\`

## Why
PEP 484 banned implicit Optional in 2021 (mypy's default is now \`no_implicit_optional = True\`). The codebase has accumulated ~950 call signatures in the old form. These are the single largest category of issues masked by Leo's \`.mypy.ini\` setting \`strict_optional = False\`. Fixing them mechanically now:

1. Makes annotations honest about nullability (closer to what the code actually accepts).
2. Unblocks future per-file \`strict_optional\` work — the ~950 implicit-Optional errors would otherwise dominate any strict run.
3. Aligns with mypy's own default and with the style used in new code already in the repo.

## Scope
- `leo/core`: 34 files
- `leo/commands`, `leo/plugins`: 37 files
- Total: 71 files, 1085 / 1085 line changes (symmetric — pure rewrite, no structural changes).

## What this does NOT do
- Does **not** enable \`strict_optional\` in \`.mypy.ini\` — that's a separate follow-up PR. This PR is strictly an annotation cleanup; current mypy gates keep the same error count (262, all pre-existing).
- Does **not** touch the 2 unrelated editCommands.py assignment errors.

## Test plan
- [x] \`ruff check leo\` — clean
- [x] \`python -m mypy --config-file .mypy.ini leo/core\` — same 262 errors as on \`devel\` (no regression)
- [ ] Smoke test: Leo launches and basic editing works (no runtime code paths change — only annotations on parameter defaults)

## How to reproduce
\`\`\`bash
pip install no_implicit_optional
no_implicit_optional --use-union-or leo/core leo/commands leo/plugins
\`\`\`