### PR TITLE
PR fixes #4626: bindings in Completion tab

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -278,7 +278,8 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
             i, tag, word, val = self.match_prefix(ch, i, j, prefix, s)
             if word:
                 # #4462: Make only one substitution in headlines.
-                if w_name.startswith('head'):
+                # #4590: Don't do this if the user explicitly called for the next placeholder.
+                if val != '__NEXT_PLACEHOLDER' and self.enabled and w_name.startswith('head'):
                     self.make_first_headline_substitution(i, j, p, val)
                     return True
                 if val == '__NEXT_PLACEHOLDER':

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from typing import Any, Optional
 from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
-from leo.plugins.qt_text import QTextMixin
 
 if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
@@ -23,6 +22,102 @@ if TYPE_CHECKING:
 
 
 # @+others
+# @+node:ekr.20250329033642.5: ** class BaseTextAPI
+class BaseTextAPI:
+    """
+    A class specifying the interface to various text widgets,
+    including Leo's headline, body pane and other widgets.
+    """
+
+    def __init__(self, c: Cmdr) -> None:
+        pass
+
+    def appendText(self, s: str) -> None:
+        pass
+
+    def clipboard_append(self, s: str) -> None:
+        pass
+
+    def clipboard_clear(self) -> None:
+        pass
+
+    def delete(self, i: int, j: int = None) -> None:
+        pass
+
+    def deleteTextSelection(self) -> None:
+        pass
+
+    def disable(self) -> None:
+        pass
+
+    def enable(self, enabled: bool = True) -> None:
+        pass
+
+    def flashCharacter(
+        self,
+        i: int,
+        bg: str = 'white',
+        fg: str = 'red',
+        flashes: int = 3,
+        delay: int = 75,
+    ) -> None:
+        pass
+
+    def get(self, i: int, j: int) -> str:
+        return ''
+
+    def getAllText(self) -> str:
+        return ''
+
+    def getInsertPoint(self) -> int:
+        return 0
+
+    def getSelectedText(self) -> str:
+        return ''
+
+    def getSelectionRange(self) -> tuple[int, int]:
+        return (0, 0)
+
+    def getXScrollPosition(self) -> int:
+        return 0
+
+    def getYScrollPosition(self) -> int:
+        return 0
+
+    def hasSelection(self) -> bool:
+        return False
+
+    def insert(self, i: int, s: str) -> None:
+        pass
+
+    def see(self, i: int) -> None:
+        pass
+
+    def seeInsertPoint(self) -> None:
+        pass
+
+    def selectAllText(self, insert: str = None) -> None:
+        pass
+
+    def setAllText(self, s: str) -> None:
+        pass
+
+    def setFocus(self) -> None:
+        pass  # Required: sets the focus to wrapper.widget.
+
+    def setInsertPoint(self, pos: str, s: str = None) -> None:
+        pass
+
+    def setSelectionRange(self, i: int, j: int, insert: int = None) -> None:
+        pass
+
+    def setXScrollPosition(self, i: int) -> None:
+        pass
+
+    def setYScrollPosition(self, i: int) -> None:
+        pass
+
+
 # @+node:ekr.20250329033642.2: ** class IconBarAPI
 class IconBarAPI:
     """The required API for c.frame.iconBar."""
@@ -39,7 +134,7 @@ class IconBarAPI:
     def addRowIfNeeded(self) -> None:
         pass
 
-    def addWidget(self, w: QTextMixin) -> None:
+    def addWidget(self, w: BaseTextAPI) -> None:
         pass
 
     def clear(self) -> None:
@@ -48,7 +143,7 @@ class IconBarAPI:
     def createChaptersIcon(self) -> None:
         pass
 
-    def deleteButton(self, w: QTextMixin) -> None:
+    def deleteButton(self, w: BaseTextAPI) -> None:
         pass
 
     def getNewFrame(self) -> None:
@@ -56,7 +151,7 @@ class IconBarAPI:
 
     def setCommandForButton(
         self,
-        button: QTextMixin,
+        button: BaseTextAPI,
         command: str,
         command_p: Position,
         controller: ScriptingController,
@@ -98,52 +193,204 @@ class StatusLineAPI:
         pass
 
 
-# @+node:ekr.20070228074228.1: ** class StringTextWrapper (QTextMixin)
-class StringTextWrapper(QTextMixin):
-    """
-    A class that represents Leo's body pane as a Python string.
-    """
+# @+node:ekr.20070228074228.1: ** class StringTextWrapper
+class StringTextWrapper:
+    """A class that represents Leo's body pane as a Python string."""
 
     # @+others
-    # @+node:ekr.20260415161218.1: *3* StringTextWrapper.__init__
-    def __init__(self, c: Cmdr, name: str = None) -> None:
-        super().__init__(c)
+    # @+node:ekr.20070228074228.2: *3* stw.ctor
+    def __init__(self, c: Cmdr, name: str) -> None:
+        """Ctor for the StringTextWrapper class."""
         self.c = c
-        self.name = name or '<no name>'
-        # Ivars unique to StringTextWrapper.
+        self.name = name
         self.ins = 0
         self.sel = 0, 0
         self.s = ''
+        self.supportsHighLevelInterface = True
+        self.virtualInsertPoint = 0
+        self.widget = None  # This ivar must exist, and be None.
 
-    # @+node:ekr.20260415161250.1: *3* StringTextWrapper.__repr__
     def __repr__(self) -> str:
-        return f"<StringTextWrapper: @ {id(self)}>"
+        return f"<StringTextWrapper: {id(self)} {self.name}>"
 
-    # @+node:ekr.20140903172510.18579: *3* StringTextWrapper.setFocus
+    def getName(self) -> str:
+        """StringTextWrapper."""
+        return self.name  # Essential.
+
+    # @+node:ekr.20140903172510.18578: *3* stw.Clipboard
+    def clipboard_clear(self) -> None:
+        g.app.gui.replaceClipboardWith('')
+
+    def clipboard_append(self, s: str) -> None:
+        s1 = g.app.gui.getTextFromClipboard()
+        g.app.gui.replaceClipboardWith(s1 + s)
+
+    # @+node:ekr.20140903172510.18579: *3* stw.Do-nothings
+    # For StringTextWrapper.
+
+    def disable(self) -> None:
+        pass
+
+    def enable(self, enabled: bool = True) -> None:
+        pass
+
+    def flashCharacter(
+        self,
+        i: int,
+        bg: str = 'white',
+        fg: str = 'red',
+        flashes: int = 3,
+        delay: int = 75,
+    ) -> None:
+        pass
+
+    def getXScrollPosition(self) -> int:
+        return 0
+
+    def getYScrollPosition(self) -> int:
+        return 0
+
+    def see(self, i: int) -> None:
+        pass
+
+    def seeInsertPoint(self) -> None:
+        pass
+
     def setFocus(self) -> None:
         pass
 
-    # @+node:ekr.20140903172510.18591: *3* StringTextWrapper: Text overrides
-    # @+node:ekr.20140903172510.18595: *4* StringTextWrapper.get
+    def setStyleClass(self, name: str) -> None:
+        pass
+
+    def setXScrollPosition(self, i: int) -> None:
+        pass
+
+    def setYScrollPosition(self, i: int) -> None:
+        pass
+
+    # @+node:ekr.20140903172510.18591: *3* stw.Text
+    # @+node:ekr.20140903172510.18592: *4* stw.appendText
+    def appendText(self, s: str) -> None:
+        """StringTextWrapper."""
+        self.s = self.s + g.toUnicode(s)  # defensive
+        self.ins = len(self.s)
+        self.sel = self.ins, self.ins
+
+    # @+node:ekr.20140903172510.18593: *4* stw.delete
+    def delete(self, i: int, j: int = None) -> None:
+        """StringTextWrapper."""
+        if j is None:
+            j = i + 1
+        # This allows subclasses to use this base class method.
+        if i > j:
+            i, j = j, i
+        s = self.getAllText()
+        self.setAllText(s[:i] + s[j:])
+        # Bug fix: 2011/11/13: Significant in external tests.
+        self.setSelectionRange(i, i, insert=i)
+
+    # @+node:ekr.20140903172510.18594: *4* stw.deleteTextSelection
+    def deleteTextSelection(self) -> None:
+        """StringTextWrapper."""
+        i, j = self.getSelectionRange()
+        self.delete(i, j)
+
+    # @+node:ekr.20140903172510.18595: *4* stw.get
     def get(self, i: int, j: Optional[int] = None) -> str:
+        """StringTextWrapper."""
         if j is None:
             j = i + 1
         s = self.s[i:j]
         return g.toUnicode(s)
 
-    # @+node:ekr.20140903172510.18598: *4* StringTextWrapper.insert
+    # @+node:ekr.20140903172510.18596: *4* stw.getAllText
+    def getAllText(self) -> str:
+        """StringTextWrapper."""
+        s = self.s
+        return g.checkUnicode(s)
+
+    # @+node:ekr.20140903172510.18584: *4* stw.getInsertPoint
+    def getInsertPoint(self) -> int:
+        """StringTextWrapper."""
+        i = self.ins
+        if i is None:
+            if self.virtualInsertPoint is None:
+                i = 0
+            else:
+                i = self.virtualInsertPoint
+        self.virtualInsertPoint = i
+        return i
+
+    # @+node:ekr.20220909182855.1: *4* stw.getLastIndex
+    def getLastIndex(self) -> int:
+        """Return the length of the self.s"""
+        return len(self.s)
+
+    # @+node:ekr.20140903172510.18597: *4* stw.getSelectedText
+    def getSelectedText(self) -> str:
+        """StringTextWrapper."""
+        i, j = self.sel
+        s = self.s[i:j]
+        return g.checkUnicode(s)
+
+    # @+node:ekr.20140903172510.18585: *4* stw.getSelectionRange
+    def getSelectionRange(self, sort: bool = True) -> tuple[int, int]:
+        """Return the selected range of the widget."""
+        sel = self.sel
+        if len(sel) == 2 and sel[0] >= 0 and sel[1] >= 0:
+            i, j = sel
+            if sort and i > j:
+                sel = j, i  # Bug fix: 10/5/07
+            return sel
+        i = self.ins
+        return i, i
+
+    # @+node:ekr.20140903172510.18586: *4* stw.hasSelection
+    def hasSelection(self) -> bool:
+        """StringTextWrapper."""
+        i, j = self.getSelectionRange()
+        return i != j
+
+    # @+node:ekr.20140903172510.18598: *4* stw.insert
     def insert(self, i: int, s: str) -> None:
+        """StringTextWrapper."""
         self.s = self.s[:i] + s + self.s[i:]
         i += len(s)
         self.ins = i
         self.sel = i, i
 
-    # @+node:ekr.20140903172510.18600: *4* StringTextWrapper.setAllText
+    # @+node:ekr.20140903172510.18589: *4* stw.selectAllText
+    def selectAllText(self, insert: int = None) -> None:
+        """StringTextWrapper."""
+        self.setSelectionRange(0, len(self.s), insert=insert)
+
+    # @+node:ekr.20140903172510.18600: *4* stw.setAllText
     def setAllText(self, s: str) -> None:
+        """StringTextWrapper."""
         self.s = s
         i = len(self.s)
         self.ins = i
         self.sel = i, i
+
+    # @+node:ekr.20140903172510.18587: *4* stw.setInsertPoint
+    def setInsertPoint(self, i: int, s: str = None) -> None:
+        """StringTextWrapper."""
+        self.virtualInsertPoint = i
+        self.ins = i
+        self.sel = i, i
+
+    # @+node:ekr.20070228111853: *4* stw.setSelectionRange
+    def setSelectionRange(self, i: int, j: int, insert: int = None) -> None:
+        """StringTextWrapper."""
+        self.sel = i, j
+        self.ins = j if insert is None else insert
+
+    # @+node:ekr.20140903172510.18582: *4* stw.toPythonIndexRowCol
+    def toPythonIndexRowCol(self, index: int) -> tuple[int, int]:
+        """StringTextWrapper."""
+        s = self.getAllText()
+        row, col = g.convertPythonIndexToRowCol(s, index)
+        return row, col
 
     # @-others
 
@@ -157,9 +404,13 @@ class TreeAPI:
 
     # Must be defined in subclasses.
 
-    # Leo 6.8.9: return None.
-    def editLabel(self, v: VNode, selectAll: bool = False, selection: tuple = None) -> None:
-        pass
+    def editLabel(
+        self,
+        v: VNode,
+        selectAll: bool = False,
+        selection: tuple = None,
+    ) -> tuple[Widget, BaseTextAPI]:
+        return None, None
 
     def edit_widget(self, p: Position) -> None:
         return None
@@ -206,7 +457,7 @@ class TreeAPI:
     def select(self, p: Position) -> None:
         pass
 
-    def updateHead(self, event: LeoKeyEvent, w: QTextMixin) -> None:
+    def updateHead(self, event: LeoKeyEvent, w: BaseTextAPI) -> None:
         pass
 
 

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -112,7 +112,6 @@ class StringTextWrapper(QTextMixin):
         self.ins = 0
         self.sel = 0, 0
         self.s = ''
-        self.supportsHighLevelInterface = True
         self.virtualInsertPoint = 0
         self.widget = None  # This ivar must exist, and be None.
 

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any, Optional
 from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
+from leo.plugins.qt_text import QTextMixin
 
 if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
@@ -193,14 +194,15 @@ class StatusLineAPI:
         pass
 
 
-# @+node:ekr.20070228074228.1: ** class StringTextWrapper
-class StringTextWrapper:
+# @+node:ekr.20070228074228.1: ** class StringTextWrapper(QTextMixin)
+class StringTextWrapper(QTextMixin):
     """A class that represents Leo's body pane as a Python string."""
 
     # @+others
     # @+node:ekr.20070228074228.2: *3* stw.ctor
     def __init__(self, c: Cmdr, name: str) -> None:
         """Ctor for the StringTextWrapper class."""
+        super().__init__(c)
         self.c = c
         self.name = name
         self.ins = 0

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -103,7 +103,7 @@ class StringTextWrapper(QTextMixin):
     """A class that represents Leo's body pane as a Python string."""
 
     # @+others
-    # @+node:ekr.20070228074228.2: *3* stw.ctor
+    # @+node:ekr.20070228074228.2: *3* StringTextWrapper.__init__
     def __init__(self, c: Cmdr, name: str) -> None:
         """Ctor for the StringTextWrapper class."""
         super().__init__(c)
@@ -123,7 +123,7 @@ class StringTextWrapper(QTextMixin):
         """StringTextWrapper."""
         return self.name  # Essential.
 
-    # @+node:ekr.20140903172510.18578: *3* stw.Clipboard
+    # @+node:ekr.20140903172510.18578: *3* StringTextWrapper: Clipboard
     def clipboard_clear(self) -> None:
         g.app.gui.replaceClipboardWith('')
 
@@ -131,7 +131,7 @@ class StringTextWrapper(QTextMixin):
         s1 = g.app.gui.getTextFromClipboard()
         g.app.gui.replaceClipboardWith(s1 + s)
 
-    # @+node:ekr.20140903172510.18579: *3* stw.Do-nothings
+    # @+node:ekr.20140903172510.18579: *3* StringTextWrapper: Do-nothings
     # For StringTextWrapper.
 
     def disable(self) -> None:
@@ -174,15 +174,15 @@ class StringTextWrapper(QTextMixin):
     def setYScrollPosition(self, i: int) -> None:
         pass
 
-    # @+node:ekr.20140903172510.18591: *3* stw.Text
-    # @+node:ekr.20140903172510.18592: *4* stw.appendText
+    # @+node:ekr.20140903172510.18591: *3* StringTextWrapper: Text
+    # @+node:ekr.20140903172510.18592: *4* StringTextWrapper.appendText
     def appendText(self, s: str) -> None:
         """StringTextWrapper."""
         self.s = self.s + g.toUnicode(s)  # defensive
         self.ins = len(self.s)
         self.sel = self.ins, self.ins
 
-    # @+node:ekr.20140903172510.18593: *4* stw.delete
+    # @+node:ekr.20140903172510.18593: *4* StringTextWrapper.delete
     def delete(self, i: int, j: int = None) -> None:
         """StringTextWrapper."""
         if j is None:
@@ -195,13 +195,13 @@ class StringTextWrapper(QTextMixin):
         # Bug fix: 2011/11/13: Significant in external tests.
         self.setSelectionRange(i, i, insert=i)
 
-    # @+node:ekr.20140903172510.18594: *4* stw.deleteTextSelection
+    # @+node:ekr.20140903172510.18594: *4* StringTextWrapper.deleteTextSelection
     def deleteTextSelection(self) -> None:
         """StringTextWrapper."""
         i, j = self.getSelectionRange()
         self.delete(i, j)
 
-    # @+node:ekr.20140903172510.18595: *4* stw.get
+    # @+node:ekr.20140903172510.18595: *4* StringTextWrapper.get
     def get(self, i: int, j: Optional[int] = None) -> str:
         """StringTextWrapper."""
         if j is None:
@@ -209,13 +209,13 @@ class StringTextWrapper(QTextMixin):
         s = self.s[i:j]
         return g.toUnicode(s)
 
-    # @+node:ekr.20140903172510.18596: *4* stw.getAllText
+    # @+node:ekr.20140903172510.18596: *4* StringTextWrapper.getAllText
     def getAllText(self) -> str:
         """StringTextWrapper."""
         s = self.s
         return g.checkUnicode(s)
 
-    # @+node:ekr.20140903172510.18584: *4* stw.getInsertPoint
+    # @+node:ekr.20140903172510.18584: *4* StringTextWrapper.getInsertPoint
     def getInsertPoint(self) -> int:
         """StringTextWrapper."""
         i = self.ins
@@ -227,19 +227,19 @@ class StringTextWrapper(QTextMixin):
         self.virtualInsertPoint = i
         return i
 
-    # @+node:ekr.20220909182855.1: *4* stw.getLastIndex
+    # @+node:ekr.20220909182855.1: *4* StringTextWrapper.getLastIndex
     def getLastIndex(self) -> int:
         """Return the length of the self.s"""
         return len(self.s)
 
-    # @+node:ekr.20140903172510.18597: *4* stw.getSelectedText
+    # @+node:ekr.20140903172510.18597: *4* StringTextWrapper.getSelectedText
     def getSelectedText(self) -> str:
         """StringTextWrapper."""
         i, j = self.sel
         s = self.s[i:j]
         return g.checkUnicode(s)
 
-    # @+node:ekr.20140903172510.18585: *4* stw.getSelectionRange
+    # @+node:ekr.20140903172510.18585: *4* StringTextWrapper.getSelectionRange
     def getSelectionRange(self, sort: bool = True) -> tuple[int, int]:
         """Return the selected range of the widget."""
         sel = self.sel
@@ -251,13 +251,13 @@ class StringTextWrapper(QTextMixin):
         i = self.ins
         return i, i
 
-    # @+node:ekr.20140903172510.18586: *4* stw.hasSelection
+    # @+node:ekr.20140903172510.18586: *4* StringTextWrapper.hasSelection
     def hasSelection(self) -> bool:
         """StringTextWrapper."""
         i, j = self.getSelectionRange()
         return i != j
 
-    # @+node:ekr.20140903172510.18598: *4* stw.insert
+    # @+node:ekr.20140903172510.18598: *4* StringTextWrapper.insert
     def insert(self, i: int, s: str) -> None:
         """StringTextWrapper."""
         self.s = self.s[:i] + s + self.s[i:]
@@ -265,12 +265,12 @@ class StringTextWrapper(QTextMixin):
         self.ins = i
         self.sel = i, i
 
-    # @+node:ekr.20140903172510.18589: *4* stw.selectAllText
+    # @+node:ekr.20140903172510.18589: *4* StringTextWrapper.selectAllText
     def selectAllText(self, insert: int = None) -> None:
         """StringTextWrapper."""
         self.setSelectionRange(0, len(self.s), insert=insert)
 
-    # @+node:ekr.20140903172510.18600: *4* stw.setAllText
+    # @+node:ekr.20140903172510.18600: *4* StringTextWrapper.setAllText
     def setAllText(self, s: str) -> None:
         """StringTextWrapper."""
         self.s = s
@@ -278,20 +278,20 @@ class StringTextWrapper(QTextMixin):
         self.ins = i
         self.sel = i, i
 
-    # @+node:ekr.20140903172510.18587: *4* stw.setInsertPoint
+    # @+node:ekr.20140903172510.18587: *4* StringTextWrapper.setInsertPoint
     def setInsertPoint(self, i: int, s: str = None) -> None:
         """StringTextWrapper."""
         self.virtualInsertPoint = i
         self.ins = i
         self.sel = i, i
 
-    # @+node:ekr.20070228111853: *4* stw.setSelectionRange
+    # @+node:ekr.20070228111853: *4* StringTextWrapper.setSelectionRange
     def setSelectionRange(self, i: int, j: int, insert: int = None) -> None:
         """StringTextWrapper."""
         self.sel = i, j
         self.ins = j if insert is None else insert
 
-    # @+node:ekr.20140903172510.18582: *4* stw.toPythonIndexRowCol
+    # @+node:ekr.20140903172510.18582: *4* StringTextWrapper.toPythonIndexRowCol
     def toPythonIndexRowCol(self, index: int) -> tuple[int, int]:
         """StringTextWrapper."""
         s = self.getAllText()

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -23,102 +23,6 @@ if TYPE_CHECKING:
 
 
 # @+others
-# @+node:ekr.20250329033642.5: ** class BaseTextAPI
-class BaseTextAPI:
-    """
-    A class specifying the interface to various text widgets,
-    including Leo's headline, body pane and other widgets.
-    """
-
-    def __init__(self, c: Cmdr) -> None:
-        pass
-
-    def appendText(self, s: str) -> None:
-        pass
-
-    def clipboard_append(self, s: str) -> None:
-        pass
-
-    def clipboard_clear(self) -> None:
-        pass
-
-    def delete(self, i: int, j: int = None) -> None:
-        pass
-
-    def deleteTextSelection(self) -> None:
-        pass
-
-    def disable(self) -> None:
-        pass
-
-    def enable(self, enabled: bool = True) -> None:
-        pass
-
-    def flashCharacter(
-        self,
-        i: int,
-        bg: str = 'white',
-        fg: str = 'red',
-        flashes: int = 3,
-        delay: int = 75,
-    ) -> None:
-        pass
-
-    def get(self, i: int, j: int) -> str:
-        return ''
-
-    def getAllText(self) -> str:
-        return ''
-
-    def getInsertPoint(self) -> int:
-        return 0
-
-    def getSelectedText(self) -> str:
-        return ''
-
-    def getSelectionRange(self) -> tuple[int, int]:
-        return (0, 0)
-
-    def getXScrollPosition(self) -> int:
-        return 0
-
-    def getYScrollPosition(self) -> int:
-        return 0
-
-    def hasSelection(self) -> bool:
-        return False
-
-    def insert(self, i: int, s: str) -> None:
-        pass
-
-    def see(self, i: int) -> None:
-        pass
-
-    def seeInsertPoint(self) -> None:
-        pass
-
-    def selectAllText(self, insert: str = None) -> None:
-        pass
-
-    def setAllText(self, s: str) -> None:
-        pass
-
-    def setFocus(self) -> None:
-        pass  # Required: sets the focus to wrapper.widget.
-
-    def setInsertPoint(self, pos: str, s: str = None) -> None:
-        pass
-
-    def setSelectionRange(self, i: int, j: int, insert: int = None) -> None:
-        pass
-
-    def setXScrollPosition(self, i: int) -> None:
-        pass
-
-    def setYScrollPosition(self, i: int) -> None:
-        pass
-
-
 # @+node:ekr.20250329033642.2: ** class IconBarAPI
 class IconBarAPI:
     """The required API for c.frame.iconBar."""
@@ -135,7 +39,7 @@ class IconBarAPI:
     def addRowIfNeeded(self) -> None:
         pass
 
-    def addWidget(self, w: BaseTextAPI) -> None:
+    def addWidget(self, w: QTextMixin) -> None:
         pass
 
     def clear(self) -> None:
@@ -144,7 +48,7 @@ class IconBarAPI:
     def createChaptersIcon(self) -> None:
         pass
 
-    def deleteButton(self, w: BaseTextAPI) -> None:
+    def deleteButton(self, w: QTextMixin) -> None:
         pass
 
     def getNewFrame(self) -> None:
@@ -152,7 +56,7 @@ class IconBarAPI:
 
     def setCommandForButton(
         self,
-        button: BaseTextAPI,
+        button: QTextMixin,
         command: str,
         command_p: Position,
         controller: ScriptingController,
@@ -411,7 +315,7 @@ class TreeAPI:
         v: VNode,
         selectAll: bool = False,
         selection: tuple = None,
-    ) -> tuple[Widget, BaseTextAPI]:
+    ) -> tuple[Widget, QTextMixin]:
         return None, None
 
     def edit_widget(self, p: Position) -> None:
@@ -459,7 +363,7 @@ class TreeAPI:
     def select(self, p: Position) -> None:
         pass
 
-    def updateHead(self, event: LeoKeyEvent, w: BaseTextAPI) -> None:
+    def updateHead(self, event: LeoKeyEvent, w: QTextMixin) -> None:
         pass
 
 

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -15,6 +15,7 @@ import io
 import json
 import os
 import pickle
+import re
 import shutil
 import sqlite3
 import tempfile
@@ -169,19 +170,17 @@ class FastRead:
         return hidden_v
 
     # @+node:ekr.20180602062323.7: *3* fast.readWithElementTree & helpers
+    # PR #4615: Don't use str.translate unless there are bad characters.
     # #1510: https://en.wikipedia.org/wiki/Valid_characters_in_XML.
     translate_dict = {z: None for z in range(20) if chr(z) not in '\t\r\n'}
-
+    bad_xml_chars_re = re.compile('[' + ''.join(chr(z) for z in translate_dict) + ']')
     bad_path_dict: dict[str, bool] = {}
 
-    def readWithElementTree(
-        self,
-        path: str,
-        s_or_b: str | bytes,
-    ) -> tuple[VNode, Value]:
+    def readWithElementTree(self, path: str, s_or_b: str | bytes) -> tuple[VNode, Value]:
         contents = g.toUnicode(s_or_b)
-        table = contents.maketrans(self.translate_dict)  # type:ignore #1510.
-        contents = contents.translate(table)  # #1036, #1046.
+        if self.bad_xml_chars_re.search(contents):  # #1036, #1046, #1510.
+            table = contents.maketrans(self.translate_dict)
+            contents = contents.translate(table)
         try:
             xroot = ElementTree.fromstring(contents)
         except Exception:

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -498,8 +498,7 @@ class LeoFrame:
     def copyText(self, event: LeoKeyEvent = None) -> None:
         """Copy the selected text from the widget to the clipboard."""
         w = event.widget if event else None
-        if w and not g.unitTesting:  ###
-            g.trace(g.isTextWrapper(w), w.__class__.__name__, repr(w.name))
+        # g.trace(g.isTextWrapper(w), w.__class__.__name__, repr(w.name))
         if not w or not g.isTextWrapper(w):
             return
         # Set the clipboard text.

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -634,8 +634,7 @@ class LeoFrame:
         else:
             c.bodyWantsFocus()
             k.setDefaultInputState()
-            # Recolor the *body* text, **not** the headline.
-            k.showStateAndMode(w=c.frame.body.wrapper)
+            k.showStateAndMode()
 
     # @+node:ekr.20031218072017.3680: *3* LeoFrame.Must be defined in subclasses
     def bringToFront(self) -> None:

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -495,9 +495,8 @@ class LeoFrame:
     @frame_cmd('copy-text')
     def copyText(self, event: LeoKeyEvent = None) -> None:
         """Copy the selected text from the widget to the clipboard."""
-        # f = self
-        w = event and event.widget
-        # wname = c.widget_name(w)
+        w = event.widget if event else None
+        g.trace(g.isTextWrapper(w), w.__class__.__name__, repr(w.name))  ###
         if not w or not g.isTextWrapper(w):
             return
         # Set the clipboard text.
@@ -769,11 +768,7 @@ class LeoLog:
 
     # @+node:ekr.20070302094848.2: *3* LeoLog.createTab
     def createTab(
-        self,
-        tabName: str,
-        createText: bool = True,
-        widget: Widget = None,
-        wrap: str = 'none',
+        self, tabName: str, createText: bool = True, widget: Widget = None, wrap: str = 'none'
     ) -> Widget:
         # Do not change the signature above.
         self.textDict[tabName] = None

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -496,7 +496,8 @@ class LeoFrame:
     def copyText(self, event: LeoKeyEvent = None) -> None:
         """Copy the selected text from the widget to the clipboard."""
         w = event.widget if event else None
-        g.trace(g.isTextWrapper(w), w.__class__.__name__, repr(w.name))  ###
+        if w and not g.unitTesting:  ###
+            g.trace(g.isTextWrapper(w), w.__class__.__name__, repr(w.name))
         if not w or not g.isTextWrapper(w):
             return
         # Set the clipboard text.

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -14,12 +14,13 @@ from collections.abc import Callable
 import os
 import re
 import string
-from typing import Any, Union
-from typing import TYPE_CHECKING
-from leo.core import leoGlobals as g
-from leo.core import leoColorizer
-from leo.core import leoMenu
-from leo.core import leoNodes
+from typing import Any, TYPE_CHECKING
+from leo.core import (
+    leoColorizer,
+    leoGlobals as g,
+    leoMenu,
+    leoNodes,
+)
 from leo.core.leoAPI import StringTextWrapper
 
 # @-<< leoFrame imports >>
@@ -47,18 +48,19 @@ if TYPE_CHECKING:  # pragma: no cover
         QtStatusLineClass,
     )
     from leo.plugins.qt_text import (
-        LeoQTextBrowser,
         QMinibufferWrapper,
         QScintillaWrapper,
         QTextEditWrapper,
     )
-    from leo.plugins.cursesGui2 import MiniBufferWrapper as CursesMiniBufferWrapper
-    from leo.plugins.cursesGui2 import BodyWrapper as CursesBodyWrapper
+    from leo.plugins.cursesGui2 import (
+        BodyWrapper as CursesBodyWrapper,
+        MiniBufferWrapper as CursesMiniBufferWrapper,
+    )
 
     Args = Any
     KWargs = Any
     Widget = Any  # 'Any' is the correct annotation for base class widgets.
-    TextAPI = Union[QScintillaWrapper, QTextEditWrapper, StringTextWrapper]
+    TextAPI = QScintillaWrapper | QTextEditWrapper | StringTextWrapper
 
 
 # @-<< leoFrame annotations >>
@@ -115,7 +117,7 @@ class LeoBody:
 
     # @+others
     # @+node:ekr.20031218072017.3657: *3* LeoBody.__init__
-    def __init__(self, frame: Union[LeoQtFrame, NullFrame]) -> None:
+    def __init__(self, frame: LeoQtFrame | NullFrame) -> None:
         """Ctor for LeoBody class."""
         c = frame.c
         frame.body = self
@@ -123,9 +125,9 @@ class LeoBody:
         self.frame = frame
         # Define these here to keep mypy happy.
         self.widget: Any = None  # cursesGui2.py: will be an npyscreen widget.
-        self.wrapper: Union[
-            StringTextWrapper, QScintillaWrapper, QTextEditWrapper, CursesBodyWrapper
-        ] = None
+        self.wrapper: (
+            StringTextWrapper | QScintillaWrapper | QTextEditWrapper | CursesBodyWrapper
+        ) = None
         # Must be overridden in subclasses...
         self.colorizer: BaseColorizer = None
         # Init user settings.
@@ -260,14 +262,14 @@ class LeoFrame:
         self.gui = gui
         # Types...
         # Objects attached to this frame...
-        self.body: Union[LeoBody, NullBody, LeoQtBody] = None
-        self.iconBar: Union[NullIconBarClass, QtIconBarClass] = None
-        self.log: Union[LeoLog, NullLog, LeoQtLog] = None
-        self.menu: Union[LeoMenu, LeoQtMenu, NullMenu] = None
-        self.miniBufferWidget: Union[QMinibufferWrapper, CursesMiniBufferWrapper] = None
-        self.statusLine: Union[NullStatusLineClass, QtStatusLineClass] = None
+        self.body: LeoBody | NullBody | LeoQtBody = None
+        self.iconBar: NullIconBarClass | QtIconBarClass = None
+        self.log: LeoLog | NullLog | LeoQtLog = None
+        self.menu: LeoMenu | LeoQtMenu | NullMenu = None
+        self.miniBufferWidget: QMinibufferWrapper | CursesMiniBufferWrapper = None
+        self.statusLine: NullStatusLineClass | QtStatusLineClass = None
         self.top: DynamicWindow = None
-        self.tree: Union[LeoTree, NullTree, LeoQtTree] = None
+        self.tree: LeoTree | NullTree | LeoQtTree = None
         self.useMiniBufferWidget = False
         # Other ivars...
         self.cursorStay = True  # May be overridden in subclass.reloadSettings.
@@ -455,7 +457,7 @@ class LeoFrame:
         if self.statusLine:
             self.statusLine.enable(background)
 
-    def getStatusLine(self) -> Union[NullStatusLineClass, QtStatusLineClass]:
+    def getStatusLine(self) -> NullStatusLineClass | QtStatusLineClass:
         return self.statusLine
 
     getStatusObject = getStatusLine
@@ -740,7 +742,7 @@ class LeoLog:
     # @+others
     # @+node:ekr.20150509054436.1: *3* LeoLog.Birth
     # @+node:ekr.20031218072017.3695: *4* LeoLog.__init__
-    def __init__(self, frame: Union[LeoLog, LeoQtFrame, NullFrame]) -> None:
+    def __init__(self, frame: LeoLog | LeoQtFrame | NullFrame) -> None:
         """Ctor for LeoLog class."""
         g._assert(frame is None or issubclass(frame.__class__, LeoFrame))
         self.frame = frame
@@ -753,7 +755,7 @@ class LeoLog:
         # Depending on the log *tab*, logCtrl may be either a wrapper or a widget.
         self.logCtrl: Widget = None
         self.tabName: str = None  # The name of the active tab.
-        self.tabFrame: Union[LeoQTextBrowser, str] = None
+        self.tabFrame: str = None
         self.frameDict: dict[str, str] = {}
         self.logNumber = 0  # To create unique name fields for text widgets.
         self.newTabCount = 0  # Number of new tabs created.
@@ -1437,7 +1439,7 @@ class NullFrame(LeoFrame):
     def fullyExpandPane(self, event: LeoKeyEvent = None) -> None:
         pass
 
-    def getIconBar(self) -> Union[NullIconBarClass, QtIconBarClass]:
+    def getIconBar(self) -> NullIconBarClass | QtIconBarClass:
         return self.iconBar
 
     getIconBarObject = getIconBar

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1,11 +1,10 @@
 # @+leo-ver=5-thin
 # @+node:ekr.20031218072017.3655: * @file leoFrame.py
 """
-This file contains:
+The base classes for all Leo Windows, their body, log and tree panes,
+key bindings and menus.
 
-- Base classes for all Leo Windows, their body, log and tree panes,
-  key bindings and menus.
-- Common annotations for these classes.
+These classes should be overridden to create frames for a particular gui.
 """
 
 # @+<< leoFrame imports >>
@@ -15,11 +14,13 @@ from collections.abc import Callable
 import os
 import re
 import string
-from typing import Any, TYPE_CHECKING
+from typing import Any, Union
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
-from leo.core import leoColorizer, leoMenu, leoNodes
+from leo.core import leoColorizer
+from leo.core import leoMenu
+from leo.core import leoNodes
 from leo.core.leoAPI import StringTextWrapper
-from leo.plugins.qt_text import QMinibufferWrapper
 
 # @-<< leoFrame imports >>
 # @+<< leoFrame annotations >>
@@ -45,10 +46,19 @@ if TYPE_CHECKING:  # pragma: no cover
         QtIconBarClass,
         QtStatusLineClass,
     )
-    from leo.plugins.qt_text import QTextMixin
+    from leo.plugins.qt_text import (
+        LeoQTextBrowser,
+        QMinibufferWrapper,
+        QScintillaWrapper,
+        QTextEditWrapper,
+    )
     from leo.plugins.cursesGui2 import MiniBufferWrapper as CursesMiniBufferWrapper
+    from leo.plugins.cursesGui2 import BodyWrapper as CursesBodyWrapper
 
+    Args = Any
+    KWargs = Any
     Widget = Any  # 'Any' is the correct annotation for base class widgets.
+    TextAPI = Union[QScintillaWrapper, QTextEditWrapper, StringTextWrapper]
 
 
 # @-<< leoFrame annotations >>
@@ -105,15 +115,17 @@ class LeoBody:
 
     # @+others
     # @+node:ekr.20031218072017.3657: *3* LeoBody.__init__
-    def __init__(self, frame: LeoQtFrame | NullFrame) -> None:
+    def __init__(self, frame: Union[LeoQtFrame, NullFrame]) -> None:
         """Ctor for LeoBody class."""
         c = frame.c
         frame.body = self
         self.c = c
         self.frame = frame
+        # Define these here to keep mypy happy.
         self.widget: Any = None  # cursesGui2.py: will be an npyscreen widget.
-        self.wrapper: QTextMixin = None
-
+        self.wrapper: Union[
+            StringTextWrapper, QScintillaWrapper, QTextEditWrapper, CursesBodyWrapper
+        ] = None
         # Must be overridden in subclasses...
         self.colorizer: BaseColorizer = None
         # Init user settings.
@@ -139,7 +151,7 @@ class LeoBody:
     # @+node:ekr.20060528100747: *3* LeoBody.Editors
     # @+node:ekr.20070424053629.1: *4* LeoBody.utils
     # @+node:ekr.20060530204135: *5* LeoBody.recolorWidget (QScintilla only)
-    def recolorWidget(self, p: Position, w: QTextMixin) -> None:
+    def recolorWidget(self, p: Position, w: TextAPI) -> None:
         # Support QScintillaColorizer.colorize.
         c = self.c
         colorizer = c.frame.body.colorizer
@@ -248,16 +260,17 @@ class LeoFrame:
         self.gui = gui
         # Types...
         # Objects attached to this frame...
