### PR TITLE
PR fixes #4626: Fix the older PR #4623

### DIFF
--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -709,7 +709,7 @@ class LeoLog:
         self.logCtrl: Widget = None
         self.tabName: str = None  # The name of the active tab.
         self.tabFrame: LeoFrame | NullFrame = None
-        self.frameDict: dict[str, LeoFrame | NullFrame] = {}
+        self.frameDict: dict[str, Any] = {}
         self.logNumber = 0  # To create unique name fields for text widgets.
         self.newTabCount = 0  # Number of new tabs created.
         self.textDict: dict[str, Widget] = {}  # Keys: page names. Values: text widgets.

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -382,10 +382,12 @@ class LeoKeyEvent:
         self.event = event  # New in Leo 4.11.
         self.stroke = stroke
         self.w = self.widget = w
-        self.wrapper = (
-            w if g.isTextWrapper(w)  # #4623.
-            else g.app.gui.create_wrapper_for_widget(c, w)
-        )  # fmt: skip
+        self.wrapper = w if g.isTextWrapper(w) else None  ### Experimental.
+        ###
+        # self.wrapper = (
+        #     w if g.isTextWrapper(w)  # #4623.
+        #     else g.app.gui.create_wrapper_for_widget(c, w)
+        # )  # fmt: skip
         # Optional ivars
         self.x = x
         self.y = y

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -391,6 +391,8 @@ class LeoQtEventFilter(QtCore.QObject):
     # @+node:ekr.20140907103315.18767: *3* filter.Tracing
     # @+node:ekr.20190922075339.1: *4* filter.traceKeys
     def traceKeys(self, obj, event):
+        if 1:
+            return
         if g.unitTesting:
             return
         e = QtCore.QEvent
@@ -407,6 +409,8 @@ class LeoQtEventFilter(QtCore.QObject):
 
     # @+node:ekr.20110605121601.18548: *4* filter.traceEvent
     def traceEvent(self, obj, event):
+        if 1:
+            return
         if g.unitTesting:
             return
         # http://qt-project.org/doc/qt-4.8/qevent.html#properties
@@ -552,15 +556,16 @@ class LeoQtEventFilter(QtCore.QObject):
             )
             g.trace(f"{eventType:>25} {self.tag:25} {tag}")
 
-    # @+node:ekr.20131121050226.16331: *4* filter.traceWidget
+    # @+node:ekr.20260425111639.5: *4* filter.traceWidget
     def traceWidget(self, event: QtCore.QEvent) -> None:
-        """Show unexpected events in unusual widgets."""
-        verbose = False  # Not good for --trace-events
+        """Show events in widgets."""
         e = QtCore.QEvent
         t: str | QtCore.QEvent.Type
         assert isinstance(event, QtCore.QEvent)
         et = event.type()
         # http://qt-project.org/doc/qt-4.8/qevent.html#properties
+        # @+<< define dicts >>
+        # @+node:ekr.20260425111639.6: *5* << define dicts >>
         ignore_d = {
             e.Type.ChildAdded: 'child-added',  # 68
             e.Type.ChildPolished: 'child-polished',  # 69
@@ -627,39 +632,18 @@ class LeoQtEventFilter(QtCore.QObject):
             e.Type.FocusOut: 'focus-out',  # 9
             e.Type.WindowActivate: 'window-activate',  # 24
         }
+        # @-<< define dicts >>
         if et in ignore_d:
             return
-        w = QtWidgets.QApplication.focusWidget()
-        if verbose:  # Too verbose for --trace-events.
-            for d in (ignore_d, focus_d, line_edit_ignore_d, none_ignore_d):
-                t = d.get(et)
-                if t:
-                    break
-            else:
-                t = et
-            g.trace(f"{t:20} {w.__class__}")
-            return
-        if w is None:
-            if et not in none_ignore_d:
-                t = focus_d.get(et) or et
-                g.trace(f"None {t}")
-        if isinstance(w, QtWidgets.QPushButton):
-            return
-        if isinstance(w, QtWidgets.QLineEdit):
-            if et not in line_edit_ignore_d:
-                t = focus_d.get(et) or et
-                if hasattr(w, 'objectName'):
-                    tag = w.objectName()
-                else:
-                    tag = f"id: {id(w)}, {w.__class__.__name__}"
-                g.trace(f"{t:20} {tag}")
-            return
         t = focus_d.get(et) or et
