### PR TITLE
PR fixes #4623: keys don't work in the log pane

### DIFF
--- a/leo/commands/commanderEditCommands.py
+++ b/leo/commands/commanderEditCommands.py
@@ -13,7 +13,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position
-    from leo.plugins.qt_text import QTextMixin
 
     Self = Cmdr  # For arguments to @g.commander_command.
     Value = Any
@@ -368,12 +367,11 @@ def editHeadline(self: Self, event: LeoKeyEvent = None) -> None:
     if g.app.batchMode:
         c.notValidInBatchMode("Edit Headline")
         return
-    wrapper: QTextMixin
-    e, wrapper = tree.editLabel(c.p)
+    tree.editLabel(c.p)
     if k:
         # k.setDefaultInputState()
         k.setEditingState()
-        k.showStateAndMode(w=wrapper)
+        k.showStateAndMode()
 
 
 # @+node:ekr.20171123135625.23: ** c_ec.extract

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3494,8 +3494,8 @@ class Commands:
         if not name.startswith('log'):
             return
         # Make sure we can insert into w.
-        log_w = event.widget
-        if not g.app.gui.isTextWidget(log_w):
+        log_w = event.wrapper  # #4623.
+        if not g.app.gui.isTextWrapper(log_w):
             return
         # Send the event to the text widget, not the LeoLog instance.
         i = log_w.getInsertPoint()

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2984,7 +2984,7 @@ class LeoFind:
             c.selectPosition(p)
             c.bodyWantsFocus()
             if showState:
-                c.k.showStateAndMode(w)
+                c.k.showStateAndMode()
             c.bodyWantsFocusNow()
             w.setSelectionRange(pos, newpos, insert=insert)
             k = g.see_more_lines(w.getAllText(), insert, 4)

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -714,7 +714,7 @@ class LeoLog:
         self.logNumber = 0  # To create unique name fields for text widgets.
         self.newTabCount = 0  # Number of new tabs created.
         self.textDict: dict[str, Widget] = {}  # Keys: page names. Values: text widgets.
-        self.wrapper: StringTextWrapper = None  # To keep mypy happy.
+        self.wrapper: QTextMixin = None
 
     # @+node:ekr.20070302094848.1: *3* LeoLog.clearTab
     def clearTab(self, tabName: str, wrap: str = 'none') -> None:

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1556,7 +1556,7 @@ class NullLog(LeoLog):
         super().__init__(frame)
         c = self.c
         self.isNull = True
-        self.widget = StringTextWrapper(c=c, name='null-log')
+        self.widget = self.wrapper = StringTextWrapper(c=c, name='null-log')
 
     # @+others
     # @+node:ekr.20120216123546.10951: *3* NullLog.finishCreate
@@ -1636,7 +1636,7 @@ class NullStatusLineClass:
         """Ctor for NullStatusLine class."""
         self.c = c
         self.enabled = False
-        self.textWidget = StringTextWrapper(c, name='status-line')
+        self.textWidget = self.wrapper = StringTextWrapper(c, name='status-line')
 
     # @+others
     # @+node:ekr.20070302171917: *3* NullStatusLineClass.methods

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -589,7 +589,6 @@ class LeoFrame:
         else:
             c.bodyWantsFocus()
             k.setDefaultInputState()
-            # Recolor the *body* text, **not** the headline.
             k.showStateAndMode()
 
     # @+node:ekr.20031218072017.3680: *3* LeoFrame.Must be defined in subclasses

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -590,7 +590,7 @@ class LeoFrame:
             c.bodyWantsFocus()
             k.setDefaultInputState()
             # Recolor the *body* text, **not** the headline.
-            k.showStateAndMode(w=c.frame.body.wrapper)
+            k.showStateAndMode()
 
     # @+node:ekr.20031218072017.3680: *3* LeoFrame.Must be defined in subclasses
     def bringToFront(self) -> None:

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -382,7 +382,10 @@ class LeoKeyEvent:
         self.event = event  # New in Leo 4.11.
         self.stroke = stroke
         self.w = self.widget = w