-        self.body: LeoBody | NullBody | LeoQtBody = None
-        self.iconBar: NullIconBarClass | QtIconBarClass = None
-        self.log: LeoLog | NullLog | LeoQtLog = None
-        self.menu: LeoMenu | LeoQtMenu | NullMenu = None
-        self.miniBufferWidget: QMinibufferWrapper | CursesMiniBufferWrapper = None
-        self.statusLine: NullStatusLineClass | QtStatusLineClass = None
+        self.body: Union[LeoBody, NullBody, LeoQtBody] = None
+        self.iconBar: Union[NullIconBarClass, QtIconBarClass] = None
+        self.log: Union[LeoLog, NullLog, LeoQtLog] = None
+        self.menu: Union[LeoMenu, LeoQtMenu, NullMenu] = None
+        self.miniBufferWidget: Union[QMinibufferWrapper, CursesMiniBufferWrapper] = None
+        self.statusLine: Union[NullStatusLineClass, QtStatusLineClass] = None
         self.top: DynamicWindow = None
-        self.tree: LeoTree | NullTree | LeoQtTree = None
+        self.tree: Union[LeoTree, NullTree, LeoQtTree] = None
         self.useMiniBufferWidget = False
         # Other ivars...
+        self.cursorStay = True  # May be overridden in subclass.reloadSettings.
         self.es_newlines = 0  # newline count for this log stream.
         self.isNullFrame = False
         self.saved = False  # True if ever saved
@@ -396,7 +409,7 @@ class LeoFrame:
         c.frame.setTabWidth(tab_width)
 
     # @+node:ekr.20061119120006: *4* LeoFrame.Icon area convenience methods
-    def addIconButton(self, *args: Any, **keys: Any) -> Any:
+    def addIconButton(self, *args: Args, **keys: KWargs) -> Any:
         if self.iconBar:
             return self.iconBar.add(*args, **keys)
         return None
@@ -442,7 +455,7 @@ class LeoFrame:
         if self.statusLine:
             self.statusLine.enable(background)
 
-    def getStatusLine(self) -> NullStatusLineClass | QtStatusLineClass:
+    def getStatusLine(self) -> Union[NullStatusLineClass, QtStatusLineClass]:
         return self.statusLine
 
     getStatusObject = getStatusLine
@@ -482,17 +495,20 @@ class LeoFrame:
     @frame_cmd('copy-text')
     def copyText(self, event: LeoKeyEvent = None) -> None:
         """Copy the selected text from the widget to the clipboard."""
-        w = event.wrapper if event else None
-        if not g.isTextWrapper(w):
+        # f = self
+        w = event and event.widget
+        # wname = c.widget_name(w)
+        if not w or not g.isTextWrapper(w):
             return
         # Set the clipboard text.
         i, j = w.getSelectionRange()
         if i == j:
             ins = w.getInsertPoint()
             i, j = g.getLine(w.getAllText(), ins)
+        # 2016/03/27: Fix a recent buglet.
+        # Don't clear the clipboard if we hit ctrl-c by mistake.
         s = w.get(i, j)
         s = s.replace('\r\n', '\n').replace('\r', '\n')  # 3759.
-        # Don't clear the clipboard if we hit ctrl-c by mistake.
         if s:
             g.app.gui.replaceClipboardWith(s)
 
@@ -503,8 +519,8 @@ class LeoFrame:
     def cutText(self, event: LeoKeyEvent = None) -> None:
         """Invoked from the mini-buffer and from shortcuts."""
         c, p, u = self.c, self.c.p, self.c.undoer
-        w = event.wrapper if event else None
-        if not g.isTextWrapper(w):
+        w = event and event.widget
+        if not w or not g.isTextWrapper(w):
             return
         bunch = u.beforeChangeBody(p)
         name = c.widget_name(w)
@@ -535,31 +551,60 @@ class LeoFrame:
         If middleButton is True, support x-windows middle-mouse-button easter-egg.
         """
         c, p, u = self.c, self.c.p, self.c.undoer
-        w = event.wrapper if event else None
-        if not g.isTextWrapper(w):
+        w = event and event.widget
+        wname = c.widget_name(w)
+        if not w or not g.isTextWrapper(w):
             return
-        wname = c.widget_name(w) or ''
         bunch = u.beforeChangeBody(p)
+        if self.cursorStay and wname.startswith('body'):
+            tCurPosition = w.getInsertPoint()
+        i, j = w.getSelectionRange()  # Returns insert point if no selection.
+
+        # 2025/12/01: c.k.previousSelection no longer exists.
+        # if middleButton and c.k.previousSelection is not None:
+        # start, end = c.k.previousSelection
+        # s = w.getAllText()
+        # s = s[start:end]
+        # c.k.previousSelection = None
+        # else:
+        # s = g.app.gui.getTextFromClipboard()
+        s = g.app.gui.getTextFromClipboard()
+        s = g.checkUnicode(s)
+        s = s.replace('\r\n', '\n').replace('\r', '\n')  # 3759.
+        singleLine = wname.startswith('head') or wname.startswith('minibuffer')
+        if singleLine:
+            # Strip trailing newlines so the truncation doesn't cause confusion.
+            while s and s[-1] in ('\n', '\r'):
+                s = s[:-1]
         # Save the horizontal scroll position.
         if hasattr(w, 'getXScrollPosition'):
             x_pos = w.getXScrollPosition()
-        s = (
-            g.checkUnicode(g.app.gui.getTextFromClipboard())
-            .replace('\r\n', '\n')
-            .replace('\r', '\n')  # 3759.
-        )
-        if wname.startswith('log'):
-            # #2593: Replace link patterns with html links.
-            c.frame.log.put_html_links(s)
         # Update the widget.
-        i, j = w.getSelectionRange()  # Returns insert point if no selection.
         if i != j:
             w.delete(i, j)
+        # #2593: Replace link patterns with html links.
+        if wname.startswith('log'):
+            if c.frame.log.put_html_links(s):
+                return  # create_html_links has done all the work.
         w.insert(i, s)
         w.see(i + len(s) + 2)
         if wname.startswith('body'):
+            if self.cursorStay:
+                if tCurPosition == j:
+                    offset = len(s) - (j - i)
+                else:
+                    offset = 0
+                newCurPosition = tCurPosition + offset
+                w.setSelectionRange(i=newCurPosition, j=newCurPosition)
             p.v.b = w.getAllText()
             u.afterChangeBody(p, 'Paste', bunch)
+        elif singleLine:
+            s = w.getAllText()
+            while s and s[-1] in ('\n', '\r'):
+                s = s[:-1]
+        else:
+            pass
+        # Never scroll horizontally.
         if hasattr(w, 'getXScrollPosition'):
             w.setXScrollPosition(x_pos)
         c.recolor()  # 4398.
@@ -589,7 +634,8 @@ class LeoFrame:
         else:
             c.bodyWantsFocus()
             k.setDefaultInputState()
-            k.showStateAndMode()
+            # Recolor the *body* text, **not** the headline.
+            k.showStateAndMode(w=c.frame.body.wrapper)
 
     # @+node:ekr.20031218072017.3680: *3* LeoFrame.Must be defined in subclasses
     def bringToFront(self) -> None:
@@ -695,7 +741,7 @@ class LeoLog:
     # @+others
     # @+node:ekr.20150509054436.1: *3* LeoLog.Birth
     # @+node:ekr.20031218072017.3695: *4* LeoLog.__init__
-    def __init__(self, frame: LeoLog | LeoQtFrame | NullFrame) -> None:
+    def __init__(self, frame: Union[LeoLog, LeoQtFrame, NullFrame]) -> None:
         """Ctor for LeoLog class."""
         g._assert(frame is None or issubclass(frame.__class__, LeoFrame))
         self.frame = frame
@@ -708,12 +754,12 @@ class LeoLog:
         # Depending on the log *tab*, logCtrl may be either a wrapper or a widget.
         self.logCtrl: Widget = None
         self.tabName: str = None  # The name of the active tab.
-        self.tabFrame: LeoFrame | NullFrame = None
-        self.frameDict: dict[str, LeoFrame | NullFrame] = {}
+        self.tabFrame: Union[LeoQTextBrowser, str] = None
+        self.frameDict: dict[str, str] = {}
         self.logNumber = 0  # To create unique name fields for text widgets.
         self.newTabCount = 0  # Number of new tabs created.
         self.textDict: dict[str, Widget] = {}  # Keys: page names. Values: text widgets.
-        self.wrapper: QTextMixin = None
+        self.wrapper: TextAPI = None  # To keep mypy happy.
 
     # @+node:ekr.20070302094848.1: *3* LeoLog.clearTab
     def clearTab(self, tabName: str, wrap: str = 'none') -> None:
@@ -732,7 +778,7 @@ class LeoLog:
     ) -> Widget:
         # Do not change the signature above.
         self.textDict[tabName] = None
-        self.frameDict[tabName] = None
+        self.frameDict[tabName] = tabName
 
     # @+node:ekr.20070302094848.5: *3* LeoLog.deleteTab
     def deleteTab(self, tabName: str) -> None:
@@ -1041,7 +1087,7 @@ class LeoTree:
         pass
 
     # @+node:ekr.20051026083544.2: *4* LeoTree.updateHead
-    def updateHead(self, event: LeoKeyEvent, w: QTextMixin) -> None:
+    def updateHead(self, event: LeoKeyEvent, w: TextAPI) -> None:
         """
         Update a headline from an event.
 
@@ -1281,7 +1327,7 @@ class NullBody(LeoBody):
 
     # @+node:ekr.20031218072017.2197: *3* NullBody: LeoBody interface
     # Birth, death...
-    def createControl(self, parentFrame: NullFrame, p: Position) -> QTextMixin:
+    def createControl(self, parentFrame: Widget, p: Position) -> TextAPI:
         pass
 
     # Events...
@@ -1318,16 +1364,16 @@ class NullFrame(LeoFrame):
         """Ctor for the NullFrame class."""
         super().__init__(c, gui)
         assert self.c
+        self.wrapper: TextAPI = None
+        self.iconBar = NullIconBarClass(self.c)
         self.initComplete = True
         self.isNullFrame = True
+        self.statusLine = NullStatusLineClass(self.c)
         self.title = title
         # Create the component objects.
         self.body = NullBody(frame=self)
-        self.iconBar = NullIconBarClass(c)
         self.log = NullLog(frame=self)
         self.menu = leoMenu.NullMenu(frame=self)
-        self.miniBufferWidget: Any = g.NullObject()
-        self.statusLine = NullStatusLineClass(c)
         self.tree = NullTree(frame=self)
         # Default window position.
         self.w = 600
@@ -1396,7 +1442,7 @@ class NullFrame(LeoFrame):
     def fullyExpandPane(self, event: LeoKeyEvent = None) -> None:
         pass
 
-    def getIconBar(self) -> NullIconBarClass | QtIconBarClass:
+    def getIconBar(self) -> Union[NullIconBarClass, QtIconBarClass]:
         return self.iconBar
 
     getIconBarObject = getIconBar
@@ -1477,13 +1523,13 @@ class NullIconBarClass:
     def addRowIfNeeded(self) -> None:
         pass
 
-    def addWidget(self, w: StringTextWrapper) -> None:
+    def addWidget(self, w: TextAPI) -> None:
         pass
 
     def createChaptersIcon(self) -> None:
         pass
 
-    def deleteButton(self, w: StringTextWrapper) -> None:
+    def deleteButton(self, w: TextAPI) -> None:
         pass
 
     def getNewFrame(self) -> None:
@@ -1496,7 +1542,7 @@ class NullIconBarClass:
         pass
 
     # @+node:ekr.20070301164543.2: *3* NullIconBarClass.add
-    def add(self, *args: Any, **keys: Any) -> Any:
+    def add(self, *args: Args, **keys: KWargs) -> Widget:
         """Add a (virtual) button to the (virtual) icon bar."""
         command: Callable = keys.get('command')
         text = keys.get('text')
@@ -1508,7 +1554,7 @@ class NullIconBarClass:
 
             command = commandCallback
 
-        class NullButtonWidget:
+        class nullButtonWidget:
             def __init__(self, c: Cmdr, command: Callable, name: str, text: str) -> None:
                 self.c = c
                 self.command = command
@@ -1518,7 +1564,7 @@ class NullIconBarClass:
             def __repr__(self) -> str:
                 return self.name
 
-        b = NullButtonWidget(self.c, command, name, text)
+        b = nullButtonWidget(self.c, command, name, text)
         return b
 
     # @+node:ekr.20140904043623.18574: *3* NullIconBarClass.clear
@@ -1552,14 +1598,18 @@ class NullIconBarClass:
 class NullLog(LeoLog):
     """A do-nothing log class."""
 
+    # @+others
+    # @+node:ekr.20070302095500: *3* NullLog.Birth
+    # @+node:ekr.20041012083237: *4* NullLog.__init__
     def __init__(self, *, frame: NullFrame = None) -> None:
         super().__init__(frame)
         c = self.c
         self.isNull = True
-        self.widget = self.wrapper = StringTextWrapper(c=c, name='null-log')
+        # self.logCtrl is now a property of the base LeoLog class.
+        self.widget = StringTextWrapper(c=c, name='null-log')
+        self.wrapper: TextAPI = None  # To keep mypy happy.
 
-    # @+others
-    # @+node:ekr.20120216123546.10951: *3* NullLog.finishCreate
+    # @+node:ekr.20120216123546.10951: *4* NullLog.finishCreate
     def finishCreate(self) -> None:
         pass
 
@@ -1568,7 +1618,7 @@ class NullLog(LeoLog):
         return self.widget.hasSelection()
 
     # @+node:ekr.20111119145033.10186: *3* NullLog.isLogWidget
-    def isLogWidget(self, w: Any) -> bool:
+    def isLogWidget(self, w: TextAPI) -> bool:
         return False
 
     # @+node:ekr.20041012083237.3: *3* NullLog.put and putnl
@@ -1636,7 +1686,7 @@ class NullStatusLineClass:
         """Ctor for NullStatusLine class."""
         self.c = c
         self.enabled = False
-        self.textWidget = self.wrapper = StringTextWrapper(c, name='status-line')
+        self.textWidget = StringTextWrapper(c, name='status-line')
 
     # @+others
     # @+node:ekr.20070302171917: *3* NullStatusLineClass.methods
@@ -1686,7 +1736,7 @@ class NullTree(LeoTree):
         self.editWidgetsDict: dict[VNode, StringTextWrapper] = {}
 
     # @+node:ekr.20070228163350.2: *3* NullTree.edit_widget
-    def edit_widget(self, p: Position) -> QTextMixin:
+    def edit_widget(self, p: Position) -> TextAPI:
         d = self.editWidgetsDict
         if not p or not p.v:
             return None

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1606,7 +1606,7 @@ class NullLog(LeoLog):
         self.isNull = True
         # self.logCtrl is now a property of the base LeoLog class.
         self.widget = StringTextWrapper(c=c, name='null-log')
-        self.wrapper: TextAPI = None  # To keep mypy happy.
+        ### self.wrapper: TextAPI = None  # To keep mypy happy.
 
     # @+node:ekr.20120216123546.10951: *4* NullLog.finishCreate
     def finishCreate(self) -> None:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6230,11 +6230,7 @@ def es(*args: Args, **kwargs: KWargs) -> None:
     if app.batchMode:
         if app.log:
             app.log.put(s)
-    elif g.unitTesting:
-        if log and not log.isNull:
-            # This makes the output of unit tests match the output of scripts.
-            g.pr(s, newline=newline)
-    elif log and app.logInited:
+    if log and (app.logInited or g.unitTesting):
         if newline:
             s += '\n'
         log.put(s, color=color, tabName=tabName, nodeLink=d['nodeLink'])

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoNodes import Position
     from leo.plugins.qt_frame import FindTabManager
-    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
+    from leo.plugins.qt_text import QTextMixin
 
     Value = Any
     Widget = Any  # 'Any' is the correct annotation for base class widgets.
@@ -308,7 +308,7 @@ class LeoGui:
         binding: str = None,
         char: str = None,
         event: LeoKeyEvent = None,
-        w: Wrapper = None,
+        w: QTextMixin = None,
         x: int = None,
         x_root: int = None,
         y: int = None,
@@ -332,7 +332,7 @@ class LeoGui:
         self.scriptFileName = scriptFileName
 
     # @+node:ekr.20110605121601.18845: *4* LeoGui.event_generate
-    def event_generate(self, c: Cmdr, char: str, shortcut: str, w: Wrapper) -> None:
+    def event_generate(self, c: Cmdr, char: str, shortcut: str, w: QTextMixin) -> None:
         event = self.create_key_event(c, binding=shortcut, char=char, w=w)
         c.k.masterKeyHandler(event)
         c.outerUpdate()

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -16,14 +16,12 @@ from collections.abc import Callable
 from typing import Any, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoFrame
-from leo.core.leoAPI import StringTextWrapper
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
-    from leo.core.leoFrame import NullFrame, NullIconBarClass
     from leo.core.leoNodes import Position
     from leo.plugins.qt_frame import FindTabManager
-    from leo.plugins.qt_text import QTextMixin
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 
     Value = Any
     Widget = Any  # 'Any' is the correct annotation for base class widgets.
@@ -64,11 +62,6 @@ class LeoGui:
         self.ignoreChars: list[str] = []  # Keys that should always be ignored.
         self.FKeys: list[str] = []  # The representation of F-keys.
         self.specialChars: list[str] = []  # A list of characters/keys to be handle specially.
-
-    # @+node:ekr.20260418103905.1: *3* LeoGui.create_wrapper_for_widget
-    def create_wrapper_for_widget(self, c: Cmdr, w: Widget) -> QTextMixin:
-        """May be overridden in subclasses."""
-        return StringTextWrapper(c)
 
     # @+node:ekr.20051206103652: *3* LeoGui.widget_name
     def widget_name(self, w: Widget) -> str:
@@ -312,11 +305,10 @@ class LeoGui:
     def create_key_event(
         self,
         c: Cmdr,
-        *,
         binding: str = None,
         char: str = None,
         event: LeoKeyEvent = None,
-        w: QTextMixin = None,
+        w: Wrapper = None,
         x: int = None,
         x_root: int = None,
         y: int = None,
@@ -340,7 +332,7 @@ class LeoGui:
         self.scriptFileName = scriptFileName
 
     # @+node:ekr.20110605121601.18845: *4* LeoGui.event_generate
-    def event_generate(self, c: Cmdr, char: str, shortcut: str, w: QTextMixin) -> None:
+    def event_generate(self, c: Cmdr, char: str, shortcut: str, w: Wrapper) -> None:
         event = self.create_key_event(c, binding=shortcut, char=char, w=w)
         c.k.masterKeyHandler(event)
         c.outerUpdate()
@@ -382,10 +374,6 @@ class LeoKeyEvent:
         self.event = event  # New in Leo 4.11.
         self.stroke = stroke
         self.w = self.widget = w
-        self.wrapper = (
-            w if g.isTextWrapper(w)  # #4623.
-            else g.app.gui.create_wrapper_for_widget(c, w)
-        )  # fmt: skip
         # Optional ivars
         self.x = x
         self.y = y
@@ -395,13 +383,10 @@ class LeoKeyEvent:
 
     # @+node:ekr.20140907103315.18774: *3* LeoKeyEvent.__repr__
     def __repr__(self) -> str:
-        result = [
-            'LeoKeyEvent:',
-            f"  {'c':>6}: {self.c.shortFileName()}",
-        ]
-        for ivar in ('char', 'event', 'stroke', 'w', 'widget', 'wrapper'):
-            result.append(f"  {ivar:>6}: {getattr(self, ivar)}")
-        return '\n'.join(result)
+        d = {'c': self.c.shortFileName()}
+        for ivar in ('char', 'event', 'stroke', 'w'):
+            d[ivar] = getattr(self, ivar)
+        return f"LeoKeyEvent:\n{g.objToString(d)}"
 
     # @+node:ekr.20150511181702.1: *3* LeoKeyEvent.get & __getitem__
     def get(self, attr: str) -> Value:
@@ -433,6 +418,7 @@ class NullGui(LeoGui):
         self.isNullGui = True
         self.idleTimeClass: Any = g.NullObject
         self.lastFrame: Widget = None  # The outer frame, to set g.app.log in runMainLoop.
+        self.plainTextWidget: Widget = g.NullObject
         self.script = None
 
     # @+node:ekr.20031218072017.3744: *3* NullGui.dialogs
@@ -598,16 +584,16 @@ class NullGui(LeoGui):
 
     def isTextWrapper(self, w: Widget) -> bool:
         """Return True if w is a Text widget suitable for text-oriented commands."""
-        return isinstance(w, StringTextWrapper)
+        return w and getattr(w, 'supportsHighLevelInterface', None)
 
     # @+node:ekr.20070301172456: *3* NullGui.panels
     def createComparePanel(self, c: Cmdr) -> None:
         """Create Compare panel."""
 
-    def createFindTab(self, c: Cmdr, parentFrame: NullFrame) -> None:
+    def createFindTab(self, c: Cmdr, parentFrame: Widget) -> None:
         """Create a find tab in the indicated frame."""
 
-    def createLeoFrame(self, c: Cmdr, title: str) -> NullFrame:
+    def createLeoFrame(self, c: Cmdr, title: str) -> Widget:
         """Create a null Leo Frame."""
         gui = self
         self.lastFrame = leoFrame.NullFrame(c, title, gui)
@@ -633,7 +619,7 @@ class NullScriptingControllerClass:
 
     This keeps pylint happy."""
 
-    def __init__(self, c: Cmdr, iconBar: NullIconBarClass = None) -> None:
+    def __init__(self, c: Cmdr, iconBar: Widget = None) -> None:
         self.c = c
         self.iconBar = iconBar
 
@@ -858,6 +844,21 @@ class StringFindTabManager:
         }  # fmt: skip
         w = d.get(checkbox_name)
         w.toggle()
+
+    # @-others
+
+
+# @+node:ekr.20170613095422.1: ** class StringGui (LeoGui)
+class StringGui(LeoGui):
+    """
+    A class representing all on-screen objects using subclasses of the
+    leoAPI.StringTextWrapper class.
+    """
+
+    # @+others
+    # @+node:ekr.20170613114120.1: *3* StringGui.runMainLoop
+    def runMainLoop(self) -> None:
+        raise NotImplementedError
 
     # @-others
 

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -848,21 +848,6 @@ class StringFindTabManager:
     # @-others
 
 
-# @+node:ekr.20170613095422.1: ** class StringGui (LeoGui)
-class StringGui(LeoGui):
-    """
-    A class representing all on-screen objects using subclasses of the
-    leoAPI.StringTextWrapper class.
-    """
-
-    # @+others
-    # @+node:ekr.20170613114120.1: *3* StringGui.runMainLoop
-    def runMainLoop(self) -> None:
-        raise NotImplementedError
-
-    # @-others
-
-
 # @+node:ekr.20171128093503.1: ** class StringLineEdit (leoGui)
 class StringLineEdit:
     """Simulate a QLineEdit."""

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -51,7 +51,6 @@ class LeoGui:
         self.leoIcon = None
         self.mGuiName = guiName
         self.mainLoop = None
-        self.plainTextWidget: Widget = None  # For SpellTabHandler class only.
         self.root: Position = None
         self.script: Optional[str] = None
         self.splashScreen: Widget = None
@@ -419,7 +418,6 @@ class NullGui(LeoGui):
         self.isNullGui = True
         self.idleTimeClass: Any = g.NullObject
         self.lastFrame: Widget = None  # The outer frame, to set g.app.log in runMainLoop.
-        self.plainTextWidget: Widget = g.NullObject
         self.script = None
 
     # @+node:ekr.20031218072017.3744: *3* NullGui.dialogs

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 from typing import Any, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoFrame
+from leo.core.leoAPI import StringTextWrapper
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
@@ -584,7 +585,7 @@ class NullGui(LeoGui):
 
     def isTextWrapper(self, w: Widget) -> bool:
         """Return True if w is a Text widget suitable for text-oriented commands."""
-        return w and getattr(w, 'supportsHighLevelInterface', None)
+        return issubclass(w.__class__, StringTextWrapper)
 
     # @+node:ekr.20070301172456: *3* NullGui.panels
     def createComparePanel(self, c: Cmdr) -> None:

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -2,9 +2,10 @@
 # @+node:ekr.20190515070742.1: * @file leoMarkup.py
 """Supports @adoc, @pandoc and @sphinx nodes and related commands."""
 
-# @+<< leoMarkup imports & annotations >>
-# @+node:ekr.20190515070742.3: ** << leoMarkup imports & annotations >>
+# @+<< leoMarkup: imports & annotations >>
+# @+node:ekr.20190515070742.3: ** << leoMarkup: imports & annotations >>
 from __future__ import annotations
+import functools
 import io
 from shutil import which
 import os
@@ -22,24 +23,33 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoNodes import Position
 
     File_List = Optional[list[str]]
-# @-<< leoMarkup imports & annotations >>
+# @-<< leoMarkup: imports & annotations >>
+# @+<< leoMarkup: cached functions >>
+# @+node:ekr.20260421071144.1: ** << leoMarkup: cached functions >>
 
-# Try RVM Ruby asciidoctor first, then fallback to system asciidoctor
-try:
-    import subprocess
 
-    rvm_gemdir = subprocess.check_output(['rvm', 'gemdir'], text=True).strip()
-    rvm_asciidoctor = os.path.join(rvm_gemdir, 'bin', 'asciidoctor')
-    if os.path.exists(rvm_asciidoctor):
-        asciidoctor_exec = rvm_asciidoctor
-    else:
-        asciidoctor_exec = which('asciidoctor')
-except Exception:
-    asciidoctor_exec = which('asciidoctor')
+# PR #4615: Defer calls to `which` until needed.
+@functools.cache
+def _asciidoctor_exec() -> Optional[str]:
+    return which('asciidoctor')
 
-asciidoc3_exec = which('asciidoc3')
-pandoc_exec = which('pandoc')
-sphinx_build = which('sphinx-build')
+
+@functools.cache
+def _asciidoc3_exec() -> Optional[str]:
+    return which('asciidoc3')
+
+
+@functools.cache
+def _pandoc_exec() -> Optional[str]:
+    return which('pandoc')
+
+
+@functools.cache
+def _sphinx_build() -> Optional[str]:
+    return which('sphinx-build')
+
+
+# @-<< leoMarkup: cached functions >>
 
 
 # @+others
@@ -368,7 +378,8 @@ class MarkupCommands:
         """
         Process the input file given by i_path with asciidoctor or asciidoc3.
         """
-        # global asciidoctor_exec, asciidoc3_exec
+        asciidoctor_exec = _asciidoctor_exec()
+        asciidoc3_exec = _asciidoc3_exec()
         assert asciidoctor_exec or asciidoc3_exec, g.callers()
         # Call the external program to write the output file.
         # The -e option deletes css.
@@ -381,8 +392,7 @@ class MarkupCommands:
         """
         Process the input file given by i_path with pandoc.
         """
-        # global pandoc_exec
-        assert pandoc_exec, g.callers()
+        assert _pandoc_exec(), g.callers()
         # Call pandoc to write the output file.
         # --quiet does no harm.
         command = f"pandoc {i_path} -t html5 -o {o_path}"
@@ -546,8 +556,7 @@ class MarkupCommands:
         preview: bool = False,
         verbose: bool = True,
     ) -> File_List:
-        # global asciidoctor_exec, asciidoc3_exec
-        if asciidoctor_exec or asciidoc3_exec:
+        if _asciidoctor_exec() or _asciidoc3_exec():
             return self.command_helper(event, kind='adoc', preview=preview, verbose=verbose)
         name = 'adoc-with-preview' if preview else 'adoc'
         g.es_print(f"{name} requires either asciidoctor or asciidoc3")
@@ -559,8 +568,7 @@ class MarkupCommands:
         preview: bool = False,
         verbose: bool = True,
     ) -> File_List:
-        # global pandoc_exec
-        if pandoc_exec:
+        if _pandoc_exec():
             return self.command_helper(event, kind='pandoc', preview=preview, verbose=verbose)
         name = 'pandoc-with-preview' if preview else 'pandoc'
         g.es_print(f"{name} requires pandoc")
@@ -572,8 +580,7 @@ class MarkupCommands:
         preview: bool = False,
         verbose: bool = True,
     ) -> File_List:
-        # global sphinx_build
-        if sphinx_build:
+        if _sphinx_build():
             return self.command_helper(event, kind='sphinx', preview=preview, verbose=verbose)
         name = 'sphinx-with-preview' if preview else 'sphinx'
         g.es_print(f"{name} requires sphinx")

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -71,7 +71,7 @@ def show_stroke(stroke: Stroke) -> str:
 class VimEvent:
     """A class to contain the components of the dot."""
 
-    def __init__(self, c: Cmdr, char: str, stroke: Stroke, w: QWidget) -> None:
+    def __init__(self, c: Cmdr, char: str, stroke: Stroke, w: QTextMixin) -> None:
         """ctor for the VimEvent class."""
         self.c: Cmdr = c
         self.char: str = char  # For Leo's core.
@@ -101,6 +101,7 @@ class VimCommands:
         """The ctor for the VimCommands class."""
         self.c = c
         self.k = c.k
+        self.w: QTextMixin = None
         # Toggled by :toggle-vim-trace.
         self.trace_flag = 'keys' in g.app.debug
         self.init_constant_ivars()
@@ -475,7 +476,7 @@ class VimCommands:
         """Init ivars that are never re-inited."""
         c = self.c
         # The widget that has focus when a ':' command begins.  May be None.
-        self.colon_w = None
+        self.colon_w: QTextMixin = None
         # True: allow f,F,h,l,t,T,x to cross line boundaries.
         self.cross_lines = c.config.getBool('vim-crosses-lines', default=True)
         self.register_d: dict[str, str] = {}  # Keys are letters; values are strings.

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -3326,7 +3326,7 @@ def trace_idle_focus(self, w: Wrapper) -> None:
         if trace:
             g.trace(f"{count:3} no focus")
 
-# @+node:ekr.20250329033642.5: *4* class BaseTextAPI
+# @+node:ekr.20260423033738.1: *4* class BaseTextAPI
 class BaseTextAPI:
     """
     A class specifying the interface to various text widgets,

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -3654,6 +3654,16 @@ def create_wrapper_for_widget(self, c: Cmdr, w: Any) -> QTextMixin:
     g.trace(f"Allocate {w.leo_wrapper.__class__.__name__} for {w.__class__.__name__}")
     return w.leo_wrapper
 
+# @+node:ekr.20260425154059.8: *4* class PlainTextWrapper(QTextMixin)
+class PlainTextWrapper(QTextMixin):
+    """A Qt class for use by the find code."""
+
+    def __init__(self, widget: QWidget) -> None:
+        """Ctor for the PlainTextWrapper class."""
+        super().__init__()
+        self.widget = widget
+
+
 # @-all
 # @@nosearch
 # @-leo

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -3631,6 +3631,29 @@ def addNewEditor(self, name: str) -> tuple[QWidget, QTextMixin]:
         body.recolorWidget(p, wrapper)
     return parent_frame, wrapper
 
+# @+node:ekr.20260425153444.1: *3* Deleted by PR #4631
+# @+node:ekr.20260418104208.1: *4*  LeoQtGui.create_wrapper_for_widge
+def create_wrapper_for_widget(self, c: Cmdr, w: Any) -> QTextMixin:
+    if w is None:
+        return None
+    if isinstance(w, QTextMixin):
+        return w
+    if getattr(w, 'wrapper', None):
+        return w.wrapper
+    if getattr(w, 'leo_wrapper', None):
+        return w.leo_wrapper
+    if isinstance(w, LeoQtTree):
+        # A strange special case: the class allocates its own wrappers.
+        return None
+    # Defensive code.
+    w.leo_wrapper = (
+             QLineEditWrapper(c=c, widget=w) if isinstance(w, QtWidgets.QLineEdit)
+        else QTextEditWrapper(c=c, widget=w) if isinstance(w, QtWidgets.QTextEdit)
+        else StringTextWrapper(c=c)
+    )  # fmt: skip
+    g.trace(f"Allocate {w.leo_wrapper.__class__.__name__} for {w.__class__.__name__}")
+    return w.leo_wrapper
+
 # @-all
 # @@nosearch
 # @-leo

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -272,6 +272,7 @@ class Importer:
         lines.
         """
         string_delims = self.string_list
+        string_delims_tuple = tuple(string_delims)  # PR #4615: create tuple for s.startswith.
         line_comment, start_comment, end_comment = g.set_delims_from_language(self.language)
         target = ''  # The string ending a multi-line comment or string.
         escape = '\\'
@@ -292,21 +293,21 @@ class Importer:
                 elif target:
                     result_line.append(' ')
                     # Clear the target, but skip any remaining characters of the target.
-                    if g.match(line, i, target):
+                    if line.startswith(target, i):
                         skip_count = max(0, (len(target) - 1))
                         target = ''
                 elif line_comment and line.startswith(line_comment, i):
                     # Skip the rest of the line. It can't contain significant characters.
                     break
-                elif any(g.match(line, i, z) for z in string_delims):
+                elif line.startswith(string_delims_tuple, i):
                     # Allow multi-character string delimiters.
                     result_line.append(' ')
                     for z in string_delims:
-                        if g.match(line, i, z):
+                        if line.startswith(z, i):
                             target = z
                             skip_count = max(0, (len(z) - 1))
                             break
-                elif start_comment and g.match(line, i, start_comment):
+                elif start_comment and line.startswith(start_comment, i):
                     result_line.append(' ')
                     target = end_comment
                     skip_count = max(0, len(start_comment) - 1)

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -391,8 +391,6 @@ class LeoQtEventFilter(QtCore.QObject):
     # @+node:ekr.20140907103315.18767: *3* LeoQtEventFilter:Tracing
     # @+node:ekr.20190922075339.1: *4* LeoQtEventFilter.traceKeys
     def traceKeys(self, obj, event):
-        if g.unitTesting:
-            return
         e = QtCore.QEvent
         key_events = {
             e.Type.KeyPress: 'key-press',  # 6
@@ -403,7 +401,9 @@ class LeoQtEventFilter(QtCore.QObject):
         kind = key_events.get(event.type())
         if kind:
             mods = ','.join(self.qtMods(event))
-            g.trace(f"{kind:>20}: {mods:>7} {event.text()!r}")
+            key = event.key()
+            key_s = chr(key) if key else ''
+            g.trace(f"{kind:>20}: {mods:>7} {key_s} {event.text()!r}")
 
     # @+node:ekr.20110605121601.18548: *4* LeoQtEventFilter.traceEvent
     def traceEvent(self, obj, event):

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -606,6 +606,8 @@ class LeoQtEventFilter(QtCore.QObject):
             e.Type.WindowBlocked: 'window-blocked',  # 103
             e.Type.WindowUnblocked: 'window-unblocked',  # 104
             e.Type.ZOrderChange: 'z-order-change',  # 126
+            e.Type.WindowActivate: 'window-activate',  # 24
+            e.Type.WindowDeactivate: 'window-deactivate',  # 25
         }
         focus_d = {
             e.Type.DeferredDelete: 'deferred-delete',  # 52
@@ -643,6 +645,7 @@ class LeoQtEventFilter(QtCore.QObject):
             if et not in none_ignore_d:
                 t = focus_d.get(et) or et
                 g.trace(f"None {t}")
+            return
         if isinstance(w, QtWidgets.QPushButton):
             return
         if isinstance(w, QtWidgets.QLineEdit):

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -73,7 +73,7 @@ class LossageData:
 # @+node:ekr.20141028061518.17: ** class LeoQtEventFilter
 class LeoQtEventFilter(QtCore.QObject):
     # @+others
-    # @+node:ekr.20110605121601.18539: *3* filter.ctor
+    # @+node:ekr.20110605121601.18539: *3* LeoQtEventFilter.__init__
     def __init__(self, c, w, tag=''):
         """Ctor for LeoQtEventFilter class."""
         super().__init__()
@@ -92,7 +92,7 @@ class LeoQtEventFilter(QtCore.QObject):
         self.ctagscompleter_active = False
         self.ctagscompleter_onKey = None
 
-    # @+node:ekr.20110605121601.18540: *3* filter.eventFilter & helpers
+    # @+node:ekr.20110605121601.18540: *3* LeoQtEventFilter.eventFilter & helpers
     def eventFilter(self, obj, event):
         """Return False if Qt should handle the event."""
         c, k = self.c, self.c.k
@@ -141,7 +141,7 @@ class LeoQtEventFilter(QtCore.QObject):
             g.es_exception()
         return True  # Whatever happens, suppress all other Qt key handling.
 
-    # @+node:ekr.20110605195119.16937: *4* filter.createKeyEvent
+    # @+node:ekr.20110605195119.16937: *4* LeoQtEventFilter.createKeyEvent
     def createKeyEvent(self, event, c, w, ch, binding):
         return leoGui.LeoKeyEvent(
             c=self.c,
@@ -157,7 +157,7 @@ class LeoQtEventFilter(QtCore.QObject):
             y_root=getattr(event, 'y_root', None) or 0,
         )
 
-    # @+node:ekr.20180413180751.2: *4* filter.doNonKeyEvent
+    # @+node:ekr.20180413180751.2: *4* LeoQtEventFilter.doNonKeyEvent
     def doNonKeyEvent(self, event, obj):
         """Handle all non-key event."""
         c = self.c
@@ -177,7 +177,7 @@ class LeoQtEventFilter(QtCore.QObject):
         # Return True unless we have a key event.
         return eventType not in (Type.ShortcutOverride, Type.KeyPress, Type.KeyRelease)
 
-    # @+node:ekr.20180413180751.3: *4* filter.shouldIgnoreKeyEvent
+    # @+node:ekr.20180413180751.3: *4* LeoQtEventFilter.shouldIgnoreKeyEvent
     def shouldIgnoreKeyEvent(self, event, obj):
         """
         Return True if we should ignore the key event.
@@ -205,7 +205,7 @@ class LeoQtEventFilter(QtCore.QObject):
         # return False # Don't ignore shortcut overrides with a real value.
         return True  # Ignore everything else.
 
-    # @+node:ekr.20110605121601.18543: *4* filter.toBinding & helpers
+    # @+node:ekr.20110605121601.18543: *4* LeoQtEventFilter.toBinding & helpers
     def toBinding(self, event):
         """
         Return (binding, actual_ch):
@@ -240,7 +240,7 @@ class LeoQtEventFilter(QtCore.QObject):
         lossage = LossageData(actual_ch, binding, ch, keynum, mods, mods2, mods3, text, toString)
         return binding, actual_ch, lossage
 
-    # @+node:ekr.20180419154543.1: *5* filter.doAltTweaks
+    # @+node:ekr.20180419154543.1: *5* LeoQtEventFilter.doAltTweaks
     def doAltTweaks(self, actual_ch, keynum, mods, toString):
         """Turn AltGr and some Alt-Ctrl keys into plain keys."""
 
@@ -282,7 +282,7 @@ class LeoQtEventFilter(QtCore.QObject):
             return removeAltCtrl(mods)
         return mods
 
-    # @+node:ekr.20180417161548.1: *5* filter.doLateTweaks
+    # @+node:ekr.20180417161548.1: *5* LeoQtEventFilter.doLateTweaks
     def doLateTweaks(self, binding, ch):
         """Make final tweaks. g.KeyStroke does other tweaks later."""
         #
@@ -298,7 +298,7 @@ class LeoQtEventFilter(QtCore.QObject):
                 binding = ch
         return binding, ch
 
-    # @+node:ekr.20180419160958.1: *5* filter.doMacTweaks
+    # @+node:ekr.20180419160958.1: *5* LeoQtEventFilter.doMacTweaks
     def doMacTweaks(self, actual_ch, ch, mods):
         """Replace MacOS Alt characters."""
         if not g.isMac:
@@ -325,7 +325,7 @@ class LeoQtEventFilter(QtCore.QObject):
                 mods = []
         return actual_ch, ch, mods
 
-    # @+node:ekr.20110605121601.18544: *5* filter.qtKey
+    # @+node:ekr.20110605121601.18544: *5* LeoQtEventFilter.qtKey
     def qtKey(self, event):
         """
         Return the components of a Qt key event.
@@ -372,7 +372,7 @@ class LeoQtEventFilter(QtCore.QObject):
             pass
         return keynum, text, toString, ch
 
-    # @+node:ekr.20120204061120.10084: *5* filter.qtMods
+    # @+node:ekr.20120204061120.10084: *5* LeoQtEventFilter.qtMods
     def qtMods(self, event):
         """Return the text version of the modifiers of the key event."""
         modifiers = event.modifiers()
@@ -388,8 +388,8 @@ class LeoQtEventFilter(QtCore.QObject):
         mods = [b for a, b in mod_table if (modifiers & a)]
         return mods
 
-    # @+node:ekr.20140907103315.18767: *3* filter.Tracing
-    # @+node:ekr.20190922075339.1: *4* filter.traceKeys
+    # @+node:ekr.20140907103315.18767: *3* LeoQtEventFilter:Tracing
+    # @+node:ekr.20190922075339.1: *4* LeoQtEventFilter.traceKeys
     def traceKeys(self, obj, event):
         if g.unitTesting:
             return
@@ -405,7 +405,7 @@ class LeoQtEventFilter(QtCore.QObject):
             mods = ','.join(self.qtMods(event))
             g.trace(f"{kind:>20}: {mods:>7} {event.text()!r}")
 
-    # @+node:ekr.20110605121601.18548: *4* filter.traceEvent
+    # @+node:ekr.20110605121601.18548: *4* LeoQtEventFilter.traceEvent
     def traceEvent(self, obj, event):
         if g.unitTesting:
             return
@@ -552,7 +552,7 @@ class LeoQtEventFilter(QtCore.QObject):
             )
             g.trace(f"{eventType:>25} {self.tag:25} {tag}")
 