-        if hasattr(w, 'objectName'):
-            tag = w.objectName()
-        else:
-            tag = f"id: {id(w)}, {w.__class__.__name__}"
-        g.trace(f"{t:20} {tag}")
+        if t in ignore_d:
+            return
+        w = QtWidgets.QApplication.focusWidget()
+        if w is None:
+            return
+        name = w.objectName() if hasattr(w, 'objectName') else None
+        tag = f"{t:20} {w.__class__.__name__:>20} {name or '<no name>'}"
+        g.trace(tag)
 
     # @-others
 

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -767,6 +767,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
             w.setFrameShape(shape)
             w.setFrameShadow(shadow)
             w.setLineWidth(lineWidth)
+            ### g.trace('NAME', repr(name), g.callers())
             self.setName(w, name)
         return w
 
@@ -2589,6 +2590,8 @@ class LeoQtLog(leoFrame.LeoLog):
             if tabName == 'Log':
                 self.logCtrl = contents  # PR #4601: Set the base-class ivar.
                 widget.setObjectName('log-widget')
+            else:
+                widget.setObjectName(tabName)  ###
             # Set binding on all log pane widgets.
             g.app.gui.setFilter(c, widget, self, tag='log')
             self.contentsDict[tabName] = widget
@@ -4168,8 +4171,8 @@ class QtStatusLineClass:
         # Create the text widgets.
         self.textWidget1 = w1 = QtWidgets.QLineEdit(self.statusBar)
         self.textWidget2 = w2 = QtWidgets.QLineEdit(self.statusBar)
-        w1.leo_wrapper = QLineEditWrapper(c=c, widget=w1)  # #4623
-        w2.leo_wrapper = QLineEditWrapper(c=c, widget=w2)  # #4623
+        ### w1.leo_wrapper = QLineEditWrapper(c=c, widget=w1)  # #4623
+        ### w2.leo_wrapper = QLineEditWrapper(c=c, widget=w2)  # #4623
         w1.setObjectName('status1')
         w2.setObjectName('status2')
         w1.setReadOnly(True)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2262,18 +2262,18 @@ class LeoQtLog(leoFrame.LeoLog):
         self.c = c = frame.c  # Also set in the base constructor, but we need it here.
         self.contentsDict: dict[str, LeoQTextBrowser] = {}  # Keys: tab names.
         self.eventFilters: list = []  # To make filters work!
-        self.qtFrameDict: dict[str, QTabWidget] = {}
-        self.qtLogCtrl: QTextEditWrapper = None
+        self.frameDict: dict[str, QTabWidget] = {}
+        self.logCtrl: QTextEditWrapper = None
         self.logDict: dict[str, LeoQTextBrowser] = {}  # Keys: tab names.
         self.logWidget: LeoLog = None
-        self.qtTabWidget: QWidget = c.frame.top.tabWidget
+        self.tabWidget: QWidget = c.frame.top.tabWidget
         self.wrapper: QTextEditWrapper = None  # #4623.
-        tw = self.qtTabWidget
+        tw = self.tabWidget
 
         # Bug 917814: Switching Log Pane tabs is done incompletely.
         tw.currentChanged.connect(self.onCurrentChanged)
         if 0:  # Not needed to make onActivateEvent work.
-            # Works only for .qtTabWidget, *not* the individual tabs!
+            # Works only for .tabWidget, *not* the individual tabs!
             theFilter = qt_events.LeoQtEventFilter(c, w=tw, tag='tabWidget')
             tw.installEventFilter(theFilter)
         tw.setMovable(True)
@@ -2286,7 +2286,7 @@ class LeoQtLog(leoFrame.LeoLog):
     # @+node:ekr.20110605121601.18315: *4* LeoQtLog.finishCreate
     def finishCreate(self) -> None:
         """Finish creating the LeoQtLog class."""
-        c, log, w = self.c, self, self.qtTabWidget
+        c, log, w = self.c, self, self.tabWidget
 
         # Create the log tab as the leftmost tab.
         log.createTab('Log')
@@ -2331,7 +2331,7 @@ class LeoQtLog(leoFrame.LeoLog):
     @log_cmd('log-clear')
     def clearLog(self, event: LeoKeyEvent = None) -> None:
         """Clear the log pane."""
-        w = self.qtLogCtrl.widget
+        w = self.logCtrl.widget
         if w:
             w.clear()
 
