### PR TITLE
Fixed 'expand_text' method to not restore the insert point when selecting next placeholder that was found..

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -346,7 +346,10 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
                     return
                 p.moveToThreadNext()
         else:
-            self.find_place_holder(p, do_placeholder)
+            if self.find_place_holder(p, do_placeholder):
+                # Don't restore the insert point when selecting next placeholder.
+                self.save_ins = None 
+                self.save_sel = None
 
     # @+node:ekr.20150514043850.13: *4* abbrev.expand_tree (entry) & helpers
     def expand_tree(self, w: QTextMixin, i: int, j: int, tree_s: str, word: str) -> None:


### PR DESCRIPTION
Fixes #4604