-    # @+node:ekr.20131121050226.16331: *4* filter.traceWidget
+    # @+node:ekr.20131121050226.16331: *4* LeoQtEventFilter.traceWidget
     def traceWidget(self, event: QtCore.QEvent) -> None:
         """Show unexpected events in unusual widgets."""
         verbose = False  # Not good for --trace-events

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -618,19 +618,19 @@ class LeoQtEventFilter(QtCore.QObject):
             e.Type.WindowActivate: 'window-activate',  # 24
             e.Type.WindowDeactivate: 'window-deactivate',  # 25
         }
-        line_edit_ignore_d = {
-            e.Type.Enter: 'enter',  # 10 (mouse over)
-            e.Type.Leave: 'leave',  # 11 (mouse over)
-            e.Type.FocusOut: 'focus-out',  # 9
-            e.Type.WindowActivate: 'window-activate',  # 24
-            e.Type.WindowDeactivate: 'window-deactivate',  # 25
-        }
-        none_ignore_d = {
-            e.Type.Enter: 'enter',  # 10 (mouse over)
-            e.Type.Leave: 'leave',  # 11 (mouse over)
-            e.Type.FocusOut: 'focus-out',  # 9
-            e.Type.WindowActivate: 'window-activate',  # 24
-        }
+        # line_edit_ignore_d = {
+        #     e.Type.Enter: 'enter',  # 10 (mouse over)
+        #     e.Type.Leave: 'leave',  # 11 (mouse over)
+        #     e.Type.FocusOut: 'focus-out',  # 9
+        #     e.Type.WindowActivate: 'window-activate',  # 24
+        #     e.Type.WindowDeactivate: 'window-deactivate',  # 25
+        # }
+        # none_ignore_d = {
+        #     e.Type.Enter: 'enter',  # 10 (mouse over)
+        #     e.Type.Leave: 'leave',  # 11 (mouse over)
+        #     e.Type.FocusOut: 'focus-out',  # 9
+        #     e.Type.WindowActivate: 'window-activate',  # 24
+        # }
         # @-<< define dicts >>
         if et in ignore_d:
             return

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -391,6 +391,8 @@ class LeoQtEventFilter(QtCore.QObject):
     # @+node:ekr.20140907103315.18767: *3* LeoQtEventFilter:Tracing
     # @+node:ekr.20190922075339.1: *4* LeoQtEventFilter.traceKeys
     def traceKeys(self, obj, event):