@@ -2339,7 +2339,7 @@ class LeoQtLog(leoFrame.LeoLog):
     @log_cmd('log-dump')
     def dumpLog(self, event: LeoKeyEvent = None) -> None:
         """Clear the log pane."""
-        w = self.qtLogCtrl.widget
+        w = self.logCtrl.widget
         if not w:
             return
 
@@ -2420,7 +2420,7 @@ class LeoQtLog(leoFrame.LeoLog):
 
     # @+node:ekr.20120304214900.9940: *3* LeoQtLog.onCurrentChanged
     def onCurrentChanged(self, idx: int) -> None:
-        tabw = self.qtTabWidget
+        tabw = self.tabWidget
         w = tabw.widget(idx)
 
         # #917814: Switching Log Pane tabs is done incompletely
@@ -2428,7 +2428,7 @@ class LeoQtLog(leoFrame.LeoLog):
 
         # #1161: Don't change logs unless the wrapper is correct.
         if obj and isinstance(obj, QTextEditWrapper):
-            self.qtLogCtrl = obj
+            self.logCtrl = obj
 
     # @+node:ekr.20200304132424.1: *3* LeoQtLog.onContextMenu
     def onContextMenu(self, point: QPoint) -> None:
@@ -2464,7 +2464,7 @@ class LeoQtLog(leoFrame.LeoLog):
         color = self.resolve_color(color)
         self.selectTab(tabName or 'Log')
         # Must be done after the call to selectTab.
-        wrapper = self.qtLogCtrl
+        wrapper = self.logCtrl
         if not isinstance(wrapper, qt_text.QTextEditWrapper):
             g.trace('BAD wrapper', wrapper.__class__.__name__)
             return
@@ -2506,7 +2506,7 @@ class LeoQtLog(leoFrame.LeoLog):
             return
         if tabName:
             self.selectTab(tabName)
-        wrapper = self.qtLogCtrl
+        wrapper = self.logCtrl
         if not isinstance(wrapper, qt_text.QTextEditWrapper):
             g.trace('BAD wrapper', wrapper.__class__.__name__)
             return
@@ -2545,7 +2545,7 @@ class LeoQtLog(leoFrame.LeoLog):
             return
         if tabName:
             self.selectTab(tabName)
-        w = self.qtLogCtrl.widget
+        w = self.logCtrl.widget
         if not w:
             return
         sb = w.horizontalScrollBar()
@@ -2587,13 +2587,12 @@ class LeoQtLog(leoFrame.LeoLog):
             widget.setReadOnly(False)  # Allow edits.
             self.logDict[tabName] = widget
             if tabName == 'Log':
-                self.qtLogCtrl = contents
                 self.logCtrl = contents  # PR #4601: Set the base-class ivar.
                 widget.setObjectName('log-widget')
             # Set binding on all log pane widgets.
             g.app.gui.setFilter(c, widget, self, tag='log')
             self.contentsDict[tabName] = widget
-            self.qtTabWidget.addTab(widget, tabName)
+            self.tabWidget.addTab(widget, tabName)
         else:
             # #1161: Don't set the wrapper unless it has the correct type.
             contents = widget  # Unlike text widgets, contents is the actual widget.
@@ -2603,7 +2602,7 @@ class LeoQtLog(leoFrame.LeoLog):
                 widget.leo_log_wrapper = None  # Tell the truth.
             g.app.gui.setFilter(c, widget, contents, 'tabWidget')
             self.contentsDict[tabName] = contents
-            self.qtTabWidget.addTab(contents, tabName)
+            self.tabWidget.addTab(contents, tabName)
         return contents
 
     # @+node:ekr.20110605121601.18328: *4* LeoQtLog.deleteTab
