### PR TITLE
Defer jupytext import to fix ~0.7s startup regression

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -18,10 +18,10 @@ import platform
 from leo.core import leoGlobals as g
 from leo.core import leoExternalFiles
 from leo.core.leoCache import GlobalCacher
-from leo.core.leoJupytext import JupytextManager
 from leo.core.leoQt import QCloseEvent
 
 if TYPE_CHECKING:
+    from leo.core.leoJupytext import JupytextManager
     StringIO = io.StringIO
     SpellDict = Any  # dict[str, list[str]]
 # @-<< leoApp imports >>

--- a/leo/core/leoJupytext.py
+++ b/leo/core/leoJupytext.py
@@ -14,12 +14,11 @@ import os
 import textwrap
 from typing import Any, Tuple, TYPE_CHECKING
 
-try:
-    import jupytext  # pylint: disable=unused-import
-
-    has_jupytext = True
-except Exception:
-    has_jupytext = False
+# Defer importing jupytext until first use: jupytext imports pandoc at module
+# level (calling subprocess to check the pandoc version), which costs ~0.7s
+# on every Leo startup even when jupytext is never used.
+jupytext = None  # Loaded lazily by _load_jupytext().
+has_jupytext: bool = False  # Set to True once jupytext loads successfully.
 
 from leo.core import leoGlobals as g
 
@@ -29,6 +28,23 @@ if TYPE_CHECKING:  # pragma: no cover
 
     Notebook = Any  # nbformat.notebooknode.NotebookNode
 # @-<< leoJupytext: imports and annotations >>
+
+
+def _ensure_jupytext() -> bool:
+    """Import jupytext on first call. Return True if available."""
+    global jupytext, has_jupytext
+    if has_jupytext:
+        return True
+    if jupytext is not None:
+        return False  # already tried and failed
+    try:
+        import jupytext as _jt
+        jupytext = _jt
+        has_jupytext = True
+        return True
+    except Exception:
+        jupytext = False  # sentinel: tried and failed
+        return False
 
 
 # @+others
@@ -184,7 +200,7 @@ class JupytextManager:
 
         On errors, print an error message and return ''.
         """
-        if not has_jupytext:
+        if not _ensure_jupytext():
             self.warn_no_jupytext()
             return ''
         if not p.h.startswith('@jupytext'):


### PR DESCRIPTION
## Problem

`jupytext` (when installed) calls `pandoc_version()` at module load time,
spawning 3 subprocesses to check the pandoc version. Because `leoApp.py`
imported `leoJupytext` at the top level, this ran on every Leo startup —
costing ~0.7s (26% of total startup time) even when jupytext is never used.

Profiled with `python -m cProfile launchLeo.py --gui=null --quit`:
- **Before:** 2.7s, with `_winapi.CreateProcess` (pandoc subprocesses) = 0.709s
- **After:** 2.0s — pandoc subprocess calls eliminated from startup path

## Fix

**`leoJupytext.py`** — replace the eagerly-evaluated `try: import jupytext`
block with a `_ensure_jupytext()` lazy loader. The `full_path()` guard (which
all jupytext operations go through) now calls `_ensure_jupytext()` instead of
checking `has_jupytext`.

**`leoApp.py`** — move `from leo.core.leoJupytext import JupytextManager`
under `TYPE_CHECKING`. Safe because `from __future__ import annotations` is
already present (PEP 563).