+        if g.unitTesting:
+            return
         e = QtCore.QEvent
         key_events = {
             e.Type.KeyPress: 'key-press',  # 6
@@ -401,9 +403,7 @@ class LeoQtEventFilter(QtCore.QObject):
         kind = key_events.get(event.type())
         if kind:
             mods = ','.join(self.qtMods(event))
-            key = event.key()
-            key_s = chr(key) if key else ''
-            g.trace(f"{kind:>20}: {mods:>7} {key_s} {event.text()!r}")
+            g.trace(f"{kind:>20}: {mods:>7} {event.text()!r}")
 
     # @+node:ekr.20110605121601.18548: *4* LeoQtEventFilter.traceEvent
     def traceEvent(self, obj, event):
@@ -424,6 +424,8 @@ class LeoQtEventFilter(QtCore.QObject):
         eventType = event.type()
         # http://doc.qt.io/qt-5/qevent.html
         show: list[tuple[QtCore.QEvent.Type, str]] = []
+        # @+<< define events >>
+        # @+node:ekr.20260425152938.1: *5* << define events >>
         ignore = [
             e.Type.MetaCall,  # 43
             e.Type.Timer,  # 1
@@ -513,6 +515,7 @@ class LeoQtEventFilter(QtCore.QObject):
             (e.Type.UpdateLater, 'update-later'),  # 78
             (e.Type.UpdateRequest, 'update'),  # 77
         )
+        # @-<< define events >>
         option_table = (
             (traceActivate, activate_events),
             (traceFocus,    focus_events),
@@ -554,13 +557,14 @@ class LeoQtEventFilter(QtCore.QObject):
 
     # @+node:ekr.20131121050226.16331: *4* LeoQtEventFilter.traceWidget
     def traceWidget(self, event: QtCore.QEvent) -> None:
-        """Show unexpected events in unusual widgets."""
-        verbose = False  # Not good for --trace-events
+        """Show events in widgets."""
         e = QtCore.QEvent
         t: str | QtCore.QEvent.Type
         assert isinstance(event, QtCore.QEvent)
         et = event.type()
         # http://qt-project.org/doc/qt-4.8/qevent.html#properties
+        # @+<< define dicts >>
+        # @+node:ekr.20260425151831.5: *5* << define dicts >>
         ignore_d = {
             e.Type.ChildAdded: 'child-added',  # 68
             e.Type.ChildPolished: 'child-polished',  # 69
@@ -606,8 +610,6 @@ class LeoQtEventFilter(QtCore.QObject):
             e.Type.WindowBlocked: 'window-blocked',  # 103
             e.Type.WindowUnblocked: 'window-unblocked',  # 104
             e.Type.ZOrderChange: 'z-order-change',  # 126
-            e.Type.WindowActivate: 'window-activate',  # 24
-            e.Type.WindowDeactivate: 'window-deactivate',  # 25
         }
         focus_d = {
             e.Type.DeferredDelete: 'deferred-delete',  # 52
@@ -629,40 +631,17 @@ class LeoQtEventFilter(QtCore.QObject):
             e.Type.FocusOut: 'focus-out',  # 9
             e.Type.WindowActivate: 'window-activate',  # 24
         }
+        # @-<< define dicts >>
         if et in ignore_d:
             return
-        w = QtWidgets.QApplication.focusWidget()
-        if verbose:  # Too verbose for --trace-events.
-            for d in (ignore_d, focus_d, line_edit_ignore_d, none_ignore_d):
-                t = d.get(et)
-                if t:
-                    break
-            else:
-                t = et
-            g.trace(f"{t:20} {w.__class__}")
-            return
-        if w is None:
-            if et not in none_ignore_d:
-                t = focus_d.get(et) or et
-                g.trace(f"None {t}")
-            return
-        if isinstance(w, QtWidgets.QPushButton):
-            return
-        if isinstance(w, QtWidgets.QLineEdit):
-            if et not in line_edit_ignore_d:
-                t = focus_d.get(et) or et
-                if hasattr(w, 'objectName'):
-                    tag = w.objectName()
-                else:
-                    tag = f"id: {id(w)}, {w.__class__.__name__}"
-                g.trace(f"{t:20} {tag}")
-            return
         t = focus_d.get(et) or et
-        if hasattr(w, 'objectName'):
-            tag = w.objectName()
-        else:
-            tag = f"id: {id(w)}, {w.__class__.__name__}"
-        g.trace(f"{t:20} {tag}")
+        if t in ignore_d:
+            return
+        w = QtWidgets.QApplication.focusWidget()
+        if w is None:
+            return
+        name = w.objectName() if hasattr(w, 'objectName') else None
+        g.trace(f"{t:20} {w.__class__.__name__:>20} {name or '<no name>'}")
 
     # @-others
 

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -14,32 +14,48 @@ import sys
 import time
 import urllib
 from typing import Any, Optional, TYPE_CHECKING
-from leo.core import leoGlobals as g
-from leo.core import leoColor
-from leo.core import leoColorizer
-from leo.core import leoFrame
-from leo.core import leoGui
-from leo.core import leoMenu
 from leo.commands import gotoCommands
 from leo.core.leoAPI import StringTextWrapper
-from leo.core.leoQt import QtCore, QtGui, QtWidgets
-from leo.core.leoQt import QAction, Qsci
-from leo.core.leoQt import AlignLeft
-from leo.core.leoQt import ContextMenuPolicy, DropAction, FocusReason, KeyboardModifier
-from leo.core.leoQt import MoveOperation, Orientation, MouseButton
+from leo.core import (
+    leoColor,
+    leoColorizer,
+    leoFrame,
+    leoGlobals as g,
+    leoGui,
+    leoMenu,
+)
 from leo.core.leoQt import (
+    AlignLeft,
+    ContextMenuPolicy,
+    DropAction,
+    FocusReason,
+    KeyboardModifier,
+    MouseButton,
+    MoveOperation,
+    Orientation,
     Policy,
+    QAction,
+    Qsci,
+    QtCore,
+    QtGui,
+    QtWidgets,
     ScrollBarPolicy,
     SelectionBehavior,
     SelectionMode,
+    Shadow,
+    Shape,
     SizeAdjustPolicy,
+    Style,
+    TextInteractionFlag,
+    ToolBarArea,
+    Type,
+    Weight,
+    WindowState,
+    WrapMode,
 )
-from leo.core.leoQt import Shadow, Shape, Style
-from leo.core.leoQt import TextInteractionFlag, ToolBarArea, Type, Weight, WindowState, WrapMode
-from leo.plugins import qt_events
-from leo.plugins import qt_text
-from leo.plugins.qt_tree import LeoQtTree
+from leo.plugins import qt_events, qt_text
 from leo.plugins.mod_scripting import build_rclick_tree
+from leo.plugins.qt_tree import LeoQtTree
 from leo.plugins.qt_layout import LayoutCacheWidget
 
 # @-<< qt_frame imports >>

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1217,7 +1217,7 @@ class FindTabManager:
     """A helper class for the LeoFind class."""
 
     # @+others
-    # @+node:ekr.20131117120458.16794: *3*  ftm.ctor
+    # @+node:ekr.20131117120458.16794: *3*  FindTabManager.__ctor__
     def __init__(self, c: Cmdr) -> None:
         """Ctor for the FindTabManager class."""
         self.c = c
@@ -1248,7 +1248,7 @@ class FindTabManager:
         self.replace_then_find_button = None
         self.replace_all_button = None
 
-    # @+node:ekr.20131119185305.16478: *3* ftm.clear_focus & init_focus & set_entry_focus
+    # @+node:ekr.20131119185305.16478: *3* FindTabManager.clear_focus & init_focus & set_entry_focus
     def clear_focus(self) -> None:
         self.entry_focus = None
         self.find_findbox.clearFocus()
@@ -1269,7 +1269,7 @@ class FindTabManager:
             w = c.frame.tree.treeWidget
         self.entry_focus = w
 
-    # @+node:ekr.20210110143917.1: *3* ftm.get_settings
+    # @+node:ekr.20210110143917.1: *3* FindTabManager.get_settings
     def get_settings(self) -> g.Bunch:
         """
         Return a g.bunch representing all widget values.
@@ -1295,7 +1295,7 @@ class FindTabManager:
             # wrapping = self.check_box_wrap_around.isChecked(),
         )
 
-    # @+node:ekr.20131117120458.16789: *3* ftm.init_widgets (creates callbacks)
+    # @+node:ekr.20131117120458.16789: *3* FindTabManager.init_widgets (creates callbacks)
     def init_widgets(self) -> None:
         """
         Init widgets and ivars from c.config settings.
@@ -1376,10 +1376,10 @@ class FindTabManager:
             w = self.radio_button_entire_outline
             w.toggle()
 
-    # @+node:ekr.20210923060904.1: *3* ftm.set_widgets_from_dict
+    # @+node:ekr.20210923060904.1: *3* FindTabManager.set_widgets_from_dict
     def set_widgets_from_dict(self, d: g.Bunch) -> None:
         """Set all settings from d."""
-        # Similar to ftm.init_widgets, which has already been called.
+        # Similar to FindTabManagerinit_widgets, which has already been called.
         c = self.c
         find = c.findCommands
         # Set find text.
@@ -1425,7 +1425,7 @@ class FindTabManager:
             w = self.radio_button_entire_outline
             w.setChecked(True)
 
-    # @+node:ekr.20210312120503.1: *3* ftm.set_body_and_headline_checkbox
+    # @+node:ekr.20210312120503.1: *3* FindTabManager.set_body_and_headline_checkbox
     def set_body_and_headline_checkbox(self) -> None:
         """Return the search-body and search-headline checkboxes to their defaults."""
         # #1840: headline-only one-shot
@@ -1444,7 +1444,7 @@ class FindTabManager:
         if find.minibuffer_mode:
             find.show_find_options_in_status_area()
 
-    # @+node:ekr.20150619082825.1: *3* ftm.set_ignore_case
+    # @+node:ekr.20150619082825.1: *3* FindTabManager.set_ignore_case
     def set_ignore_case(self, aBool: bool) -> None:
         """Set the ignore-case checkbox to the given value."""
         c = self.c
@@ -1452,7 +1452,7 @@ class FindTabManager:
         w = self.check_box_ignore_case
         w.setChecked(aBool)
 
-    # @+node:ekr.20131117120458.16792: *3* ftm.set_radio_button
+    # @+node:ekr.20131117120458.16792: *3* FindTabManager.set_radio_button
     def set_radio_button(self, name: str) -> None:
         """Set the value of the radio buttons"""
         c = self.c
@@ -1471,7 +1471,7 @@ class FindTabManager:
         if find.minibuffer_mode:
             find.show_find_options_in_status_area()
 
-    # @+node:ekr.20131117164142.16853: *3* ftm.text getters/setters
+    # @+node:ekr.20131117164142.16853: *3* FindTabManager.text getters/setters
     def get_find_text(self) -> str:
         s = self.find_findbox.text()
         if s and s[-1] in ('\r', '\n'):
@@ -1498,7 +1498,7 @@ class FindTabManager:
         w.clear()
         w.insert(s)
 
-    # @+node:ekr.20131117120458.16791: *3* ftm.toggle_checkbox
+    # @+node:ekr.20131117120458.16791: *3* FindTabManager.toggle_checkbox
     def toggle_checkbox(self, checkbox_name: str) -> None:
         """Toggle the value of the checkbox whose name is given."""
         c = self.c
@@ -3605,13 +3605,13 @@ class LeoQtSpellTab:
         else:
             self.handler.loaded = False
 
-    # @+node:ekr.20110605121601.18389: *3* Event handlers
-    # @+node:ekr.20110605121601.18390: *4* onAddButton
+    # @+node:ekr.20110605121601.18389: *3* LeoQtSpellTab:Event handlers
+    # @+node:ekr.20110605121601.18390: *4* LeoQtSpellTab.onAddButton
     def onAddButton(self) -> None:
         """Handle a click in the Add button in the Check Spelling dialog."""
         self.handler.add()
 
-    # @+node:ekr.20110605121601.18391: *4* onChangeButton & onChangeThenFindButton
+    # @+node:ekr.20110605121601.18391: *4* LeoQtSpellTab.onChangeButton & onChangeThenFindButton
     def onChangeButton(self, event: QEvent = None) -> None:
         """Handle a click in the Change button in the Spell tab."""
         state = self.updateButtons()
@@ -3628,7 +3628,7 @@ class LeoQtSpellTab:
                 self.handler.find()
             self.updateButtons()
 
-    # @+node:ekr.20110605121601.18392: *4* onFindButton
+    # @+node:ekr.20110605121601.18392: *4* LeoQtSpellTab.onFindButton
     def onFindButton(self) -> None:
         """Handle a click in the Find button in the Spell tab."""
         c = self.c
@@ -3637,34 +3637,34 @@ class LeoQtSpellTab:
         c.invalidateFocus()
         c.bodyWantsFocus()
 
-    # @+node:ekr.20110605121601.18393: *4* onHideButton
+    # @+node:ekr.20110605121601.18393: *4* LeoQtSpellTab.onHideButton
     def onHideButton(self) -> None:
         """Handle a click in the Hide button in the Spell tab."""
         self.handler.hide()
 
-    # @+node:ekr.20110605121601.18394: *4* onIgnoreButton
+    # @+node:ekr.20110605121601.18394: *4* LeoQtSpellTab.onIgnoreButton
     def onIgnoreButton(self, event: QEvent = None) -> None:
         """Handle a click in the Ignore button in the Check Spelling dialog."""
         self.handler.ignore()
 
-    # @+node:ekr.20110605121601.18395: *4* onMap
+    # @+node:ekr.20110605121601.18395: *4* LeoQtSpellTab.onMap
     def onMap(self, event: QEvent = None) -> None:
         """Respond to a Tk <Map> event."""
         self.update(show=False, fill=False)
 
-    # @+node:ekr.20110605121601.18396: *4* onSelectListBox
+    # @+node:ekr.20110605121601.18396: *4* LeoQtSpellTab.onSelectListBox
     def onSelectListBox(self, event: QEvent = None) -> None:
         """Respond to a click in the selection listBox."""
         c = self.c
         self.updateButtons()
         c.bodyWantsFocus()
 
-    # @+node:ekr.20110605121601.18397: *3* Helpers
-    # @+node:ekr.20110605121601.18398: *4* bringToFront (LeoQtSpellTab)
+    # @+node:ekr.20110605121601.18397: *3* LeoQtSpellTab:Helpers
+    # @+node:ekr.20110605121601.18398: *4* LeoQtSpellTab.bringToFront
     def bringToFront(self) -> None:
         self.c.frame.log.selectTab('Spell')
 
-    # @+node:ekr.20110605121601.18399: *4* fillbox (LeoQtSpellTab)
+    # @+node:ekr.20110605121601.18399: *4* LeoQtSpellTab.fillbox
     def fillbox(self, alts: list[str], word: str = None) -> None:
         """Update the suggestions listBox in the Check Spelling dialog."""
         self.suggestions = alts
@@ -3676,14 +3676,14 @@ class LeoQtSpellTab:
             self.listBox.addItems(self.suggestions)
             self.listBox.setCurrentRow(0)
 
-    # @+node:ekr.20110605121601.18400: *4* getSuggestion (LeoQtSpellTab)
+    # @+node:ekr.20110605121601.18400: *4* LeoQtSpellTab.getSuggestion
     def getSuggestion(self) -> str:
         """Return the selected suggestion from the listBox."""
         idx = self.listBox.currentRow()
         value = self.suggestions[idx]
         return value
 
-    # @+node:ekr.20141113094129.13: *4* setFocus (LeoQtSpellTab)
+    # @+node:ekr.20141113094129.13: *4* LeoQtSpellTab.setFocus
     def setFocus(self) -> None:
         """Actually put focus in the tab."""
         # Not a great idea: there is no indication of focus.
@@ -3692,7 +3692,7 @@ class LeoQtSpellTab:
             w = self.c.frame.top.spellFrame
             c.widgetWantsFocus(w)
 
-    # @+node:ekr.20110605121601.18401: *4* update (LeoQtSpellTab)
+    # @+node:ekr.20110605121601.18401: *4* LeoQtSpellTab.update
     def update(self, show: bool = True, fill: bool = False) -> None:
         """Update the Spell Check dialog."""
         c = self.c
@@ -3703,7 +3703,7 @@ class LeoQtSpellTab:
             self.bringToFront()
             c.bodyWantsFocus()
 
-    # @+node:ekr.20110605121601.18402: *4* updateButtons (spellTab)
+    # @+node:ekr.20110605121601.18402: *4* LeoQtSpellTab.updateButtons
     def updateButtons(self) -> bool:
         """Enable or disable buttons in the Check Spelling dialog."""
         c = self.c
@@ -3726,7 +3726,7 @@ class LeoQtTreeTab:
 
     # @+others
     # @+node:ekr.20110605121601.18439: *3*  Birth & death
-    # @+node:ekr.20110605121601.18440: *4*  ctor (LeoQtTreeTab)
+    # @+node:ekr.20110605121601.18440: *4*  LeoQtTreeTab.__init__
     def __init__(self, c: Cmdr, iconBar: LeoQtLog) -> None:
         """Ctor for LeoQtTreeTab class."""
 
@@ -3740,7 +3740,7 @@ class LeoQtTreeTab:
         # self.reloadSettings()
         self.createControl()
 
-    # @+node:ekr.20110605121601.18441: *4* tt.createControl (defines class LeoQComboBox)
+    # @+node:ekr.20110605121601.18441: *4* LeoQtTreeTab.createControl (defines class LeoQComboBox)
     def createControl(self) -> None:
         class LeoQComboBox(QtWidgets.QComboBox):
             """Create a subclass in order to handle focusInEvents."""
@@ -3787,7 +3787,7 @@ class LeoQtTreeTab:
         # A change: the argument could now be an int instead of a string.
         w.currentIndexChanged.connect(onIndexChanged)
 
-    # @+node:ekr.20110605121601.18443: *3* tt.createTab
+    # @+node:ekr.20110605121601.18443: *3* LeoQtTreeTab.createTab
     def createTab(self, tabName: str, select: bool = True) -> None:
         """LeoQtTreeTab."""
         tt = self
@@ -3796,7 +3796,7 @@ class LeoQtTreeTab:
             tt.tabNames.append(tabName)
             tt.setNames()
 
-    # @+node:ekr.20110605121601.18444: *3* tt.destroyTab
+    # @+node:ekr.20110605121601.18444: *3* LeoQtTreeTab.destroyTab
     def destroyTab(self, tabName: str) -> None:
         """LeoQtTreeTab."""
         tt = self
@@ -3804,7 +3804,7 @@ class LeoQtTreeTab:
             tt.tabNames.remove(tabName)
             tt.setNames()
 
-    # @+node:ekr.20110605121601.18445: *3* tt.selectTab
+    # @+node:ekr.20110605121601.18445: *3* LeoQtTreeTab.selectTab
     def selectTab(self, tabName: str) -> None:
         """LeoQtTreeTab."""
         tt, c, cc = self, self.c, self.cc
@@ -3818,7 +3818,7 @@ class LeoQtTreeTab:
         c.redraw()
         c.outerUpdate()
 
-    # @+node:ekr.20110605121601.18446: *3* tt.setTabLabel
+    # @+node:ekr.20110605121601.18446: *3* LeoQtTreeTab.setTabLabel
     def setTabLabel(self, tabName: str) -> None:
         """LeoQtTreeTab."""
         w = self.w
@@ -3826,7 +3826,7 @@ class LeoQtTreeTab:
         if i > -1:
             w.setCurrentIndex(i)
 
-    # @+node:ekr.20110605121601.18447: *3* tt.setNames
+    # @+node:ekr.20110605121601.18447: *3* LeoQtTreeTab.setNames
     def setNames(self) -> None:
         """LeoQtTreeTab: Recreate the list of items."""
         w = self.w
@@ -4399,12 +4399,12 @@ class QtStatusLineClass:
 # @+node:peckj.20140505102552.10377: ** class QtTabBarWrapper (QTabBar)
 class QtTabBarWrapper(QtWidgets.QTabBar):
     # @+others
-    # @+node:peckj.20140516114832.10108: *3* __init__
+    # @+node:peckj.20140516114832.10108: *3* QtTabBarWrapper.__init__
     def __init__(self, parent: QWidget = None) -> None:
         super().__init__(parent)
         self.setMovable(True)
 
-    # @+node:peckj.20140516114832.10109: *3* mouseReleaseEvent (QtTabBarWrapper)
+    # @+node:peckj.20140516114832.10109: *3* QtTabBarWrapper.mouseReleaseEvent
     def mouseReleaseEvent(self, event: QMouseEvent) -> None:
         # middle click close on tabs -- JMP 20140505
         # closes Launchpad bug: https://bugs.launchpad.net/leo-editor/+bug/1183528

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -15,45 +15,29 @@ import time
 import urllib
 from typing import Any, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
-from leo.core import (
-    leoColor,
-    leoColorizer,
-    leoFrame,
-    leoGui,
-    leoMenu,
-)
+from leo.core import leoColor
+from leo.core import leoColorizer
+from leo.core import leoFrame
+from leo.core import leoGui
+from leo.core import leoMenu
 from leo.commands import gotoCommands
+from leo.core.leoAPI import StringTextWrapper
+from leo.core.leoQt import QtCore, QtGui, QtWidgets
+from leo.core.leoQt import QAction, Qsci
+from leo.core.leoQt import AlignLeft
+from leo.core.leoQt import ContextMenuPolicy, DropAction, FocusReason, KeyboardModifier
+from leo.core.leoQt import MoveOperation, Orientation, MouseButton
 from leo.core.leoQt import (
-    AlignLeft,
-    ContextMenuPolicy,
-    DropAction,
-    FocusReason,
-    KeyboardModifier,
-    MouseButton,
-    MoveOperation,
-    Orientation,
     Policy,
-    QAction,
-    Qsci,
-    QtCore,
-    QtGui,
-    QtWidgets,
     ScrollBarPolicy,
     SelectionBehavior,
     SelectionMode,
     SizeAdjustPolicy,
-    Shadow,
-    Shape,
-    Style,
-    TextInteractionFlag,
-    ToolBarArea,
-    Type,
-    Weight,
-    WindowState,
-    WrapMode,
 )
-from leo.plugins import qt_events, qt_text
-from leo.plugins.qt_text import QLineEditWrapper, QTextEditWrapper
+from leo.core.leoQt import Shadow, Shape, Style
+from leo.core.leoQt import TextInteractionFlag, ToolBarArea, Type, Weight, WindowState, WrapMode
+from leo.plugins import qt_events
+from leo.plugins import qt_text
 from leo.plugins.qt_tree import LeoQtTree
 from leo.plugins.mod_scripting import build_rclick_tree
 from leo.plugins.qt_layout import LayoutCacheWidget
@@ -68,14 +52,9 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoGui
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position
-    from leo.plugins.leoFrame import LeoLog, NullFrame
+    from leo.plugins.leoFrame import LeoLog
     from leo.plugins.mod_scripting import ScriptingController
-    from leo.plugins.qt_text import (
-        LeoQTextBrowser,
-        QMinibufferWrapper,
-        QScintillaWrapper,
-        QTextMixin,
-    )
+    from leo.plugins.qt_text import LeoQTextBrowser, QScintillaWrapper, QTextEditWrapper
 
     Args = Any
     KWargs = Any
@@ -99,8 +78,12 @@ if TYPE_CHECKING:  # pragma: no cover
     QTextBlock = QtGui.QTextBlock
     QTextCursor = QtGui.QTextCursor
     QWidget = QtWidgets.QWidget
-    RClick = tuple
+    RClick = tuple  # Union[tuple, namedtuple('RClick', 'position,children')]
     RClicks = list[RClick]
+
+    # LeoFrame defines TextAPI as:
+    # TextAPI = Union[QScintillaWrapper, QTextEditWrapper, StringTextWrapper]
+    QtWrapper = QScintillaWrapper | QTextEditWrapper
 
 
 # @-<< qt_frame annotations >>
@@ -515,7 +498,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
 
         # Define class EventWrapper.
         # @+others
-        # @+node:ekr.20131118172620.16892: *6* class EventWrapper (in DynamicWindow class)
+        # @+node:ekr.20131118172620.16892: *6* class EventWrapper
         class EventWrapper:
             def __init__(self, c: Cmdr, w: QWidget, next_w: QWidget, func: Callable) -> None:
                 self.c = c
@@ -842,6 +825,33 @@ class DynamicWindow(QtWidgets.QMainWindow):
         self.leo_master.select(c)
 
     # @+node:ekr.20110605121601.18142: *3* dw: top-level methods
+    # @+node:ekr.20190118150859.10: *4* dw.addNewEditor
+    def addNewEditor(self, name: str) -> tuple[QWidget, QTextEditWrapper]:
+        """Create a new body editor."""
+        c, p = self.leo_c, self.leo_c.p
+        body = c.frame.body
+        assert isinstance(body, LeoQtBody), repr(body)
+        # Step 1: create the editor.
+        parent_frame = c.frame.top.leo_body_inner_frame
+        widget = qt_text.LeoQTextBrowser(parent_frame, c, self)
+        widget.setObjectName('richTextEdit')  # Will be changed later.
+        wrapper = qt_text.QTextEditWrapper(widget, name='body', c=c)
+        self.packLabel(widget)
+        # Step 2: inject ivars, set bindings, etc.
+        inner_frame = c.frame.top.leo_body_inner_frame  # Inject ivars *here*.
+        body.injectIvars(inner_frame, name, p, wrapper)
+        body.updateInjectedIvars(widget, p)
+        wrapper.setAllText(p.b)
+        wrapper.see(0)
+        c.k.completeAllBindingsForWidget(wrapper)
+        if isinstance(widget, QtWidgets.QTextEdit):
+            colorizer = leoColorizer.make_colorizer(c, widget)
+            colorizer.highlighter.setDocument(widget.document())
+        else:
+            # Scintilla only.
+            body.recolorWidget(p, wrapper)
+        return parent_frame, wrapper
+
     # @+node:ekr.20110605121601.18143: *4* dw.createBodyPane
     def createBodyPane(self, parent: QWidget) -> QWidget:
         """
@@ -1040,7 +1050,6 @@ class DynamicWindow(QtWidgets.QMainWindow):
         lineEdit = VisLineEdit(frame)
         lineEdit._sel_and_insert = (0, 0, 0)
         lineEdit.setObjectName('lineEdit')  # name important.
-        lineEdit.leo_wrapper = QLineEditWrapper(widget=lineEdit)  # #4623.
         # Pack.
         hLayout = self.createHLayout(frame, 'minibufferHLayout', spacing=4)
         hLayout.setContentsMargins(3, 2, 2, 0)
@@ -1669,7 +1678,7 @@ class LeoQtBody(leoFrame.LeoBody):
         c = self.c
         assert c.frame == frame and frame.c == c
         self.colorizer: BaseColorizer = None
-        self.wrapper: QScintillaWrapper | QTextMixin = None
+        self.wrapper: QtWrapper = None
         self.widget: QWidget = None
         self.reloadSettings()
         self.set_widget()  # Sets self.widget and self.wrapper.
@@ -1800,12 +1809,13 @@ class LeoQtFrame(leoFrame.LeoFrame):
         leoFrame.LeoFrame.instances += 1  # Increment the class var.
 
         # Official ivars for objects.
+        self.bar1: LeoQtFrame = None
+        self.bar2: LeoQtFrame = None
         self.body: LeoQtBody = None
         self.iconBar: QtIconBarClass = None
         self.iconFrame: QtIconBarClass = None
         self.log: LeoQtLog = None
         self.statusLine: QtStatusLineClass = None
-        self.miniBufferWidget: QMinibufferWrapper = None
         self.tree: LeoQtTree = None
         self.top: DynamicWindow = None
 
@@ -1821,6 +1831,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
 
     def reloadSettings(self) -> None:
         c = self.c
+        self.cursorStay = c.config.getBool("cursor-stay-on-paste", default=True)
         self.use_chapters = c.config.getBool('use-chapters')
         self.use_chapter_tabs = c.config.getBool('use-chapter-tabs')
 
@@ -1949,6 +1960,69 @@ class LeoQtFrame(leoFrame.LeoFrame):
             n1, n2 = aList
             return float(n1) / float(n1 + n2) if n2 > 0 else 0.5
         return 0.5
+
+    # @+node:ekr.20110605121601.18275: *4* LeoQtFrame.configureBar
+    def configureBar(self, bar: QMenuBar, verticalFlag: bool) -> None:  # pylint: disable=disallowed-name
+        c = self.c
+        # Get configuration settings.
+        w = c.config.getInt("split-bar-width")
+        if not w or w < 1:
+            w = 7
+        relief = c.config.get("split_bar_relief", "relief")
+        if not relief:
+            relief = "flat"
+        color = c.config.getColor("split-bar-color")
+        if not color:
+            color = "LightSteelBlue2"
+        try:
+            if verticalFlag:
+                # Panes arranged vertically; horizontal splitter bar
+                bar.configure(relief=relief, height=w, bg=color, cursor="sb_v_double_arrow")
+            else:
+                # Panes arranged horizontally; vertical splitter bar
+                bar.configure(relief=relief, width=w, bg=color, cursor="sb_h_double_arrow")
+        except Exception:
+            # Could be a user error. Use all defaults
+            g.es("exception in user configuration for splitbar")
+            g.es_exception()
+            if verticalFlag:
+                # Panes arranged vertically; horizontal splitter bar
+                bar.configure(height=7, cursor="sb_v_double_arrow")
+            else:
+                # Panes arranged horizontally; vertical splitter bar
+                bar.configure(width=7, cursor="sb_h_double_arrow")
+
+    # @+node:ekr.20110605121601.18276: *4* LeoQtFrame.configureBarsFromConfig
+    def configureBarsFromConfig(self) -> None:
+        c = self.c
+        w = c.config.getInt("split-bar-width")
+        if not w or w < 1:
+            w = 7
+        relief = c.config.get("split_bar_relief", "relief")
+        if not relief or relief == "":
+            relief = "flat"
+        color = c.config.getColor("split-bar-color")
+        if not color or color == "":
+            color = "LightSteelBlue2"
+        if self.splitVerticalFlag:
+            bar1, bar2 = self.bar1, self.bar2
+        else:
+            bar1, bar2 = self.bar2, self.bar1
+        try:
+            bar1.configure(relief=relief, height=w, bg=color)
+            bar2.configure(relief=relief, width=w, bg=color)
+        except Exception:
+            # Could be a user error.
+            g.es("exception in user configuration for splitbar")
+            g.es_exception()
+
+    # @+node:ekr.20110605121601.18277: *4* LeoQtFrame.reconfigureFromConfig
+    def reconfigureFromConfig(self) -> None:
+        """Init the configuration of the Qt frame from settings."""
+        c, frame = self.c, self
+        frame.configureBarsFromConfig()
+        frame.setTabWidth(c.tab_width)
+        c.redraw()
 
     # @+node:ekr.20110605121601.18278: *4* LeoQtFrame.setInitialWindowGeometry
     def setInitialWindowGeometry(self) -> None:
@@ -2259,15 +2333,16 @@ class LeoQtLog(leoFrame.LeoLog):
     def __init__(self, frame: LeoQtFrame) -> None:
         """Ctor for LeoQtLog class."""
         super().__init__(frame)  # Calls createControl.
+        assert self.logCtrl is None, self.logCtrl
         self.c = c = frame.c  # Also set in the base constructor, but we need it here.
         self.contentsDict: dict[str, LeoQTextBrowser] = {}  # Keys: tab names.
         self.eventFilters: list = []  # To make filters work!
         self.qtFrameDict: dict[str, QTabWidget] = {}
-        self.qtLogCtrl: QTextEditWrapper = None
+        self.logCtrl: QWidget = None  # A union.
         self.logDict: dict[str, LeoQTextBrowser] = {}  # Keys: tab names.
         self.logWidget: LeoLog = None
+        self.menu: qt_text.LeoQTextBrowser = None
         self.qtTabWidget: QWidget = c.frame.top.tabWidget
-        self.wrapper: QTextEditWrapper = None  # #4623.
         tw = self.qtTabWidget
 
         # Bug 917814: Switching Log Pane tabs is done incompletely.
@@ -2291,9 +2366,6 @@ class LeoQtLog(leoFrame.LeoLog):
         # Create the log tab as the leftmost tab.
         log.createTab('Log')
         self.logWidget = self.contentsDict.get('Log')
-        self.wrapper = QTextEditWrapper(c=c, widget=self.logWidget)  # #4623.
-
-        # Configure.
         logWidget = self.logWidget
         logWidget.setWordWrapMode(WrapMode.WordWrap if self.wrap else WrapMode.NoWrap)
         w.insertTab(0, logWidget, 'Log')  # Required.
@@ -2331,7 +2403,8 @@ class LeoQtLog(leoFrame.LeoLog):
     @log_cmd('log-clear')
     def clearLog(self, event: LeoKeyEvent = None) -> None:
         """Clear the log pane."""
-        w = self.qtLogCtrl.widget
+        # self.logCtrl may be either a wrapper or a widget.
+        w = self.logCtrl.widget
         if w:
             w.clear()
 
@@ -2339,7 +2412,8 @@ class LeoQtLog(leoFrame.LeoLog):
     @log_cmd('log-dump')
     def dumpLog(self, event: LeoKeyEvent = None) -> None:
         """Clear the log pane."""
-        w = self.qtLogCtrl.widget
+        # self.logCtrl may be either a wrapper or a widget.
+        w = self.logCtrl.widget
         if not w:
             return
 
@@ -2427,8 +2501,8 @@ class LeoQtLog(leoFrame.LeoLog):
         obj = getattr(w, 'leo_log_wrapper', None)
 
         # #1161: Don't change logs unless the wrapper is correct.
-        if obj and isinstance(obj, QTextEditWrapper):
-            self.qtLogCtrl = obj
+        if obj and isinstance(obj, qt_text.QTextEditWrapper):
+            self.logCtrl = obj
 
     # @+node:ekr.20200304132424.1: *3* LeoQtLog.onContextMenu
     def onContextMenu(self, point: QPoint) -> None:
@@ -2464,7 +2538,7 @@ class LeoQtLog(leoFrame.LeoLog):
         color = self.resolve_color(color)
         self.selectTab(tabName or 'Log')
         # Must be done after the call to selectTab.
-        wrapper = self.qtLogCtrl
+        wrapper = self.logCtrl
         if not isinstance(wrapper, qt_text.QTextEditWrapper):
             g.trace('BAD wrapper', wrapper.__class__.__name__)
             return
@@ -2506,7 +2580,7 @@ class LeoQtLog(leoFrame.LeoLog):
             return
         if tabName:
             self.selectTab(tabName)
-        wrapper = self.qtLogCtrl
+        wrapper = self.logCtrl
         if not isinstance(wrapper, qt_text.QTextEditWrapper):
             g.trace('BAD wrapper', wrapper.__class__.__name__)
             return
@@ -2545,7 +2619,7 @@ class LeoQtLog(leoFrame.LeoLog):
             return
         if tabName:
             self.selectTab(tabName)
-        w = self.qtLogCtrl.widget
+        w = self.logCtrl.widget
         if not w:
             return
         sb = w.horizontalScrollBar()
@@ -2568,7 +2642,7 @@ class LeoQtLog(leoFrame.LeoLog):
         createText: bool = True,
         widget: QWidget = None,
         wrap: str = 'none',
-    ) -> QTextMixin:
+    ) -> QWidget:  # Widget or LeoQTextBrowser.
         """
         Create a new tab in tab widget
         if widget is None, Create a QTextBrowser,
@@ -2587,8 +2661,7 @@ class LeoQtLog(leoFrame.LeoLog):
             widget.setReadOnly(False)  # Allow edits.
             self.logDict[tabName] = widget
             if tabName == 'Log':
-                self.qtLogCtrl = contents
-                self.logCtrl = contents  # PR #4601: Set the base-class ivar.
+                self.logCtrl = contents
                 widget.setObjectName('log-widget')
             # Set binding on all log pane widgets.
             g.app.gui.setFilter(c, widget, self, tag='log')
@@ -2661,17 +2734,9 @@ class LeoQtLog(leoFrame.LeoLog):
 
     # @+node:ekr.20110605121601.18331: *4* LeoQtLog.selectTab & helpers
     def selectTab(self, tabName: str, wrap: str = 'none') -> None:
-        """
-        Create the tab if necessary and make it active.
-
-        Any plugin or script can call this method to create a new tab.
-        There is no need to call c.frame.log.createTab first.
-
-        As a result, this code can *not* be moved to the startup logic.
-        """
+        """Create the tab if necessary and make it active."""
         i = self.findTabIndex(tabName)
         if i is None:
-            # This does happen, but not often.
             self.createTab(tabName, wrap=wrap)
             self.finishCreateTab(tabName)
         self.finishSelectTab(tabName)
@@ -2693,8 +2758,7 @@ class LeoQtLog(leoFrame.LeoLog):
             if widget:
                 wrapper = getattr(widget, 'leo_log_wrapper', None)
                 if wrapper and isinstance(wrapper, qt_text.QTextEditWrapper):
-                    self.qtLogCtrl = wrapper
-                    self.logCtrl = wrapper  # Required!
+                    self.logCtrl = wrapper
             if not wrapper:
                 g.trace('NO LOG WRAPPER')
         if tabName == 'Find':
@@ -2989,10 +3053,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
 
     # @+node:ekr.20120922041923.10607: *4* LeoQtMenu.activateAllParentMenus
     def activateAllParentMenus(self, menu: QObject) -> None:
-        """
-        menu is a QtMenuWrapper or a QObject.
-        Activate it and all parent menus.
-        """
+        """menu is a QtMenuWrapper.  Activate it and all parent menus."""
         parent = menu.parent()
         action = menu.menuAction()
         if action:
@@ -3545,6 +3606,8 @@ class LeoQtSpellTab:
         self.c = c
         top = c.frame.top
         self.handler = handler
+        # hack:
+        handler.workCtrl = StringTextWrapper(c, 'spell-workctrl')
         self.tabName = tabName
         if hasattr(top, 'leo_spell_label'):
             self.wordLabel = top.leo_spell_label
@@ -4056,13 +4119,7 @@ class QtIconBarClass:
 class QtMenuWrapper(LeoQtMenu, QtWidgets.QMenu):  # type:ignore
     # @+others
     # @+node:ekr.20110605121601.18459: *3* ctor and __repr__(QtMenuWrapper)
-    def __init__(
-        self,
-        c: Cmdr,
-        frame: LeoQtFrame | NullFrame,
-        parent: QWidget,
-        label: str,
-    ) -> None:
+    def __init__(self, c: Cmdr, frame: LeoQtFrame, parent: QWidget, label: str) -> None:
         """ctor for QtMenuWrapper class."""
         assert c
         assert frame
@@ -4170,8 +4227,6 @@ class QtStatusLineClass:
         # Create the text widgets.
         self.textWidget1 = w1 = QtWidgets.QLineEdit(self.statusBar)
         self.textWidget2 = w2 = QtWidgets.QLineEdit(self.statusBar)
-        w1.leo_wrapper = QLineEditWrapper(c=c, widget=w1)  # #4623
-        w2.leo_wrapper = QLineEditWrapper(c=c, widget=w2)  # #4623
         w1.setObjectName('status1')
         w2.setObjectName('status2')
         w1.setReadOnly(True)
@@ -4354,8 +4409,6 @@ class QtStatusLineClass:
 
 # @+node:peckj.20140505102552.10377: ** class QtTabBarWrapper (QTabBar)
 class QtTabBarWrapper(QtWidgets.QTabBar):
-    """An internal class that overrides one method."""
-
     # @+others
     # @+node:peckj.20140516114832.10108: *3* __init__
     def __init__(self, parent: QWidget = None) -> None:

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1741,10 +1741,11 @@ class LeoQtBody(leoFrame.LeoBody):
         """Handle a focus-in event in the body pane."""
         if obj.objectName() == 'richTextEdit':
             self.onFocusColorHelper('focus-in', obj)
-            if hasattr(obj, 'leo_copy_button') and obj.leo_copy_button:
-                obj.setReadOnly(True)
-            else:
-                obj.setReadOnly(False)
+            # if hasattr(obj, 'leo_copy_button') and obj.leo_copy_button:
+            #     obj.setReadOnly(True)
+            # else:
+            #     obj.setReadOnly(False)
+            obj.setReadOnly(False)
             obj.setFocus()  # Weird, but apparently necessary.
 
     # @+node:ekr.20110930174206.15473: *4* LeoQtBody.onFocusOut

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -94,11 +94,9 @@ if TYPE_CHECKING:  # pragma: no cover
     QTextBlock = QtGui.QTextBlock
     QTextCursor = QtGui.QTextCursor
     QWidget = QtWidgets.QWidget
-    RClick = tuple  # Union[tuple, namedtuple('RClick', 'position,children')]
+    RClick = tuple
     RClicks = list[RClick]
 
-    # LeoFrame defines TextAPI as:
-    # TextAPI = Union[QScintillaWrapper, QTextEditWrapper, StringTextWrapper]
     QtWrapper = QScintillaWrapper | QTextEditWrapper
 
 

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1949,69 +1949,6 @@ class LeoQtFrame(leoFrame.LeoFrame):
             return float(n1) / float(n1 + n2) if n2 > 0 else 0.5
         return 0.5
 
-    # @+node:ekr.20110605121601.18275: *4* LeoQtFrame.configureBar
-    def configureBar(self, bar: QMenuBar, verticalFlag: bool) -> None:  # pylint: disable=disallowed-name
-        c = self.c
-        # Get configuration settings.
-        w = c.config.getInt("split-bar-width")
-        if not w or w < 1:
-            w = 7
-        relief = c.config.get("split_bar_relief", "relief")
-        if not relief:
-            relief = "flat"
-        color = c.config.getColor("split-bar-color")
-        if not color:
-            color = "LightSteelBlue2"
-        try:
-            if verticalFlag:
-                # Panes arranged vertically; horizontal splitter bar
-                bar.configure(relief=relief, height=w, bg=color, cursor="sb_v_double_arrow")
-            else:
-                # Panes arranged horizontally; vertical splitter bar
-                bar.configure(relief=relief, width=w, bg=color, cursor="sb_h_double_arrow")
-        except Exception:
-            # Could be a user error. Use all defaults
-            g.es("exception in user configuration for splitbar")
-            g.es_exception()
-            if verticalFlag:
-                # Panes arranged vertically; horizontal splitter bar
-                bar.configure(height=7, cursor="sb_v_double_arrow")
-            else:
-                # Panes arranged horizontally; vertical splitter bar
-                bar.configure(width=7, cursor="sb_h_double_arrow")
-
-    # @+node:ekr.20110605121601.18276: *4* LeoQtFrame.configureBarsFromConfig
-    def configureBarsFromConfig(self) -> None:
-        c = self.c
-        w = c.config.getInt("split-bar-width")
-        if not w or w < 1:
-            w = 7
-        relief = c.config.get("split_bar_relief", "relief")
-        if not relief or relief == "":
-            relief = "flat"
-        color = c.config.getColor("split-bar-color")
-        if not color or color == "":
-            color = "LightSteelBlue2"
-        if self.splitVerticalFlag:
-            bar1, bar2 = self.bar1, self.bar2
-        else:
-            bar1, bar2 = self.bar2, self.bar1
-        try:
-            bar1.configure(relief=relief, height=w, bg=color)
-            bar2.configure(relief=relief, width=w, bg=color)
-        except Exception:
-            # Could be a user error.
-            g.es("exception in user configuration for splitbar")
-            g.es_exception()
-
-    # @+node:ekr.20110605121601.18277: *4* LeoQtFrame.reconfigureFromConfig
-    def reconfigureFromConfig(self) -> None:
-        """Init the configuration of the Qt frame from settings."""
-        c, frame = self.c, self
-        frame.configureBarsFromConfig()
-        frame.setTabWidth(c.tab_width)
-        c.redraw()
-
     # @+node:ekr.20110605121601.18278: *4* LeoQtFrame.setInitialWindowGeometry
     def setInitialWindowGeometry(self) -> None:
         """Set the position and size of the frame to config params."""

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoGui
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position
-    from leo.plugins.leoFrame import LeoLog, NullFrame
+    from leo.plugins.leoFrame import LeoLog
     from leo.plugins.mod_scripting import ScriptingController
     from leo.plugins.qt_text import LeoQTextBrowser, QScintillaWrapper, QTextEditWrapper
 
@@ -746,7 +746,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
                 shadow = Shadow.Plain
             if shape is None:
                 shape = Shape.NoFrame
-            w = qt_text.LeoQTextBrowser(parent, c, None)
+            w = qt_text.LeoQTextBrowser(parent, c)
             w.setFrameShape(shape)
             w.setFrameShadow(shadow)
             w.setLineWidth(lineWidth)
@@ -825,33 +825,6 @@ class DynamicWindow(QtWidgets.QMainWindow):
         self.leo_master.select(c)
 
     # @+node:ekr.20110605121601.18142: *3* dw: top-level methods
-    # @+node:ekr.20190118150859.10: *4* dw.addNewEditor
-    def addNewEditor(self, name: str) -> tuple[QWidget, QTextEditWrapper]:
-        """Create a new body editor."""
-        c, p = self.leo_c, self.leo_c.p
-        body = c.frame.body
-        assert isinstance(body, LeoQtBody), repr(body)
-        # Step 1: create the editor.
-        parent_frame = c.frame.top.leo_body_inner_frame
-        widget = qt_text.LeoQTextBrowser(parent_frame, c, self)
-        widget.setObjectName('richTextEdit')  # Will be changed later.
-        wrapper = qt_text.QTextEditWrapper(widget, name='body', c=c)
-        self.packLabel(widget)
-        # Step 2: inject ivars, set bindings, etc.
-        inner_frame = c.frame.top.leo_body_inner_frame  # Inject ivars *here*.
-        body.injectIvars(inner_frame, name, p, wrapper)
-        body.updateInjectedIvars(widget, p)
-        wrapper.setAllText(p.b)
-        wrapper.see(0)
-        c.k.completeAllBindingsForWidget(wrapper)
-        if isinstance(widget, QtWidgets.QTextEdit):
-            colorizer = leoColorizer.make_colorizer(c, widget)
-            colorizer.highlighter.setDocument(widget.document())
-        else:
-            # Scintilla only.
-            body.recolorWidget(p, wrapper)
-        return parent_frame, wrapper
-
     # @+node:ekr.20110605121601.18143: *4* dw.createBodyPane
     def createBodyPane(self, parent: QWidget) -> QWidget:
         """
@@ -2652,7 +2625,7 @@ class LeoQtLog(leoFrame.LeoLog):
         contents: Any
         if widget is None:
             # widget is subclass of QTextBrowser.
-            widget = qt_text.LeoQTextBrowser(parent=None, c=c, wrapper=self)
+            widget = qt_text.LeoQTextBrowser(parent=None, c=c)
             # contents is a wrapper.
             contents = qt_text.QTextEditWrapper(widget=widget, name='log', c=c)
             # Inject an ivar into the QTextBrowser that points to the wrapper.

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -65,8 +65,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import TypeAlias  # Requires Python 3.12+
     from leo.core.leoColorizer import BaseColorizer
     from leo.core.leoCommands import Commands as Cmdr
-    from leo.core.leoGui import LeoGui
-    from leo.core.leoGui import LeoKeyEvent
+    from leo.core.leoGui import LeoGui, LeoKeyEvent, NullFrame
     from leo.core.leoNodes import Position
     from leo.plugins.leoFrame import LeoLog
     from leo.plugins.mod_scripting import ScriptingController
@@ -4044,7 +4043,13 @@ class QtIconBarClass:
 class QtMenuWrapper(LeoQtMenu, QtWidgets.QMenu):  # type:ignore
     # @+others
     # @+node:ekr.20110605121601.18459: *3* QtMenuWrapper.__init__ and __repr__
-    def __init__(self, c: Cmdr, frame: Any, parent: QWidget, label: str) -> None:
+    def __init__(
+        self,
+        c: Cmdr,
+        frame: LeoQtFrame | NullFrame,
+        parent: QWidget,
+        label: str,
+    ) -> None:
         """ctor for QtMenuWrapper class."""
         assert c
         assert frame

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2342,13 +2342,13 @@ class LeoQtLog(leoFrame.LeoLog):
         self.logDict: dict[str, LeoQTextBrowser] = {}  # Keys: tab names.
         self.logWidget: LeoLog = None
         self.menu: qt_text.LeoQTextBrowser = None
-        self.qtTabWidget: QWidget = c.frame.top.tabWidget
-        tw = self.qtTabWidget
+        self.tabWidget: QWidget = c.frame.top.tabWidget
+        tw = self.tabWidget
 
         # Bug 917814: Switching Log Pane tabs is done incompletely.
         tw.currentChanged.connect(self.onCurrentChanged)
         if 0:  # Not needed to make onActivateEvent work.
-            # Works only for .qtTabWidget, *not* the individual tabs!
+            # Works only for .tabWidget, *not* the individual tabs!
             theFilter = qt_events.LeoQtEventFilter(c, w=tw, tag='tabWidget')
             tw.installEventFilter(theFilter)
         tw.setMovable(True)
@@ -2361,7 +2361,7 @@ class LeoQtLog(leoFrame.LeoLog):
     # @+node:ekr.20110605121601.18315: *4* LeoQtLog.finishCreate
     def finishCreate(self) -> None:
         """Finish creating the LeoQtLog class."""
-        c, log, w = self.c, self, self.qtTabWidget
+        c, log, w = self.c, self, self.tabWidget
 
         # Create the log tab as the leftmost tab.
         log.createTab('Log')
@@ -2494,7 +2494,7 @@ class LeoQtLog(leoFrame.LeoLog):
 
     # @+node:ekr.20120304214900.9940: *3* LeoQtLog.onCurrentChanged
     def onCurrentChanged(self, idx: int) -> None:
-        tabw = self.qtTabWidget
+        tabw = self.tabWidget
         w = tabw.widget(idx)
 
         # #917814: Switching Log Pane tabs is done incompletely
@@ -2666,7 +2666,7 @@ class LeoQtLog(leoFrame.LeoLog):
             # Set binding on all log pane widgets.
             g.app.gui.setFilter(c, widget, self, tag='log')
             self.contentsDict[tabName] = widget
-            self.qtTabWidget.addTab(widget, tabName)
+            self.tabWidget.addTab(widget, tabName)
         else:
             # #1161: Don't set the wrapper unless it has the correct type.
             contents = widget  # Unlike text widgets, contents is the actual widget.
@@ -2676,7 +2676,7 @@ class LeoQtLog(leoFrame.LeoLog):
                 widget.leo_log_wrapper = None  # Tell the truth.
             g.app.gui.setFilter(c, widget, contents, 'tabWidget')
             self.contentsDict[tabName] = contents
-            self.qtTabWidget.addTab(contents, tabName)
+            self.tabWidget.addTab(contents, tabName)
         return contents
 
     # @+node:ekr.20110605121601.18328: *4* LeoQtLog.deleteTab
@@ -2685,7 +2685,7 @@ class LeoQtLog(leoFrame.LeoLog):
         Delete the tab if it exists.  Otherwise do *nothing*.
         """
         c = self.c
-        w = self.qtTabWidget
+        w = self.tabWidget
         i = self.findTabIndex(tabName)
         if i is None:
             return
@@ -2697,7 +2697,7 @@ class LeoQtLog(leoFrame.LeoLog):
     # @+node:ekr.20190603062456.1: *4* LeoQtLog.findTabIndex
     def findTabIndex(self, tabName: str) -> Optional[int]:
         """Return the tab index for tabName, or None."""
-        w = self.qtTabWidget
+        w = self.tabWidget
         for i in range(w.count()):
             if tabName == w.tabText(i):
                 return i
@@ -2710,13 +2710,13 @@ class LeoQtLog(leoFrame.LeoLog):
     # @+node:ekr.20111122080923.10185: *4* LeoQtLog.orderedTabNames
     def orderedTabNames(self, LeoLog: str = None) -> list[str]:  # Unused: LeoLog
         """Return a list of tab names in the order in which they appear in the QTabbedWidget."""
-        w = self.qtTabWidget
+        w = self.tabWidget
         return [w.tabText(i) for i in range(w.count())]
 
     # @+node:ekr.20221022062949.1: *4* LeoQtLog.renameTab
     def renameTab(self, oldTabName: str, tabName: str) -> None:
         """Rename the text tab"""
-        w = self.qtTabWidget
+        w = self.tabWidget
         i = self.findTabIndex(oldTabName)
         if i is None:
             self.createTab(tabName)
@@ -2773,12 +2773,12 @@ class LeoQtLog(leoFrame.LeoLog):
                     findbox.setFocus()
         if tabName == 'Spell':
             # Set a flag for the spell system.
-            self.qtFrameDict['Spell'] = self.qtTabWidget.widget(i)
+            self.qtFrameDict['Spell'] = self.tabWidget.widget(i)
 
     # @+node:ekr.20190603064816.1: *5* LeoQtLog.finishSelectTab
     def finishSelectTab(self, tabName: str) -> None:
         """Select the proper tab."""
-        w = self.qtTabWidget
+        w = self.tabWidget
         # Special case for Spell tab.
         if tabName == 'Spell':
             return

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoGui
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position
-    from leo.plugins.leoFrame import LeoLog
+    from leo.plugins.leoFrame import LeoLog, NullFrame
     from leo.plugins.mod_scripting import ScriptingController
     from leo.plugins.qt_text import LeoQTextBrowser, QScintillaWrapper, QTextEditWrapper
 
@@ -4119,7 +4119,7 @@ class QtIconBarClass:
 class QtMenuWrapper(LeoQtMenu, QtWidgets.QMenu):  # type:ignore
     # @+others
     # @+node:ekr.20110605121601.18459: *3* ctor and __repr__(QtMenuWrapper)
-    def __init__(self, c: Cmdr, frame: LeoQtFrame, parent: QWidget, label: str) -> None:
+    def __init__(self, c: Cmdr, frame: Any, parent: QWidget, label: str) -> None:
         """ctor for QtMenuWrapper class."""
         assert c
         assert frame

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -4107,7 +4107,7 @@ class QtIconBarClass:
 
 class QtMenuWrapper(LeoQtMenu, QtWidgets.QMenu):  # type:ignore
     # @+others
-    # @+node:ekr.20110605121601.18459: *3* ctor and __repr__(QtMenuWrapper)
+    # @+node:ekr.20110605121601.18459: *3* QtMenuWrapper.__init__ and __repr__
     def __init__(self, c: Cmdr, frame: Any, parent: QWidget, label: str) -> None:
         """ctor for QtMenuWrapper class."""
         assert c
@@ -4129,7 +4129,7 @@ class QtMenuWrapper(LeoQtMenu, QtWidgets.QMenu):  # type:ignore
     def __repr__(self) -> str:
         return f"<QtMenuWrapper {self.leo_menu_label}>"
 
-    # @+node:ekr.20110605121601.18460: *3* onAboutToShow & helpers (QtMenuWrapper)
+    # @+node:ekr.20110605121601.18460: *3* QtMenuWrapper.onAboutToShow & helpers
     def onAboutToShow(self, *args: Args, **keys: KWargs) -> None:
         name = self.leo_menu_label
         if not name:
@@ -4141,14 +4141,14 @@ class QtMenuWrapper(LeoQtMenu, QtWidgets.QMenu):  # type:ignore
                 self.leo_enable_menu_item(action, commandName)
                 self.leo_update_menu_label(action, commandName)
 
-    # @+node:ekr.20120120095156.10261: *4* leo_enable_menu_item
+    # @+node:ekr.20120120095156.10261: *4* QtMenuWrapper.leo_enable_menu_item
     def leo_enable_menu_item(self, action: QAction, commandName: str) -> None:
         func = self.c.frame.menu.enable_dict.get(commandName)
         if action and func:
             val = func()
             action.setEnabled(bool(val))
 
-    # @+node:ekr.20120124115444.10190: *4* leo_update_menu_label
+    # @+node:ekr.20120124115444.10190: *4* QtMenuWrapper.leo_update_menu_label
     def leo_update_menu_label(self, action: QAction, commandName: str) -> None:
         c = self.c
         if action and commandName == 'mark':
@@ -4156,7 +4156,7 @@ class QtMenuWrapper(LeoQtMenu, QtWidgets.QMenu):  # type:ignore
             # Set the proper shortcut.
             self.leo_update_shortcut(action, commandName)
 
-    # @+node:ekr.20120120095156.10260: *4* leo_update_shortcut
+    # @+node:ekr.20120120095156.10260: *4* QtMenuWrapper.leo_update_shortcut
     def leo_update_shortcut(self, action: QAction, commandName: str) -> None:
         c, k = self.c, self.c.k
         if action:

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -12,7 +12,7 @@ import re
 import sys
 import textwrap
 from time import sleep
-from typing import Any, Generator, Optional, Tuple, Union, TYPE_CHECKING
+from typing import Any, Generator, Optional, Tuple, TYPE_CHECKING
 from leo.core import leoColor
 from leo.core import leoGlobals as g
 from leo.core import leoGui
@@ -1186,7 +1186,7 @@ class LeoQtGui(leoGui.LeoGui):
 
     # @+node:ekr.20110605121601.18514: *3* LeoQtGui.Icons
     # @+node:ekr.20110605121601.18515: *4* LeoQtGui.attachLeoIcon
-    def attachLeoIcon(self, window: Union[QMainWindow, QDialog]) -> None:
+    def attachLeoIcon(self, window: QMainWindow | QDialog) -> None:
         """Attach a Leo icon to the window."""
         if self.appIcon:
             window.setWindowIcon(self.appIcon)

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -62,7 +62,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position
-    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
+    from leo.plugins.qt_text import QTextEditWrapper, QTextMixin
 
     Args = Any
     KWargs = Any
@@ -1092,7 +1092,7 @@ class LeoQtGui(leoGui.LeoGui):
         g.doHook('activate', c=c, p=c.p, v=c.p, event=event)
 
     # @+node:ekr.20130921043420.21175: *4* LeoQtGui.setFilter
-    def setFilter(self, c: Cmdr, obj: object, w: Wrapper, tag: str) -> None:
+    def setFilter(self, c: Cmdr, obj: object, w: QWidget, tag: str) -> None:
         """
         Create an event filter in obj.
         w is a wrapper object, not necessarily a QWidget.
@@ -1131,7 +1131,7 @@ class LeoQtGui(leoGui.LeoGui):
         return w
 
     # @+node:ekr.20190601054959.1: *4* LeoQtGui.set_focus
-    def set_focus(self, c: Cmdr, w: Wrapper) -> None:
+    def set_focus(self, c: Cmdr, w: QWidget) -> None:
         """Put the focus on the widget."""
         if not w:
             return
@@ -1425,7 +1425,7 @@ class LeoQtGui(leoGui.LeoGui):
         # @-<< create press-buttonText-button command >>
 
     # @+node:ekr.20200304125716.1: *3* LeoQtGui.onContextMenu
-    def onContextMenu(self, c: Cmdr, w: Wrapper, point: QPoint) -> None:
+    def onContextMenu(self, c: Cmdr, w: QTextMixin, point: QPoint) -> None:
         """LeoQtGui: Common context menu handling."""
         # #1286.
         handlers = g.tree_popup_handlers
@@ -1713,13 +1713,13 @@ class LeoQtGui(leoGui.LeoGui):
         return self.find_widget_by_name(c, 'main_splitter')
 
     # @+node:ekr.20110605121601.18522: *4* LeoQtGui.isTextWidget/Wrapper
-    def isTextWidget(self, w: Wrapper) -> bool:
+    def isTextWidget(self, w: Any) -> bool:
         """Return True if w is some kind of Qt text widget."""
         if Qsci:
             return isinstance(w, (Qsci.QsciScintilla, QtWidgets.QTextEdit))
         return isinstance(w, QtWidgets.QTextEdit)
 
-    def isTextWrapper(self, w: Wrapper) -> bool:
+    def isTextWrapper(self, w: Any) -> bool:
         """Return True if w is a Text widget suitable for text-oriented commands."""
         if w is None:
             return False
@@ -1728,7 +1728,7 @@ class LeoQtGui(leoGui.LeoGui):
         return bool(getattr(w, 'supportsHighLevelInterface', None))
 
     # @+node:ekr.20110605121601.18527: *4* LeoQtGui.widget_name
-    def widget_name(self, w: Wrapper) -> str:
+    def widget_name(self, w: QWidget) -> str:
         # First try the widget's getName method.
         if not w:
             name = '<no widget>'
@@ -1845,7 +1845,7 @@ class StyleClassManager:
 
     # @+others
     # @+node:tbrown.20150724090431.2: *3* update_view
-    def update_view(self, w: Wrapper) -> None:
+    def update_view(self, w: QTextMixin) -> None:
         """update_view - Make Qt apply w's style
 
         :param QWidgit w: widget to style
@@ -1854,7 +1854,7 @@ class StyleClassManager:
         w.setStyleSheet("/* */")  # forces visual update
 
     # @+node:tbrown.20150724090431.3: *3* add_sclass
-    def add_sclass(self, w: Wrapper, prop: str) -> None:
+    def add_sclass(self, w: QTextMixin, prop: str) -> None:
         """Add style class to QWidget w"""
         if not prop:
             return
@@ -1864,12 +1864,12 @@ class StyleClassManager:
             self.set_sclasses(w, props)
 
     # @+node:tbrown.20150724090431.4: *3* clear_sclasses
-    def clear_sclasses(self, w: Wrapper) -> None:
+    def clear_sclasses(self, w: QTextMixin) -> None:
         """Remove all style classes from QWidget w"""
         w.setProperty(self.style_sclass_property, '')
 
     # @+node:tbrown.20150724090431.5: *3* has_sclass
-    def has_sclass(self, w: Wrapper, prop: str) -> bool:
+    def has_sclass(self, w: QTextMixin, prop: str) -> bool:
         """Check for style class or list of classes prop on QWidget w"""
         if not prop:
             return None
@@ -1881,7 +1881,7 @@ class StyleClassManager:
         return all(ans)
 
     # @+node:tbrown.20150724090431.6: *3* remove_sclass
-    def remove_sclass(self, w: Wrapper, prop: str) -> None:
+    def remove_sclass(self, w: QTextMixin, prop: str) -> None:
         """Remove style class or list of classes prop from QWidget w"""
         if not prop:
             return
@@ -1894,12 +1894,12 @@ class StyleClassManager:
         self.set_sclasses(w, props)
 
     # @+node:tbrown.20150724090431.8: *3* sclasses
-    def sclasses(self, w: Wrapper) -> list[str]:
+    def sclasses(self, w: QTextMixin) -> list[str]:
         """return list of style classes for QWidget w"""
         return str(w.property(self.style_sclass_property) or '').split()
 
     # @+node:tbrown.20150724090431.9: *3* set_sclasses
-    def set_sclasses(self, w: Wrapper, classes: list[str]) -> None:
+    def set_sclasses(self, w: QTextMixin, classes: list[str]) -> None:
         """Set style classes for QWidget w to list in classes"""
         w.setProperty(self.style_sclass_property, f" {' '.join(set(classes))} ")
 

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -233,6 +233,9 @@ class LeoQtGui(leoGui.LeoGui):
 
     # @+node:ekr.20110605121601.18484: *3*  LeoQtGui.destroySelf (calls qtApp.quit)
     def destroySelf(self) -> None:
+        """Stop executing the qt gui after printing any stats."""
+        if g.app.statsDict:
+            g.printStats()
         QtCore.pyqtRemoveInputHook()
         if 'shutdown' in g.app.debug:
             g.pr('LeoQtGui.destroySelf: calling qtApp.Quit')

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -47,7 +47,6 @@ from leo.plugins import (
     qt_events,
     qt_frame,
     qt_idle_time,
-    qt_text,
 )
 from leo.plugins.qt_text import QTextMixin
 
@@ -61,7 +60,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position
-    from leo.plugins.qt_text import QTextEditWrapper
+    # from leo.plugins.qt_text import QTextEditWrapper
 
     Args = Any
     KWargs = Any
@@ -118,7 +117,6 @@ class LeoQtGui(leoGui.LeoGui):
         self.idleTimeClass = qt_idle_time.IdleTime
         self.insert_char_flag = False  # A flag for eventFilter.
         self.mGuiName = 'qt'
-        self.plainTextWidget = qt_text.PlainTextWrapper
         self.show_tips_flag = False  # #2390: Can't be inited in reload_settings.
         self.styleSheetManagerClass = StyleSheetManager
         # Be aware of the systems native colors, fonts, etc.

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -13,24 +13,44 @@ import sys
 import textwrap
 from time import sleep
 from typing import Any, Generator, Optional, Tuple, TYPE_CHECKING
-from leo.core import leoColor
-from leo.core import leoGlobals as g
-from leo.core import leoGui
-from leo.core.leoQt import Qt, Qsci, QtCore
-from leo.core.leoQt import QtGui, QtWidgets, QtSvg
-from leo.core.leoQt import ButtonRole, Checked, DialogCode, Icon, Information, Policy, Unchecked
+from leo.core import (
+    leoColor,
+    leoGlobals as g,
+    leoGui,
+)
+from leo.core.leoQt import (
+    ButtonRole,
+    Checked,
+    DialogCode,
+    Icon,
+    Information,
+    Policy,
+    Qsci,
+    Qt,
+    QtCore,
+    QtGui,
+    QtSvg,
+    QtWidgets,
+    Unchecked,
+)
 
 # This import causes pylint to fail on this file and on leoBridge.py.
 # The failure is in astroid: raw_building.py.
-from leo.core.leoQt import Shadow, Shape, StandardButton, Weight, WindowType
-from leo.plugins import qt_events
-from leo.plugins import qt_frame
-from leo.plugins import qt_idle_time
-from leo.plugins import qt_text
-
-# This defines the commands defined by @g.command.
-from leo.plugins import qt_commands
+from leo.core.leoQt import (
+    Shadow,
+    Shape,
+    StandardButton,
+    Weight,
+    WindowType,
+)
 from leo.core.leoTips import UserTip
+from leo.plugins import (
+    qt_commands,
+    qt_events,
+    qt_frame,
+    qt_idle_time,
+    qt_text,
+)
 
 assert Qt
 assert qt_commands

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -12,35 +12,21 @@ import re
 import sys
 import textwrap
 from time import sleep
-from typing import Any, Generator, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Generator, Optional, Tuple, Union, TYPE_CHECKING
 from leo.core import leoColor
 from leo.core import leoGlobals as g
 from leo.core import leoGui
-from leo.core.leoQt import (
-    ButtonRole,
-    Checked,
-    DialogCode,
-    Icon,
-    Information,
-    Policy,
-    Qsci,
-    Qt,
-    QtCore,
-    QtGui,
-    QtSvg,
-    QtWidgets,
-    Unchecked,
-)
+from leo.core.leoQt import Qt, Qsci, QtCore
+from leo.core.leoQt import QtGui, QtWidgets, QtSvg
+from leo.core.leoQt import ButtonRole, Checked, DialogCode, Icon, Information, Policy, Unchecked
 
 # This import causes pylint to fail on this file and on leoBridge.py.
 # The failure is in astroid: raw_building.py.
-from leo.core.leoAPI import StringTextWrapper
 from leo.core.leoQt import Shadow, Shape, StandardButton, Weight, WindowType
 from leo.plugins import qt_events
 from leo.plugins import qt_frame
 from leo.plugins import qt_idle_time
-from leo.plugins.qt_text import QTextMixin, QLineEditWrapper, QTextEditWrapper
-from leo.plugins.qt_tree import LeoQtTree
+from leo.plugins import qt_text
 
 # This defines the commands defined by @g.command.
 from leo.plugins import qt_commands
@@ -56,6 +42,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 
     Args = Any
     KWargs = Any
@@ -78,7 +65,6 @@ if TYPE_CHECKING:  # pragma: no cover
     QVBoxLayout = QtWidgets.QVBoxLayout
     QWidget = QtWidgets.QWidget
     Value = Any
-    Widget = Any
 
 
 # @-<< qt_gui annotations >>
@@ -113,6 +99,7 @@ class LeoQtGui(leoGui.LeoGui):
         self.idleTimeClass = qt_idle_time.IdleTime
         self.insert_char_flag = False  # A flag for eventFilter.
         self.mGuiName = 'qt'
+        self.plainTextWidget = qt_text.PlainTextWrapper
         self.show_tips_flag = False  # #2390: Can't be inited in reload_settings.
         self.styleSheetManagerClass = StyleSheetManager
         # Be aware of the systems native colors, fonts, etc.
@@ -226,36 +213,10 @@ class LeoQtGui(leoGui.LeoGui):
 
     # @+node:ekr.20110605121601.18484: *3*  LeoQtGui.destroySelf (calls qtApp.quit)
     def destroySelf(self) -> None:
-        """Stop executing the qt gui after printing any stats."""
-        if g.app.statsDict:
-            g.printStats()
-
         QtCore.pyqtRemoveInputHook()
         if 'shutdown' in g.app.debug:
             g.pr('LeoQtGui.destroySelf: calling qtApp.Quit')
         self.qtApp.quit()
-
-    # @+node:ekr.20260418104208.1: *3*  LeoQtGui.create_wrapper_for_widget
-    def create_wrapper_for_widget(self, c: Cmdr, w: Any) -> QTextMixin:
-        if w is None:
-            return None
-        if isinstance(w, QTextMixin):
-            return w
-        if getattr(w, 'wrapper', None):
-            return w.wrapper
-        if getattr(w, 'leo_wrapper', None):
-            return w.leo_wrapper
-        if isinstance(w, LeoQtTree):
-            # A strange special case: the class allocates its own wrappers.
-            return None
-        # Defensive code.
-        w.leo_wrapper = (
-                 QLineEditWrapper(c=c, widget=w) if isinstance(w, QtWidgets.QLineEdit)
-            else QTextEditWrapper(c=c, widget=w) if isinstance(w, QtWidgets.QTextEdit)
-            else StringTextWrapper(c=c)
-        )  # fmt: skip
-        g.trace(f"Allocate {w.leo_wrapper.__class__.__name__} for {w.__class__.__name__}")
-        return w.leo_wrapper
 
     # @+node:ekr.20110605121601.18485: *3* LeoQtGui.Clipboard
     # @+node:ekr.20160917125946.1: *4* LeoQtGui.replaceClipboardWith
@@ -1108,11 +1069,13 @@ class LeoQtGui(leoGui.LeoGui):
         g.doHook('activate', c=c, p=c.p, v=c.p, event=event)
 
     # @+node:ekr.20130921043420.21175: *4* LeoQtGui.setFilter
-    def setFilter(self, c: Cmdr, obj: object, w: QWidget, tag: str) -> None:
+    def setFilter(self, c: Cmdr, obj: object, w: Wrapper, tag: str) -> None:
         """
         Create an event filter in obj.
         w is a wrapper object, not necessarily a QWidget.
         """
+        # w's type is in (DynamicWindow,QMinibufferWrapper,LeoQtLog,LeoQtTree,
+        # QTextEditWrapper,LeoQTextBrowser,LeoQuickSearchWidget,cleoQtUI)
         assert isinstance(obj, QtWidgets.QWidget), obj
         theFilter = qt_events.LeoQtEventFilter(c, w=w, tag=tag)
         obj.installEventFilter(theFilter)
@@ -1145,7 +1108,7 @@ class LeoQtGui(leoGui.LeoGui):
         return w
 
     # @+node:ekr.20190601054959.1: *4* LeoQtGui.set_focus
-    def set_focus(self, c: Cmdr, w: QWidget) -> None:
+    def set_focus(self, c: Cmdr, w: Wrapper) -> None:
         """Put the focus on the widget."""
         if not w:
             return
@@ -1223,7 +1186,7 @@ class LeoQtGui(leoGui.LeoGui):
 
     # @+node:ekr.20110605121601.18514: *3* LeoQtGui.Icons
     # @+node:ekr.20110605121601.18515: *4* LeoQtGui.attachLeoIcon
-    def attachLeoIcon(self, window: QMainWindow | QDialog) -> None:
+    def attachLeoIcon(self, window: Union[QMainWindow, QDialog]) -> None:
         """Attach a Leo icon to the window."""
         if self.appIcon:
             window.setWindowIcon(self.appIcon)
@@ -1439,7 +1402,7 @@ class LeoQtGui(leoGui.LeoGui):
         # @-<< create press-buttonText-button command >>
 
     # @+node:ekr.20200304125716.1: *3* LeoQtGui.onContextMenu
-    def onContextMenu(self, c: Cmdr, w: QTextMixin, point: QPoint) -> None:
+    def onContextMenu(self, c: Cmdr, w: Wrapper, point: QPoint) -> None:
         """LeoQtGui: Common context menu handling."""
         # #1286.
         handlers = g.tree_popup_handlers
@@ -1726,20 +1689,23 @@ class LeoQtGui(leoGui.LeoGui):
     def get_top_splitter(self, c: Cmdr) -> QWidget:
         return self.find_widget_by_name(c, 'main_splitter')
 
-    # @+node:ekr.20110605121601.18522: *4* LeoQtGui.isTextWidget/isTextWrapper
-    def isTextWidget(self, w: Any) -> bool:
+    # @+node:ekr.20110605121601.18522: *4* LeoQtGui.isTextWidget/Wrapper
+    def isTextWidget(self, w: Wrapper) -> bool:
         """Return True if w is some kind of Qt text widget."""
-        widget_list = [QtWidgets.QTextEdit, QtWidgets.QLineEdit]
         if Qsci:
-            widget_list.append(Qsci.QsciScintilla)
-        return isinstance(w, tuple(widget_list))
+            return isinstance(w, (Qsci.QsciScintilla, QtWidgets.QTextEdit))
+        return isinstance(w, QtWidgets.QTextEdit)
 
-    def isTextWrapper(self, w: Any) -> bool:
+    def isTextWrapper(self, w: Wrapper) -> bool:
         """Return True if w is a Text widget suitable for text-oriented commands."""
-        return isinstance(w, (g.NullObject, g.TracingNullObject, QTextMixin))
+        if w is None:
+            return False
+        if isinstance(w, (g.NullObject, g.TracingNullObject)):
+            return True
+        return bool(getattr(w, 'supportsHighLevelInterface', None))
 
     # @+node:ekr.20110605121601.18527: *4* LeoQtGui.widget_name
-    def widget_name(self, w: QWidget) -> str:
+    def widget_name(self, w: Wrapper) -> str:
         # First try the widget's getName method.
         if not w:
             name = '<no widget>'
@@ -1855,16 +1821,17 @@ class StyleClassManager:
     style_sclass_property = 'style_class'  # name of QObject property for styling
 
     # @+others
-    # @+node:tbrown.20150724090431.2: *3* StyleClassManager.update_view
-    def update_view(self, w: QTextMixin) -> None:
+    # @+node:tbrown.20150724090431.2: *3* update_view
+    def update_view(self, w: Wrapper) -> None:
         """update_view - Make Qt apply w's style
 
         :param QWidgit w: widget to style
         """
+
         w.setStyleSheet("/* */")  # forces visual update
 
-    # @+node:tbrown.20150724090431.3: *3* StyleClassManager.add_sclass
-    def add_sclass(self, w: QTextMixin, prop: str) -> None:
+    # @+node:tbrown.20150724090431.3: *3* add_sclass
+    def add_sclass(self, w: Wrapper, prop: str) -> None:
         """Add style class to QWidget w"""
         if not prop:
             return
@@ -1873,13 +1840,13 @@ class StyleClassManager:
             props.append(prop)
             self.set_sclasses(w, props)
 
-    # @+node:tbrown.20150724090431.4: *3* StyleClassManager.clear_sclasses
-    def clear_sclasses(self, w: QTextMixin) -> None:
+    # @+node:tbrown.20150724090431.4: *3* clear_sclasses
+    def clear_sclasses(self, w: Wrapper) -> None:
         """Remove all style classes from QWidget w"""
         w.setProperty(self.style_sclass_property, '')
 
-    # @+node:tbrown.20150724090431.5: *3* StyleClassManager.has_sclass
-    def has_sclass(self, w: QTextMixin, prop: str) -> bool:
+    # @+node:tbrown.20150724090431.5: *3* has_sclass
+    def has_sclass(self, w: Wrapper, prop: str) -> bool:
         """Check for style class or list of classes prop on QWidget w"""
         if not prop:
             return None
@@ -1890,8 +1857,8 @@ class StyleClassManager:
             ans = [i in props for i in prop]
         return all(ans)
 
-    # @+node:tbrown.20150724090431.6: *3* StyleClassManager.remove_sclass
-    def remove_sclass(self, w: QTextMixin, prop: str) -> None:
+    # @+node:tbrown.20150724090431.6: *3* remove_sclass
+    def remove_sclass(self, w: Wrapper, prop: str) -> None:
         """Remove style class or list of classes prop from QWidget w"""
         if not prop:
             return
@@ -1903,13 +1870,13 @@ class StyleClassManager:
 
         self.set_sclasses(w, props)
 
-    # @+node:tbrown.20150724090431.8: *3* StyleClassManager.sclasses
-    def sclasses(self, w: QTextMixin) -> list[str]:
+    # @+node:tbrown.20150724090431.8: *3* sclasses
+    def sclasses(self, w: Wrapper) -> list[str]:
         """return list of style classes for QWidget w"""
         return str(w.property(self.style_sclass_property) or '').split()
 
-    # @+node:tbrown.20150724090431.9: *3* StyleClassManager.set_sclasses
-    def set_sclasses(self, w: QTextMixin, classes: list[str]) -> None:
+    # @+node:tbrown.20150724090431.9: *3* set_sclasses
+    def set_sclasses(self, w: Wrapper, classes: list[str]) -> None:
         """Set style classes for QWidget w to list in classes"""
         w.setProperty(self.style_sclass_property, f" {' '.join(set(classes))} ")
 

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -34,8 +34,6 @@ from leo.core.leoQt import (
     Unchecked,
 )
 
-# This import causes pylint to fail on this file and on leoBridge.py.
-# The failure is in astroid: raw_building.py.
 from leo.core.leoQt import (
     Shadow,
     Shape,
@@ -51,6 +49,7 @@ from leo.plugins import (
     qt_idle_time,
     qt_text,
 )
+from leo.plugins.qt_text import QTextMixin
 
 assert Qt
 assert qt_commands
@@ -62,7 +61,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position
-    from leo.plugins.qt_text import QTextEditWrapper, QTextMixin
+    from leo.plugins.qt_text import QTextEditWrapper
 
     Args = Any
     KWargs = Any
@@ -1725,7 +1724,7 @@ class LeoQtGui(leoGui.LeoGui):
             return False
         if isinstance(w, (g.NullObject, g.TracingNullObject)):
             return True
-        return bool(getattr(w, 'supportsHighLevelInterface', None))
+        return issubclass(w.__class__, QTextMixin)
 
     # @+node:ekr.20110605121601.18527: *4* LeoQtGui.widget_name
     def widget_name(self, w: QWidget) -> str:

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -564,7 +564,7 @@ if QtWidgets:
         """A subclass of QTextBrowser that overrides the mouse event handlers."""
 
         # @+others
-        # @+node:ekr.20110605121601.18006: *3*  lqtb.ctor
+        # @+node:ekr.20110605121601.18006: *3*  LeoQTextBrowser.__init__
         def __init__(self, parent: QWidget, c: Cmdr) -> None:
             """
             ctor for LeoQTextBrowser class, a subclass of QtWidgets.QTextBrowser.
@@ -603,13 +603,13 @@ if QtWidgets:
                 'last_hl_color': hl_color,
             }
 
-        # @+node:ekr.20110605121601.18007: *3* lqtb. __repr__ & __str__
+        # @+node:ekr.20110605121601.18007: *3* LeoQTextBrowser. __repr__ & __str__
         def __repr__(self) -> str:
             return f"(LeoQTextBrowser) {id(self)}"
 
         __str__ = __repr__
 
-        # @+node:ekr.20110605121601.18008: *3* lqtb.Auto completion
+        # @+node:ekr.20110605121601.18008: *3* lqtb:Auto completion
         # @+node:ekr.20110605121601.18009: *4* class LeoQListWidget(QListWidget)
         class LeoQListWidget(QtWidgets.QListWidget):
             # @+others
@@ -763,7 +763,7 @@ if QtWidgets:
 
             # @-others
 
-        # @+node:ekr.20110605121601.18017: *4* lqtb.lqtb.init_completer
+        # @+node:ekr.20110605121601.18017: *4* LeoQTextBrowser.init_completer
         def init_completer(self, options: list[str]) -> LeoQListWidget:
             """Connect a QCompleter."""
             c = self.leo_c
@@ -778,7 +778,7 @@ if QtWidgets:
             qc.show_completions(options)
             return qc
 
-        # @+node:ekr.20110605121601.18018: *4* lqtb.redirections to LeoQListWidget
+        # @+node:ekr.20110605121601.18018: *4* LeoQTextBrowser.redirections to LeoQListWidget
         def end_completer(self) -> None:
             if hasattr(self, 'leo_qc'):
                 self.leo_qc.end_completer()
@@ -789,7 +789,7 @@ if QtWidgets:
                 self.leo_qc.show_completions(aList)
 
         # @+node:tom.20210827230127.1: *3* lqtb Highlight Current Line
-        # @+node:tom.20210827225119.3: *4* lqtb.parse_css
+        # @+node:tom.20210827225119.3: *4* LeoQTextBrowser.parse_css
         # @@language python
         @staticmethod
         def parse_css(css_string: str, clas: str = '') -> tuple[str, str]:
@@ -825,7 +825,7 @@ if QtWidgets:
                     break
             return color, bg
 
-        # @+node:tom.20210827225119.4: *4* lqtb.assign_bg
+        # @+node:tom.20210827225119.4: *4* LeoQTextBrowser.assign_bg
         # @@language python
         @staticmethod
         def assign_bg(fg: str) -> QColor:
@@ -852,7 +852,7 @@ if QtWidgets:
                     bg = 'black'
             return QColor(bg)
 
-        # @+node:tom.20210827225119.5: *4* lqtb.calc_hl
+        # @+node:tom.20210827225119.5: *4* LeoQTextBrowser.calc_hl
         # @@language python
         @staticmethod
         def calc_hl(palette: QtGui.QPalette) -> QColor:
@@ -881,7 +881,7 @@ if QtWidgets:
                     hl = bg.lighter(140)
             return hl
 
-        # @+node:tom.20210827225119.2: *4* lqtb.highlightCurrentLine
+        # @+node:tom.20210827225119.2: *4* LeoQTextBrowser.highlightCurrentLine
         # @@language python
         def highlightCurrentLine(self) -> None:
             """Highlight cursor line."""
@@ -959,7 +959,7 @@ if QtWidgets:
             editor.setExtraSelections([selection])
             # @-<< Apply Highlight >>
 
-        # @+node:ekr.20141103061944.31: *3* lqtb.get/setXScrollPosition
+        # @+node:ekr.20141103061944.31: *3* LeoQTextBrowser.get/setXScrollPosition
         def getXScrollPosition(self) -> int:
             """Get the horizontal scrollbar position."""
             w = self
@@ -974,7 +974,7 @@ if QtWidgets:
                 sb = w.horizontalScrollBar()
                 sb.setSliderPosition(pos)
 
-        # @+node:ekr.20111002125540.7021: *3* lqtb.get/setYScrollPosition
+        # @+node:ekr.20111002125540.7021: *3* LeoQTextBrowser.get/setYScrollPosition
         def getYScrollPosition(self) -> int:
             """Get the vertical scrollbar position."""
             w = self
@@ -990,7 +990,7 @@ if QtWidgets:
             sb = w.verticalScrollBar()
             sb.setSliderPosition(pos)
 
-        # @+node:ekr.20110605121601.18019: *3* lqtb.leo_dumpButton
+        # @+node:ekr.20110605121601.18019: *3* LeoQTextBrowser.leo_dumpButton
         def leo_dumpButton(self, event: LeoKeyEvent, tag: str) -> str:
             button = event.button()
             table = (
@@ -1007,14 +1007,14 @@ if QtWidgets:
                 kind = f"unknown: {repr(button)}"
             return kind
 
-        # @+node:ekr.20200304130514.1: *3* lqtb.onContextMenu
+        # @+node:ekr.20200304130514.1: *3* LeoQTextBrowser.onContextMenu
         def onContextMenu(self, point: QPoint) -> None:
             """LeoQTextBrowser: Callback for customContextMenuRequested events."""
             # #1286.
             c, w = self.leo_c, self
             g.app.gui.onContextMenu(c, w, point)
 
-        # @+node:ekr.20120925061642.13506: *3* lqtb.onSliderChanged
+        # @+node:ekr.20120925061642.13506: *3* LeoQTextBrowser.onSliderChanged
         def onSliderChanged(self, arg: int) -> None:
             """Handle a Qt onSliderChanged event."""
             c = self.leo_c
@@ -1029,7 +1029,7 @@ if QtWidgets:
             if p:
                 p.v.scrollBarSpot = arg
 
-        # @+node:ekr.20201204172235.1: *3* lqtb.paintEvent
+        # @+node:ekr.20201204172235.1: *3* LeoQTextBrowser.paintEvent
         leo_cursor_width = 0
 
         leo_vim_mode: bool = None
@@ -1117,7 +1117,7 @@ if QtWidgets:
             qp.drawRect(w.cursorRect())
             qp.end()
 
-        # @+node:tbrown.20130411145310.18855: *3* lqtb.wheelEvent
+        # @+node:tbrown.20130411145310.18855: *3* LeoQTextBrowser.wheelEvent
         def wheelEvent(self, event: QWheelEvent) -> None:
             """Handle a wheel event."""
             if KeyboardModifier.ControlModifier & event.modifiers():
@@ -1311,7 +1311,7 @@ class QHeadlineWrapper(QLineEditWrapper):
     """
 
     # @+others
-    # @+node:ekr.20110605121601.18117: *3* qhw.Birth
+    # @+node:ekr.20110605121601.18117: *3* QHeadlineWrapper.Birth
     def __init__(self, c: Cmdr, item: QTreeWidgetItem, name: str, widget: QLineEdit) -> None:
         """The ctor for the QHeadlineWrapper class."""
         assert isinstance(widget, QtWidgets.QLineEdit), widget
@@ -1328,7 +1328,7 @@ class QHeadlineWrapper(QLineEditWrapper):
     def __repr__(self) -> str:
         return f"QHeadlineWrapper: {id(self)}"
 
-    # @+node:ekr.20110605121601.18119: *3* qhw.check
+    # @+node:ekr.20110605121601.18119: *3* QHeadlineWrapper.check
     def check(self) -> bool:
         """Return True if the tree item exists and it's edit widget exists."""
         tree = self.c.frame.tree
@@ -1404,7 +1404,7 @@ class QScintillaWrapper(QTextMixin):
     """
 
     # @+others
-    # @+node:ekr.20110605121601.18105: *3* qsciw.ctor
+    # @+node:ekr.20110605121601.18105: *3* QScintillaWrapper.ctor
     def __init__(self, widget: QWidget, c: Cmdr, name: str = None) -> None:
         """Ctor for the QScintillaWrapper class."""
         super().__init__(c)
@@ -1418,7 +1418,7 @@ class QScintillaWrapper(QTextMixin):
         # Set the signal.
         g.app.gui.setFilter(c, widget, self, tag=name)
 
-    # @+node:ekr.20110605121601.18106: *3* qsciw.set_config
+    # @+node:ekr.20110605121601.18106: *3* QScintillaWrapper.set_config
     def set_config(self) -> None:
         """Set QScintillaWrapper configuration options."""
         c, w = self.c, self.widget
@@ -1434,8 +1434,8 @@ class QScintillaWrapper(QTextMixin):
         w.setIndentationsUseTabs(False)
         w.setAutoIndent(True)
 
-    # @+node:ekr.20110605121601.18107: *3* qsciw.WidgetAPI
-    # @+node:ekr.20140901062324.18593: *4* qsciw.delete
+    # @+node:ekr.20110605121601.18107: *3* QScintillaWrapper.WidgetAPI
+    # @+node:ekr.20140901062324.18593: *4* QScintillaWrapper.delete
     def delete(self, i: int, j: int = None) -> None:
         """Delete s[i:j]"""
         w = self.widget
@@ -1448,7 +1448,7 @@ class QScintillaWrapper(QTextMixin):
         finally:
             self.changingText = False
 
-    # @+node:ekr.20140901062324.18594: *4* qsciw.flashCharacter (disabled)
+    # @+node:ekr.20140901062324.18594: *4* QScintillaWrapper.flashCharacter (disabled)
     def flashCharacter(
         self,
         i: int,
@@ -1508,7 +1508,7 @@ class QScintillaWrapper(QTextMixin):
             self.flashFg = None if fg.lower() == 'same' else fg
             addFlashCallback()
 
-    # @+node:ekr.20140901062324.18595: *4* qsciw.get
+    # @+node:ekr.20140901062324.18595: *4* QScintillaWrapper.get
     def get(self, i: int, j: int = None) -> str:
         # Fix the following two bugs by using vanilla code:
         # https://bugs.launchpad.net/leo-editor/+bug/979142
@@ -1516,20 +1516,20 @@ class QScintillaWrapper(QTextMixin):
         s = self.getAllText()
         return s[i:j]
 
-    # @+node:ekr.20110605121601.18108: *4* qsciw.getAllText
+    # @+node:ekr.20110605121601.18108: *4* QScintillaWrapper.getAllText
     def getAllText(self) -> str:
         """Get all text from a QsciScintilla widget."""
         w = self.widget
         return w.text()
 
-    # @+node:ekr.20110605121601.18109: *4* qsciw.getInsertPoint
+    # @+node:ekr.20110605121601.18109: *4* QScintillaWrapper.getInsertPoint
     def getInsertPoint(self) -> int:
         """Get the insertion point from a QsciScintilla widget."""
         w = self.widget
         i = int(w.SendScintilla(w.SCI_GETCURRENTPOS))
         return i
 
-    # @+node:ekr.20110605121601.18110: *4* qsciw.getSelectionRange
+    # @+node:ekr.20110605121601.18110: *4* QScintillaWrapper.getSelectionRange
     def getSelectionRange(self, sort: bool = True) -> tuple[int, int]:
         """Get the selection range from a QsciScintilla widget."""
         w = self.widget
@@ -1539,7 +1539,7 @@ class QScintillaWrapper(QTextMixin):
             i, j = j, i
         return i, j
 
-    # @+node:ekr.20140901062324.18599: *4* qsciw.getX/YScrollPosition
+    # @+node:ekr.20140901062324.18599: *4* QScintillaWrapper.getX/YScrollPosition
     def getXScrollPosition(self) -> int:
         # w = self.widget
         return 0  # Not ready yet.
@@ -1548,12 +1548,12 @@ class QScintillaWrapper(QTextMixin):
         # w = self.widget
         return 0  # Not ready yet.
 
-    # @+node:ekr.20110605121601.18111: *4* qsciw.hasSelection
+    # @+node:ekr.20110605121601.18111: *4* QScintillaWrapper.hasSelection
     def hasSelection(self) -> bool:
         """Return True if a QsciScintilla widget has a selection range."""
         return self.widget.hasSelectedText()
 
-    # @+node:ekr.20140901062324.18601: *4* qsciw.insert
+    # @+node:ekr.20140901062324.18601: *4* QScintillaWrapper.insert
     def insert(self, i: int, s: str) -> int:
         """Insert s at position i."""
         w = self.widget
@@ -1563,14 +1563,14 @@ class QScintillaWrapper(QTextMixin):
         w.SendScintilla(w.SCI_SETSEL, i, i)
         return i
 
-    # @+node:ekr.20140901062324.18603: *4* qsciw.linesPerPage
+    # @+node:ekr.20140901062324.18603: *4* QScintillaWrapper.linesPerPage
     def linesPerPage(self) -> int:
         """Return the number of lines presently visible."""
         # Not used in Leo's core. Not tested.
         w = self.widget
         return int(w.SendScintilla(w.SCI_LINESONSCREEN))
 
-    # @+node:ekr.20140901062324.18604: *4* qsciw.scrollDelegate (maybe)
+    # @+node:ekr.20140901062324.18604: *4* QScintillaWrapper.scrollDelegate (maybe)
     if 0:  # Not yet.
 
         def scrollDelegate(self, kind: str) -> None:
@@ -1604,7 +1604,7 @@ class QScintillaWrapper(QTextMixin):
             vScroll.setValue(val + (delta * lineSpacing))
             c.bodyWantsFocus()
 
-    # @+node:ekr.20110605121601.18112: *4* qsciw.see
+    # @+node:ekr.20110605121601.18112: *4* QScintillaWrapper.see
     def see(self, i: int) -> None:
         """Ensure insert point i is visible in a QsciScintilla widget."""
         # Ok for now.  Using SCI_SETYCARETPOLICY might be better.
@@ -1613,7 +1613,7 @@ class QScintillaWrapper(QTextMixin):
         row, col = g.convertPythonIndexToRowCol(s, i)
         w.ensureLineVisible(row)
 
-    # @+node:ekr.20110605121601.18113: *4* qsciw.setAllText
+    # @+node:ekr.20110605121601.18113: *4* QScintillaWrapper.setAllText
     def setAllText(self, s: str) -> None:
         """Set the text of a QScintilla widget."""
         w = self.widget
@@ -1621,7 +1621,7 @@ class QScintillaWrapper(QTextMixin):
         w.setText(s)
         # w.update()
 
-    # @+node:ekr.20110605121601.18114: *4* qsciw.setInsertPoint
+    # @+node:ekr.20110605121601.18114: *4* QScintillaWrapper.setInsertPoint
     def setInsertPoint(self, i: int, s: str = None) -> None:
         """Set the insertion point in a QsciScintilla widget."""
         w = self.widget
@@ -1629,7 +1629,7 @@ class QScintillaWrapper(QTextMixin):
         # w.SendScintilla(w.SCI_SETANCHOR,i)
         w.SendScintilla(w.SCI_SETSEL, i, i)
 
-    # @+node:ekr.20110605121601.18115: *4* qsciw.setSelectionRange
+    # @+node:ekr.20110605121601.18115: *4* QScintillaWrapper.setSelectionRange
     def setSelectionRange(self, i: int, j: int, insert: int = None, s: str = None) -> None:
         """Set the selection range in a QsciScintilla widget."""
         w = self.widget
@@ -1640,7 +1640,7 @@ class QScintillaWrapper(QTextMixin):
         else:
             w.SendScintilla(w.SCI_SETSEL, j, i)
 
-    # @+node:ekr.20140901062324.18609: *4* qsciw.setX/YScrollPosition
+    # @+node:ekr.20140901062324.18609: *4* QScintillaWrapper.setX/YScrollPosition
     def setXScrollPosition(self, pos: int) -> None:
         """Set the position of the horizontal scrollbar."""
 
@@ -1726,7 +1726,7 @@ class QTextEditWrapper(QTextMixin):
 
     # @+node:ekr.20110605121601.18078: *3* QTextEditWrapper.High-level interface
     # These are all widget-dependent
-    # @+node:ekr.20110605121601.18079: *4* qtew.delete (avoid call to setAllText)
+    # @+node:ekr.20110605121601.18079: *4* QTextEditWrapper.delete (avoid call to setAllText)
     def delete(self, i: int, j: int = None) -> None:
         """QTextEditWrapper."""
         w = self.widget
@@ -1755,7 +1755,7 @@ class QTextEditWrapper(QTextMixin):
             self.changingText = False
         sb.setSliderPosition(pos)
 
-    # @+node:ekr.20110605121601.18080: *4* qtew.flashCharacter
+    # @+node:ekr.20110605121601.18080: *4* QTextEditWrapper.flashCharacter
     def flashCharacter(
         self,
         i: int,
@@ -1811,18 +1811,18 @@ class QTextEditWrapper(QTextMixin):
         self.flashFg = None if fg.lower() == 'same' else fg
         addFlashCallback()
 
-    # @+node:ekr.20110605121601.18081: *4* qtew.getAllText
+    # @+node:ekr.20110605121601.18081: *4* QTextEditWrapper.getAllText
     def getAllText(self) -> str:
         """QTextEditWrapper."""
         w = self.widget
         return w.toPlainText()
 
-    # @+node:ekr.20110605121601.18082: *4* qtew.getInsertPoint
+    # @+node:ekr.20110605121601.18082: *4* QTextEditWrapper.getInsertPoint
     def getInsertPoint(self) -> int:
         """QTextEditWrapper."""
         return self.widget.textCursor().position()
 
-    # @+node:ekr.20110605121601.18083: *4* qtew.getSelectionRange
+    # @+node:ekr.20110605121601.18083: *4* QTextEditWrapper.getSelectionRange
     def getSelectionRange(self, sort: bool = True) -> tuple[int, int]:
         """QTextEditWrapper."""
         w = self.widget
@@ -1830,7 +1830,7 @@ class QTextEditWrapper(QTextMixin):
         i, j = tc.selectionStart(), tc.selectionEnd()
         return i, j
 
-    # @+node:ekr.20110605121601.18084: *4* qtew.getX/YScrollPosition
+    # @+node:ekr.20110605121601.18084: *4* QTextEditWrapper.getX/YScrollPosition
     # **Important**: There is a Qt bug here: the scrollbar position
     # is valid only if cursor is visible.  Otherwise the *reported*
     # scrollbar position will be such that the cursor *is* visible.
@@ -1849,12 +1849,12 @@ class QTextEditWrapper(QTextMixin):
         pos = sb.sliderPosition()
         return pos
 
-    # @+node:ekr.20110605121601.18085: *4* qtew.hasSelection
+    # @+node:ekr.20110605121601.18085: *4* QTextEditWrapper.hasSelection
     def hasSelection(self) -> bool:
         """QTextEditWrapper."""
         return self.widget.textCursor().hasSelection()
 
-    # @+node:ekr.20110605121601.18089: *4* qtew.insert (avoid call to setAllText)
+    # @+node:ekr.20110605121601.18089: *4* QTextEditWrapper.insert (avoid call to setAllText)
     def insert(self, i: int, s: str) -> None:
         """QTextEditWrapper."""
         w = self.widget
@@ -1867,7 +1867,7 @@ class QTextEditWrapper(QTextMixin):
         finally:
             self.changingText = False
 
-    # @+node:ekr.20110605121601.18077: *4* qtew.leoMoveCursorHelper & helper
+    # @+node:ekr.20110605121601.18077: *4* QTextEditWrapper.leoMoveCursorHelper & helper
     def leoMoveCursorHelper(self, kind: str, extend: bool = False, linesPerPage: int = 15) -> None:
         """QTextEditWrapper."""
         w = self.widget
@@ -1925,7 +1925,7 @@ class QTextEditWrapper(QTextMixin):
             g.app.gui.setClipboardSelection(sel)
         self.c.frame.updateStatusLine()
 
-    # @+node:btheado.20120129145543.8180: *5* qtew.pageUpDown
+    # @+node:btheado.20120129145543.8180: *5* QTextEditWrapper.pageUpDown
     def pageUpDown(self, op: object, moveMode: object) -> None:
         """
         The QTextEdit PageUp/PageDown functionality seems to be "baked-in"
@@ -1957,7 +1957,7 @@ class QTextEditWrapper(QTextMixin):
                 sb.triggerAction(SliderAction.SliderPageStepAdd)
         control.setTextCursor(cursor)
 
-    # @+node:ekr.20110605121601.18087: *4* qtew.linesPerPage
+    # @+node:ekr.20110605121601.18087: *4* QTextEditWrapper.linesPerPage
     def linesPerPage(self) -> float:
         """QTextEditWrapper."""
         # Not used in Leo's core.
@@ -1967,7 +1967,7 @@ class QTextEditWrapper(QTextMixin):
         n = h / lineSpacing
         return n
 
-    # @+node:ekr.20110605121601.18088: *4* qtew.scrollDelegate
+    # @+node:ekr.20110605121601.18088: *4* QTextEditWrapper.scrollDelegate
     def scrollDelegate(self, kind: str) -> None:
         """
         Scroll a QTextEdit up or down one page.
@@ -1999,7 +1999,7 @@ class QTextEditWrapper(QTextMixin):
         vScroll.setValue(val + (delta * lineSpacing))
         c.bodyWantsFocus()
 
-    # @+node:ekr.20110605121601.18090: *4* qtew.see & seeInsertPoint
+    # @+node:ekr.20110605121601.18090: *4* QTextEditWrapper.see & seeInsertPoint
     def see(self, see_i: int) -> None:
         """Scroll so that position see_i is visible."""
         w = self.widget
@@ -2020,7 +2020,7 @@ class QTextEditWrapper(QTextMixin):
         """Make sure the insert point is visible."""
         self.widget.ensureCursorVisible()
 
-    # @+node:ekr.20110605121601.18092: *4* qtew.setAllText
+    # @+node:ekr.20110605121601.18092: *4* QTextEditWrapper.setAllText
     def setAllText(self, s: str) -> None:
         """Set the text of body pane."""
         w = self.widget
@@ -2031,13 +2031,13 @@ class QTextEditWrapper(QTextMixin):
         finally:
             self.changingText = False
 
-    # @+node:ekr.20110605121601.18095: *4* qtew.setInsertPoint
+    # @+node:ekr.20110605121601.18095: *4* QTextEditWrapper.setInsertPoint
     def setInsertPoint(self, i: int, s: str = None) -> None:
         # Fix bug 981849: incorrect body content shown.
         # Use the more careful code in setSelectionRange.
         self.setSelectionRange(i=i, j=i, insert=i, s=s)
 
-    # @+node:ekr.20110605121601.18096: *4* qtew.setSelectionRange
+    # @+node:ekr.20110605121601.18096: *4* QTextEditWrapper.setSelectionRange
     def setSelectionRange(
         self,
         i: Optional[int],
@@ -2098,7 +2098,7 @@ class QTextEditWrapper(QTextMixin):
         v.selectionLength = j - i
         v.scrollBarSpot = w.verticalScrollBar().value()
 
-    # @+node:ekr.20141103061944.40: *4* qtew.setXScrollPosition
+    # @+node:ekr.20141103061944.40: *4* QTextEditWrapper.setXScrollPosition
     def setXScrollPosition(self, pos: int) -> None:
         """Set the position of the horizontal scrollbar."""
         if pos is not None:
@@ -2106,7 +2106,7 @@ class QTextEditWrapper(QTextMixin):
             sb = w.horizontalScrollBar()
             sb.setSliderPosition(pos)
 
-    # @+node:ekr.20110605121601.18098: *4* qtew.setYScrollPosition
+    # @+node:ekr.20110605121601.18098: *4* QTextEditWrapper.setYScrollPosition
     def setYScrollPosition(self, pos: int) -> None:
         """Set the vertical scrollbar position."""
         if pos is not None:
@@ -2114,7 +2114,7 @@ class QTextEditWrapper(QTextMixin):
             sb = w.verticalScrollBar()
             sb.setSliderPosition(pos)
 
-    # @+node:ekr.20110605121601.18101: *4* qtew.toPythonIndexRowCol (fast)
+    # @+node:ekr.20110605121601.18101: *4* QTextEditWrapper.toPythonIndexRowCol (fast)
     def toPythonIndexRowCol(self, index: int) -> tuple[int, int]:
         te = self.widget
         doc = te.document()

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -164,7 +164,7 @@ class QTextMixin:
         self.tags: dict[str, str] = {}
         self.permanent = True  # False if selecting the minibuffer will make the widget go away.
         self.useScintilla = False  # This is used!
-        self.virtualInsertPoint = None
+        self.virtualInsertPoint: int = None
         self.widget: Any = None  # 'Any' is correct for the QTextMixin class.
         if c:
             self.injectIvars(c)
@@ -309,13 +309,11 @@ class QTextMixin:
         return s[i:j]
 
     # @+node:ekr.20140901062324.18704: *5* QTextMixin.getLastIndex & getLength
-    def getLastIndex(self, s: str = None) -> int:
-        """QTextMixin"""
-        return len(self.getAllText()) if s is None else len(s)
+    def getLastIndex(self) -> int:
+        return len(self.getAllText())
 
-    def getLength(self, s: str = None) -> int:
-        """QTextMixin"""
-        return len(self.getAllText()) if s is None else len(s)
+    def getLength(self) -> int:
+        return len(self.getAllText())
 
     # @+node:ekr.20140901062324.18705: *5* QTextMixin.getSelectedText
     def getSelectedText(self) -> str:
@@ -341,9 +339,8 @@ class QTextMixin:
         self.see(self.getInsertPoint())
 
     # @+node:ekr.20140902135648.18668: *5* QTextMixin.selectAllText
-    def selectAllText(self, s: str = None) -> None:
-        """QTextMixin."""
-        self.setSelectionRange(0, self.getLength(s))
+    def selectAllText(self) -> None:
+        self.setSelectionRange(0, self.getLength())
 
     # @+node:ekr.20140901141402.18704: *5* QTextMixin.toPythonIndexRowCol
     def toPythonIndexRowCol(self, index: int) -> tuple[int, int]:

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -16,7 +16,6 @@ from leo.core.leoQt import Shadow, Shape, SliderAction, SolidLine, WindowType, W
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
-    from leo.plugins.leoAPI import BaseTextAPI
 
     Args = Any
     KWargs = Any
@@ -566,11 +565,9 @@ if QtWidgets:
 
         # @+others
         # @+node:ekr.20110605121601.18006: *3*  lqtb.ctor
-        def __init__(self, parent: QWidget, c: Cmdr, wrapper: BaseTextAPI) -> None:
+        def __init__(self, parent: QWidget, c: Cmdr) -> None:
             """
             ctor for LeoQTextBrowser class, a subclass of QtWidgets.QTextBrowser.
-
-            wrapper is a LeoQtBody or LeoQtLog.
             """
             assert not hasattr(QtWidgets.QTextBrowser, 'leo_c')
             self.leo_c = c

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -158,8 +158,6 @@ class QTextMixin:
         self.c = c
         self.changingText = False  # A lockout for onTextChanged.
         self.enabled = True
-        # A flag for k.masterKeyHandler and isTextWrapper.
-        self.supportsHighLevelInterface = True
         self.tags: dict[str, str] = {}
         self.permanent = True  # False if selecting the minibuffer will make the widget go away.
         self.useScintilla = False  # This is used!

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -1295,16 +1295,6 @@ class NumberBar(QtWidgets.QFrame):
     # @-others
 
 
-# @+node:ekr.20140901141402.18700: ** class PlainTextWrapper(QTextMixin)
-class PlainTextWrapper(QTextMixin):
-    """A Qt class for use by the find code."""
-
-    def __init__(self, widget: QWidget) -> None:
-        """Ctor for the PlainTextWrapper class."""
-        super().__init__()
-        self.widget = widget
-
-
 # @+node:ekr.20110605121601.18116: ** class QHeadlineWrapper (QLineEditWrapper)
 class QHeadlineWrapper(QLineEditWrapper):
     """

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -264,11 +264,11 @@ class QTextMixin:
         # Call the base class
         assert isinstance(
             self.widget,
-            (  # type:ignore
+            (
                 QtWidgets.QTextBrowser,
                 QtWidgets.QLineEdit,
                 QtWidgets.QTextEdit,
-                Qsci and Qsci.QsciScintilla,  # This line causes the mypy complaint.
+                Qsci and Qsci.QsciScintilla,
             ),
         ), self.widget
         QtWidgets.QTextBrowser.setFocus(self.widget)

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -258,7 +258,6 @@ class QTextMixin:
 
     # @+node:ekr.20140901062324.18698: *4* QTextMixin.setFocus
     def setFocus(self) -> None:
-        """QTextMixin"""
         if 'focus' in g.app.debug:
             print('BaseQTextWrapper.setFocus', self.widget)
         # Call the base class
@@ -276,14 +275,12 @@ class QTextMixin:
     # @+node:ekr.20140901062324.18717: *4* QTextMixin.Generic text
     # @+node:ekr.20140901062324.18703: *5* QTextMixin.appendText
     def appendText(self, s: str) -> None:
-        """QTextMixin"""
         s2 = self.getAllText()
         self.setAllText(s2 + s)
         self.setInsertPoint(len(s2))
 
     # @+node:ekr.20140901141402.18706: *5* QTextMixin.delete
     def delete(self, i: int, j: int = None) -> None:
-        """QTextMixin"""
         if j is None:
             j = i + 1
         # This allows subclasses to use this base class method.
@@ -296,13 +293,11 @@ class QTextMixin:
 
     # @+node:ekr.20140901062324.18827: *5* QTextMixin.deleteTextSelection
     def deleteTextSelection(self) -> None:
-        """QTextMixin"""
         i, j = self.getSelectionRange()
         self.delete(i, j)
 
     # @+node:ekr.20110605121601.18102: *5* QTextMixin.get
     def get(self, i: int, j: int = None) -> str:
-        """QTextMixin"""
         # 2012/04/12: fix the following two bugs by using the vanilla code:
         # https://bugs.launchpad.net/leo-editor/+bug/979142
         # https://bugs.launchpad.net/leo-editor/+bug/971166
@@ -318,7 +313,6 @@ class QTextMixin:
 
     # @+node:ekr.20140901062324.18705: *5* QTextMixin.getSelectedText
     def getSelectedText(self) -> str:
-        """QTextMixin"""
         i, j = self.getSelectionRange()  # Returns (int, int)
         if i == j:
             return ''
@@ -327,7 +321,6 @@ class QTextMixin:
 
     # @+node:ekr.20140901141402.18702: *5* QTextMixin.insert
     def insert(self, i: int, s: str) -> int:
-        """QTextMixin"""
         s2 = self.getAllText()
         self.setAllText(s2[:i] + s + s2[i:])
         self.setInsertPoint(i + len(s))
@@ -345,7 +338,6 @@ class QTextMixin:
 
     # @+node:ekr.20140901141402.18704: *5* QTextMixin.toPythonIndexRowCol
     def toPythonIndexRowCol(self, index: int) -> tuple[int, int]:
-        """QTextMixin"""
         s = self.getAllText()
         row, col = g.convertPythonIndexToRowCol(s, index)
         return row, col

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -8,29 +8,15 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
-from leo.core.leoQt import (
-    ContextMenuPolicy,
-    Key,
-    KeyboardModifier,
-    MouseButton,
-    MoveMode,
-    MoveOperation,
-    Qsci,
-    QtCore,
-    QtGui,
-    QtWidgets,
-    Shadow,
-    Shape,
-    SliderAction,
-    SolidLine,
-    WindowType,
-    WrapMode,
-)
+from leo.core.leoQt import QtCore, QtGui, Qsci, QtWidgets
+from leo.core.leoQt import ContextMenuPolicy, Key, KeyboardModifier
+from leo.core.leoQt import MouseButton, MoveMode, MoveOperation
+from leo.core.leoQt import Shadow, Shape, SliderAction, SolidLine, WindowType, WrapMode
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
-    from leo.plugins.qt_text import LeoQtLog  # pylint: disable=import-self
+    from leo.plugins.leoAPI import BaseTextAPI
 
     Args = Any
     KWargs = Any
@@ -164,36 +150,26 @@ def helpForRMarginGuides(self, event=None):
 
 # @+node:ekr.20140901062324.18719: **   class QTextMixin
 class QTextMixin:
-    """
-    A mixin class for StringTextWrapper, QTextEditWrapper and QScintillaWrapper classes.
+    """A minimal mixin class for QTextEditWrapper and QScintillaWrapper classes."""
 
-    This is also the annotation for all text-related wrappers.
-    """
-
+    # @+others
+    # @+node:ekr.20140901062324.18732: *3* QTextMixin.ctor & helper
     def __init__(self, c: Cmdr = None) -> None:
+        """Ctor for QTextMixin class"""
         self.c = c
         self.changingText = False  # A lockout for onTextChanged.
         self.enabled = True
-        self.name: str = None  # Set in subclasses.
         # A flag for k.masterKeyHandler and isTextWrapper.
+        self.supportsHighLevelInterface = True
         self.tags: dict[str, str] = {}
         self.permanent = True  # False if selecting the minibuffer will make the widget go away.
         self.useScintilla = False  # This is used!
-        self.virtualInsertPoint: int = None
+        self.virtualInsertPoint = None
         self.widget: Any = None  # 'Any' is correct for the QTextMixin class.
         if c:
             self.injectIvars(c)
 
-    # @+others
-    # @+node:ekr.20260406104530.1: *3* QTextMixin.__repr__
-    def __repr__(self) -> str:
-        return f"<QTextMixin: {id(self)} {self.name}>"
-
-    # @+node:ekr.20140901062324.18825: *3* QTextMixin.getName
-    def getName(self) -> str:
-        return self.name  # Essential.
-
-    # @+node:ekr.20140901062324.18721: *3* QTextMixin.injectIvars
+    # @+node:ekr.20140901062324.18721: *4* QTextMixin.injectIvars
     def injectIvars(self, c: Cmdr) -> QTextMixin:
         """Inject standard leo ivars into the QTextEdit or QsciScintilla widget."""
         w = self
@@ -204,31 +180,11 @@ class QTextMixin:
         w.leo_frame = None
         return w
 
-    # @+node:ekr.20260406044142.1: *3* QTextMixin: Do-nothings
-    def flashCharacter(
-        self, i: int, bg: str = 'white', fg: str = 'red', flashes: int = 3, delay: int = 75
-    ) -> None:
-        pass
+    # @+node:ekr.20140901062324.18825: *3* QTextMixin.getName
+    def getName(self) -> str:
+        return self.name  # Essential.
 
-    def getXScrollPosition(self) -> int:
-        return 0
-
-    def getYScrollPosition(self) -> int:
-        return 0
-
-    def see(self, i: int) -> None:
-        pass
-
-    def setStyleClass(self, name: str) -> None:
-        pass
-
-    def setXScrollPosition(self, i: int) -> None:
-        pass
-
-    def setYScrollPosition(self, i: int) -> None:
-        pass
-
-    # @+node:ekr.20140901122110.18733: *3* QTextMixin: Event handlers
+    # @+node:ekr.20140901122110.18733: *3* QTextMixin.Event handlers
     # These are independent of the kind of Qt widget.
     # @+node:ekr.20140901062324.18716: *4* QTextMixin.onCursorPositionChanged
     def onCursorPositionChanged(self, event: QEvent = None) -> None:
@@ -282,8 +238,15 @@ class QTextMixin:
             newSel=newSel,
         )
 
-    # @+node:ekr.20140901122110.18734: *3* QTextMixin: Generic high-level interface
+    # @+node:ekr.20140901122110.18734: *3* QTextMixin.Generic high-level interface
     # These call only wrapper methods.
+    # @+node:ekr.20140902181058.18645: *4* QTextMixin.Enable/disable
+    def disable(self) -> None:
+        self.enabled = False
+
+    def enable(self, enabled: bool = True) -> None:
+        self.enabled = enabled
+
     # @+node:ekr.20140902181058.18644: *4* QTextMixin.Clipboard
     def clipboard_append(self, s: str) -> None:
         s1 = g.app.gui.getTextFromClipboard()
@@ -292,12 +255,102 @@ class QTextMixin:
     def clipboard_clear(self) -> None:
         g.app.gui.replaceClipboardWith('')
 
-    # @+node:ekr.20140902181058.18645: *4* QTextMixin.Enable/disable
-    def disable(self) -> None:
-        self.enabled = False
+    # @+node:ekr.20140901062324.18698: *4* QTextMixin.setFocus
+    def setFocus(self) -> None:
+        """QTextMixin"""
+        if 'focus' in g.app.debug:
+            print('BaseQTextWrapper.setFocus', self.widget)
+        # Call the base class
+        assert isinstance(
+            self.widget,
+            (  # type:ignore
+                QtWidgets.QTextBrowser,
+                QtWidgets.QLineEdit,
+                QtWidgets.QTextEdit,
+                Qsci and Qsci.QsciScintilla,  # This line causes the mypy complaint.
+            ),
+        ), self.widget
+        QtWidgets.QTextBrowser.setFocus(self.widget)
 
-    def enable(self, enabled: bool = True) -> None:
-        self.enabled = enabled
+    # @+node:ekr.20140901062324.18717: *4* QTextMixin.Generic text
+    # @+node:ekr.20140901062324.18703: *5* QTextMixin.appendText
+    def appendText(self, s: str) -> None:
+        """QTextMixin"""
+        s2 = self.getAllText()
+        self.setAllText(s2 + s)
+        self.setInsertPoint(len(s2))
+
+    # @+node:ekr.20140901141402.18706: *5* QTextMixin.delete
+    def delete(self, i: int, j: int = None) -> None:
+        """QTextMixin"""
+        if j is None:
+            j = i + 1
+        # This allows subclasses to use this base class method.
+        if i > j:
+            i, j = j, i
+        s = self.getAllText()
+        self.setAllText(s[:i] + s[j:])
+        # Bug fix: Significant in external tests.
+        self.setSelectionRange(i, i, insert=i)
+
+    # @+node:ekr.20140901062324.18827: *5* QTextMixin.deleteTextSelection
+    def deleteTextSelection(self) -> None:
+        """QTextMixin"""
+        i, j = self.getSelectionRange()
+        self.delete(i, j)
+
+    # @+node:ekr.20110605121601.18102: *5* QTextMixin.get
+    def get(self, i: int, j: int = None) -> str:
+        """QTextMixin"""
+        # 2012/04/12: fix the following two bugs by using the vanilla code:
+        # https://bugs.launchpad.net/leo-editor/+bug/979142
+        # https://bugs.launchpad.net/leo-editor/+bug/971166
+        s = self.getAllText()
+        return s[i:j]
+
+    # @+node:ekr.20140901062324.18704: *5* QTextMixin.getLastIndex & getLength
+    def getLastIndex(self, s: str = None) -> int:
+        """QTextMixin"""
+        return len(self.getAllText()) if s is None else len(s)
+
+    def getLength(self, s: str = None) -> int:
+        """QTextMixin"""
+        return len(self.getAllText()) if s is None else len(s)
+
+    # @+node:ekr.20140901062324.18705: *5* QTextMixin.getSelectedText
+    def getSelectedText(self) -> str:
+        """QTextMixin"""
+        i, j = self.getSelectionRange()  # Returns (int, int)
+        if i == j:
+            return ''
+        s = self.getAllText()
+        return s[i:j]
+
+    # @+node:ekr.20140901141402.18702: *5* QTextMixin.insert
+    def insert(self, i: int, s: str) -> int:
+        """QTextMixin"""
+        s2 = self.getAllText()
+        self.setAllText(s2[:i] + s + s2[i:])
+        self.setInsertPoint(i + len(s))
+        return i
+
+    # @+node:ekr.20140902084950.18634: *5* QTextMixin.seeInsertPoint
+    def seeInsertPoint(self) -> None:
+        """Ensure the insert point is visible."""
+        # getInsertPoint defined in client classes.
+        self.see(self.getInsertPoint())
+
+    # @+node:ekr.20140902135648.18668: *5* QTextMixin.selectAllText
+    def selectAllText(self, s: str = None) -> None:
+        """QTextMixin."""
+        self.setSelectionRange(0, self.getLength(s))
+
+    # @+node:ekr.20140901141402.18704: *5* QTextMixin.toPythonIndexRowCol
+    def toPythonIndexRowCol(self, index: int) -> tuple[int, int]:
+        """QTextMixin"""
+        s = self.getAllText()
+        row, col = g.convertPythonIndexToRowCol(s, index)
+        return row, col
 
     # @+node:ekr.20140901062324.18729: *4* QTextMixin.rememberSelectionAndScroll
     def rememberSelectionAndScroll(self) -> None:
@@ -312,134 +365,6 @@ class QTextMixin:
         v.selectionLength = j - i
         v.scrollBarSpot = w.getYScrollPosition()
 
-    # @+node:ekr.20140901062324.18698: *4* QTextMixin.setFocus
-    def setFocus(self) -> None:
-        if 'focus' in g.app.debug:
-            print('QTextMixin.setFocus', self.widget)
-        # Call the base class
-        assert isinstance(
-            self.widget,
-            (  # type:ignore
-                QtWidgets.QTextBrowser,
-                QtWidgets.QLineEdit,
-                QtWidgets.QTextEdit,
-                Qsci and Qsci.QsciScintilla,  # This line causes the mypy complaint.
-            ),
-        ), self.widget
-        QtWidgets.QTextBrowser.setFocus(self.widget)
-
-    # @+node:ekr.20140901062324.18717: *4* QTextMixin: Generic text
-    # @+node:ekr.20140901062324.18703: *5* QTextMixin.appendText
-    def appendText(self, s: str) -> None:
-        s2 = self.getAllText()
-        self.setAllText(s2 + s)
-        self.setInsertPoint(len(s2))
-
-    # @+node:ekr.20140901141402.18706: *5* QTextMixin.delete
-    def delete(self, i: int, j: int = None) -> None:
-        if j is None:
-            j = i + 1
-        # This allows subclasses to use this base class method.
-        if i > j:
-            i, j = j, i
-        s = self.getAllText()
-        self.setAllText(s[:i] + s[j:])
-        self.setSelectionRange(i, i, insert=i)
-
-    # @+node:ekr.20140901062324.18827: *5* QTextMixin.deleteTextSelection
-    def deleteTextSelection(self) -> None:
-        i, j = self.getSelectionRange()
-        self.delete(i, j)
-
-    # @+node:ekr.20110605121601.18102: *5* QTextMixin.get
-    def get(self, i: int, j: int = None) -> str:
-        # 2012/04/12: fix the following two bugs by using the vanilla code:
-        # https://bugs.launchpad.net/leo-editor/+bug/979142
-        # https://bugs.launchpad.net/leo-editor/+bug/971166
-        s = self.getAllText()
-        return s[i:j]
-
-    # @+node:ekr.20260406043110.1: *5* QTextMixin.getAllText
-    def getAllText(self) -> str:
-        s = self.s
-        return g.checkUnicode(s)
-
-    # @+node:ekr.20260406043211.1: *5* QTextMixin.getInsertPoint
-    def getInsertPoint(self) -> int:
-        i = self.ins
-        if i is None:
-            if self.virtualInsertPoint is None:
-                i = 0
-            else:
-                i = self.virtualInsertPoint
-        self.virtualInsertPoint = i
-        return i
-
-    # @+node:ekr.20140901062324.18704: *5* QTextMixin.getLastIndex & getLength
-    def getLastIndex(self) -> int:
-        return len(self.getAllText())
-
-    def getLength(self) -> int:
-        return len(self.getAllText())
-
-    # @+node:ekr.20140901062324.18705: *5* QTextMixin.getSelectedText
-    def getSelectedText(self) -> str:
-        i, j = self.getSelectionRange()  # Returns (int, int)
-        if i == j:
-            return ''
-        s = self.getAllText()
-        return s[i:j]
-
-    # @+node:ekr.20260406043557.1: *5* QTextMixin.getSelectionRange
-    def getSelectionRange(self, sort: bool = True) -> tuple[int, int]:
-        """Return the selected range of the widget."""
-        sel = self.sel
-        if len(sel) == 2 and sel[0] >= 0 and sel[1] >= 0:
-            i, j = sel
-            if sort and i > j:
-                sel = j, i  # Bug fix: 10/5/07
-            return sel
-        i = self.ins
-        return i, i
-
-    # @+node:ekr.20260406044235.1: *5* QTextMixin.hasSelection
-    def hasSelection(self) -> bool:
-        i, j = self.getSelectionRange()
-        return i != j
-
-    # @+node:ekr.20140901141402.18702: *5* QTextMixin.insert
-    def insert(self, i: int, s: str) -> int:
-        s2 = self.getAllText()
-        self.setAllText(s2[:i] + s + s2[i:])
-        self.setInsertPoint(i + len(s))
-        return i
-
-    # @+node:ekr.20140902084950.18634: *5* QTextMixin.seeInsertPoint
-    def seeInsertPoint(self) -> None:
-        """Ensure the insert point is visible."""
-        self.see(self.getInsertPoint())
-
-    # @+node:ekr.20140902135648.18668: *5* QTextMixin.selectAllText
-    def selectAllText(self) -> None:
-        self.setSelectionRange(0, self.getLength())
-
-    # @+node:ekr.20260406043726.1: *5* QTextMixin.setInsertPoint
-    def setInsertPoint(self, i: int, s: str = None) -> None:
-        self.virtualInsertPoint = i
-        self.ins = i
-        self.sel = i, i
-
-    # @+node:ekr.20260406043803.1: *5* QTextMixin.setSelectionRange (NEW)
-    def setSelectionRange(self, i: int, j: int, insert: int = None) -> None:
-        self.sel = i, j
-        self.ins = j if insert is None else insert
-
-    # @+node:ekr.20140901141402.18704: *5* QTextMixin.toPythonIndexRowCol
-    def toPythonIndexRowCol(self, index: int) -> tuple[int, int]:
-        s = self.getAllText()
-        row, col = g.convertPythonIndexToRowCol(s, index)
-        return row, col
-
     # @-others
 
 
@@ -453,8 +378,9 @@ class QLineEditWrapper(QTextMixin):
     """
 
     # @+others
-    # @+node:ekr.20110605121601.18060: *3* QLineEditWrapper.__init__ and __repr__
-    def __init__(self, widget: QLineEdit, name: str = None, c: Cmdr = None) -> None:
+    # @+node:ekr.20110605121601.18060: *3* qlew.Birth
+    def __init__(self, widget: QLineEdit, name: str, c: Cmdr = None) -> None:
+        """Ctor for QLineEditWrapper class."""
         super().__init__(c)
         self.widget = widget
         self.name = name
@@ -465,63 +391,106 @@ class QLineEditWrapper(QTextMixin):
 
     __str__ = __repr__
 
-    # @+node:ekr.20110605121601.18120: *3* QLineEditWrapper.getAllText
+    # @+node:ekr.20140901191541.18599: *3* qlew.check
+    def check(self) -> bool:
+        """
+        QLineEditWrapper.
+        """
+        return True
+
+    # @+node:ekr.20110605121601.18118: *3* qlew.Widget-specific overrides
+    # @+node:ekr.20220911105050.1: *4* qlew: do-nothings
+    def flashCharacter(
+        self, i: int, bg: str = 'white', fg: str = 'red', flashes: int = 3, delay: int = 75
+    ) -> None:
+        pass
+
+    def getXScrollPosition(self) -> int:
+        return 0
+
+    def getYScrollPosition(self) -> int:
+        return 0
+
+    def setXScrollPosition(self, i: int) -> None:
+        pass
+
+    def setYScrollPosition(self, i: int) -> None:
+        pass
+
+    # @+node:ekr.20110605121601.18120: *4* qlew.getAllText
     def getAllText(self) -> str:
-        w = self.widget
-        return w.text()
+        """QHeadlineWrapper."""
+        if self.check():
+            w = self.widget
+            return w.text()
+        return ''
 
-    # @+node:ekr.20110605121601.18121: *3* QLineEditWrapper.getInsertPoint
+    # @+node:ekr.20110605121601.18121: *4* qlew.getInsertPoint
     def getInsertPoint(self) -> int:
-        return self.widget.cursorPosition()
+        """QHeadlineWrapper."""
+        if self.check():
+            return self.widget.cursorPosition()
+        return 0
 
-    # @+node:ekr.20110605121601.18122: *3* QLineEditWrapper.getSelectionRange
+    # @+node:ekr.20110605121601.18122: *4* qlew.getSelectionRange
     def getSelectionRange(self, sort: bool = True) -> tuple[int, int]:
+        """QHeadlineWrapper."""
         w = self.widget
-        if w.hasSelectedText():
-            i = w.selectionStart()
-            s = w.selectedText()
-            j = i + len(s)
-        else:
-            i = j = w.cursorPosition()
-        return i, j
+        if self.check():
+            if w.hasSelectedText():
+                i = w.selectionStart()
+                s = w.selectedText()
+                j = i + len(s)
+            else:
+                i = j = w.cursorPosition()
+            return i, j
+        return 0, 0
 
-    # @+node:ekr.20110605121601.18123: *3* QLineEditWrapper.hasSelection
+    # @+node:ekr.20110605121601.18123: *4* qlew.hasSelection
     def hasSelection(self) -> bool:
-        return self.widget.hasSelectedText()
+        """QHeadlineWrapper."""
+        if self.check():
+            return self.widget.hasSelectedText()
+        return False
 
-    # @+node:ekr.20260419060623.1: *3* QLineEditWrapper.insert
-    def insert(self, i: int, s: str) -> int:
-        # New in Leo 6.8.7.
-        s.replace('\n', '').replace('\r', '')
-        s2 = self.getAllText()
-        self.setAllText(s2[:i] + s + s2[i:])
-        self.setInsertPoint(i + len(s))
-        return i
+    # @+node:ekr.20110605121601.18124: *4* qlew.see & seeInsertPoint
+    def see(self, i: int) -> None:
+        """QHeadlineWrapper."""
 
-    # @+node:ekr.20110605121601.18125: *3* QLineEditWrapper.setAllText
+    def seeInsertPoint(self) -> None:
+        """QHeadlineWrapper."""
+
+    # @+node:ekr.20110605121601.18125: *4* qlew.setAllText
     def setAllText(self, s: str) -> None:
         """Set all text of a Qt headline widget."""
-        w = self.widget
-        # New in Leo 6.8.7.
-        s = s.replace('\n', '').replace('\r', '')
-        w.setText(s)
+        if self.check():
+            w = self.widget
+            w.setText(s)
 
-    # @+node:ekr.20110605121601.18128: *3* QLineEditWrapper.setFocus
+    # @+node:ekr.20110605121601.18128: *4* qlew.setFocus
     def setFocus(self) -> None:
-        g.app.gui.set_focus(self.c, self.widget)
+        """QHeadlineWrapper."""
+        if self.check():
+            g.app.gui.set_focus(self.c, self.widget)
 
-    # @+node:ekr.20110605121601.18129: *3* QLineEditWrapper.setInsertPoint
+    # @+node:ekr.20110605121601.18129: *4* qlew.setInsertPoint
     def setInsertPoint(self, i: int, s: str = None) -> None:
+        """QHeadlineWrapper."""
+        if not self.check():
+            return
         w = self.widget
         if s is None:
             s = w.text()
         i = max(0, min(i, len(s)))
         w.setCursorPosition(i)
 
-    # @+node:ekr.20110605121601.18130: *3* QLineEditWrapper.setSelectionRange
+    # @+node:ekr.20110605121601.18130: *4* qlew.setSelectionRange
     def setSelectionRange(
         self, i: int, j: int, insert: Optional[int] = None, s: str = None
     ) -> None:
+        """QHeadlineWrapper."""
+        if not self.check():
+            return
         w = self.widget
         if i > j:
             i, j = j, i
@@ -543,30 +512,6 @@ class QLineEditWrapper(QTextMixin):
                 w.setSelection(j, -length)
             else:
                 w.setSelection(i, length)
-
-    # @+node:ekr.20220911105050.1: *3* QLineEditWrapper: do-nothings
-    def flashCharacter(
-        self, i: int, bg: str = 'white', fg: str = 'red', flashes: int = 3, delay: int = 75
-    ) -> None:
-        pass
-
-    def getXScrollPosition(self) -> int:
-        return 0
-
-    def getYScrollPosition(self) -> int:
-        return 0
-
-    def see(self, i: int) -> None:
-        pass
-
-    def seeInsertPoint(self) -> None:
-        pass
-
-    def setXScrollPosition(self, i: int) -> None:
-        pass
-
-    def setYScrollPosition(self, i: int) -> None:
-        pass
 
     # @-others
 
@@ -623,19 +568,18 @@ if QtWidgets:
         """A subclass of QTextBrowser that overrides the mouse event handlers."""
 
         # @+others
-        # @+node:ekr.20110605121601.18006: *3*  LeoQTextBrowser.__init__
-        def __init__(self, parent: QWidget, c: Cmdr, wrapper: LeoQtLog) -> None:
+        # @+node:ekr.20110605121601.18006: *3*  lqtb.ctor
+        def __init__(self, parent: QWidget, c: Cmdr, wrapper: BaseTextAPI) -> None:
             """
             ctor for LeoQTextBrowser class, a subclass of QtWidgets.QTextBrowser.
 
             wrapper is a LeoQtBody or LeoQtLog.
             """
-            super().__init__(parent)
             assert not hasattr(QtWidgets.QTextBrowser, 'leo_c')
             self.leo_c = c
             self.leo_s = ''  # The cached text.
-            self.leo_wrapper = QTextEditWrapper(c=c, widget=self)  # #4623.
             self.htmlFlag = True
+            super().__init__(parent)
             self.setCursorWidth(c.config.getInt('qt-cursor-width') or 1)
 
             # Connect event handlers...
@@ -665,13 +609,13 @@ if QtWidgets:
                 'last_hl_color': hl_color,
             }
 
-        # @+node:ekr.20110605121601.18007: *3* LeoQTextBrowser. __repr__ & __str__
+        # @+node:ekr.20110605121601.18007: *3* lqtb. __repr__ & __str__
         def __repr__(self) -> str:
             return f"(LeoQTextBrowser) {id(self)}"
 
         __str__ = __repr__
 
-        # @+node:ekr.20110605121601.18008: *3* LeoQTextBrowser.Auto completion
+        # @+node:ekr.20110605121601.18008: *3* lqtb.Auto completion
         # @+node:ekr.20110605121601.18009: *4* class LeoQListWidget(QListWidget)
         class LeoQListWidget(QtWidgets.QListWidget):
             # @+others
@@ -825,7 +769,7 @@ if QtWidgets:
 
             # @-others
 
-        # @+node:ekr.20110605121601.18017: *4* LeoQTextBrowser.init_completer
+        # @+node:ekr.20110605121601.18017: *4* lqtb.lqtb.init_completer
         def init_completer(self, options: list[str]) -> LeoQListWidget:
             """Connect a QCompleter."""
             c = self.leo_c
@@ -840,7 +784,7 @@ if QtWidgets:
             qc.show_completions(options)
             return qc
 
-        # @+node:ekr.20110605121601.18018: *4* LeoQTextBrowser.redirections to LeoQListWidget
+        # @+node:ekr.20110605121601.18018: *4* lqtb.redirections to LeoQListWidget
         def end_completer(self) -> None:
             if hasattr(self, 'leo_qc'):
                 self.leo_qc.end_completer()
@@ -850,8 +794,8 @@ if QtWidgets:
             if hasattr(self, 'leo_qc'):
                 self.leo_qc.show_completions(aList)
 
-        # @+node:tom.20210827230127.1: *3* LeoQTextBrowser Highlight Current Line
-        # @+node:tom.20210827225119.3: *4* LeoQTextBrowser.parse_css
+        # @+node:tom.20210827230127.1: *3* lqtb Highlight Current Line
+        # @+node:tom.20210827225119.3: *4* lqtb.parse_css
         # @@language python
         @staticmethod
         def parse_css(css_string: str, clas: str = '') -> tuple[str, str]:
@@ -887,7 +831,7 @@ if QtWidgets:
                     break
             return color, bg
 
-        # @+node:tom.20210827225119.4: *4* LeoQTextBrowser.assign_bg
+        # @+node:tom.20210827225119.4: *4* lqtb.assign_bg
         # @@language python
         @staticmethod
         def assign_bg(fg: str) -> QColor:
@@ -914,7 +858,7 @@ if QtWidgets:
                     bg = 'black'
             return QColor(bg)
 
-        # @+node:tom.20210827225119.5: *4* LeoQTextBrowser.calc_hl
+        # @+node:tom.20210827225119.5: *4* lqtb.calc_hl
         # @@language python
         @staticmethod
         def calc_hl(palette: QtGui.QPalette) -> QColor:
@@ -943,7 +887,7 @@ if QtWidgets:
                     hl = bg.lighter(140)
             return hl
 
-        # @+node:tom.20210827225119.2: *4* LeoQTextBrowser.highlightCurrentLine
+        # @+node:tom.20210827225119.2: *4* lqtb.highlightCurrentLine
         # @@language python
         def highlightCurrentLine(self) -> None:
             """Highlight cursor line."""
@@ -1021,7 +965,7 @@ if QtWidgets:
             editor.setExtraSelections([selection])
             # @-<< Apply Highlight >>
 
-        # @+node:ekr.20141103061944.31: *3* LeoQTextBrowser.get/setXScrollPosition
+        # @+node:ekr.20141103061944.31: *3* lqtb.get/setXScrollPosition
         def getXScrollPosition(self) -> int:
             """Get the horizontal scrollbar position."""
             w = self
@@ -1036,7 +980,7 @@ if QtWidgets:
                 sb = w.horizontalScrollBar()
                 sb.setSliderPosition(pos)
 
-        # @+node:ekr.20111002125540.7021: *3* LeoQTextBrowser.get/setYScrollPosition
+        # @+node:ekr.20111002125540.7021: *3* lqtb.get/setYScrollPosition
         def getYScrollPosition(self) -> int:
             """Get the vertical scrollbar position."""
             w = self
@@ -1052,7 +996,7 @@ if QtWidgets:
             sb = w.verticalScrollBar()
             sb.setSliderPosition(pos)
 
-        # @+node:ekr.20110605121601.18019: *3* LeoQTextBrowser.leo_dumpButton
+        # @+node:ekr.20110605121601.18019: *3* lqtb.leo_dumpButton
         def leo_dumpButton(self, event: LeoKeyEvent, tag: str) -> str:
             button = event.button()
             table = (
@@ -1069,14 +1013,14 @@ if QtWidgets:
                 kind = f"unknown: {repr(button)}"
             return kind
 
-        # @+node:ekr.20200304130514.1: *3* LeoQTextBrowser.onContextMenu
+        # @+node:ekr.20200304130514.1: *3* lqtb.onContextMenu
         def onContextMenu(self, point: QPoint) -> None:
             """LeoQTextBrowser: Callback for customContextMenuRequested events."""
             # #1286.
             c, w = self.leo_c, self
             g.app.gui.onContextMenu(c, w, point)
 
-        # @+node:ekr.20120925061642.13506: *3* LeoQTextBrowser.onSliderChanged
+        # @+node:ekr.20120925061642.13506: *3* lqtb.onSliderChanged
         def onSliderChanged(self, arg: int) -> None:
             """Handle a Qt onSliderChanged event."""
             c = self.leo_c
@@ -1091,7 +1035,7 @@ if QtWidgets:
             if p:
                 p.v.scrollBarSpot = arg
 
-        # @+node:ekr.20201204172235.1: *3* LeoQTextBrowser.paintEvent
+        # @+node:ekr.20201204172235.1: *3* lqtb.paintEvent
         leo_cursor_width = 0
 
         leo_vim_mode: bool = None
@@ -1179,7 +1123,7 @@ if QtWidgets:
             qp.drawRect(w.cursorRect())
             qp.end()
 
-        # @+node:tbrown.20130411145310.18855: *3* LeoQTextBrowser.wheelEvent
+        # @+node:tbrown.20130411145310.18855: *3* lqtb.wheelEvent
         def wheelEvent(self, event: QWheelEvent) -> None:
             """Handle a wheel event."""
             if KeyboardModifier.ControlModifier & event.modifiers():
@@ -1355,6 +1299,16 @@ class NumberBar(QtWidgets.QFrame):
     # @-others
 
 
+# @+node:ekr.20140901141402.18700: ** class PlainTextWrapper(QTextMixin)
+class PlainTextWrapper(QTextMixin):
+    """A Qt class for use by the find code."""
+
+    def __init__(self, widget: QWidget) -> None:
+        """Ctor for the PlainTextWrapper class."""
+        super().__init__()
+        self.widget = widget
+
+
 # @+node:ekr.20110605121601.18116: ** class QHeadlineWrapper (QLineEditWrapper)
 class QHeadlineWrapper(QLineEditWrapper):
     """
@@ -1397,8 +1351,6 @@ class QHeadlineWrapper(QLineEditWrapper):
 
 # @+node:ekr.20110605121601.18131: ** class QMinibufferWrapper (QLineEditWrapper)
 class QMinibufferWrapper(QLineEditWrapper):
-    # @+others
-    # @+node:ekr.20260418085528.1: *3* QMinibufferWrapper.__init__
     def __init__(self, c: Cmdr) -> None:
         """Ctor for QMinibufferWrapper class."""
         self.c = c
@@ -1409,7 +1361,7 @@ class QMinibufferWrapper(QLineEditWrapper):
 
         # Monkey-patch the event handlers
         # @+<< define mouseReleaseEvent >>
-        # @+node:ekr.20110605121601.18132: *4* << define mouseReleaseEvent >> (QMinibufferWrapper)
+        # @+node:ekr.20110605121601.18132: *3* << define mouseReleaseEvent >> (QMinibufferWrapper)
         def mouseReleaseEvent(event: QEvent, self: QMinibufferWrapper = self) -> None:
             """Override QLineEdit.mouseReleaseEvent.
 
@@ -1428,7 +1380,6 @@ class QMinibufferWrapper(QLineEditWrapper):
 
         w.mouseReleaseEvent = mouseReleaseEvent
 
-    # @+node:ekr.20260418085529.1: *3* QMinibufferWrapper.setStyleClass
     def setStyleClass(self, style_class: Value) -> None:
         self.widget.setProperty('style_class', style_class)
         #
@@ -1440,16 +1391,11 @@ class QMinibufferWrapper(QLineEditWrapper):
         # level sheet will get pushed down quite frequently.
         self.widget.setStyleSheet(self.c.frame.top.styleSheet())
 
-    # @+node:ekr.20260418085530.1: *3* QMinibufferWrapper.setSelectionRange
     def setSelectionRange(self, i: int, j: int, insert: int = None, s: str = None) -> None:
-        super().setSelectionRange(i, j, insert, s)
-        if not self.widget:
-            return
-        if insert is None:
-            insert = j
-        self.widget._sel_and_insert = (i, j, insert)
-
-    # @-others
+        QLineEditWrapper.setSelectionRange(self, i, j, insert, s)
+        insert = j if insert is None else insert
+        if self.widget:
+            self.widget._sel_and_insert = (i, j, insert)
 
 
 # @+node:ekr.20110605121601.18103: ** class QScintillaWrapper(QTextMixin)
@@ -1712,17 +1658,12 @@ class QScintillaWrapper(QTextMixin):
 
 # @+node:ekr.20110605121601.18071: ** class QTextEditWrapper(QTextMixin)
 class QTextEditWrapper(QTextMixin):
-    """
-    A wrapper for a QTextEdit/QTextBrowser supporting the high-level interface.
-    """
+    """A wrapper for a QTextEdit/QTextBrowser supporting the high-level interface."""
 
     # @+others
     # @+node:ekr.20110605121601.18073: *3* QTextEditWrapper.ctor & helpers
     def __init__(self, widget: QWidget, name: str = 'TestWrapper', c: Cmdr = None) -> None:
-        """
-        Ctor for QTextEditWrapper class.
-        widget is a QTextEdit/QTextBrowser or a QLineEdit.
-        """
+        """Ctor for QTextEditWrapper class. widget is a QTextEdit/QTextBrowser."""
         super().__init__(c)
         # Make sure all ivars are set.
         self.baseClassName = 'QTextEditWrapper'
@@ -1791,8 +1732,9 @@ class QTextEditWrapper(QTextMixin):
 
     # @+node:ekr.20110605121601.18078: *3* QTextEditWrapper.High-level interface
     # These are all widget-dependent
-    # @+node:ekr.20110605121601.18079: *4* QTextEditWrapper.delete (avoid call to setAllText)
+    # @+node:ekr.20110605121601.18079: *4* qtew.delete (avoid call to setAllText)
     def delete(self, i: int, j: int = None) -> None:
+        """QTextEditWrapper."""
         w = self.widget
         if j is None:
             j = i + 1
@@ -1819,7 +1761,7 @@ class QTextEditWrapper(QTextMixin):
             self.changingText = False
         sb.setSliderPosition(pos)
 
-    # @+node:ekr.20110605121601.18080: *4* QTextEditWrapper.flashCharacter
+    # @+node:ekr.20110605121601.18080: *4* qtew.flashCharacter
     def flashCharacter(
         self,
         i: int,
@@ -1828,7 +1770,7 @@ class QTextEditWrapper(QTextMixin):
         flashes: int = 3,
         delay: int = 75,
     ) -> None:
-        """QTextEditWrapper: flash a character."""
+        """QTextEditWrapper."""
         # numbered color names don't work in Ubuntu 8.10, so...
         if bg[-1].isdigit() and bg[0] != '#':
             bg = bg[:-1]
@@ -1875,23 +1817,26 @@ class QTextEditWrapper(QTextMixin):
         self.flashFg = None if fg.lower() == 'same' else fg
         addFlashCallback()
 
-    # @+node:ekr.20110605121601.18081: *4* QTextEditWrapper.getAllText
+    # @+node:ekr.20110605121601.18081: *4* qtew.getAllText
     def getAllText(self) -> str:
+        """QTextEditWrapper."""
         w = self.widget
         return w.toPlainText()
 
-    # @+node:ekr.20110605121601.18082: *4* QTextEditWrapper.getInsertPoint
+    # @+node:ekr.20110605121601.18082: *4* qtew.getInsertPoint
     def getInsertPoint(self) -> int:
+        """QTextEditWrapper."""
         return self.widget.textCursor().position()
 
-    # @+node:ekr.20110605121601.18083: *4* QTextEditWrapper.getSelectionRange
+    # @+node:ekr.20110605121601.18083: *4* qtew.getSelectionRange
     def getSelectionRange(self, sort: bool = True) -> tuple[int, int]:
+        """QTextEditWrapper."""
         w = self.widget
         tc = w.textCursor()
         i, j = tc.selectionStart(), tc.selectionEnd()
         return i, j
 
-    # @+node:ekr.20110605121601.18084: *4* QTextEditWrapper.getX/YScrollPosition
+    # @+node:ekr.20110605121601.18084: *4* qtew.getX/YScrollPosition
     # **Important**: There is a Qt bug here: the scrollbar position
     # is valid only if cursor is visible.  Otherwise the *reported*
     # scrollbar position will be such that the cursor *is* visible.
@@ -1910,12 +1855,14 @@ class QTextEditWrapper(QTextMixin):
         pos = sb.sliderPosition()
         return pos
 
-    # @+node:ekr.20110605121601.18085: *4* QTextEditWrapper.hasSelection
+    # @+node:ekr.20110605121601.18085: *4* qtew.hasSelection
     def hasSelection(self) -> bool:
+        """QTextEditWrapper."""
         return self.widget.textCursor().hasSelection()
 
-    # @+node:ekr.20110605121601.18089: *4* QTextEditWrapper.insert (avoid call to setAllText)
+    # @+node:ekr.20110605121601.18089: *4* qtew.insert (avoid call to setAllText)
     def insert(self, i: int, s: str) -> None:
+        """QTextEditWrapper."""
         w = self.widget
         cursor = w.textCursor()
         try:
@@ -1926,8 +1873,9 @@ class QTextEditWrapper(QTextMixin):
         finally:
             self.changingText = False
 
-    # @+node:ekr.20110605121601.18077: *4* QTextEditWrapper.leoMoveCursorHelper & helper
+    # @+node:ekr.20110605121601.18077: *4* qtew.leoMoveCursorHelper & helper
     def leoMoveCursorHelper(self, kind: str, extend: bool = False, linesPerPage: int = 15) -> None:
+        """QTextEditWrapper."""
         w = self.widget
         d = {
             'begin-line': MoveOperation.StartOfLine,  # Was start-line
@@ -1983,7 +1931,7 @@ class QTextEditWrapper(QTextMixin):
             g.app.gui.setClipboardSelection(sel)
         self.c.frame.updateStatusLine()
 
-    # @+node:btheado.20120129145543.8180: *5* QTextEditWrapper.pageUpDown
+    # @+node:btheado.20120129145543.8180: *5* qtew.pageUpDown
     def pageUpDown(self, op: object, moveMode: object) -> None:
         """
         The QTextEdit PageUp/PageDown functionality seems to be "baked-in"
@@ -2015,8 +1963,9 @@ class QTextEditWrapper(QTextMixin):
                 sb.triggerAction(SliderAction.SliderPageStepAdd)
         control.setTextCursor(cursor)
 
-    # @+node:ekr.20110605121601.18087: *4* QTextEditWrapper.linesPerPage
+    # @+node:ekr.20110605121601.18087: *4* qtew.linesPerPage
     def linesPerPage(self) -> float:
+        """QTextEditWrapper."""
         # Not used in Leo's core.
         w = self.widget
         h = w.size().height()
@@ -2024,7 +1973,7 @@ class QTextEditWrapper(QTextMixin):
         n = h / lineSpacing
         return n
 
-    # @+node:ekr.20110605121601.18088: *4* QTextEditWrapper.scrollDelegate
+    # @+node:ekr.20110605121601.18088: *4* qtew.scrollDelegate
     def scrollDelegate(self, kind: str) -> None:
         """
         Scroll a QTextEdit up or down one page.
@@ -2056,7 +2005,7 @@ class QTextEditWrapper(QTextMixin):
         vScroll.setValue(val + (delta * lineSpacing))
         c.bodyWantsFocus()
 
-    # @+node:ekr.20110605121601.18090: *4* QTextEditWrapper.see & seeInsertPoint
+    # @+node:ekr.20110605121601.18090: *4* qtew.see & seeInsertPoint
     def see(self, see_i: int) -> None:
         """Scroll so that position see_i is visible."""
         w = self.widget
@@ -2077,7 +2026,7 @@ class QTextEditWrapper(QTextMixin):
         """Make sure the insert point is visible."""
         self.widget.ensureCursorVisible()
 
-    # @+node:ekr.20110605121601.18092: *4* QTextEditWrapper.setAllText
+    # @+node:ekr.20110605121601.18092: *4* qtew.setAllText
     def setAllText(self, s: str) -> None:
         """Set the text of body pane."""
         w = self.widget
@@ -2088,13 +2037,13 @@ class QTextEditWrapper(QTextMixin):
         finally:
             self.changingText = False
 
-    # @+node:ekr.20110605121601.18095: *4* QTextEditWrapper.setInsertPoint
+    # @+node:ekr.20110605121601.18095: *4* qtew.setInsertPoint
     def setInsertPoint(self, i: int, s: str = None) -> None:
         # Fix bug 981849: incorrect body content shown.
         # Use the more careful code in setSelectionRange.
         self.setSelectionRange(i=i, j=i, insert=i, s=s)
 
-    # @+node:ekr.20110605121601.18096: *4* QTextEditWrapper.setSelectionRange
+    # @+node:ekr.20110605121601.18096: *4* qtew.setSelectionRange
     def setSelectionRange(
         self,
         i: Optional[int],
@@ -2155,7 +2104,7 @@ class QTextEditWrapper(QTextMixin):
         v.selectionLength = j - i
         v.scrollBarSpot = w.verticalScrollBar().value()
 
-    # @+node:ekr.20141103061944.40: *4* QTextEditWrapper.setXScrollPosition
+    # @+node:ekr.20141103061944.40: *4* qtew.setXScrollPosition
     def setXScrollPosition(self, pos: int) -> None:
         """Set the position of the horizontal scrollbar."""
         if pos is not None:
@@ -2163,7 +2112,7 @@ class QTextEditWrapper(QTextMixin):
             sb = w.horizontalScrollBar()
             sb.setSliderPosition(pos)
 
-    # @+node:ekr.20110605121601.18098: *4* QTextEditWrapper.setYScrollPosition
+    # @+node:ekr.20110605121601.18098: *4* qtew.setYScrollPosition
     def setYScrollPosition(self, pos: int) -> None:
         """Set the vertical scrollbar position."""
         if pos is not None:
@@ -2171,7 +2120,7 @@ class QTextEditWrapper(QTextMixin):
             sb = w.verticalScrollBar()
             sb.setSliderPosition(pos)
 
-    # @+node:ekr.20110605121601.18101: *4* QTextEditWrapper.toPythonIndexRowCol (fast)
+    # @+node:ekr.20110605121601.18101: *4* qtew.toPythonIndexRowCol (fast)
     def toPythonIndexRowCol(self, index: int) -> tuple[int, int]:
         te = self.widget
         doc = te.document()

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -149,7 +149,11 @@ def helpForRMarginGuides(self, event=None):
 
 # @+node:ekr.20140901062324.18719: **   class QTextMixin
 class QTextMixin:
-    """A minimal mixin class for QTextEditWrapper and QScintillaWrapper classes."""
+    """
+    A mixin class for StringTextWrapper, QTextEditWrapper and QScintillaWrapper classes.
+
+    This is also the annotation for all text-related wrappers.
+    """
 
     # @+others
     # @+node:ekr.20140901062324.18732: *3* QTextMixin.ctor & helper

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -43,8 +43,8 @@ class LeoQtTree(leoFrame.LeoTree):
     """Leo Qt tree class"""
 
     # @+others
-    # @+node:ekr.20110605121601.18404: *3* qtree.Birth
-    # @+node:ekr.20110605121601.18405: *4* qtree.__init__
+    # @+node:ekr.20110605121601.18404: *3* LeoQtTree:Birth
+    # @+node:ekr.20110605121601.18405: *4* LeoQtTree.__init__
     def __init__(self, c: Cmdr, frame: LeoQtFrame) -> None:  # Frame is a LeoQtFrame.
         """Ctor for the LeoQtTree class."""
         super().__init__(frame)
@@ -104,12 +104,12 @@ class LeoQtTree(leoFrame.LeoTree):
         n = c.config.getInt('icon-height') or 16
         w.setIconSize(QtCore.QSize(160, n))
 
-    # @+node:ekr.20110605121601.17866: *4* qtree.get_name
+    # @+node:ekr.20110605121601.17866: *4* LeoQtTree.get_name
     def getName(self) -> str:
         """Return the name of this widget: must start with "canvas"."""
         return 'canvas(tree)'
 
-    # @+node:ekr.20110605121601.18406: *4* qtree.initAfterLoad
+    # @+node:ekr.20110605121601.18406: *4* LeoQtTree.initAfterLoad
     def initAfterLoad(self) -> None:
         """Do late-state inits."""
         # Called by Leo's core.
@@ -131,7 +131,7 @@ class LeoQtTree(leoFrame.LeoTree):
         # The read logic sets c.changed to indicate nodes have changed.
         # c.clearChanged()
 
-    # @+node:ekr.20110605121601.17871: *4* qtree.reloadSettings
+    # @+node:ekr.20110605121601.17871: *4* LeoQtTree.reloadSettings
     def reloadSettings(self) -> None:
         """LeoQtTree."""
         c = self.c
@@ -147,7 +147,7 @@ class LeoQtTree(leoFrame.LeoTree):
             'use-mouse-expand-gestures', default=False
         )
 
-    # @+node:ekr.20110605121601.17868: *3* qtree.Debugging & tracing
+    # @+node:ekr.20110605121601.17868: *3* LeoQtTree:Debugging & tracing
     def error(self, s: str) -> None:
         if not g.unitTesting:
             g.trace('LeoQtTree Error: ', s, g.callers())
@@ -158,14 +158,14 @@ class LeoQtTree(leoFrame.LeoTree):
             return f"item {id(item)}: {self.getItemText(item)}"
         return '<no item>'
 
-    # @+node:ekr.20110605121601.17872: *3* qtree.Drawing
-    # @+node:ekr.20110605121601.18408: *4* qtree.clear
+    # @+node:ekr.20110605121601.17872: *3* LeoQtTree:Drawing
+    # @+node:ekr.20110605121601.18408: *4* LeoQtTree.clear
     def clear(self) -> None:
         """Clear all widgets in the tree."""
         w = self.treeWidget
         w.clear()
 
-    # @+node:ekr.20110605121601.17873: *4* qtree.full_redraw & helpers
+    # @+node:ekr.20110605121601.17873: *4* LeoQtTree.full_redraw & helpers
     def full_redraw(self, p: Position = None) -> Position:
         """
         Redraw all visible nodes of the tree.
@@ -206,7 +206,7 @@ class LeoQtTree(leoFrame.LeoTree):
     redraw_now = full_redraw  # type:ignore
 
     # @+node:vitalije.20200329160945.1: *5* tree declutter code
-    # @+node:tbrown.20150807090639.1: *6* qtree.declutter_node & helpers
+    # @+node:tbrown.20150807090639.1: *6* LeoQtTree.declutter_node & helpers
     def declutter_node(self, c: Cmdr, v: VNode, item: QTreeWidgetItem) -> QIcon:
         """declutter_node - change the appearance of a node
 
@@ -407,7 +407,7 @@ class LeoQtTree(leoFrame.LeoTree):
         # There is always at least a box icon.
         return icon
 
-    # @+node:vitalije.20200327162532.1: *6* qtree.get_declutter_patterns
+    # @+node:vitalije.20200327162532.1: *6* LeoQtTree.get_declutter_patterns
     def get_declutter_patterns(self) -> list[tuple[Value, Value]]:
         "Initializes self.declutter_patterns from configuration and returns it"
         if self.declutter_patterns is not None:
@@ -440,7 +440,7 @@ class LeoQtTree(leoFrame.LeoTree):
         self.declutter_patterns = patterns
         return patterns
 
-    # @+node:ekr.20110605121601.17874: *5* qtree.drawChildren
+    # @+node:ekr.20110605121601.17874: *5* LeoQtTree.drawChildren
     def drawChildren(self, p: Position, parent_item: QTreeWidgetItem) -> None:
         """Draw the children of p if they should be expanded."""
         if not p:
@@ -460,7 +460,7 @@ class LeoQtTree(leoFrame.LeoTree):
         else:
             self.contractItem(parent_item)
 
-    # @+node:ekr.20110605121601.17875: *5* qtree.drawNode
+    # @+node:ekr.20110605121601.17875: *5* LeoQtTree.drawNode
     def drawNode(self, p: Position, parent_item: QTreeWidgetItem) -> QTreeWidgetItem:
         """Draw the node p."""
         c = self.c
@@ -492,7 +492,7 @@ class LeoQtTree(leoFrame.LeoTree):
             item.setIcon(0, icon)
         return item
 
-    # @+node:ekr.20110605121601.17876: *5* qtree.drawTopTree
+    # @+node:ekr.20110605121601.17876: *5* LeoQtTree.drawTopTree
     def drawTopTree(self, p: Position) -> None:
         """Draw the tree rooted at p."""
         trace = 'drawing' in g.app.debug and not g.unitTesting
@@ -521,7 +521,7 @@ class LeoQtTree(leoFrame.LeoTree):
             t2 = time.process_time()
             g.trace(f"{t2 - t1:5.2f} sec.", g.callers(3))
 
-    # @+node:ekr.20110605121601.17877: *5* qtree.drawTree
+    # @+node:ekr.20110605121601.17877: *5* LeoQtTree.drawTree
     def drawTree(self, p: Position, parent_item: QTreeWidgetItem = None) -> None:
         if g.app.gui.isNullGui:
             return
@@ -530,7 +530,7 @@ class LeoQtTree(leoFrame.LeoTree):
         # Draw all the visible children.
         self.drawChildren(p, parent_item=item)
 
-    # @+node:ekr.20110605121601.17878: *5* qtree.initData
+    # @+node:ekr.20110605121601.17878: *5* LeoQtTree.initData
     def initData(self) -> None:
         self.item2positionDict = {}
         self.item2vnodeDict = {}
@@ -538,7 +538,7 @@ class LeoQtTree(leoFrame.LeoTree):
         self.vnode2itemsDict = {}
         self.editWidgetsDict = {}
 
-    # @+node:ekr.20110605121601.17882: *4* qtree.redraw_after_head_changed
+    # @+node:ekr.20110605121601.17882: *4* LeoQtTree.redraw_after_head_changed
     def redraw_after_head_changed(self) -> None:
         """Redraw all Qt outline items cloned to c.p."""
         if self.busy:
@@ -553,7 +553,7 @@ class LeoQtTree(leoFrame.LeoTree):
                         icon = self.declutter_node(c, p, item)
                         item.setIcon(0, icon)  # 0 is the column number.
 
-    # @+node:ekr.20110605121601.17884: *4* qtree.redraw_after_select
+    # @+node:ekr.20110605121601.17884: *4* LeoQtTree.redraw_after_select
     def redraw_after_select(self, p: Position = None) -> None:
         """Redraw the entire tree when an invisible node is selected."""
         if self.busy:
@@ -564,16 +564,16 @@ class LeoQtTree(leoFrame.LeoTree):
         # c.redraw_after_select calls tree.select indirectly.
         # Do not call it again here.
 
-    # @+node:ekr.20140907201613.18986: *4* qtree.repaint (not used)
+    # @+node:ekr.20140907201613.18986: *4* LeoQtTree.repaint (not used)
     def repaint(self) -> None:
         """Repaint the widget."""
         w = self.treeWidget
         w.repaint()
         w.resizeColumnToContents(0)  # 2009/12/22
 
-    # @+node:ekr.20110605121601.17885: *3* qtree.Event handlers
-    # @+node:ekr.20110605121601.17887: *4*  qtree.Click Box
-    # @+node:ekr.20110605121601.17888: *5* qtree.onClickBoxClick
+    # @+node:ekr.20110605121601.17885: *3* LeoQtTree:Event handlers
+    # @+node:ekr.20110605121601.17887: *4*  LeoQtTree.Click Box
+    # @+node:ekr.20110605121601.17888: *5* LeoQtTree.onClickBoxClick
     def onClickBoxClick(self, event: LeoKeyEvent, p: Position = None) -> None:
         if self.busy:
             return
@@ -582,7 +582,7 @@ class LeoQtTree(leoFrame.LeoTree):
         g.doHook("boxclick2", c=c, p=p, event=event)
         c.outerUpdate()
 
-    # @+node:ekr.20110605121601.17889: *5* qtree.onClickBoxRightClick
+    # @+node:ekr.20110605121601.17889: *5* LeoQtTree.onClickBoxRightClick
     def onClickBoxRightClick(self, event: LeoKeyEvent, p: Position = None) -> None:
         if self.busy:
             return
@@ -591,7 +591,7 @@ class LeoQtTree(leoFrame.LeoTree):
         g.doHook("boxrclick2", c=c, p=p, event=event)
         c.outerUpdate()
 
-    # @+node:ekr.20110605121601.17890: *5* qtree.onPlusBoxRightClick
+    # @+node:ekr.20110605121601.17890: *5* LeoQtTree.onPlusBoxRightClick
     def onPlusBoxRightClick(self, event: LeoKeyEvent, p: Position = None) -> None:
         if self.busy:
             return
@@ -599,9 +599,9 @@ class LeoQtTree(leoFrame.LeoTree):
         g.doHook('rclick-popup', c=c, p=p, event=event, context_menu='plusbox')
         c.outerUpdate()
 
-    # @+node:ekr.20110605121601.17891: *4*  qtree.Icon Box
+    # @+node:ekr.20110605121601.17891: *4*  LeoQtTree.Icon Box
     # For Qt, there seems to be no way to trigger these events.
-    # @+node:ekr.20110605121601.17892: *5* qtree.onIconBoxClick
+    # @+node:ekr.20110605121601.17892: *5* LeoQtTree.onIconBoxClick
     def onIconBoxClick(self, event: LeoKeyEvent, p: Position = None) -> None:
         if self.busy:
             return
@@ -610,7 +610,7 @@ class LeoQtTree(leoFrame.LeoTree):
         g.doHook("iconclick2", c=c, p=p, event=event)
         c.outerUpdate()
 
-    # @+node:ekr.20110605121601.17893: *5* qtree.onIconBoxRightClick
+    # @+node:ekr.20110605121601.17893: *5* LeoQtTree.onIconBoxRightClick
     def onIconBoxRightClick(self, event: LeoKeyEvent, p: Position = None) -> None:
         """Handle a right click in any outline widget."""
         if self.busy:
@@ -620,7 +620,7 @@ class LeoQtTree(leoFrame.LeoTree):
         g.doHook("iconrclick2", c=c, p=p, event=event)
         c.outerUpdate()
 
-    # @+node:ekr.20110605121601.17894: *5* qtree.onIconBoxDoubleClick
+    # @+node:ekr.20110605121601.17894: *5* LeoQtTree.onIconBoxDoubleClick
     def onIconBoxDoubleClick(self, event: LeoKeyEvent, p: Position = None) -> None:
         if self.busy:
             return
@@ -633,14 +633,14 @@ class LeoQtTree(leoFrame.LeoTree):
         g.doHook("icondclick2", c=c, p=p, event=event)
         c.outerUpdate()
 
-    # @+node:ekr.20110605121601.18437: *4* qtree.onContextMenu
+    # @+node:ekr.20110605121601.18437: *4* LeoQtTree.onContextMenu
     def onContextMenu(self, point: QPoint) -> None:
         """LeoQtTree: Callback for customContextMenuRequested events."""
         # #1286.
         c, w = self.c, self.treeWidget
         g.app.gui.onContextMenu(c, w, point)
 
-    # @+node:ekr.20110605121601.17896: *4* qtree.onItemClicked
+    # @+node:ekr.20110605121601.17896: *4* LeoQtTree.onItemClicked
     def onItemClicked(self, item: QTreeWidgetItem, col: int) -> None:  # Col not used.
         """Handle a click in a BaseNativeTree widget item."""
         # This is called after an item is selected.
@@ -683,7 +683,7 @@ class LeoQtTree(leoFrame.LeoTree):
         finally:
             self.busy = False
 
-    # @+node:ekr.20110605121601.17895: *4* qtree.onItemCollapsed
+    # @+node:ekr.20110605121601.17895: *4* LeoQtTree.onItemCollapsed
     def onItemCollapsed(self, item: QTreeWidgetItem) -> None:
         """Handle Qt tree-collapsed events."""
         if self.busy:
@@ -702,7 +702,7 @@ class LeoQtTree(leoFrame.LeoTree):
             p.contract()
         c.redraw()
 
-    # @+node:ekr.20110605121601.17897: *4* qtree.onItemDoubleClicked
+    # @+node:ekr.20110605121601.17897: *4* LeoQtTree.onItemDoubleClicked
     def onItemDoubleClicked(self, item: QTreeWidgetItem, col: int) -> None:  # col not used.
         """Handle a double click in a BaseNativeTree widget item."""
         if self.busy:  # Required.
@@ -724,51 +724,7 @@ class LeoQtTree(leoFrame.LeoTree):
         g.doHook("headclick2", c=c, p=p, event=None)
         c.outerUpdate()
 
-    # @+node:ekr.20110605121601.17898: *4* qtree.onItemExpanded
-    def onItemExpanded(self, item: QTreeWidgetItem) -> None:
-        """Handle Qt tree-expansion events."""
-        if self.busy:  # Required
-            return
-        if 'drawing' in g.app.debug:
-            g.trace(g.callers(1))
-        c = self.c
-        p = self.item2position(item)
-        if not p:
-            self.error('no p')
-            return
-        # Do **not** set lockouts here.
-        # Only methods that actually generate events should set lockouts.
-        self.select(p)
-        if not p.isExpanded():
-            p.expand()
-        c.redraw()
-
-    # @+node:ekr.20110605121601.17899: *4* qtree.onTreeSelect
-    def onTreeSelect(self) -> None:
-        """Select the proper position when a tree node is selected."""
-        if self.busy:  # Required
-            return
-        c = self.c
-        item = self.getCurrentItem()
-        p = self.item2position(item)
-        if not p:
-            self.error(f"no p for item: {item}")
-            return
-        # Do **not** set lockouts here.
-        # Only methods that actually generate events should set lockouts.
-        self.select(p)  # This is a call to LeoTree.select(!!)
-        c.outerUpdate()
-
-    # @+node:ekr.20110605121601.17944: *3* qtree.Focus
-    def getFocus(self) -> QWidget:
-        return g.app.gui.get_focus(self.c)  # Bug fix: 2009/6/30
-
-    findFocus = getFocus
-
-    def setFocus(self) -> None:
-        g.app.gui.set_focus(self.c, self.treeWidget)
-
-    # @+node:tom.20230324155453.1: *3* qtree.onItemEntered
+    # @+node:tom.20230324155453.1: *4* LeoQtTree.onItemEntered
     def onItemEntered(self, item: QTreeWidgetItem, col: int):
         """Expand/Contract a node when mouse moves over it.
 
@@ -787,8 +743,52 @@ class LeoQtTree(leoFrame.LeoTree):
             elif isShift and not isCtrl:
                 self.contractItem(item)
 
-    # @+node:ekr.20110605121601.18409: *3* qtree.Icons
-    # @+node:ekr.20110605121601.18411: *4* qtree.getIcon & helpers
+    # @+node:ekr.20110605121601.17898: *4* LeoQtTree.onItemExpanded
+    def onItemExpanded(self, item: QTreeWidgetItem) -> None:
+        """Handle Qt tree-expansion events."""
+        if self.busy:  # Required
+            return
+        if 'drawing' in g.app.debug:
+            g.trace(g.callers(1))
+        c = self.c
+        p = self.item2position(item)
+        if not p:
+            self.error('no p')
+            return
+        # Do **not** set lockouts here.
+        # Only methods that actually generate events should set lockouts.
+        self.select(p)
+        if not p.isExpanded():
+            p.expand()
+        c.redraw()
+
+    # @+node:ekr.20110605121601.17899: *4* LeoQtTree.onTreeSelect
+    def onTreeSelect(self) -> None:
+        """Select the proper position when a tree node is selected."""
+        if self.busy:  # Required
+            return
+        c = self.c
+        item = self.getCurrentItem()
+        p = self.item2position(item)
+        if not p:
+            self.error(f"no p for item: {item}")
+            return
+        # Do **not** set lockouts here.
+        # Only methods that actually generate events should set lockouts.
+        self.select(p)  # This is a call to LeoTree.select(!!)
+        c.outerUpdate()
+
+    # @+node:ekr.20110605121601.17944: *3* LeoQtTree:Focus
+    def getFocus(self) -> QWidget:
+        return g.app.gui.get_focus(self.c)  # Bug fix: 2009/6/30
+
+    findFocus = getFocus
+
+    def setFocus(self) -> None:
+        g.app.gui.set_focus(self.c, self.treeWidget)
+
+    # @+node:ekr.20110605121601.18409: *3* LeoQtTree:Icons
+    # @+node:ekr.20110605121601.18411: *4* LeoQtTree.getIcon & helpers
     def getIcon(self, v: VNode) -> QIcon:
         """Return the proper icon for position p."""
         if self.use_declutter:
@@ -797,7 +797,7 @@ class LeoQtTree(leoFrame.LeoTree):
                 return self.declutter_node(self.c, v, items[0])
         return self.getCompositeIconImage(v)
 
-    # @+node:vitalije.20200329153148.1: *5* qtree.icon_filenames_for_node
+    # @+node:vitalije.20200329153148.1: *5* LeoQtTree.icon_filenames_for_node
     def icon_filenames_for_node(self, v: VNode) -> list[str]:
         """Returns a list of icon filenames for v."""
         nicon = f'box{v.iconVal:02d}.png'
@@ -819,7 +819,7 @@ class LeoQtTree(leoFrame.LeoTree):
                 loaded_images[f] = g.app.gui.getImageImage(f)
         return fnames
 
-    # @+node:vitalije.20200329153154.1: *5* qtree.make_composite_icon
+    # @+node:vitalije.20200329153154.1: *5* LeoQtTree.make_composite_icon
     def make_composite_icon(self, images: list[Any]) -> QIcon:
         hsep = self.c.config.getInt('tree-icon-separation') or 0
         images = [x for x in images if x]
@@ -838,7 +838,7 @@ class LeoQtTree(leoFrame.LeoTree):
             painter.end()
         return QtGui.QIcon(QtGui.QPixmap.fromImage(pix))
 
-    # @+node:ekr.20110605121601.18412: *5* qtree.getCompositeIconImage
+    # @+node:ekr.20110605121601.18412: *5* LeoQtTree.getCompositeIconImage
     def getCompositeIconImage(self, v: VNode) -> QIcon:
         """Get the icon at v."""
         v.iconVal = v.computeIcon()
@@ -852,7 +852,7 @@ class LeoQtTree(leoFrame.LeoTree):
             g.app.gui.iconimages[h] = icon
         return icon
 
-    # @+node:ekr.20110605121601.17950: *4* qtree.setItemIcon
+    # @+node:ekr.20110605121601.17950: *4* LeoQtTree.setItemIcon
     def setItemIcon(self, item: QTreeWidgetItem, icon: QIcon) -> None:
         valid = item and self.isValidItem(item)
         if icon and valid:
@@ -861,8 +861,8 @@ class LeoQtTree(leoFrame.LeoTree):
             # but there is no itemChanged event handler.
             item.setIcon(0, icon)
 
-    # @+node:ekr.20110605121601.18414: *3* qtree.Items
-    # @+node:ekr.20110605121601.17943: *4*  qtree.item dict getters
+    # @+node:ekr.20110605121601.18414: *3* LeoQtTree:Items
+    # @+node:ekr.20110605121601.17943: *4*  LeoQtTree.item dict getters
     def itemHash(self, item: QTreeWidgetItem) -> str:
         return f"{repr(item)} at {str(id(item))}"
 
@@ -886,7 +886,7 @@ class LeoQtTree(leoFrame.LeoTree):
         itemHash = self.itemHash(item)
         return itemHash in self.item2vnodeDict  # was item.
 
-    # @+node:ekr.20110605121601.18415: *4* qtree.childIndexOfItem
+    # @+node:ekr.20110605121601.18415: *4* LeoQtTree.childIndexOfItem
     def childIndexOfItem(self, item: QTreeWidgetItem) -> int:
         parent = item and item.parent()
         if parent:
@@ -896,7 +896,7 @@ class LeoQtTree(leoFrame.LeoTree):
             n = w.indexOfTopLevelItem(item)
         return n
 
-    # @+node:ekr.20110605121601.18416: *4* qtree.childItems
+    # @+node:ekr.20110605121601.18416: *4* LeoQtTree.childItems
     def childItems(self, parent_item: QTreeWidgetItem) -> list[QTreeWidgetItem]:
         """
         Return the list of child items of the parent item,
@@ -911,7 +911,7 @@ class LeoQtTree(leoFrame.LeoTree):
             items = [w.topLevelItem(z) for z in range(n)]
         return items
 
-    # @+node:ekr.20110605121601.18418: *4* qtree.connectEditorWidget & callback
+    # @+node:ekr.20110605121601.18418: *4* LeoQtTree.connectEditorWidget & callback
     def connectEditorWidget(self, e: QLineEdit, item: QTreeWidgetItem) -> QHeadlineWrapper:
         """
         Connect QLineEdit e to QTreeItem item.
@@ -955,14 +955,14 @@ class LeoQtTree(leoFrame.LeoTree):
         # g.trace('can not happen: no e')
         return None
 
-    # @+node:ekr.20110605121601.18419: *4* qtree.contractItem & expandItem
+    # @+node:ekr.20110605121601.18419: *4* LeoQtTree.contractItem & expandItem
     def contractItem(self, item: QTreeWidgetItem) -> None:
         self.treeWidget.collapseItem(item)
 
     def expandItem(self, item: QTreeWidgetItem) -> None:
         self.treeWidget.expandItem(item)
 
-    # @+node:ekr.20110605121601.18420: *4* qtree.createTreeEditorForItem
+    # @+node:ekr.20110605121601.18420: *4* LeoQtTree.createTreeEditorForItem
     def createTreeEditorForItem(self, item: QTreeWidgetItem) -> None:
         c = self.c
         w = self.treeWidget
@@ -977,7 +977,7 @@ class LeoQtTree(leoFrame.LeoTree):
         self.connectEditorWidget(e, item)
         self.sizeTreeEditor(c, e)
 
-    # @+node:ekr.20110605121601.18421: *4* qtree.createTreeItem
+    # @+node:ekr.20110605121601.18421: *4* LeoQtTree.createTreeItem
     def createTreeItem(self, p: Position, parent_item: QTreeWidgetItem) -> QTreeWidgetItem:
         w = self.treeWidget
         itemOrTree = parent_item or w
@@ -993,26 +993,26 @@ class LeoQtTree(leoFrame.LeoTree):
             pass  # g.unitTesting.
         return item
 
-    # @+node:ekr.20110605121601.18423: *4* qtree.getCurrentItem
+    # @+node:ekr.20110605121601.18423: *4* LeoQtTree.getCurrentItem
     def getCurrentItem(self) -> QTreeWidgetItem:
         w = self.treeWidget
         return w.currentItem()
 
-    # @+node:ekr.20110605121601.18424: *4* qtree.getItemText
+    # @+node:ekr.20110605121601.18424: *4* LeoQtTree.getItemText
     def getItemText(self, item: QTreeWidgetItem) -> str:
         """Return the text of the item."""
         return item.text(0) if item else '<no item>'
 
-    # @+node:ekr.20110605121601.18425: *4* qtree.getParentItem
+    # @+node:ekr.20110605121601.18425: *4* LeoQtTree.getParentItem
     def getParentItem(self, item: QTreeWidgetItem) -> QTreeWidgetItem:
         return item and item.parent()
 
-    # @+node:ekr.20110605121601.18426: *4* qtree.getSelectedItems
+    # @+node:ekr.20110605121601.18426: *4* LeoQtTree.getSelectedItems
     def getSelectedItems(self) -> list:
         w = self.treeWidget
         return w.selectedItems()
 
-    # @+node:ekr.20110605121601.18427: *4* qtree.getTreeEditorForItem
+    # @+node:ekr.20110605121601.18427: *4* LeoQtTree.getTreeEditorForItem
     def getTreeEditorForItem(self, item: QTreeWidgetItem) -> QLineEdit:
         """Return the edit widget if it exists.
         Do *not* create one if it does not exist.
@@ -1021,7 +1021,7 @@ class LeoQtTree(leoFrame.LeoTree):
         e = w.itemWidget(item, 0)
         return e
 
-    # @+node:ekr.20110605121601.18428: *4* qtree.getWrapper
+    # @+node:ekr.20110605121601.18428: *4* LeoQtTree.getWrapper
     def getWrapper(self, e: QLineEdit, item: QTreeWidgetItem) -> QHeadlineWrapper:
         """Return the QHeadlineWrapper that wraps e (a QLineEdit)."""
         c = self.c
@@ -1038,7 +1038,7 @@ class LeoQtTree(leoFrame.LeoTree):
         g.trace('no e')
         return None
 
-    # @+node:ekr.20110605121601.18429: *4* qtree.nthChildItem
+    # @+node:ekr.20110605121601.18429: *4* LeoQtTree.nthChildItem
     def nthChildItem(self, n: int, parent_item: QTreeWidgetItem) -> QTreeWidgetItem:
         children = self.childItems(parent_item)
         if n < len(children):
@@ -1049,7 +1049,7 @@ class LeoQtTree(leoFrame.LeoTree):
             item = None
         return item
 
-    # @+node:ekr.20110605121601.18430: *4* qtree.scrollToItem
+    # @+node:ekr.20110605121601.18430: *4* LeoQtTree.scrollToItem
     def scrollToItem(self, item: QTreeWidgetItem) -> None:
         """
         Scroll the tree widget so that item is visible.
@@ -1062,19 +1062,19 @@ class LeoQtTree(leoFrame.LeoTree):
         w.scrollToItem(item, w.EnsureVisible)
         self.setHScroll(0)  # Necessary
 
-    # @+node:ekr.20110605121601.18431: *4* qtree.setCurrentItemHelper
+    # @+node:ekr.20110605121601.18431: *4* LeoQtTree.setCurrentItemHelper
     def setCurrentItemHelper(self, item: QTreeWidgetItem) -> None:
         w = self.treeWidget
         w.setCurrentItem(item)
 
-    # @+node:ekr.20110605121601.18432: *4* qtree.setItemText
+    # @+node:ekr.20110605121601.18432: *4* LeoQtTree.setItemText
     def setItemText(self, item: QTreeWidgetItem, s: str) -> None:
         if item:
             item.setText(0, s)
             if self.use_declutter:
                 item._real_text = s
 
-    # @+node:tbrown.20160406221505.1: *4* qtree.sizeTreeEditor
+    # @+node:tbrown.20160406221505.1: *4* LeoQtTree.sizeTreeEditor
     @staticmethod
     def sizeTreeEditor(c: Cmdr, editor: QLineEdit) -> None:
         """Size a QLineEdit in a tree headline so scrolling occurs"""
@@ -1085,8 +1085,8 @@ class LeoQtTree(leoFrame.LeoTree):
         # limit width to available space
         editor.resize(space - used, editor.size().height())
 
-    # @+node:ekr.20110605121601.18433: *3* qtree.Scroll bars
-    # @+node:ekr.20110605121601.18434: *4* qtree.getSCroll
+    # @+node:ekr.20110605121601.18433: *3* LeoQtTree:Scroll bars
+    # @+node:ekr.20110605121601.18434: *4* LeoQtTree.getSCroll
     def getScroll(self) -> tuple[int, int]:
         """Return the hPos,vPos for the tree's scrollbars."""
         w = self.treeWidget
@@ -1096,7 +1096,7 @@ class LeoQtTree(leoFrame.LeoTree):
         vPos = vScroll.sliderPosition()
         return hPos, vPos
 
-    # @+node:btheado.20111110215920.7164: *4* qtree.scrollDelegate
+    # @+node:btheado.20111110215920.7164: *4* LeoQtTree.scrollDelegate
     def scrollDelegate(self, kind: str) -> None:
         """
         Scroll a QTreeWidget up or down or right or left.
@@ -1135,7 +1135,7 @@ class LeoQtTree(leoFrame.LeoTree):
             vScroll.setValue(int(val + delta))
         c.treeWantsFocus()
 
-    # @+node:ekr.20110605121601.18435: *4* qtree.setH/VScroll
+    # @+node:ekr.20110605121601.18435: *4* LeoQtTree.setH/VScroll
     def setHScroll(self, hPos: int) -> None:
         w = self.treeWidget
         hScroll = w.horizontalScrollBar()
@@ -1146,8 +1146,8 @@ class LeoQtTree(leoFrame.LeoTree):
         vScroll = w.verticalScrollBar()
         vScroll.setValue(vPos)
 
-    # @+node:ekr.20110605121601.17905: *3* qtree.Selecting & editing
-    # @+node:ekr.20110605121601.17908: *4* qtree.edit_widget
+    # @+node:ekr.20110605121601.17905: *3* LeoQtTree:Selecting & editing
+    # @+node:ekr.20110605121601.17908: *4* LeoQtTree.edit_widget
     def edit_widget(self, p: Position) -> QHeadlineWrapper:
         """Returns the edit widget (A QLineEdit) for position p."""
         item = self.position2item(p)
@@ -1162,7 +1162,7 @@ class LeoQtTree(leoFrame.LeoTree):
             return None
         return None
 
-    # @+node:ekr.20110605121601.17909: *4* qtree.editLabel and helper
+    # @+node:ekr.20110605121601.17909: *4* LeoQtTree.editLabel and helper
     def editLabel(
         self,
         p: Position,
@@ -1190,7 +1190,7 @@ class LeoQtTree(leoFrame.LeoTree):
             c.requestedFocusWidget = e
         return e, wrapper
 
-    # @+node:ekr.20110605121601.18422: *5* qtree.editLabelHelper
+    # @+node:ekr.20110605121601.18422: *5* LeoQtTree.editLabelHelper
     def editLabelHelper(
         self,
         item: QTreeWidgetItem,
@@ -1239,7 +1239,7 @@ class LeoQtTree(leoFrame.LeoTree):
                 g.trace('not a text widget!', wrapper)
         return e, wrapper
 
-    # @+node:ekr.20110605121601.17911: *4* qtree.endEditLabel
+    # @+node:ekr.20110605121601.17911: *4* LeoQtTree.endEditLabel
     def endEditLabel(self) -> None:
         """
         Override LeoTree.endEditLabel.
@@ -1258,11 +1258,11 @@ class LeoQtTree(leoFrame.LeoTree):
         w.closeEditor(e, EndEditHint.NoHint)
         w.setCurrentItem(item)
 
-    # @+node:ekr.20110605121601.17915: *4* qtree.getSelectedPositions
+    # @+node:ekr.20110605121601.17915: *4* LeoQtTree.getSelectedPositions
     def getSelectedPositions(self) -> list[Position]:
         return [self.item2position(z) for z in self.getSelectedItems()]
 
-    # @+node:ekr.20110605121601.17914: *4* qtree.setHeadline
+    # @+node:ekr.20110605121601.17914: *4* LeoQtTree.setHeadline
     def setHeadline(self, p: Position, s: str) -> None:
         """Force the actual text of the headline widget to p.h."""
         # This is used by unit tests to force the headline and p into alignment.
@@ -1278,7 +1278,7 @@ class LeoQtTree(leoFrame.LeoTree):
             if item:
                 self.setItemText(item, s)
 
-    # @+node:ekr.20110605121601.17913: *4* qtree.setItemForCurrentPosition
+    # @+node:ekr.20110605121601.17913: *4* LeoQtTree.setItemForCurrentPosition
     def setItemForCurrentPosition(self) -> QTreeWidgetItem:
         """Select the item for c.p"""
         p = self.c.p
@@ -1302,7 +1302,7 @@ class LeoQtTree(leoFrame.LeoTree):
             self.busy = False
         return item
 
-    # @+node:ekr.20190613080606.1: *4* qtree.unselectItem
+    # @+node:ekr.20190613080606.1: *4* LeoQtTree.unselectItem
     def unselectItem(self, p: Position) -> None:
         item = self.position2item(p)
         if item:

--- a/leo/unittests/core/test_leoserver.py
+++ b/leo/unittests/core/test_leoserver.py
@@ -6,11 +6,13 @@ import json
 import os
 import leo.core.leoserver as leoserver
 from leo.core.leoTest2 import LeoUnitTest
+from leo.core import leoGlobals as global_g
 
 # Globals.
 g = None
 g_leoserver = None
 g_server = None
+global_g_es = global_g.es
 
 
 # @+others
@@ -48,6 +50,7 @@ class TestLeoServer(LeoUnitTest):
         g.unitTesting = True
 
     def tearDown(self):
+        global_g.es = global_g_es
         g.unitTesting = False
 
     # @+node:felix.20210621233316.100: *3* TestLeoServer._request

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -249,7 +249,6 @@ class TestQtGui(LeoUnitTest):
             w.setFocus()
             w.clear()
             w.setText('before')
-            # Create ctrl c keyboard event.
             g.app.gui.replaceClipboardWith(class_name)
             qtApp.processEvents()
             w.setReadOnly(False)

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -110,155 +110,6 @@ class TestQtGui(LeoUnitTest):
         except Exception:
             self.skipTest('Requires Qt')
 
-    # @+node:ekr.20210913120449.1: *3* TestQtGui.test_bug_2164
-    def test_bug_2164(self):
-        # show-invisibles crashes with PyQt6.
-        from leo.core.leoQt import QtGui
-
-        # Test the commands.
-        c = self.c
-        for command in ('toggle-invisibles', 'hide-invisibles', 'show-invisibles'):
-            c.doCommandByName(command)
-
-        # Test the Qt6 flag.
-        option = QtGui.QTextOption()
-        assert hasattr(option.Flag, 'ShowTabsAndSpaces')
-
-    # @+node:ekr.20210912140946.1: *3* TestQtGui.test_do_nothing1/2/3
-    # These tests exist to test the startup logic.
-    if 0:  # pragma: no cover
-
-        def test_do_nothing1(self):
-            time.sleep(0.1)
-
-        def test_do_nothing2(self):
-            time.sleep(0.1)
-
-        def test_do_nothing3(self):
-            time.sleep(0.1)
-
-    # @+node:ekr.20210912064439.2: *3* TestQtGui.test_qt_ctors_for_all_dialogs
-    def test_qt_ctors_for_all_dialogs(self):
-        # Make sure the dialogs don't crash.
-        c = self.c
-        gui = g.app.gui
-        self.assertEqual(gui.__class__.__name__, 'LeoQtGui')
-        gui.runAboutLeoDialog(c, 'version', 'copyright', 'url', 'email')
-        gui.runAskOkDialog(c, 'title', 'message')
-        gui.runAskOkCancelNumberDialog(c, 'title', 'message')
-        gui.runAskOkCancelStringDialog(c, 'title', 'message')
-        gui.runAskYesNoDialog(c, 'title', 'message')
-        gui.runAskYesNoCancelDialog(c, 'title', 'message')
-
-    # @+node:ekr.20210912133358.1: *3* TestQtGui.test_qt_enums
-    def test_qt_enums(self):
-        # https://github.com/leo-editor/leo-editor/issues/1973 list of enums
-
-        if not QtCore and QtCore.Qt:
-            self.skipTest('Requires Qt')  # pragma: no cover
-        table = (
-            'DropAction',
-            'ItemFlag',
-            'KeyboardModifier',
-            'MouseButton',
-            'Orientation',
-            'TextInteractionFlag',
-            'ToolBarArea',
-            'WindowType',
-            'WindowState',
-        )
-        for ivar in table:
-            assert hasattr(QtCore.Qt, ivar), repr(ivar)
-
-    # @+node:ekr.20220411165627.1: *3* TestQtGui.test_put_html_links
-    def test_put_html_links(self):
-        c, p = self.c, self.c.p
-        # Create a test outline.
-        assert p == self.root_p
-        assert p.h == 'root'
-        p2 = p.insertAsLastChild()
-        p2.h = '@file test_file.py'
-        # Run the tests.
-        table = (
-            # python.
-            (
-                True,
-                'File "test_file.py", line 5',
-            ),
-            # pylint.
-            (
-                True,
-                r'leo\unittest\test_file.py:1326:8: W0101: Unreachable code (unreachable)',
-            ),
-            # pyflakes.
-            (
-                True,
-                r"test_file.py:51:13 'leo.core.leoQt5.*' imported but unused",
-            ),
-            # mypy...
-            (
-                True,
-                'test_file.py:116: error: Function is missing a return type annotation  [no-untyped-def]',
-            ),
-            (
-                True,
-                r'leo\core\test_file.py:116: note: Use "-> None" if function does not return a value',
-            ),
-            (
-                False,
-                'Found 1 error in 1 file (checked 1 source file)',
-            ),
-            (
-                False,
-                'mypy: done',
-            ),
-            # Random output.
-            (
-                False,
-                'Hello world\n',
-            ),
-        )
-        for expected, s in table:
-            s = s.replace('\\', os.sep).rstrip() + '\n'
-            result = c.frame.log.put_html_links(s)
-            self.assertEqual(result, expected, msg=repr(s))
-
-    # @+node:ekr.20220912093438.1: *3* TestQtGui.test_qt_attributes
-    def test_qt_attributes(self):
-        # Various preliminary tests.
-        c = self.c
-        if 0:
-            print('')
-            for z in dir(g.app.gui):
-                if not z.startswith('__'):
-                    obj = getattr(g.app.gui, z, None)
-                    print(f"{z:>30} {g.objToString(obj)}")
-        if 0:
-            print('')
-            g.trace(g.app.gui)
-            g.trace(c.frame.body)
-        if 0:
-            g.trace(c.frame.body.wrapper)
-            for method in ('delete', 'insert', 'toPythonIndexRowCol'):
-                f = getattr(c.frame.body.wrapper, method, None)
-                print(repr(f))
-
-    # @+node:ekr.20220912140743.1: *3* TestQtGui.test_QTextEditWrapper_delete
-    def test_QTextEditWrapper_delete(self):
-        c = self.c
-        wrapper = c.frame.body.wrapper
-        widget = wrapper.widget
-        self.assertTrue(isinstance(wrapper, QTextEditWrapper))
-        self.assertTrue(isinstance(widget, LeoQTextBrowser))
-        widget.setText('line1\nline2')
-        # g.trace(wrapper.getAllText())
-        wrapper.delete(0, 6)
-        # g.trace(wrapper.getAllText())
-        widget.setText('line1\nline2')
-        # g.trace(wrapper.getAllText())
-        wrapper.delete(6, 0)
-        # g.trace(wrapper.getAllText())
-
     # @+node:ekr.20260404143610.1: *3* TestQtGui.test_annotations
     def test_annotations(self):
         # This test establishes the basis of Leo's Qt-related annotations.
@@ -338,6 +189,180 @@ class TestQtGui(LeoUnitTest):
             QTextMixin,  # Every class is a subclass of itself.
         ):
             assert issubclass(class_, QTextMixin), repr(class_)
+
+    # @+node:ekr.20210913120449.1: *3* TestQtGui.test_bug_2164
+    def test_bug_2164(self):
+        # show-invisibles crashes with PyQt6.
+        from leo.core.leoQt import QtGui
+
+        # Test the commands.
+        c = self.c
+        for command in ('toggle-invisibles', 'hide-invisibles', 'show-invisibles'):
+            c.doCommandByName(command)
+
+        # Test the Qt6 flag.
+        option = QtGui.QTextOption()
+        assert hasattr(option.Flag, 'ShowTabsAndSpaces')
+
+    # @+node:ekr.20260423040149.1: *3* TestQtGui.test_copy_in_completions_tab
+    def test_copy_in_completions_tab(self):
+        # A minimal test.
+        import textwrap
+        from leo.core.leoGui import LeoKeyEvent
+
+        c = self.c
+        k = c.k
+        log = c.frame.log
+        event = LeoKeyEvent(c, 'a', event=None, binding=None, w=None)
+        k.fullCommand(event=event)
+        k.extendLabel('a')
+        # Force g.es to print to the log.
+        try:
+            g.unitTesting = False
+            g.app.logInited = True
+            g.app.log = log
+            k.doTabCompletion(['a', 'ab', 'abc'])
+        finally:
+            g.unitTesting = True
+        s = log.logCtrl.getAllText()
+        s = textwrap.dedent(s)
+        k.keyboardQuit()
+        assert s == 'a\nab\nabc\n', repr(s)
+
+    # @+node:ekr.20210912140946.1: *3* TestQtGui.test_do_nothing1/2/3
+    # These tests exist to test the startup logic.
+    if 0:  # pragma: no cover
+
+        def test_do_nothing1(self):
+            time.sleep(0.1)
+
+        def test_do_nothing2(self):
+            time.sleep(0.1)
+
+        def test_do_nothing3(self):
+            time.sleep(0.1)
+
+    # @+node:ekr.20220411165627.1: *3* TestQtGui.test_put_html_links
+    def test_put_html_links(self):
+        c, p = self.c, self.c.p
+        # Create a test outline.
+        assert p == self.root_p
+        assert p.h == 'root'
+        p2 = p.insertAsLastChild()
+        p2.h = '@file test_file.py'
+        # Run the tests.
+        table = (
+            # python.
+            (
+                True,
+                'File "test_file.py", line 5',
+            ),
+            # pylint.
+            (
+                True,
+                r'leo\unittest\test_file.py:1326:8: W0101: Unreachable code (unreachable)',
+            ),
+            # pyflakes.
+            (
+                True,
+                r"test_file.py:51:13 'leo.core.leoQt5.*' imported but unused",
+            ),
+            # mypy...
+            (
+                True,
+                'test_file.py:116: error: Function is missing a return type annotation  [no-untyped-def]',
+            ),
+            (
+                True,
+                r'leo\core\test_file.py:116: note: Use "-> None" if function does not return a value',
+            ),
+            (
+                False,
+                'Found 1 error in 1 file (checked 1 source file)',
+            ),
+            (
+                False,
+                'mypy: done',
+            ),
+            # Random output.
+            (
+                False,
+                'Hello world\n',
+            ),
+        )
+        for expected, s in table:
+            s = s.replace('\\', os.sep).rstrip() + '\n'
+            result = c.frame.log.put_html_links(s)
+            self.assertEqual(result, expected, msg=repr(s))
+
+    # @+node:ekr.20220912093438.1: *3* TestQtGui.test_qt_attributes
+    def test_qt_attributes(self):
+        # Various preliminary tests.
+        c = self.c
+        if 0:
+            print('')
+            for z in dir(g.app.gui):
+                if not z.startswith('__'):
+                    obj = getattr(g.app.gui, z, None)
+                    print(f"{z:>30} {g.objToString(obj)}")
+        if 0:
+            print('')
+            g.trace(g.app.gui)
+            g.trace(c.frame.body)
+        if 0:
+            g.trace(c.frame.body.wrapper)
+            for method in ('delete', 'insert', 'toPythonIndexRowCol'):
+                f = getattr(c.frame.body.wrapper, method, None)
+                print(repr(f))
+
+    # @+node:ekr.20210912064439.2: *3* TestQtGui.test_qt_ctors_for_all_dialogs
+    def test_qt_ctors_for_all_dialogs(self):
+        # Make sure the dialogs don't crash.
+        c = self.c
+        gui = g.app.gui
+        self.assertEqual(gui.__class__.__name__, 'LeoQtGui')
+        gui.runAboutLeoDialog(c, 'version', 'copyright', 'url', 'email')
+        gui.runAskOkDialog(c, 'title', 'message')
+        gui.runAskOkCancelNumberDialog(c, 'title', 'message')
+        gui.runAskOkCancelStringDialog(c, 'title', 'message')
+        gui.runAskYesNoDialog(c, 'title', 'message')
+        gui.runAskYesNoCancelDialog(c, 'title', 'message')
+
+    # @+node:ekr.20210912133358.1: *3* TestQtGui.test_qt_enums
+    def test_qt_enums(self):
+        # https://github.com/leo-editor/leo-editor/issues/1973 list of enums
+
+        if not QtCore and QtCore.Qt:
+            self.skipTest('Requires Qt')  # pragma: no cover
+        table = (
+            'DropAction',
+            'ItemFlag',
+            'KeyboardModifier',
+            'MouseButton',
+            'Orientation',
+            'TextInteractionFlag',
+            'ToolBarArea',
+            'WindowType',
+            'WindowState',
+        )
+        for ivar in table:
+            assert hasattr(QtCore.Qt, ivar), repr(ivar)
+
+    # @+node:ekr.20220912140743.1: *3* TestQtGui.test_QTextEditWrapper_delete
+    def test_QTextEditWrapper_delete(self):
+        c = self.c
+        wrapper = c.frame.body.wrapper
+        widget = wrapper.widget
+        self.assertTrue(isinstance(wrapper, QTextEditWrapper))
+        self.assertTrue(isinstance(widget, LeoQTextBrowser))
+        widget.setText('line1\nline2')
+        # g.trace(wrapper.getAllText())
+        wrapper.delete(0, 6)
+        # g.trace(wrapper.getAllText())
+        widget.setText('line1\nline2')
+        # g.trace(wrapper.getAllText())
+        wrapper.delete(6, 0)
+        # g.trace(wrapper.getAllText())
 
     # @-others
 

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -243,32 +243,45 @@ class TestQtGui(LeoUnitTest):
             ('c.frame.miniBufferWidget.widget', c.frame.miniBufferWidget.widget),
         )
 
-        # Construct a Ctrl+C event.
-        key_event = QtGui.QKeyEvent(
-            QtCore.QEvent.Type.KeyPress,
-            QtCore.Qt.Key.Key_C,
-            QtCore.Qt.KeyboardModifier.ControlModifier,
-            '',
-        )
+        # Construct two events
+        c_key = QtCore.Qt.Key.Key_C
+        ctrl_mod = QtCore.Qt.KeyboardModifier.ControlModifier
+        key_press_t = QtCore.QEvent.Type.KeyPress
+        key_release_t = QtCore.QEvent.Type.KeyRelease
+        key_press_event = QtGui.QKeyEvent(key_press_t, c_key, ctrl_mod, '')
+        key_release_event = QtGui.QKeyEvent(key_release_t, c_key, ctrl_mod, '')
 
         text_widgets = (QtWidgets.QTextEdit, QtWidgets.QLineEdit)
-        for kind, w in table:
-            class_name = w.__class__.__name__
-            assert issubclass(w.__class__, text_widgets), w.__class__
-            qtApp.processEvents()
-            w.setFocus()
-            w.clear()
-            w.setText('before')
-            g.app.gui.replaceClipboardWith(class_name)
-            qtApp.processEvents()
-            w.setReadOnly(False)
-            # print('clipboard', g.app.gui.getTextFromClipboard())
-            w.selectAll()
-            # This is a cheat. We want to test that Ctrl-c actually does the paste!
-            w.paste()
-            qtApp.processEvents()
-            s = w.toPlainText() if issubclass(w.__class__, QtWidgets.QTextEdit) else w.text()
-            assert s == class_name, f"Expected: {class_name}, got: {s}"
+        g.app.debug = ['events']
+        try:
+            for kind, w in table:
+                print(kind)
+                class_name = w.__class__.__name__
+                assert issubclass(w.__class__, text_widgets), w.__class__
+                w.setFocus()
+                qtApp.processEvents()
+                ### w.clear()
+                ### w.setText('before')
+                ### g.app.gui.replaceClipboardWith(class_name)
+                ### w.setText(class_name)
+                ### qtApp.processEvents()
+                expected = (
+                    w.toPlainText() if issubclass(w.__class__, QtWidgets.QTextEdit) else w.text()
+                )
+                w.setReadOnly(False)
+                # print('clipboard', g.app.gui.getTextFromClipboard())
+                w.selectAll()
+                # This is a cheat. We want to test that Ctrl-c actually does the copy!
+                # w.paste()
+                # qtApp.processEvents()
+
+                # was_handled = QtCore.QCoreApplication.sendEvent(w, key_event)
+                qtApp.sendEvent(w, key_press_event)
+                qtApp.sendEvent(w, key_release_event)
+                s = g.app.gui.getTextFromClipboard()
+                assert s == expected, f"Expected: {expected}, got: {s}"
+        finally:
+            g.app.debug = []
 
     # @+node:ekr.20210912140946.1: *3* TestQtGui.test_do_nothing1/2/3
     # These tests exist to test the startup logic.

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -11,7 +11,12 @@ from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest, create_app
 
 try:
-    from leo.core.leoQt import Qt, QtCore
+    from leo.core.leoQt import (
+        Qt,
+        QtCore,
+        QtGui,
+        QtWidgets,
+    )
     from leo.core.leoAPI import (
         IconBarAPI,
         StatusLineAPI,
@@ -23,19 +28,36 @@ try:
         NullIconBarClass,
         NullStatusLineClass,
         NullTree,
+        # QTabWidget,
     )
     from leo.core.leoGui import LeoKeyEvent
-    from leo.plugins.qt_frame import QtIconBarClass, QtStatusLineClass
+    from leo.plugins.qt_frame import (
+        DynamicWindow,
+        LeoQtBody,
+        LeoQtFrame,
+        LeoQtLog,
+        LeoQtMenu,
+        LeoQtTree,
+        LeoQTreeWidget,
+        QtIconBarClass,
+        QtStatusLineClass,
+    )
     from leo.plugins.qt_text import (
         LeoQTextBrowser,
+        QHeadlineWrapper,
         QLineEditWrapper,
+        QMinibufferWrapper,
         QScintillaWrapper,
         QTextEditWrapper,
         QTextMixin,
     )
-    from leo.plugins.qt_tree import LeoQtTree
+
+    QTabWidget = QtWidgets.QTabWidget
 except Exception:
+    g.es_exception()  ###
     Qt = QtCore = None
+    QTabWidget = None
+
 # @-<< test_gui imports >>
 
 
@@ -113,43 +135,12 @@ class TestQtGui(LeoUnitTest):
     def setUp(self):
         super().setUp()
         # Don't run *any* tests if Qt has not been installed.
-        try:
-            from leo.core.leoQt import Qt
-
-            assert Qt
-        except Exception:
-            self.skipTest('Requires Qt')
+        if not Qt:
+            self.skipTest('import Qt failed')
 
     # @+node:ekr.20260404143610.1: *3* TestQtGui.test_annotations
     def test_annotations(self):
         # This test establishes the basis of Leo's Qt-related annotations.
-        # @+<< TestQtGui.test_annotations: imports >>
-        # @+node:ekr.20260406021200.1: *4* << TestQtGui.test_annotations: imports >>
-        from leo.core.leoQt import QtWidgets
-        from leo.plugins.qt_frame import (
-            DynamicWindow,
-            LeoQtBody,
-            LeoQtFrame,
-            LeoQtLog,
-            LeoQtMenu,
-            LeoQtTree,
-            LeoQTreeWidget,
-            QtIconBarClass,
-            QtStatusLineClass,
-            # QTabWidget,
-        )
-        from leo.plugins.qt_text import (
-            LeoQTextBrowser,
-            QHeadlineWrapper,
-            QLineEditWrapper,
-            QMinibufferWrapper,
-            QScintillaWrapper,
-            QTextEditWrapper,
-            QTextMixin,
-        )
-
-        QTabWidget = QtWidgets.QTabWidget
-        # @-<< TestQtGui.test_annotations: imports >>
         c = self.c
         table = (
             # LeoQtFrame ivars...
@@ -203,9 +194,6 @@ class TestQtGui(LeoUnitTest):
     # @+node:ekr.20210913120449.1: *3* TestQtGui.test_bug_2164
     def test_bug_2164(self):
         # show-invisibles crashes with PyQt6.
-        from leo.core.leoQt import QtGui
-
-        # Test the commands.
         c = self.c
         for command in ('toggle-invisibles', 'hide-invisibles', 'show-invisibles'):
             c.doCommandByName(command)

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -209,9 +209,6 @@ class TestQtGui(LeoUnitTest):
         k = c.k
         log = c.frame.log
         qtApp = g.app.gui.qtApp
-        g.app.debug = ['events']
-
-        # from PyQt6.QtTest import QTest
 
         # Part 1: Create the 'Completion' tab, and copy it's contets to the clipboard.
         event = LeoKeyEvent(c, 'a', event=None, binding=None, w=None)
@@ -240,30 +237,29 @@ class TestQtGui(LeoUnitTest):
         # Part 3: Test Ctrl-C in all text widgets.
         table = (
             ('c.frame.body.widget', c.frame.body.widget),
-            # ('c.frame.log.logCtrl.widget', c.frame.log.logCtrl.widget),
-            ### ('c.frame.log.logWidget', c.frame.log.logWidget),
-            # ('c.frame.miniBufferWidget.widget', c.frame.miniBufferWidget.widget),
+            ('c.frame.log.logCtrl.widget', c.frame.log.logCtrl.widget),
+            ('c.frame.log.logWidget', c.frame.log.logWidget),
+            ('c.frame.miniBufferWidget.widget', c.frame.miniBufferWidget.widget),
         )
         text_widgets = (QtWidgets.QTextEdit, QtWidgets.QLineEdit)
         for kind, w in table:
             class_name = w.__class__.__name__
-            # print(kind, class_name)
             assert issubclass(w.__class__, text_widgets), w.__class__
             qtApp.processEvents()
             w.setFocus()
             w.clear()
             w.setText('before')
-            w.selectAll()
             # Create ctrl c keyboard event.
             g.app.gui.replaceClipboardWith(class_name)
-            # QTest.keyClick(w, Qt.Key.Key_Paste)
             qtApp.processEvents()
+            w.setReadOnly(False)
+            # print('clipboard', g.app.gui.getTextFromClipboard())
+            w.selectAll()
+            # This is a cheat. We want to test that Ctrl-c actually does the paste!
             w.paste()
             qtApp.processEvents()
-            s = w.toPlainText()
+            s = w.toPlainText() if issubclass(w.__class__, QtWidgets.QTextEdit) else w.text()
             assert s == class_name, f"Expected: {class_name}, got: {s}"
-        # Cleanup.
-        g.app.debug = []
 
     # @+node:ekr.20210912140946.1: *3* TestQtGui.test_do_nothing1/2/3
     # These tests exist to test the startup logic.

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -72,7 +72,7 @@ class TestNullGui(LeoUnitTest):
             (c.frame.body, NullBody),
             (c.frame.iconBar, NullIconBarClass),
             (c.frame.log, NullLog),
-            (c.frame.miniBufferWidget, NullObject),
+            (c.frame.miniBufferWidget, None.__class__),  ###
             (c.frame.statusLine, NullStatusLineClass),
             (c.frame.tree, NullTree),
             # NullBody ivars...
@@ -84,8 +84,8 @@ class TestNullGui(LeoUnitTest):
         for obj, class_ in table:
             assert isinstance(obj, class_), (repr(obj), repr(class_))
 
-        for obj in (c.frame.body, c.frame.log, c.frame.statusLine):
-            assert getattr(obj, 'wrapper', None), repr(obj)
+        # for obj in (c.frame.body, c.frame.log, c.frame.statusLine):
+        #     assert getattr(obj, 'wrapper', None), repr(obj)
 
     # @-others
 
@@ -306,9 +306,9 @@ class TestQtGui(LeoUnitTest):
             (c.frame.body.wrapper, QTextEditWrapper),
             (c.frame.body.widget, LeoQTextBrowser),
             # LeoQtLog ivars...
-            (c.frame.log.qtLogCtrl, QTextEditWrapper),
+            (c.frame.log.logCtrl, QTextEditWrapper),
             (c.frame.log.logWidget, LeoQTextBrowser),
-            (c.frame.log.qtTabWidget, QTabWidget),
+            (c.frame.log.tabWidget, QTabWidget),
             # LeoQtTree ivars...
             (c.frame.tree.treeWidget, LeoQTreeWidget),
         )
@@ -318,13 +318,13 @@ class TestQtGui(LeoUnitTest):
                 # Every subclass of QTextMix is an instance of QTextMixin.
                 assert isinstance(obj, QTextMixin)
 
-        for obj in (
-            c.frame.body,
-            c.frame.statusLine.textWidget1,
-            c.frame.statusLine.textWidget2,
-            c.frame.log,
-        ):
-            assert getattr(obj, 'wrapper', None) or getattr(obj, 'leo_wrapper', None), repr(obj)
+        # for obj in (
+        #     c.frame.body,
+        #     c.frame.statusLine.textWidget1,
+        #     c.frame.statusLine.textWidget2,
+        #     c.frame.log,
+        # ):
+        #     assert getattr(obj, 'wrapper', None) or getattr(obj, 'leo_wrapper', None), repr(obj)
 
         # Test the class hierarchy of text-related classes.
         assert issubclass(LeoQTextBrowser, QtWidgets.QTextBrowser)
@@ -402,7 +402,8 @@ class TestAPIClasses(LeoUnitTest):
         if Qt:
             classes.extend([QLineEditWrapper, QTextEditWrapper, QScintillaWrapper])
         for cls in classes:
-            self.assertFalse(get_missing(cls), msg=f"Missing {cls.__class__.__name__} methods")
+            missing = get_missing(cls)
+            self.assertFalse(missing, msg=f"Missing {cls} methods: {missing}")
 
     # @-others
 

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -63,7 +63,6 @@ class TestNullGui(LeoUnitTest):
             StringTextWrapper,
         )
 