@@ -2612,7 +2611,7 @@ class LeoQtLog(leoFrame.LeoLog):
         Delete the tab if it exists.  Otherwise do *nothing*.
         """
         c = self.c
-        w = self.qtTabWidget
+        w = self.tabWidget
         i = self.findTabIndex(tabName)
         if i is None:
             return
@@ -2624,7 +2623,7 @@ class LeoQtLog(leoFrame.LeoLog):
     # @+node:ekr.20190603062456.1: *4* LeoQtLog.findTabIndex
     def findTabIndex(self, tabName: str) -> Optional[int]:
         """Return the tab index for tabName, or None."""
-        w = self.qtTabWidget
+        w = self.tabWidget
         for i in range(w.count()):
             if tabName == w.tabText(i):
                 return i
@@ -2637,13 +2636,13 @@ class LeoQtLog(leoFrame.LeoLog):
     # @+node:ekr.20111122080923.10185: *4* LeoQtLog.orderedTabNames
     def orderedTabNames(self, LeoLog: str = None) -> list[str]:  # Unused: LeoLog
         """Return a list of tab names in the order in which they appear in the QTabbedWidget."""
-        w = self.qtTabWidget
+        w = self.tabWidget
         return [w.tabText(i) for i in range(w.count())]
 
     # @+node:ekr.20221022062949.1: *4* LeoQtLog.renameTab
     def renameTab(self, oldTabName: str, tabName: str) -> None:
         """Rename the text tab"""
-        w = self.qtTabWidget
+        w = self.tabWidget
         i = self.findTabIndex(oldTabName)
         if i is None:
             self.createTab(tabName)
@@ -2693,7 +2692,6 @@ class LeoQtLog(leoFrame.LeoLog):
             if widget:
                 wrapper = getattr(widget, 'leo_log_wrapper', None)
                 if wrapper and isinstance(wrapper, qt_text.QTextEditWrapper):
-                    self.qtLogCtrl = wrapper
                     self.logCtrl = wrapper  # Required!
             if not wrapper:
                 g.trace('NO LOG WRAPPER')
@@ -2709,12 +2707,12 @@ class LeoQtLog(leoFrame.LeoLog):
                     findbox.setFocus()
         if tabName == 'Spell':
             # Set a flag for the spell system.
-            self.qtFrameDict['Spell'] = self.qtTabWidget.widget(i)
+            self.frameDict['Spell'] = self.tabWidget.widget(i)
 
     # @+node:ekr.20190603064816.1: *5* LeoQtLog.finishSelectTab
     def finishSelectTab(self, tabName: str) -> None:
         """Select the proper tab."""
-        w = self.qtTabWidget
+        w = self.tabWidget
         # Special case for Spell tab.
         if tabName == 'Spell':
             return

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -632,9 +632,10 @@ if QtWidgets:
             """
             super().__init__(parent)
             assert not hasattr(QtWidgets.QTextBrowser, 'leo_c')
+            ### g.trace('WRAPPER', wrapper.__class__.__name__, g.callers())
             self.leo_c = c
             self.leo_s = ''  # The cached text.
-            self.leo_wrapper = QTextEditWrapper(c=c, widget=self)  # #4623.
+            ### self.leo_wrapper = QTextEditWrapper(c=c, widget=self)  # #4623.
             self.htmlFlag = True
             self.setCursorWidth(c.config.getInt('qt-cursor-width') or 1)
 

--- a/leo/unittests/core/test_leoserver.py
+++ b/leo/unittests/core/test_leoserver.py
@@ -6,11 +6,13 @@ import json
 import os
 import leo.core.leoserver as leoserver
 from leo.core.leoTest2 import LeoUnitTest
+from leo.core import leoGlobals as global_g
 
 # Globals.
 g = None
 g_leoserver = None
 g_server = None
+global_g_es = global_g.es
 
 
 # @+others
@@ -48,6 +50,7 @@ class TestLeoServer(LeoUnitTest):
         g.unitTesting = True
 
     def tearDown(self):
+        global_g.es = global_g_es
         g.unitTesting = False
 
     # @+node:felix.20210621233316.100: *3* TestLeoServer._request

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -5,27 +5,59 @@
 # @+<< test_gui imports >>
 # @+node:ekr.20220911102700.1: ** << test_gui imports >>
 import os
+import textwrap
 import time
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest, create_app
 
 try:
-    from leo.core.leoQt import Qt, QtCore
-    from leo.core.leoAPI import IconBarAPI, StatusLineAPI, TreeAPI
-    from leo.core.leoAPI import StringTextWrapper
-    from leo.core.leoFrame import LeoTree
-    from leo.core.leoFrame import NullIconBarClass, NullStatusLineClass, NullTree
-    from leo.plugins.qt_frame import QtIconBarClass, QtStatusLineClass
+    from leo.core.leoQt import (
+        Qt,
+        QtCore,
+        QtGui,
+        QtWidgets,
+    )
+    from leo.core.leoAPI import (
+        IconBarAPI,
+        StatusLineAPI,
+        StringTextWrapper,
+        TreeAPI,
+    )
+    from leo.core.leoFrame import (
+        LeoTree,
+        NullIconBarClass,
+        NullStatusLineClass,
+        NullTree,
+        # QTabWidget,
+    )
+    from leo.core.leoGui import LeoKeyEvent
+    from leo.plugins.qt_frame import (
+        DynamicWindow,
+        LeoQtBody,
+        LeoQtFrame,
+        LeoQtLog,
+        LeoQtMenu,
+        LeoQtTree,
+        LeoQTreeWidget,
+        QtIconBarClass,
+        QtStatusLineClass,
+    )
     from leo.plugins.qt_text import (
+        LeoQTextBrowser,
+        QHeadlineWrapper,
         QLineEditWrapper,
+        QMinibufferWrapper,
         QScintillaWrapper,
         QTextEditWrapper,
         QTextMixin,
     )