-        self.wrapper = g.app.gui.create_wrapper_for_widget(c, w)
+        self.wrapper = (
+            w if g.isTextWrapper(w)  # #4623.
+            else g.app.gui.create_wrapper_for_widget(c, w)
+        )  # fmt: skip
         # Optional ivars
         self.x = x
         self.y = y

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -382,7 +382,7 @@ class LeoKeyEvent:
         self.event = event  # New in Leo 4.11.
         self.stroke = stroke
         self.w = self.widget = w
-        self.wrapper = g.app.gui.create_wrapper_for_widget(c, w)  ### Experimental
+        self.wrapper = g.app.gui.create_wrapper_for_widget(c, w)
         # Optional ivars
         self.x = x
         self.y = y

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -4509,39 +4509,15 @@ class KeyHandlerClass:
         # k.showStateAndMode()
 
     # @+node:ekr.20061031131434.192: *4* k.showStateAndMode
-    def showStateAndMode(
-        self,
-        w: QTextMixin = None,
-        prompt: str = None,
-        setFocus: bool = True,
-    ) -> None:
+    def showStateAndMode(self, *, prompt: str = None, setFocus: bool = True) -> None:
         """Show the state and mode at the start of the minibuffer."""
         c, k = self.c, self
         state = k.unboundKeyAction
         mode = k.getStateKind()
         if not g.app.gui:
             return
-        if not w:
-            if hasattr(g.app.gui, 'set_minibuffer_label'):
-                pass  # we don't need w
-            else:
-                w = g.app.gui.get_focus(c)
-                if not w:
-                    return
 