-
         # @-<< TestNullGui.test_annotations: imports >>
         c = self.c
         table = (

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -235,12 +235,22 @@ class TestQtGui(LeoUnitTest):
         assert s2 == s, (repr(s), repr(s2))
 
         # Part 3: Test Ctrl-C in all text widgets.
+        # c.k.manufactureKeyPressForCommandName(c.frame.body, 'copy-text') returns 'Ctrl+c'.
         table = (
             ('c.frame.body.widget', c.frame.body.widget),
             ('c.frame.log.logCtrl.widget', c.frame.log.logCtrl.widget),
             ('c.frame.log.logWidget', c.frame.log.logWidget),
             ('c.frame.miniBufferWidget.widget', c.frame.miniBufferWidget.widget),
         )
+
+        # Construct a Ctrl+C event.
+        key_event = QtGui.QKeyEvent(
+            QtCore.QEvent.Type.KeyPress,
+            QtCore.Qt.Key.Key_C,
+            QtCore.Qt.KeyboardModifier.ControlModifier,
+            '',
+        )
+
         text_widgets = (QtWidgets.QTextEdit, QtWidgets.QLineEdit)
         for kind, w in table:
             class_name = w.__class__.__name__

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -63,6 +63,7 @@ class TestNullGui(LeoUnitTest):
             StringTextWrapper,
         )
 