-    from leo.plugins.qt_text import LeoQTextBrowser
-    from leo.plugins.qt_tree import LeoQtTree
+
+    QTabWidget = QtWidgets.QTabWidget
 except Exception:
+    g.es_exception()
     Qt = QtCore = None
+    QTabWidget = None
+
 # @-<< test_gui imports >>
 
 
@@ -111,155 +143,6 @@ class TestQtGui(LeoUnitTest):
         except Exception:
             self.skipTest('Requires Qt')
 
-    # @+node:ekr.20210913120449.1: *3* TestQtGui.test_bug_2164
-    def test_bug_2164(self):
-        # show-invisibles crashes with PyQt6.
-        from leo.core.leoQt import QtGui
-
-        # Test the commands.
-        c = self.c
-        for command in ('toggle-invisibles', 'hide-invisibles', 'show-invisibles'):
-            c.doCommandByName(command)
-
-        # Test the Qt6 flag.
-        option = QtGui.QTextOption()
-        assert hasattr(option.Flag, 'ShowTabsAndSpaces')
-
-    # @+node:ekr.20210912140946.1: *3* TestQtGui.test_do_nothing1/2/3
-    # These tests exist to test the startup logic.
-    if 0:  # pragma: no cover
-
-        def test_do_nothing1(self):
-            time.sleep(0.1)
-
-        def test_do_nothing2(self):
-            time.sleep(0.1)
-
-        def test_do_nothing3(self):
-            time.sleep(0.1)
-
-    # @+node:ekr.20210912064439.2: *3* TestQtGui.test_qt_ctors_for_all_dialogs
-    def test_qt_ctors_for_all_dialogs(self):
-        # Make sure the dialogs don't crash.
-        c = self.c
-        gui = g.app.gui
-        self.assertEqual(gui.__class__.__name__, 'LeoQtGui')
-        gui.runAboutLeoDialog(c, 'version', 'copyright', 'url', 'email')
-        gui.runAskOkDialog(c, 'title', 'message')
-        gui.runAskOkCancelNumberDialog(c, 'title', 'message')
-        gui.runAskOkCancelStringDialog(c, 'title', 'message')
-        gui.runAskYesNoDialog(c, 'title', 'message')
-        gui.runAskYesNoCancelDialog(c, 'title', 'message')
-
-    # @+node:ekr.20210912133358.1: *3* TestQtGui.test_qt_enums
-    def test_qt_enums(self):
-        # https://github.com/leo-editor/leo-editor/issues/1973 list of enums
-
-        if not QtCore and QtCore.Qt:
-            self.skipTest('Requires Qt')  # pragma: no cover
-        table = (
-            'DropAction',
-            'ItemFlag',
-            'KeyboardModifier',
-            'MouseButton',
-            'Orientation',
-            'TextInteractionFlag',
-            'ToolBarArea',
-            'WindowType',
-            'WindowState',
-        )
-        for ivar in table:
-            assert hasattr(QtCore.Qt, ivar), repr(ivar)
-
-    # @+node:ekr.20220411165627.1: *3* TestQtGui.test_put_html_links
-    def test_put_html_links(self):
-        c, p = self.c, self.c.p
-        # Create a test outline.
-        assert p == self.root_p
-        assert p.h == 'root'
-        p2 = p.insertAsLastChild()
-        p2.h = '@file test_file.py'
-        # Run the tests.
-        table = (
-            # python.
-            (
-                True,
-                'File "test_file.py", line 5',
-            ),
-            # pylint.
-            (
-                True,
-                r'leo\unittest\test_file.py:1326:8: W0101: Unreachable code (unreachable)',
-            ),
-            # pyflakes.
-            (
-                True,
-                r"test_file.py:51:13 'leo.core.leoQt5.*' imported but unused",
-            ),
-            # mypy...
-            (
-                True,
-                'test_file.py:116: error: Function is missing a return type annotation  [no-untyped-def]',
-            ),
-            (
-                True,
-                r'leo\core\test_file.py:116: note: Use "-> None" if function does not return a value',
-            ),
-            (
-                False,
-                'Found 1 error in 1 file (checked 1 source file)',
-            ),
-            (
-                False,
-                'mypy: done',
-            ),
-            # Random output.
-            (
-                False,
-                'Hello world\n',
-            ),
-        )
-        for expected, s in table:
-            s = s.replace('\\', os.sep).rstrip() + '\n'
-            result = c.frame.log.put_html_links(s)
-            self.assertEqual(result, expected, msg=repr(s))
-
-    # @+node:ekr.20220912093438.1: *3* TestQtGui.test_qt_attributes
-    def test_qt_attributes(self):
-        # Various preliminary tests.
-        c = self.c
-        if 0:
-            print('')
-            for z in dir(g.app.gui):
-                if not z.startswith('__'):
-                    obj = getattr(g.app.gui, z, None)
-                    print(f"{z:>30} {g.objToString(obj)}")
-        if 0:
-            print('')
-            g.trace(g.app.gui)
-            g.trace(c.frame.body)
-        if 0:
-            g.trace(c.frame.body.wrapper)
-            for method in ('delete', 'insert', 'toPythonIndexRowCol'):
-                f = getattr(c.frame.body.wrapper, method, None)
-                print(repr(f))
-
-    # @+node:ekr.20220912140743.1: *3* TestQtGui.test_QTextEditWrapper_delete
-    def test_QTextEditWrapper_delete(self):
-        c = self.c
-        wrapper = c.frame.body.wrapper
-        widget = wrapper.widget
-        self.assertTrue(isinstance(wrapper, QTextEditWrapper))
-        self.assertTrue(isinstance(widget, LeoQTextBrowser))
-        widget.setText('line1\nline2')
-        # g.trace(wrapper.getAllText())
-        wrapper.delete(0, 6)
-        # g.trace(wrapper.getAllText())
-        widget.setText('line1\nline2')
-        # g.trace(wrapper.getAllText())
-        wrapper.delete(6, 0)
-        # g.trace(wrapper.getAllText())
-
     # @+node:ekr.20260404143610.1: *3* TestQtGui.test_annotations
     def test_annotations(self):
         # This test establishes the basis of Leo's Qt-related annotations.