-        # This fixes a problem with the tk gui plugin.
-        if mode and mode.lower().startswith('isearch'):
-            return
-        wname = g.app.gui.widget_name(w).lower()
-
-        # Get the wrapper for the headline widget.
-        if wname.startswith('head'):
-            if hasattr(c.frame.tree, 'getWrapper'):
-                if hasattr(w, 'widget'):
-                    w2 = w.widget
-                else:
-                    w2 = w
-                w = c.frame.tree.getWrapper(w2, item=None)
+        # Set the prompt.
         if mode:
             if mode in ('getArg', 'getFileName', 'full-command'):
                 s = None

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -3603,6 +3603,34 @@ for command_or_key in [
         c.k.masterKeyHandler(event)
         g.app.gui.qtApp.processEvents()
         g.sleep(1.0)  # Testing only.
+# @+node:ekr.20260420174001.1: *3* Deleted by PR #4624
+# @+node:ekr.20260420154627.8: *4* dw.addNewEditor
+def addNewEditor(self, name: str) -> tuple[QWidget, QTextMixin]:
+    """Create a new body editor."""
+    c, p = self.leo_c, self.leo_c.p
+    body = c.frame.body
+    assert isinstance(body, LeoQtBody), repr(body)
+    # Step 1: create the editor.
+    parent_frame = c.frame.top.leo_body_inner_frame
+    widget = qt_text.LeoQTextBrowser(parent_frame, c, self)
+    widget.setObjectName('richTextEdit')  # Will be changed later.
+    wrapper = qt_text.QTextEditWrapper(widget, name='body', c=c)
+    self.packLabel(widget)
+    # Step 2: inject ivars, set bindings, etc.
+    inner_frame = c.frame.top.leo_body_inner_frame  # Inject ivars *here*.
+    body.injectIvars(inner_frame, name, p, wrapper)
+    body.updateInjectedIvars(widget, p)
+    wrapper.setAllText(p.b)
+    wrapper.see(0)
+    c.k.completeAllBindingsForWidget(wrapper)
+    if isinstance(widget, QtWidgets.QTextEdit):
+        colorizer = leoColorizer.make_colorizer(c, widget)
+        colorizer.highlighter.setDocument(widget.document())
+    else:
+        # Scintilla only.
+        body.recolorWidget(p, wrapper)
+    return parent_frame, wrapper
+
 # @-all
 # @@nosearch
 # @-leo

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -842,33 +842,6 @@ class DynamicWindow(QtWidgets.QMainWindow):
         self.leo_master.select(c)
 
     # @+node:ekr.20110605121601.18142: *3* dw: top-level methods
-    # @+node:ekr.20190118150859.10: *4* dw.addNewEditor
-    def addNewEditor(self, name: str) -> tuple[QWidget, QTextMixin]:
-        """Create a new body editor."""
-        c, p = self.leo_c, self.leo_c.p
-        body = c.frame.body
-        assert isinstance(body, LeoQtBody), repr(body)
-        # Step 1: create the editor.
-        parent_frame = c.frame.top.leo_body_inner_frame
-        widget = qt_text.LeoQTextBrowser(parent_frame, c, self)
-        widget.setObjectName('richTextEdit')  # Will be changed later.
-        wrapper = qt_text.QTextEditWrapper(widget, name='body', c=c)
-        self.packLabel(widget)
-        # Step 2: inject ivars, set bindings, etc.
-        inner_frame = c.frame.top.leo_body_inner_frame  # Inject ivars *here*.
-        body.injectIvars(inner_frame, name, p, wrapper)
-        body.updateInjectedIvars(widget, p)
-        wrapper.setAllText(p.b)
-        wrapper.see(0)
-        c.k.completeAllBindingsForWidget(wrapper)
-        if isinstance(widget, QtWidgets.QTextEdit):
-            colorizer = leoColorizer.make_colorizer(c, widget)
-            colorizer.highlighter.setDocument(widget.document())
-        else:
-            # Scintilla only.
-            body.recolorWidget(p, wrapper)
-        return parent_frame, wrapper
-
     # @+node:ekr.20110605121601.18143: *4* dw.createBodyPane
     def createBodyPane(self, parent: QWidget) -> QWidget:
         """
@@ -4197,6 +4170,8 @@ class QtStatusLineClass:
         # Create the text widgets.
         self.textWidget1 = w1 = QtWidgets.QLineEdit(self.statusBar)
         self.textWidget2 = w2 = QtWidgets.QLineEdit(self.statusBar)
+        w1.leo_wrapper = QLineEditWrapper(c=c, widget=w1)  # #4623
+        w2.leo_wrapper = QLineEditWrapper(c=c, widget=w2)  # #4623
         w1.setObjectName('status1')
         w2.setObjectName('status2')
         w1.setReadOnly(True)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -53,7 +53,7 @@ from leo.core.leoQt import (
     WrapMode,
 )
 from leo.plugins import qt_events, qt_text
-from leo.plugins.qt_text import QTextEditWrapper
+from leo.plugins.qt_text import QLineEditWrapper, QTextEditWrapper
 from leo.plugins.qt_tree import LeoQtTree
 from leo.plugins.mod_scripting import build_rclick_tree
 from leo.plugins.qt_layout import LayoutCacheWidget
@@ -1067,6 +1067,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         lineEdit = VisLineEdit(frame)
         lineEdit._sel_and_insert = (0, 0, 0)
         lineEdit.setObjectName('lineEdit')  # name important.
+        lineEdit.leo_wrapper = QLineEditWrapper(widget=lineEdit)  # #4623.
         # Pack.
         hLayout = self.createHLayout(frame, 'minibufferHLayout', spacing=4)
         hLayout.setContentsMargins(3, 2, 2, 0)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2293,6 +2293,7 @@ class LeoQtLog(leoFrame.LeoLog):
         self.logDict: dict[str, LeoQTextBrowser] = {}  # Keys: tab names.
         self.logWidget: LeoLog = None
         self.qtTabWidget: QWidget = c.frame.top.tabWidget
+        self.wrapper: QTextEditWrapper = None  # #4623.
         tw = self.qtTabWidget
 
         # Bug 917814: Switching Log Pane tabs is done incompletely.
@@ -2316,6 +2317,9 @@ class LeoQtLog(leoFrame.LeoLog):
         # Create the log tab as the leftmost tab.
         log.createTab('Log')
         self.logWidget = self.contentsDict.get('Log')
+        self.wrapper = QTextEditWrapper(c=c, widget=self.logWidget)  # #4623.
+
+        # Configure.
         logWidget = self.logWidget
         logWidget.setWordWrapMode(WrapMode.WordWrap if self.wrap else WrapMode.NoWrap)
         w.insertTab(0, logWidget, 'Log')  # Required.

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -34,12 +34,13 @@ from leo.core.leoQt import (
 
 # This import causes pylint to fail on this file and on leoBridge.py.
 # The failure is in astroid: raw_building.py.
+from leo.core.leoAPI import StringTextWrapper
 from leo.core.leoQt import Shadow, Shape, StandardButton, Weight, WindowType
 from leo.plugins import qt_events
 from leo.plugins import qt_frame
 from leo.plugins import qt_idle_time
-from leo.plugins.qt_frame import LeoQtLog
-from leo.plugins.qt_text import QLineEditWrapper, QTextEditWrapper, QTextMixin
+from leo.plugins.qt_text import QTextMixin, QLineEditWrapper, QTextEditWrapper
+from leo.plugins.qt_tree import LeoQtTree
 
 # This defines the commands defined by @g.command.
 from leo.plugins import qt_commands
@@ -242,15 +243,26 @@ class LeoQtGui(leoGui.LeoGui):
             return w
         if getattr(w, 'wrapper', None):
             return w.wrapper
-        # To do: inject leo_wrapper into subclasses of QLineEdit and QTextEdit.
+        if getattr(w, 'leo_wrapper', None):
+            return w.leo_wrapper
+        if isinstance(w, LeoQtTree):
+            # A strange special case: the class allocates its own wrappers.
+            return None
+
+        def oops(w: Any, wrapper_name: str) -> None:
+            g.trace(f"Allocate {wrapper_name} for: {w.__class__.__name__}")
+
+        # Defensive code.
         if isinstance(w, QtWidgets.QLineEdit):
-            g.trace('QLineEdit: allocate wrapper')
-            return QLineEditWrapper(c=c, widget=w)
-        if isinstance(w, QtWidgets.QTextEdit):
-            g.trace('QTextEdit: allocate wrapper')
-            return QTextEditWrapper(c=c, widget=w)
-        g.trace('Oops', w.__class__.__name__)  ###
-        return None
+            oops(w, 'QLineEditWrapper')
+            w.leo_wrapper = QLineEditWrapper(c=c, widget=w)
+        elif isinstance(w, QtWidgets.QTextEdit):
+            oops(w, 'QTextEditWrapper')
+            w.leo_wrapper = QTextEditWrapper(c=c, widget=w)
+        else:
+            oops(w, 'StringTextWrapper')
+            w.leo_wrapper = StringTextWrapper(c=c)
+        return w.leo_wrapper
 
     # @+node:ekr.20110605121601.18485: *3* LeoQtGui.Clipboard
     # @+node:ekr.20160917125946.1: *4* LeoQtGui.replaceClipboardWith

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -236,14 +236,21 @@ class LeoQtGui(leoGui.LeoGui):
 
     # @+node:ekr.20260418104208.1: *3*  LeoQtGui.create_wrapper_for_widget
     def create_wrapper_for_widget(self, c: Cmdr, w: Any) -> QTextMixin:
-        return (
-            # Order matters.
-            w if isinstance(w, QTextMixin)
-            else QLineEditWrapper(c=c, widget=w) if isinstance(w, QtWidgets.QLineEdit)
-            else QTextEditWrapper(c=c, widget=w) if isinstance(w, QtWidgets.QTextEdit)
-            else w.wrapper if getattr(w, 'wrapper', None)
-            else None
-        )  # fmt: skip
+        if w is None:
+            return None
+        if isinstance(w, QTextMixin):
+            return w
+        if getattr(w, 'wrapper', None):
+            return w.wrapper
+        # To do: inject leo_wrapper into subclasses of QLineEdit and QTextEdit.
+        if isinstance(w, QtWidgets.QLineEdit):
+            g.trace('QLineEdit: allocate wrapper')
+            return QLineEditWrapper(c=c, widget=w)
+        if isinstance(w, QtWidgets.QTextEdit):
+            g.trace('QTextEdit: allocate wrapper')
+            return QTextEditWrapper(c=c, widget=w)
+        g.trace('Oops', w.__class__.__name__)  ###
+        return None
 
     # @+node:ekr.20110605121601.18485: *3* LeoQtGui.Clipboard
     # @+node:ekr.20160917125946.1: *4* LeoQtGui.replaceClipboardWith

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -248,20 +248,13 @@ class LeoQtGui(leoGui.LeoGui):
         if isinstance(w, LeoQtTree):
             # A strange special case: the class allocates its own wrappers.
             return None
-
-        def oops(w: Any, wrapper_name: str) -> None:
-            g.trace(f"Allocate {wrapper_name} for: {w.__class__.__name__}")
-
         # Defensive code.
-        if isinstance(w, QtWidgets.QLineEdit):
-            oops(w, 'QLineEditWrapper')
-            w.leo_wrapper = QLineEditWrapper(c=c, widget=w)
-        elif isinstance(w, QtWidgets.QTextEdit):
-            oops(w, 'QTextEditWrapper')
-            w.leo_wrapper = QTextEditWrapper(c=c, widget=w)
-        else:
-            oops(w, 'StringTextWrapper')
-            w.leo_wrapper = StringTextWrapper(c=c)
+        w.leo_wrapper = (
+                 QLineEditWrapper(c=c, widget=w) if isinstance(w, QtWidgets.QLineEdit)
+            else QTextEditWrapper(c=c, widget=w) if isinstance(w, QtWidgets.QTextEdit)
+            else StringTextWrapper(c=c)
+        )  # fmt: skip
+        g.trace(f"Allocate {w.leo_wrapper.__class__.__name__} for {w.__class__.__name__}")
         return w.leo_wrapper
 
     # @+node:ekr.20110605121601.18485: *3* LeoQtGui.Clipboard

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -38,6 +38,7 @@ from leo.core.leoQt import Shadow, Shape, StandardButton, Weight, WindowType
 from leo.plugins import qt_events
 from leo.plugins import qt_frame
 from leo.plugins import qt_idle_time
+from leo.plugins.qt_frame import LeoQtLog
 from leo.plugins.qt_text import QLineEditWrapper, QTextEditWrapper, QTextMixin
 
 # This defines the commands defined by @g.command.
@@ -236,9 +237,11 @@ class LeoQtGui(leoGui.LeoGui):
     # @+node:ekr.20260418104208.1: *3*  LeoQtGui.create_wrapper_for_widget
     def create_wrapper_for_widget(self, c: Cmdr, w: Any) -> QTextMixin:
         return (
+            # Order matters.
             w if isinstance(w, QTextMixin)
             else QLineEditWrapper(c=c, widget=w) if isinstance(w, QtWidgets.QLineEdit)
             else QTextEditWrapper(c=c, widget=w) if isinstance(w, QtWidgets.QTextEdit)
+            else w.wrapper if getattr(w, 'wrapper', None)
             else None
         )  # fmt: skip
 

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -630,11 +630,12 @@ if QtWidgets:
 
             wrapper is a LeoQtBody or LeoQtLog.
             """
+            super().__init__(parent)
             assert not hasattr(QtWidgets.QTextBrowser, 'leo_c')
             self.leo_c = c
             self.leo_s = ''  # The cached text.
+            self.leo_wrapper = QTextEditWrapper(c=c, widget=self)  # #4623.
             self.htmlFlag = True
-            super().__init__(parent)
             self.setCursorWidth(c.config.getInt('qt-cursor-width') or 1)
 
             # Connect event handlers...

--- a/leo/unittests/commands/test_editCommands.py
+++ b/leo/unittests/commands/test_editCommands.py
@@ -4402,7 +4402,7 @@ class TestEditCommands(LeoUnitTest):
         paste = 'ABC'
         g.app.gui.replaceClipboardWith(paste)
         w.setSelectionRange(end, end)
-        c.frame.pasteText(event=g.Bunch(widget=w, wrapper=w))
+        c.frame.pasteText(event=g.app.gui.create_key_event(c, w=w))
         g.app.gui.event_generate(c, '\n', 'Return', w)
         self.assertEqual(p.h, h + paste)
         k.manufactureKeyPressForCommandName(w, 'undo')
@@ -4421,7 +4421,7 @@ class TestEditCommands(LeoUnitTest):
         paste = 'ABC'
         g.app.gui.replaceClipboardWith(paste)
         w.setSelectionRange(1, 2)
-        c.frame.pasteText(event=g.Bunch(widget=w, wrapper=w))
+        c.frame.pasteText(event=g.app.gui.create_key_event(c, w=w))
         g.app.gui.event_generate(c, '\n', 'Return', w)
         self.assertEqual(p.h, h[0] + paste + h[2:])
         k.manufactureKeyPressForCommandName(w, 'undo')
@@ -4443,7 +4443,7 @@ class TestEditCommands(LeoUnitTest):
         g.app.gui.replaceClipboardWith(paste)
         g.app.gui.set_focus(c, w)
         w.setSelectionRange(end, end)
-        c.frame.pasteText(event=g.Bunch(widget=w, wrapper=w))
+        c.frame.pasteText(event=g.app.gui.create_key_event(c, w=w))
         g.app.gui.event_generate(c, '\n', 'Return', w)
         self.assertEqual(p.h, h + paste)
 
@@ -4461,7 +4461,7 @@ class TestEditCommands(LeoUnitTest):
         w.setSelectionRange(end, end, insert=end)
         paste = 'ABC'
         g.app.gui.replaceClipboardWith(paste)
-        c.frame.pasteText(event=g.Bunch(widget=w, wrapper=w))
+        c.frame.pasteText(event=g.app.gui.create_key_event(c, w=w))
         # Move around and and make sure it doesn't change.
         try:
             # g.trace('before select',w,w.getAllText())
@@ -4516,7 +4516,7 @@ class TestEditCommands(LeoUnitTest):
         paste = 'ABC'
         g.app.gui.replaceClipboardWith(paste)
         w.setSelectionRange(end, end)
-        c.frame.pasteText(event=g.Bunch(widget=w, wrapper=w))
+        c.frame.pasteText(event=g.app.gui.create_key_event(c, w=w))
         c.selectPosition(p.visBack(c))
         self.assertEqual(p.h, h + paste)
         c.undoer.undo()

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -84,6 +84,9 @@ class TestNullGui(LeoUnitTest):
         for obj, class_ in table:
             assert isinstance(obj, class_), (repr(obj), repr(class_))
 
+        for obj in (c.frame.body, c.frame.log, c.frame.statusLine):
+            assert getattr(obj, 'wrapper', None), repr(obj)
+
     # @-others
 
 
@@ -314,6 +317,14 @@ class TestQtGui(LeoUnitTest):
             if issubclass(obj.__class__, QTextMixin):
                 # Every subclass of QTextMix is an instance of QTextMixin.
                 assert isinstance(obj, QTextMixin)
+
+        for obj in (
+            c.frame.body,
+            c.frame.statusLine.textWidget1,
+            c.frame.statusLine.textWidget2,
+            c.frame.log,
+        ):
+            assert getattr(obj, 'wrapper', None) or getattr(obj, 'leo_wrapper', None), repr(obj)
 
         # Test the class hierarchy of text-related classes.
         assert issubclass(LeoQTextBrowser, QtWidgets.QTextBrowser)


### PR DESCRIPTION
See #4623.

**Fix the immediate bug**

- [x] `c.insertCharFromEvent`: test for a wrapper, not a widget.
- [x] Add the `LeoQtLog.wrapper ivar`.
- [x] `LeoQtLog.finishCreate`: set the new `wrapper` ivar.
- [x] Inject the `leo_wrapper` ivar into the `VisLineEdit`, `LeoQTextBrowser`, and `QtStatusLineClass` classes.
- [x] Rewrite ` LeoQtGui.create_wrapper_for_widget`
    - Test for `w.wrapper` and `w.leo_wrapper` ivars.
    - Add defensive code that creates wrappers in emergencies.
- [x] Test copy/paste manually into headlines, minibuffer and log pane.

**Other changes**

- [x] Delete unused `DynamicWindow.addNewEditor` method and move it to the attic.
- [x] Remove the `w` arg from `k.showStateAndMode`, collapsing its complexity.
- [x] Require kwargs in `k.showStateAndMode`.
- [x] Use `LeoKeyEvent` in unit tests instead of `g.Bunch`. This removes a major hack.
- [x] Improve the two `test_annotations` unit tests.