+
         # @-<< TestNullGui.test_annotations: imports >>
         c = self.c
         table = (

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -251,35 +251,34 @@ class TestQtGui(LeoUnitTest):
         key_press_event = QtGui.QKeyEvent(key_press_t, c_key, ctrl_mod, '')
         key_release_event = QtGui.QKeyEvent(key_release_t, c_key, ctrl_mod, '')
 
+        # The main loop.
         text_widgets = (QtWidgets.QTextEdit, QtWidgets.QLineEdit)
-        g.app.debug = ['events']
+        # g.app.debug = ['events']
         try:
             for kind, w in table:
-                print(kind)
+                is_QTextEdit = issubclass(w.__class__, QtWidgets.QTextEdit)
                 class_name = w.__class__.__name__
                 assert issubclass(w.__class__, text_widgets), w.__class__
+                # Put the class name in the widget.
                 w.setFocus()
                 qtApp.processEvents()
-                ### w.clear()
-                ### w.setText('before')
-                ### g.app.gui.replaceClipboardWith(class_name)
-                ### w.setText(class_name)
-                ### qtApp.processEvents()
-                expected = (
-                    w.toPlainText() if issubclass(w.__class__, QtWidgets.QTextEdit) else w.text()
-                )
                 w.setReadOnly(False)
-                # print('clipboard', g.app.gui.getTextFromClipboard())
+                w.clear()
+                expected = f"{id(w)}: {class_name}"
+                w.setText(expected)
                 w.selectAll()
-                # This is a cheat. We want to test that Ctrl-c actually does the copy!
-                # w.paste()
-                # qtApp.processEvents()
-
-                # was_handled = QtCore.QCoreApplication.sendEvent(w, key_event)
-                qtApp.sendEvent(w, key_press_event)
-                qtApp.sendEvent(w, key_release_event)
+                qtApp.processEvents()
+                if 1:  # works.
+                    # print('Contents:', w.toPlainText() if is_QTextEdit else w.text())
+                    g.app.gui.replaceClipboardWith(expected)
+                else:  # Fails
+                    # Execute Ctrl-c.
+                    qtApp.sendEvent(w, key_press_event)
+                    qtApp.sendEvent(w, key_release_event)
+                    qtApp.processEvents()
                 s = g.app.gui.getTextFromClipboard()
-                assert s == expected, f"Expected: {expected}, got: {s}"
+                # Not ready yet.
+                assert s == expected, f"{kind}\nExpected: {expected!r}\n     Got: {s!r}"
         finally:
             g.app.debug = []
 

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -208,8 +208,12 @@ class TestQtGui(LeoUnitTest):
         c = self.c
         k = c.k
         log = c.frame.log
+        qtApp = g.app.gui.qtApp
+        g.app.debug = ['events']
 
-        # Part 1: Create the 'Completion' tab, and copy it to the clipboard.
+        # from PyQt6.QtTest import QTest
+
+        # Part 1: Create the 'Completion' tab, and copy it's contets to the clipboard.
         event = LeoKeyEvent(c, 'a', event=None, binding=None, w=None)
         k.fullCommand(event=event)
         k.extendLabel('a')
@@ -230,21 +234,36 @@ class TestQtGui(LeoUnitTest):
         event2 = LeoKeyEvent(c, char=None, binding=None, event=None, w=wrapper)
         c.frame.copyText(event2)
         s2 = g.app.gui.getTextFromClipboard()
+        k.keyboardQuit()
+        assert s2 == s, (repr(s), repr(s2))
 
         # Part 3: Test Ctrl-C in all text widgets.
         table = (
             ('c.frame.body.widget', c.frame.body.widget),
-            ('c.frame.log.logCtrl.widget', c.frame.log.logCtrl.widget),
-            ('c.frame.log.logWidget', c.frame.log.logWidget),
-            ('c.frame.miniBufferWidget.widget', c.frame.miniBufferWidget.widget),
+            # ('c.frame.log.logCtrl.widget', c.frame.log.logCtrl.widget),
+            ### ('c.frame.log.logWidget', c.frame.log.logWidget),
+            # ('c.frame.miniBufferWidget.widget', c.frame.miniBufferWidget.widget),
         )
         text_widgets = (QtWidgets.QTextEdit, QtWidgets.QLineEdit)
-        for kind, obj in table:
-            # print(f"{kind:>25} {obj.__class__.__name__}")
-            assert issubclass(obj.__class__, text_widgets), obj.__class__
-
-        k.keyboardQuit()
-        assert s2 == s, (repr(s), repr(s2))
+        for kind, w in table:
+            class_name = w.__class__.__name__
+            # print(kind, class_name)
+            assert issubclass(w.__class__, text_widgets), w.__class__
+            qtApp.processEvents()
+            w.setFocus()
+            w.clear()
+            w.setText('before')
+            w.selectAll()
+            # Create ctrl c keyboard event.
+            g.app.gui.replaceClipboardWith(class_name)
+            # QTest.keyClick(w, Qt.Key.Key_Paste)
+            qtApp.processEvents()
+            w.paste()
+            qtApp.processEvents()
+            s = w.toPlainText()
+            assert s == class_name, f"Expected: {class_name}, got: {s}"
+        # Cleanup.
+        g.app.debug = []
 
     # @+node:ekr.20210912140946.1: *3* TestQtGui.test_do_nothing1/2/3
     # These tests exist to test the startup logic.

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -230,6 +230,19 @@ class TestQtGui(LeoUnitTest):
         event2 = LeoKeyEvent(c, char=None, binding=None, event=None, w=wrapper)
         c.frame.copyText(event2)
         s2 = g.app.gui.getTextFromClipboard()
+
+        # Part 3: Test Ctrl-C in all text widgets.
+        table = (
+            ('c.frame.body.widget', c.frame.body.widget),
+            ('c.frame.log.logCtrl.widget', c.frame.log.logCtrl.widget),
+            ('c.frame.log.logWidget', c.frame.log.logWidget),
+            ('c.frame.miniBufferWidget.widget', c.frame.miniBufferWidget.widget),
+        )
+        text_widgets = (QtWidgets.QTextEdit, QtWidgets.QLineEdit)
+        for kind, obj in table:
+            # print(f"{kind:>25} {obj.__class__.__name__}")
+            assert issubclass(obj.__class__, text_widgets), obj.__class__
+
         k.keyboardQuit()
         assert s2 == s, (repr(s), repr(s2))
 

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -256,7 +256,7 @@ class TestQtGui(LeoUnitTest):
         # g.app.debug = ['events']
         try:
             for kind, w in table:
-                is_QTextEdit = issubclass(w.__class__, QtWidgets.QTextEdit)
+                # is_QTextEdit = issubclass(w.__class__, QtWidgets.QTextEdit)
                 class_name = w.__class__.__name__
                 assert issubclass(w.__class__, text_widgets), w.__class__
                 # Put the class name in the widget.

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -62,7 +62,6 @@ class TestNullGui(LeoUnitTest):
             NullTree,
             StringTextWrapper,
         )