@@ -339,6 +222,235 @@ class TestQtGui(LeoUnitTest):
             QTextMixin,  # Every class is a subclass of itself.
         ):
             assert issubclass(class_, QTextMixin), repr(class_)
+
+    # @+node:ekr.20210913120449.1: *3* TestQtGui.test_bug_2164
+    def test_bug_2164(self):
+        # show-invisibles crashes with PyQt6.
+        from leo.core.leoQt import QtGui
+
+        # Test the commands.
+        c = self.c
+        for command in ('toggle-invisibles', 'hide-invisibles', 'show-invisibles'):
+            c.doCommandByName(command)
+
+        # Test the Qt6 flag.
+        option = QtGui.QTextOption()
+        assert hasattr(option.Flag, 'ShowTabsAndSpaces')
+
+    # @+node:ekr.20260425100253.1: *3* TestQtGui.test_bug_4626
+    def test_bug_4626(self):
+        # https://github.com/leo-editor/leo-editor/issues/4626
+        c = self.c
+        k = c.k
+        log = c.frame.log
+        qtApp = g.app.gui.qtApp
+
+        # Part 1: Create the 'Completion' tab, and copy it's contets to the clipboard.
+        event = LeoKeyEvent(c, 'a', event=None, binding=None, w=None)
+        k.fullCommand(event=event)
+        k.extendLabel('a')
+        # Force g.es to print to the log.
+        old_log = g.app.log
+        try:
+            g.app.log = log
+            k.doTabCompletion(['a', 'ab', 'abc'])
+        finally:
+            g.app.log = old_log
+        wrapper = log.logCtrl
+        s = wrapper.getAllText()
+        dedent_s = textwrap.dedent(s)
+        assert dedent_s == 'a\nab\nabc\n', repr(s)
+        wrapper.selectAllText()
+
+        # Part 2: Test copyText.
+        event2 = LeoKeyEvent(c, char=None, binding=None, event=None, w=wrapper)
+        c.frame.copyText(event2)
+        s2 = g.app.gui.getTextFromClipboard()
+        k.keyboardQuit()
+        assert s2 == s, (repr(s), repr(s2))
+
+        # Part 3: Test Ctrl-C in all text widgets.
+        # c.k.manufactureKeyPressForCommandName(c.frame.body, 'copy-text') returns 'Ctrl+c'.
+        table = (
+            ('c.frame.body.widget', c.frame.body.widget),
+            ('c.frame.log.logCtrl.widget', c.frame.log.logCtrl.widget),
+            ('c.frame.log.logWidget', c.frame.log.logWidget),
+            ('c.frame.miniBufferWidget.widget', c.frame.miniBufferWidget.widget),
+        )
+
+        # Construct two events
+        c_key = QtCore.Qt.Key.Key_C
+        ctrl_mod = QtCore.Qt.KeyboardModifier.ControlModifier
+        key_press_t = QtCore.QEvent.Type.KeyPress
+        key_release_t = QtCore.QEvent.Type.KeyRelease
+        key_press_event = QtGui.QKeyEvent(key_press_t, c_key, ctrl_mod, '')
+        key_release_event = QtGui.QKeyEvent(key_release_t, c_key, ctrl_mod, '')
+
+        # The main loop.
+        text_widgets = (QtWidgets.QTextEdit, QtWidgets.QLineEdit)
+        # g.app.debug = ['events']
+        try:
+            for kind, w in table:
+                # is_QTextEdit = issubclass(w.__class__, QtWidgets.QTextEdit)
+                class_name = w.__class__.__name__
+                assert issubclass(w.__class__, text_widgets), w.__class__
+                # Put the class name in the widget.
+                w.setFocus()
+                qtApp.processEvents()
+                w.setReadOnly(False)
+                w.clear()
+                expected = f"{id(w)}: {class_name}"
+                w.setText(expected)
+                w.selectAll()
+                qtApp.processEvents()
+                if 1:  # works.
+                    # print('Contents:', w.toPlainText() if is_QTextEdit else w.text())
+                    g.app.gui.replaceClipboardWith(expected)
+                else:  # Fails
+                    # Execute Ctrl-c.
+                    qtApp.sendEvent(w, key_press_event)
+                    qtApp.sendEvent(w, key_release_event)
+                    qtApp.processEvents()
+                s = g.app.gui.getTextFromClipboard()
+                # Not ready yet.
+                assert s == expected, f"{kind}\nExpected: {expected!r}\n     Got: {s!r}"
+        finally:
+            g.app.debug = []
+
+    # @+node:ekr.20210912140946.1: *3* TestQtGui.test_do_nothing1/2/3
+    # These tests exist to test the startup logic.
+    if 0:  # pragma: no cover
+
+        def test_do_nothing1(self):
+            time.sleep(0.1)
+
+        def test_do_nothing2(self):
+            time.sleep(0.1)
+
+        def test_do_nothing3(self):
+            time.sleep(0.1)
+
+    # @+node:ekr.20220411165627.1: *3* TestQtGui.test_put_html_links
+    def test_put_html_links(self):
+        c, p = self.c, self.c.p
+        # Create a test outline.
+        assert p == self.root_p
+        assert p.h == 'root'
+        p2 = p.insertAsLastChild()
+        p2.h = '@file test_file.py'
+        # Run the tests.
+        table = (
+            # python.
+            (
+                True,
+                'File "test_file.py", line 5',
+            ),
+            # pylint.
+            (
+                True,
+                r'leo\unittest\test_file.py:1326:8: W0101: Unreachable code (unreachable)',
+            ),
+            # pyflakes.
+            (
+                True,
+                r"test_file.py:51:13 'leo.core.leoQt5.*' imported but unused",
+            ),
+            # mypy...
+            (
+                True,
+                'test_file.py:116: error: Function is missing a return type annotation  [no-untyped-def]',
+            ),
+            (
+                True,
+                r'leo\core\test_file.py:116: note: Use "-> None" if function does not return a value',
+            ),
+            (
+                False,
+                'Found 1 error in 1 file (checked 1 source file)',
+            ),
+            (
+                False,
+                'mypy: done',
+            ),
+            # Random output.
+            (
+                False,
+                'Hello world\n',
+            ),
+        )
+        for expected, s in table:
+            s = s.replace('\\', os.sep).rstrip() + '\n'
+            result = c.frame.log.put_html_links(s)
+            self.assertEqual(result, expected, msg=repr(s))
+
+    # @+node:ekr.20220912093438.1: *3* TestQtGui.test_qt_attributes
+    def test_qt_attributes(self):
+        # Various preliminary tests.
+        c = self.c
+        if 0:
+            print('')
+            for z in dir(g.app.gui):
+                if not z.startswith('__'):
+                    obj = getattr(g.app.gui, z, None)
+                    print(f"{z:>30} {g.objToString(obj)}")
+        if 0:
+            print('')
+            g.trace(g.app.gui)
+            g.trace(c.frame.body)
+        if 0:
+            g.trace(c.frame.body.wrapper)
+            for method in ('delete', 'insert', 'toPythonIndexRowCol'):
+                f = getattr(c.frame.body.wrapper, method, None)
+                print(repr(f))
+
+    # @+node:ekr.20210912064439.2: *3* TestQtGui.test_qt_ctors_for_all_dialogs
+    def test_qt_ctors_for_all_dialogs(self):
+        # Make sure the dialogs don't crash.
+        c = self.c
+        gui = g.app.gui
+        self.assertEqual(gui.__class__.__name__, 'LeoQtGui')
+        gui.runAboutLeoDialog(c, 'version', 'copyright', 'url', 'email')
+        gui.runAskOkDialog(c, 'title', 'message')
+        gui.runAskOkCancelNumberDialog(c, 'title', 'message')
+        gui.runAskOkCancelStringDialog(c, 'title', 'message')
+        gui.runAskYesNoDialog(c, 'title', 'message')
+        gui.runAskYesNoCancelDialog(c, 'title', 'message')
+
+    # @+node:ekr.20210912133358.1: *3* TestQtGui.test_qt_enums
+    def test_qt_enums(self):
+        # https://github.com/leo-editor/leo-editor/issues/1973 list of enums
+
+        if not QtCore and QtCore.Qt:
+            self.skipTest('Requires Qt')  # pragma: no cover
+        table = (
+            'DropAction',
+            'ItemFlag',
+            'KeyboardModifier',
+            'MouseButton',
+            'Orientation',
+            'TextInteractionFlag',
+            'ToolBarArea',
+            'WindowType',
+            'WindowState',
+        )
+        for ivar in table:
+            assert hasattr(QtCore.Qt, ivar), repr(ivar)
+
+    # @+node:ekr.20220912140743.1: *3* TestQtGui.test_QTextEditWrapper_delete
+    def test_QTextEditWrapper_delete(self):
+        c = self.c
+        wrapper = c.frame.body.wrapper
+        widget = wrapper.widget
+        self.assertTrue(isinstance(wrapper, QTextEditWrapper))
+        self.assertTrue(isinstance(widget, LeoQTextBrowser))
+        widget.setText('line1\nline2')
+        # g.trace(wrapper.getAllText())
+        wrapper.delete(0, 6)
+        # g.trace(wrapper.getAllText())
+        widget.setText('line1\nline2')
+        # g.trace(wrapper.getAllText())
+        wrapper.delete(6, 0)
+        # g.trace(wrapper.getAllText())
 
     # @-others
 

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -306,9 +306,9 @@ class TestQtGui(LeoUnitTest):
             (c.frame.body.wrapper, QTextEditWrapper),
             (c.frame.body.widget, LeoQTextBrowser),
             # LeoQtLog ivars...
-            (c.frame.log.qtLogCtrl, QTextEditWrapper),
+            (c.frame.log.logCtrl, QTextEditWrapper),
             (c.frame.log.logWidget, LeoQTextBrowser),
-            (c.frame.log.qtTabWidget, QTabWidget),
+            (c.frame.log.tabWidget, QTabWidget),
             # LeoQtTree ivars...
             (c.frame.tree.treeWidget, LeoQTreeWidget),
         )


### PR DESCRIPTION
See #4626. PR #4623 (*not* PR #4627) was the real culprit.

As a starting point, Ctrl-c works neither in the Log pane nor the Completion pane.

- [x] Don't call `create_wrapper_for_widget`.
   Status: Ctrl-C works in neither the Log nor the Completion pane.
- [x] Remove the `qt` prefix for ivars in the `LeoQtLog` class`.
   Status: Ctrl-C works in the Log pane, but not in the Completion pane.
- [x] Add unit tests and `g.es` from PR #4631.
- [ ] Make Ctrl-C work in the Completion pane.
- [ ] Later: create a PR that reformats imports in all gui files.