-        from leo.core.leoGlobals import NullObject
 
         # @-<< TestNullGui.test_annotations: imports >>
         c = self.c

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -5,24 +5,34 @@
 # @+<< test_gui imports >>
 # @+node:ekr.20220911102700.1: ** << test_gui imports >>
 import os
+import textwrap
 import time
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest, create_app
 
 try:
     from leo.core.leoQt import Qt, QtCore
-    from leo.core.leoAPI import IconBarAPI, StatusLineAPI, TreeAPI
-    from leo.core.leoAPI import StringTextWrapper
-    from leo.core.leoFrame import LeoTree
-    from leo.core.leoFrame import NullIconBarClass, NullStatusLineClass, NullTree
+    from leo.core.leoAPI import (
+        IconBarAPI,
+        StatusLineAPI,
+        StringTextWrapper,
+        TreeAPI,
+    )
+    from leo.core.leoFrame import (
+        LeoTree,
+        NullIconBarClass,
+        NullStatusLineClass,
+        NullTree,
+    )
+    from leo.core.leoGui import LeoKeyEvent
     from leo.plugins.qt_frame import QtIconBarClass, QtStatusLineClass
     from leo.plugins.qt_text import (
+        LeoQTextBrowser,
         QLineEditWrapper,
         QScintillaWrapper,
         QTextEditWrapper,
         QTextMixin,
     )
-    from leo.plugins.qt_text import LeoQTextBrowser
     from leo.plugins.qt_tree import LeoQtTree
 except Exception:
     Qt = QtCore = None
@@ -204,30 +214,36 @@ class TestQtGui(LeoUnitTest):
         option = QtGui.QTextOption()
         assert hasattr(option.Flag, 'ShowTabsAndSpaces')
 
-    # @+node:ekr.20260423040149.1: *3* TestQtGui.test_copy_in_completions_tab
-    def test_copy_in_completions_tab(self):
-        # A minimal test.
-        import textwrap
-        from leo.core.leoGui import LeoKeyEvent
-
+    # @+node:ekr.20260423040149.1: *3* TestQtGui.test_bug_4626
+    def test_bug_4626(self):
+        # https://github.com/leo-editor/leo-editor/issues/4626
         c = self.c
         k = c.k
         log = c.frame.log
+
+        # Part 1: Create the 'Completion' tab, and copy it to the clipboard.
         event = LeoKeyEvent(c, 'a', event=None, binding=None, w=None)
         k.fullCommand(event=event)
         k.extendLabel('a')
         # Force g.es to print to the log.
+        old_log = g.app.log
         try:
-            g.unitTesting = False
-            g.app.logInited = True
             g.app.log = log
             k.doTabCompletion(['a', 'ab', 'abc'])
         finally:
-            g.unitTesting = True
-        s = log.logCtrl.getAllText()
-        s = textwrap.dedent(s)
+            g.app.log = old_log
+        wrapper = log.logCtrl
+        s = wrapper.getAllText()
+        dedent_s = textwrap.dedent(s)
+        assert dedent_s == 'a\nab\nabc\n', repr(s)
+        wrapper.selectAllText()
+
+        # Part 2: Test copyText.
+        event2 = LeoKeyEvent(c, char=None, binding=None, event=None, w=wrapper)
+        c.frame.copyText(event2)
+        s2 = g.app.gui.getTextFromClipboard()
         k.keyboardQuit()
-        assert s == 'a\nab\nabc\n', repr(s)
+        assert s2 == s, (repr(s), repr(s2))
 
     # @+node:ekr.20210912140946.1: *3* TestQtGui.test_do_nothing1/2/3
     # These tests exist to test the startup logic.

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -3817,9 +3817,6 @@ class TestPython(BaseTestImporter):
     def test_long_declaration(self):
 
         # ekr-mypy2/mypy/applytype.py
-
-        # Note: the return type uses the python 3.11 syntax for Union.
-
         s = """
         def get_target_type(
             tvar: TypeVarLikeType,


### PR DESCRIPTION
See #4626.  #4634 suggests further improvements.

PR #4624 (merged into devel) added a worthy bug. Last good commit: 780cb2f. First bad commit: cf2d872.

**Phase 1: take 6 entire files from the last good commit**

- [x] (Rev 743f6e0): Take  6 *entire* files from the `ekr-last-good-commit` branch:
    ```console
    gco ekr-last-good-commit -- leo/core/leoAPI.py
    gco ekr-last-good-commit -- leo/core/leoFrame.py
    gco ekr-last-good-commit -- leo/core/leoGui.py
    gco ekr-last-good-commit -- leo/plugins/qt_frame.py
    gco ekr-last-good-commit -- leo/plugins/qt_gui.py
    gco ekr-last-good-commit -- leo/plugins/qt_text.py
    ```
Reverting these files (rev 743f6e0) fixed the bug.

**Phase 2: Restore clobbered work *without* re-introducing the bug!**

- [x] Replace `Union` by `|` syntax.
- [x] Restore annotations. Replace `TextAPI` by `QTextMixin`.
- [x] Restore improvements to headlines.
- [x] Delete previously deleted methods.
- [x] Add `TestQtGui.test_bug_4626`.
        It should test that Ctrl-c copies text as expected in all text widgets.
        #4634 will attempt to make it work as desired.

**Other changes**

- [x] Make `g.es` work better with unit tests.
- [x] Fix a bug in `test_leoserver.py` that interfered with other unit tests.
- [x] Improve event tracing.
 