### PR TITLE
PR: Fix copy/paste from the menu

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -251,7 +251,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514043850.11: *3* abbrev.expandAbbrev & helpers (entry point)
     def expandAbbrev(self, event: LeoKeyEvent, stroke: g.KeyStroke) -> bool:
         """
-        Not a command.  Expand abbreviations in event.widget.
+        Not a command.  Expand abbreviations..
 
         Words start with '@'.
 

--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -59,7 +59,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
         self.save_sel = None  # Saved selection range.
         self.store = {'rlist': [], 'stext': ''}  # For dynamic expansion.
         self.tree_abbrevs_d: dict[str, str] = {}  # Keys are names, values are (tree,tag).
-        self.w = None
+        self.w: QTextMixin = None
 
     # @+node:ekr.20150514043850.5: *4* abbrev.finishCreate & helpers
     def finishCreate(self) -> None:

--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -87,8 +87,7 @@ class BaseEditCommandsClass:
     def editWidget(self, event: LeoKeyEvent, forceFocus: bool = True) -> QTextMixin:
         """Return the edit widget for the event. Also sets self.w"""
         c = self.c
-        w = event and event.widget
-        # wname = c.widget_name(w) if w else '<no widget>'
+        w = event.widget if event else None  # event.widget is correct.
         if w and g.isTextWrapper(w):
             pass
         else:

--- a/leo/commands/bufferCommands.py
+++ b/leo/commands/bufferCommands.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position, VNode
+    from leo.plugins.qt_text import QTextMixin
 # @-<< bufferCommands imports & annotations >>
 
 
@@ -41,6 +42,7 @@ class BufferCommandsClass(BaseEditCommandsClass):
         self.nameList: list[str] = []  # [n: <headline>]
         self.names: dict[str, list[str]] = {}
         self.vnodes: dict[str, VNode] = {}  # Keys are n: <headline>, values are vnodes.
+        self.w: QTextMixin = None
 
     # @+node:ekr.20150514045829.5: *3* buffer.Entry points
     # @+node:ekr.20150514045829.6: *4* appendToBuffer

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -444,7 +444,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self.moveSpot: int = None  # For retaining preferred column when moving up or down.
         self.moveCol: int = None  # For retaining preferred column when moving up or down.
         self.sampleWidget = None  # Created later.
-        self.w = None  # For use by state handlers.
+        self.w: QTextMixin = None  # For use by state handlers.
         # Settings...
         cf = c.config
         self.autocompleteBrackets = cf.getBool('autocomplete-brackets')

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -441,8 +441,8 @@ class EditCommandsClass(BaseEditCommandsClass):
         # Set by the set-fill-column command.
         self.fillColumn = 0  # For line centering. If zero, use @pagewidth value.
         self.moveSpotNode = None  # A VNode.
-        self.moveSpot = None  # For retaining preferred column when moving up or down.
-        self.moveCol = None  # For retaining preferred column when moving up or down.
+        self.moveSpot: int = None  # For retaining preferred column when moving up or down.
+        self.moveCol: int = None  # For retaining preferred column when moving up or down.
         self.sampleWidget = None  # Created later.
         self.w = None  # For use by state handlers.
         # Settings...

--- a/leo/commands/rectangleCommands.py
+++ b/leo/commands/rectangleCommands.py
@@ -26,7 +26,7 @@ def cmd(name: str) -> Callable:
 # @+node:ekr.20160514120751.1: ** class RectangleCommandsClass
 class RectangleCommandsClass(BaseEditCommandsClass):
     # @+others
-    # @+node:ekr.20150514063305.448: *3* rectangle.ctor
+    # @+node:ekr.20150514063305.448: *3* rectangle.__init__
     def __init__(self, c: Cmdr) -> None:
         """Ctor for RectangleCommandsClass."""
         # pylint: disable=super-init-not-called

--- a/leo/commands/rectangleCommands.py
+++ b/leo/commands/rectangleCommands.py
@@ -13,6 +13,7 @@ from leo.commands.baseCommands import BaseEditCommandsClass
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
+    from leo.plugins.qt_text import QTextMixin
 # @-<< rectangleCommands imports & annotations >>
 
 
@@ -41,6 +42,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
             't': ('string-rectangle', self.stringRectangle),
             'y': ('yank-rectangle', self.yankRectangle),
         }
+        self.w: QTextMixin = None
 
     # @+node:ekr.20150514063305.451: *3* check
     def check(self, event: LeoKeyEvent, warning: str = 'No rectangle selected') -> bool:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3410,14 +3410,10 @@ class Commands:
         """
         This method is an ugly hack, called by k.masterKeyHandler and other places.
 
-        Handle the character given by event, ignoring various special keys:
-        - getArg state: k.getArg.
-        - Tree: onCanvasKey or onHeadlineKey.
-        - Body: ec.selfInsertCommand
-        - Log: log_w.insert
+        Handle the character given by event.stroke, ignoring various special keys.
         """
         trace = all(z in g.app.debug for z in ('keys', 'verbose'))
-        c, k, w = self, self.k, event.widget
+        c, k, w = self, self.k, event.w
         name = c.widget_name(w)
         stroke = event.stroke
         if trace:

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -495,6 +495,8 @@ class LeoFrame:
     def copyText(self, event: LeoKeyEvent = None) -> None:
         """Copy the selected text from the widget to the clipboard."""
         w = event.w
+        if not g.isTextWrapper(w):
+            return
         # Set the clipboard text.
         i, j = w.getSelectionRange()
         if i == j:
@@ -515,6 +517,8 @@ class LeoFrame:
         """Invoked from the mini-buffer and from shortcuts."""
         c, p, u = self.c, self.c.p, self.c.undoer
         w = event.w
+        if not g.isTextWrapper(w):
+            return
         bunch = u.beforeChangeBody(p)
         name = c.widget_name(w)
         oldText = w.getAllText()
@@ -545,6 +549,8 @@ class LeoFrame:
         """
         c, p, u = self.c, self.c.p, self.c.undoer
         w = event.w
+        if not g.isTextWrapper(w):
+            return
         wname = c.widget_name(w)
         bunch = u.beforeChangeBody(p)
         i, j = w.getSelectionRange()  # Returns insert point if no selection.

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -494,21 +494,13 @@ class LeoFrame:
     @frame_cmd('copy-text')
     def copyText(self, event: LeoKeyEvent = None) -> None:
         """Copy the selected text from the widget to the clipboard."""
-        ### w = event.widget if event else None
-        w = event.w if event else None
-        if not g.isTextWrapper(w):
-            g.trace(
-                f"event.w: {event.w.__class__.__name__} "
-                f"event.widget: {event.widget.__class__.__name__}"
-            )  # fmt: skip
-            # g.trace(g.isTextWrapper(w), w.__class__.__name__, g.callers())
-            return
+        w = event.w
         # Set the clipboard text.
         i, j = w.getSelectionRange()
         if i == j:
+            # Copy the entire line.
             ins = w.getInsertPoint()
             i, j = g.getLine(w.getAllText(), ins)
-        # 2016/03/27: Fix a recent buglet.
         # Don't clear the clipboard if we hit ctrl-c by mistake.
         s = w.get(i, j)
         s = s.replace('\r\n', '\n').replace('\r', '\n')  # 3759.
@@ -522,14 +514,7 @@ class LeoFrame:
     def cutText(self, event: LeoKeyEvent = None) -> None:
         """Invoked from the mini-buffer and from shortcuts."""
         c, p, u = self.c, self.c.p, self.c.undoer
-        # w = event.widget if event else None
-        w = event.w if event else None
-        if not g.isTextWrapper(w):
-            g.trace(
-                f"event.w: {event.w.__class__.__name__} "
-                f"event.widget: {event.widget.__class__.__name__}"
-            )  # fmt: skip
-            return
+        w = event.w
         bunch = u.beforeChangeBody(p)
         name = c.widget_name(w)
         oldText = w.getAllText()
@@ -559,15 +544,8 @@ class LeoFrame:
         If middleButton is True, support x-windows middle-mouse-button easter-egg.
         """
         c, p, u = self.c, self.c.p, self.c.undoer
-        ### w = event.widget if event else None
-        w = event.w if event else None
+        w = event.w
         wname = c.widget_name(w)
-        if not g.isTextWrapper(w):
-            g.trace(
-                f"event.w: {event.w.__class__.__name__} "
-                f"event.widget: {event.widget.__class__.__name__}"
-            )  # fmt: skip
-            return
         bunch = u.beforeChangeBody(p)
         i, j = w.getSelectionRange()  # Returns insert point if no selection.
         s = g.app.gui.getTextFromClipboard()

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -494,8 +494,14 @@ class LeoFrame:
     @frame_cmd('copy-text')
     def copyText(self, event: LeoKeyEvent = None) -> None:
         """Copy the selected text from the widget to the clipboard."""
-        w = event.widget if event else None
+        ### w = event.widget if event else None
+        w = event.w if event else None
         if not g.isTextWrapper(w):
+            g.trace(
+                f"event.w: {event.w.__class__.__name__} "
+                f"event.widget: {event.widget.__class__.__name__}"
+            )  # fmt: skip
+            # g.trace(g.isTextWrapper(w), w.__class__.__name__, g.callers())
             return
         # Set the clipboard text.
         i, j = w.getSelectionRange()
@@ -516,8 +522,13 @@ class LeoFrame:
     def cutText(self, event: LeoKeyEvent = None) -> None:
         """Invoked from the mini-buffer and from shortcuts."""
         c, p, u = self.c, self.c.p, self.c.undoer
-        w = event.widget if event else None
+        # w = event.widget if event else None
+        w = event.w if event else None
         if not g.isTextWrapper(w):
+            g.trace(
+                f"event.w: {event.w.__class__.__name__} "
+                f"event.widget: {event.widget.__class__.__name__}"
+            )  # fmt: skip
             return
         bunch = u.beforeChangeBody(p)
         name = c.widget_name(w)
@@ -548,9 +559,14 @@ class LeoFrame:
         If middleButton is True, support x-windows middle-mouse-button easter-egg.
         """
         c, p, u = self.c, self.c.p, self.c.undoer
-        w = event.widget if event else None
+        ### w = event.widget if event else None
+        w = event.w if event else None
         wname = c.widget_name(w)
         if not g.isTextWrapper(w):
+            g.trace(
+                f"event.w: {event.w.__class__.__name__} "
+                f"event.widget: {event.widget.__class__.__name__}"
+            )  # fmt: skip
             return
         bunch = u.beforeChangeBody(p)
         i, j = w.getSelectionRange()  # Returns insert point if no selection.

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:  # pragma: no cover
         QMinibufferWrapper,
         QScintillaWrapper,
         QTextEditWrapper,
+        QTextMixin,
     )
     from leo.plugins.cursesGui2 import (
         BodyWrapper as CursesBodyWrapper,
@@ -58,7 +59,6 @@ if TYPE_CHECKING:  # pragma: no cover
     )
 
     Widget = Any  # 'Any' is the correct annotation for base class widgets.
-    TextAPI = QScintillaWrapper | QTextEditWrapper | StringTextWrapper
 
 
 # @-<< leoFrame annotations >>
@@ -151,7 +151,7 @@ class LeoBody:
     # @+node:ekr.20060528100747: *3* LeoBody.Editors
     # @+node:ekr.20070424053629.1: *4* LeoBody.utils
     # @+node:ekr.20060530204135: *5* LeoBody.recolorWidget (QScintilla only)
-    def recolorWidget(self, p: Position, w: TextAPI) -> None:
+    def recolorWidget(self, p: Position, w: QTextMixin) -> None:
         # Support QScintillaColorizer.colorize.
         c = self.c
         colorizer = c.frame.body.colorizer
@@ -741,7 +741,7 @@ class LeoLog:
         self.logNumber = 0  # To create unique name fields for text widgets.
         self.newTabCount = 0  # Number of new tabs created.
         self.textDict: dict[str, Widget] = {}  # Keys: page names. Values: text widgets.
-        self.wrapper: TextAPI = None  # To keep mypy happy.
+        self.wrapper: QTextMixin = None  # To keep mypy happy.
 
     # @+node:ekr.20070302094848.1: *3* LeoLog.clearTab
     def clearTab(self, tabName: str, wrap: str = 'none') -> None:
@@ -1050,8 +1050,10 @@ class LeoTree:
     # @+node:ekr.20040803072955.88: *4* LeoTree.onHeadlineKey
     def onHeadlineKey(self, event: LeoKeyEvent) -> None:
         """Handle a key event in a headline."""
-        w = event.widget if event else None
-        ch = event.char if event else ''
+        if not event:
+            return
+        w = event.widget
+        ch = event.char
         # This test prevents flashing in the headline when the control key is held down.
         if ch:
             self.updateHead(event, w)
@@ -1065,7 +1067,7 @@ class LeoTree:
         pass
 
     # @+node:ekr.20051026083544.2: *4* LeoTree.updateHead
-    def updateHead(self, event: LeoKeyEvent, w: TextAPI) -> None:
+    def updateHead(self, event: LeoKeyEvent, w: QTextMixin) -> None:
         """
         Update a headline from an event.
 
@@ -1305,7 +1307,7 @@ class NullBody(LeoBody):
 
     # @+node:ekr.20031218072017.2197: *3* NullBody: LeoBody interface
     # Birth, death...
-    def createControl(self, parentFrame: Widget, p: Position) -> TextAPI:
+    def createControl(self, parentFrame: Widget, p: Position) -> QTextMixin:
         pass
 
     # Events...
@@ -1342,7 +1344,7 @@ class NullFrame(LeoFrame):
         """Ctor for the NullFrame class."""
         super().__init__(c, gui)
         assert self.c
-        self.wrapper: TextAPI = None
+        self.wrapper: QTextMixin = None
         self.iconBar = NullIconBarClass(self.c)
         self.initComplete = True
         self.isNullFrame = True
@@ -1501,13 +1503,13 @@ class NullIconBarClass:
     def addRowIfNeeded(self) -> None:
         pass
 
-    def addWidget(self, w: TextAPI) -> None:
+    def addWidget(self, w: QTextMixin) -> None:
         pass
 
     def createChaptersIcon(self) -> None:
         pass
 
-    def deleteButton(self, w: TextAPI) -> None:
+    def deleteButton(self, w: QTextMixin) -> None:
         pass
 
     def getNewFrame(self) -> None:
@@ -1585,7 +1587,6 @@ class NullLog(LeoLog):
         self.isNull = True
         # self.logCtrl is now a property of the base LeoLog class.
         self.widget = StringTextWrapper(c=c, name='null-log')
-        ### self.wrapper: TextAPI = None  # To keep mypy happy.
 
     # @+node:ekr.20120216123546.10951: *4* NullLog.finishCreate
     def finishCreate(self) -> None:
@@ -1596,7 +1597,7 @@ class NullLog(LeoLog):
         return self.widget.hasSelection()
 
     # @+node:ekr.20111119145033.10186: *3* NullLog.isLogWidget
-    def isLogWidget(self, w: TextAPI) -> bool:
+    def isLogWidget(self, w: QTextMixin) -> bool:
         return False
 
     # @+node:ekr.20041012083237.3: *3* NullLog.put and putnl
@@ -1714,7 +1715,7 @@ class NullTree(LeoTree):
         self.editWidgetsDict: dict[VNode, StringTextWrapper] = {}
 
     # @+node:ekr.20070228163350.2: *3* NullTree.edit_widget
-    def edit_widget(self, p: Position) -> TextAPI:
+    def edit_widget(self, p: Position) -> QTextMixin:
         d = self.editWidgetsDict
         if not p or not p.v:
             return None

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1030,10 +1030,10 @@ class LeoTree:
         """Handle a key event in a headline."""
         if not event:
             return
-        w = event.widget
+        w = event.w
         ch = event.char
         # This test prevents flashing in the headline when the control key is held down.
-        if ch:
+        if ch and w:
             self.updateHead(event, w)
 
     # @+node:ekr.20120314064059.9739: *4* LeoTree.OnIconCtrlClick (@url)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -8444,15 +8444,20 @@ def openUrlOnClick(event: QMouseEvent, url: str = None) -> Optional[str]:  # pra
 # @+node:ekr.20170216091704.1: *4* g.openUrlHelper
 def openUrlHelper(event: LeoKeyEvent, url: str = None) -> Optional[str]:
     """Open the unl, url or gnx under the cursor.  Return it for unit testing."""
-    c = getattr(event, 'c', None)
+    ### c = getattr(event, 'c', None)
+    ###
+    # w = getattr(event, 'w', c.frame.body.wrapper)
+    # if not g.app.gui.isTextWrapper(w):
+    #     g.internalError('must be a text wrapper', w)
+    #     return None
+    # if event:
+    #     event.widget = w
+    c = event.c
+    w = event.w
     if not c:
         return None
-    w = getattr(event, 'w', c.frame.body.wrapper)
-    if not g.app.gui.isTextWrapper(w):
-        g.internalError('must be a text wrapper', w)
+    if not g.app.gui.isTextWrapper(w):  ###
         return None
-    if event:
-        event.widget = w
     # Part 1: get the url.
     if url is None:
         s = w.getAllText()

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -8440,7 +8440,7 @@ def openUrlOnClick(event: QMouseEvent, url: str = None) -> Optional[str]:  # pra
     try:
         c = g.app.log.c  # A hack.
         widget = c.frame.body.widget  # Another hack.
-        wrapper = QTextEditWrapper(widget=widget, name='QMouseEvent-wrapper')
+        wrapper = QTextEditWrapper(widget=widget, name='QMouseEvent-wrapper', c=c)
         leo_event = LeoKeyEvent(c, w=wrapper)
         return openUrlHelper(leo_event, url)
     except Exception:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -8432,10 +8432,17 @@ def openUrl(p: Position) -> None:  # pragma: no cover
 # @+node:ekr.20110605121601.18135: *3* g.openUrlOnClick (open-url-under-cursor)
 def openUrlOnClick(event: QMouseEvent, url: str = None) -> Optional[str]:  # pragma: no cover
     """Open the URL under the cursor.  Return it for unit testing."""
+    from leo.core.leoGui import LeoKeyEvent
+    from leo.plugins.qt_text import QTextEditWrapper
+
     # QTextEditWrapper.mouseReleaseEvent calls this outside Leo's command logic.
     # Make sure to catch all exceptions!
     try:
-        return openUrlHelper(event, url)
+        c = g.app.log.c  # A hack.
+        widget = c.frame.body.widget  # Another hack.
+        wrapper = QTextEditWrapper(widget=widget, name='QMouseEvent-wrapper')
+        leo_event = LeoKeyEvent(c, w=wrapper)
+        return openUrlHelper(leo_event, url)
     except Exception:
         g.es_exception()
         return None
@@ -8444,19 +8451,12 @@ def openUrlOnClick(event: QMouseEvent, url: str = None) -> Optional[str]:  # pra
 # @+node:ekr.20170216091704.1: *4* g.openUrlHelper
 def openUrlHelper(event: LeoKeyEvent, url: str = None) -> Optional[str]:
     """Open the unl, url or gnx under the cursor.  Return it for unit testing."""
-    ### c = getattr(event, 'c', None)
-    ###
-    # w = getattr(event, 'w', c.frame.body.wrapper)
-    # if not g.app.gui.isTextWrapper(w):
-    #     g.internalError('must be a text wrapper', w)
-    #     return None
-    # if event:
-    #     event.widget = w
-    c = event.c
-    w = event.w
+    if not event:
+        return None
+    c, w = event.c, event.w
     if not c:
         return None
-    if not g.app.gui.isTextWrapper(w):  ###
+    if not g.app.gui.isTextWrapper(w):
         return None
     # Part 1: get the url.
     if url is None:

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -372,7 +372,18 @@ class LeoKeyEvent:
         self.w: QTextMixin
         self.widget: Any  # The best we can do.
         if w is None:
-            self.w = self.widget = None
+            # Special case for headlines.
+            edit_wrapper = c.edit_widget(c.p)
+            if edit_wrapper:
+                self.w = edit_wrapper
+                self.widget = self.w.widget
+            else:
+                focus_widget = g.app.gui.get_focus()
+                widget = focus_widget if g.isTextWrapper(focus_widget) else c.frame.body.widget
+                self.widget = widget
+                name = c.widget_name(widget) if widget else 'dummy-wrapper'
+                self.w = QTextEditWrapper(widget=widget, name=name)
+                # print(f"LeoKeyEvent: new {self.w.__class__.__name__} from {widget.__class__.__name__}"O
         elif isinstance(w, QtWidgets.QWidget):
             self.widget = w
             self.w = QTextEditWrapper(widget=w, name=c.widget_name(w))

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -382,13 +382,13 @@ class LeoKeyEvent:
                 widget = focus_widget if g.isTextWrapper(focus_widget) else c.frame.body.widget
                 self.widget = widget
                 name = c.widget_name(widget) if widget else 'dummy-wrapper'
-                self.w = QTextEditWrapper(widget=widget, name=name)
+                self.w = QTextEditWrapper(widget=widget, name=name, c=c)
                 # print(f"LeoKeyEvent: new {self.w.__class__.__name__} from {widget.__class__.__name__}"
         elif c.widget_name(w).startswith('log'):
             self.w = self.widget = c.frame.log.logCtrl
         elif isinstance(w, QtWidgets.QWidget):
             self.widget = w
-            self.w = QTextEditWrapper(widget=w, name=c.widget_name(w))
+            self.w = QTextEditWrapper(widget=w, name=c.widget_name(w), c=c)
             # print(f"LeoKeyEvent: new {self.w.__class__.__name__} from {w.__class__.__name__}")
         else:
             self.w = self.widget = w

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -383,17 +383,15 @@ class LeoKeyEvent:
                 self.widget = widget
                 name = c.widget_name(widget) if widget else 'dummy-wrapper'
                 self.w = QTextEditWrapper(widget=widget, name=name)
-                # print(f"LeoKeyEvent: new {self.w.__class__.__name__} from {widget.__class__.__name__}"O
+                # print(f"LeoKeyEvent: new {self.w.__class__.__name__} from {widget.__class__.__name__}"
+        elif c.widget_name(w).startswith('log'):
+            self.w = self.widget = c.frame.log.logCtrl
         elif isinstance(w, QtWidgets.QWidget):
             self.widget = w
             self.w = QTextEditWrapper(widget=w, name=c.widget_name(w))
             # print(f"LeoKeyEvent: new {self.w.__class__.__name__} from {w.__class__.__name__}")
         else:
             self.w = self.widget = w
-
-        # A final hack, formerly in k.setEventWidget.
-        if c.widget_name(w).startswith('log'):
-            self.w = c.frame.log.logCtrl
 
         # Optional ivars
         self.x = x

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -17,6 +17,7 @@ from typing import Any, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoFrame
 from leo.core.leoAPI import StringTextWrapper
+from leo.core.leoQt import QtWidgets
 from leo.plugins.qt_text import QTextEditWrapper
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -368,12 +369,16 @@ class LeoKeyEvent:
         )
         assert g.isStrokeOrNone(self.stroke), f"(LeoKeyEvent) {self.stroke!r} {g.callers()}"
 
-        self.widget: Any = w
-        self.w: Any
-        if g.isTextWrapper(w):
-            self.w = w
-        else:
+        self.w: QTextMixin
+        self.widget: Any  # The best we can do.
+        if w is None:
+            self.w = self.widget = None
+        elif isinstance(w, QtWidgets.QWidget):
+            self.widget = w
             self.w = QTextEditWrapper(widget=w, name=c.widget_name(w))
+            # print(f"LeoKeyEvent: new {self.w.__class__.__name__} from {w.__class__.__name__}")
+        else:
+            self.w = self.widget = w
 
         # Optional ivars
         self.x = x

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -380,6 +380,10 @@ class LeoKeyEvent:
         else:
             self.w = self.widget = w
 
+        # A final hack, formerly in k.setEventWidget.
+        if c.widget_name(w).startswith('log'):
+            self.w = c.frame.log.logCtrl
+
         # Optional ivars
         self.x = x
         self.y = y

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -17,6 +17,7 @@ from typing import Any, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoFrame
 from leo.core.leoAPI import StringTextWrapper
+from leo.plugins.qt_text import QTextEditWrapper
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
@@ -366,7 +367,14 @@ class LeoKeyEvent:
             binding if g.isStroke(binding) else g.KeyStroke(binding) if binding else None
         )
         assert g.isStrokeOrNone(self.stroke), f"(LeoKeyEvent) {self.stroke!r} {g.callers()}"
-        self.w = self.widget = w
+
+        self.widget: Any = w
+        self.w: Any
+        if g.isTextWrapper(w):
+            self.w = w
+        else:
+            self.w = QTextEditWrapper(widget=w, name=c.widget_name(w))
+
         # Optional ivars
         self.x = x
         self.y = y

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -19,6 +19,7 @@ from types import ModuleType
 from leo.core import leoGlobals as g
 from leo.external import codewise
 from leo.core.leoFrame import NullLog
+from leo.core.leoQt import QtWidgets
 
 try:
     import jedi
@@ -32,7 +33,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGlobals import BindingInfo
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position
-    from leo.core.leoQt import QtWidgets
     from leo.plugins.qt_frame import LeoQtLog
     from leo.plugins.qt_text import QTextMixin
 
@@ -3453,10 +3453,14 @@ class KeyHandlerClass:
         c = self.c
         assert event is not None
         c.check_event(event)
-        assert hasattr(event, 'char')
-        assert hasattr(event, 'stroke')
-        assert g.isTextWrapper(event.w)
+        assert hasattr(event, 'char'), repr(event)
+        assert hasattr(event, 'stroke'), repr(event)
+        assert hasattr(event, 'w'), repr(event)
+        assert hasattr(event, 'widget'), repr(event)
         assert g.isStrokeOrNone(event.stroke)
+        # Important: event.w does *not* have to be a *text* wrapper.
+        #            event.w can be *any* non-Qt widget.
+        assert not isinstance(event.w, QtWidgets.QWidget), repr(event.w)
 
         # A continuous unit test.
         assert event.stroke.s not in g.app.gui.ignoreChars, repr(event.stroke.s)

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2605,7 +2605,6 @@ class KeyHandlerClass:
                 c.endEditing()
                 c.bodyWantsFocusNow()
                 # Change the event widget so we don't refer to the to-be-deleted headline widget.
-                ### event.w = event.widget = c.frame.body.wrapper.widget
                 event.w = c.frame.body.wrapper
                 event.widget = c.frame.body.wrapper.widget
             else:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -3422,7 +3422,6 @@ class KeyHandlerClass:
             )
             print('')
         k.checkKeyEvent(event)
-        k.setEventWidget(event)
         k.traceVars(event)
         # Order is very important here...
         if k.isSpecialKey(event):
@@ -3464,17 +3463,6 @@ class KeyHandlerClass:
 
         # A continuous unit test.
         assert event.stroke.s not in g.app.gui.ignoreChars, repr(event.stroke.s)
-
-    # @+node:ekr.20180418034305.1: *6* k.setEventWidget
-    def setEventWidget(self, event: LeoKeyEvent) -> None:
-        """
-        A hack: redirect the event to the text part of the log.
-        """
-        c = self.c
-        w = event.widget
-        w_name = c.widget_name(w)
-        if w_name.startswith('log'):
-            event.widget = c.frame.log.logCtrl
 
     # @+node:ekr.20180418031417.1: *6* k.traceVars
     def traceVars(self, event: LeoKeyEvent) -> None:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2536,7 +2536,7 @@ class KeyHandlerClass:
                 k.commandHistoryBackwd()
             elif char in ('\n', 'Return'):
                 # Fix bug 157: save and restore the selection.
-                w = k.mb_event and k.mb_event.w
+                w = k.mb_event.w if k.mb_event else None
                 if w and hasattr(w, 'hasSelection') and w.hasSelection():
                     sel1, sel2 = w.getSelectionRange()
                     ins = w.getInsertPoint()
@@ -3455,10 +3455,7 @@ class KeyHandlerClass:
         c.check_event(event)
         assert hasattr(event, 'char')
         assert hasattr(event, 'stroke')
-        ###
-        # if not hasattr(event, 'widget'):
-        #     event.widget = None
-        assert g.isTextWrapper(event.w)  ###
+        assert g.isTextWrapper(event.w)
         assert g.isStrokeOrNone(event.stroke)
 
         # A continuous unit test.
@@ -3893,7 +3890,7 @@ class KeyHandlerClass:
         key: str,
         name: str,
         stroke: Stroke,
-        w: QWidget,
+        w: QTextMixin,
     ) -> g.BindingInfo:
         """Find a binding for the widget with the given name."""
         c, k = self.c, self

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1639,8 +1639,6 @@ class GetArg:
         # Enter the next state.
         c.widgetWantsFocus(c.frame.body.wrapper)
         k.setState('getArg', 1, k.getArg)
-        # pylint: disable=consider-using-ternary
-        k.afterArgWidget = event and event.widget or c.frame.body.wrapper
         if useMinibuffer:
             c.minibufferWantsFocus()
 

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2605,7 +2605,9 @@ class KeyHandlerClass:
                 c.endEditing()
                 c.bodyWantsFocusNow()
                 # Change the event widget so we don't refer to the to-be-deleted headline widget.
-                event.w = event.widget = c.frame.body.wrapper.widget
+                ### event.w = event.widget = c.frame.body.wrapper.widget
+                event.w = c.frame.body.wrapper
+                event.widget = c.frame.body.wrapper.widget
             else:
                 c.widgetWantsFocusNow(event and event.widget)  # So cut-text works, e.g.
             try:
@@ -3453,12 +3455,14 @@ class KeyHandlerClass:
         c.check_event(event)
         assert hasattr(event, 'char')
         assert hasattr(event, 'stroke')
-        if not hasattr(event, 'widget'):
-            event.widget = None
+        ###
+        # if not hasattr(event, 'widget'):
+        #     event.widget = None
+        assert g.isTextWrapper(event.w)  ###
         assert g.isStrokeOrNone(event.stroke)
-        if event:
-            # A continuous unit test.
-            assert event.stroke.s not in g.app.gui.ignoreChars, repr(event.stroke.s)
+
+        # A continuous unit test.
+        assert event.stroke.s not in g.app.gui.ignoreChars, repr(event.stroke.s)
 
     # @+node:ekr.20180418034305.1: *6* k.setEventWidget
     def setEventWidget(self, event: LeoKeyEvent) -> None:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -3456,8 +3456,7 @@ class KeyHandlerClass:
         assert hasattr(event, 'w'), repr(event)
         assert hasattr(event, 'widget'), repr(event)
         assert g.isStrokeOrNone(event.stroke)
-        # Important: event.w does *not* have to be a *text* wrapper.
-        #            event.w can be *any* non-Qt widget.
+        # See LeoKeyEvent.__init__ for why the following test is correct.
         assert not isinstance(event.w, QtWidgets.QWidget), repr(event.w)
 
         # A continuous unit test.

--- a/leo/plugins/freewin.py
+++ b/leo/plugins/freewin.py
@@ -702,7 +702,7 @@ class ZEditorWin(QtWidgets.QMainWindow):
         self.render_pane_type = BROWSER_VIEW
 
         self.editor = QTextEdit()
-        wrapper = qt_text.QTextEditWrapper(self.editor, name='zwin', c=c)
+        wrapper = qt_text.QTextEditWrapper(widget=self.editor, name='zwin', c=c)
         c.k.completeAllBindingsForWidget(wrapper)
 
         self.editor.cursorPositionChanged.connect(self.highlightCurrentLine)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1706,7 +1706,7 @@ class LeoQtBody(leoFrame.LeoBody):
             self.colorizer = leoColorizer.QScintillaColorizer(c, self.widget)
         else:
             self.widget = top.richTextEdit  # A LeoQTextBrowser
-            self.wrapper = qt_text.QTextEditWrapper(self.widget, name='body', c=c)
+            self.wrapper = qt_text.QTextEditWrapper(widget=self.widget, name='body', c=c)
             self.widget.setAcceptRichText(False)
             self.colorizer = leoColorizer.make_colorizer(c, self.widget)
 

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -1637,7 +1637,7 @@ class QTextEditWrapper(QTextMixin):
 
     # @+others
     # @+node:ekr.20110605121601.18073: *3* QTextEditWrapper.ctor & helpers
-    def __init__(self, widget: QWidget, name: str = 'TestWrapper', c: Cmdr = None) -> None:
+    def __init__(self, widget: Any, name: str = 'TestWrapper', c: Cmdr = None) -> None:
         """Ctor for QTextEditWrapper class. widget is a QTextEdit/QTextBrowser."""
         super().__init__(c)
         # Make sure all ivars are set.

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -1637,7 +1637,7 @@ class QTextEditWrapper(QTextMixin):
 
     # @+others
     # @+node:ekr.20110605121601.18073: *3* QTextEditWrapper.ctor & helpers
-    def __init__(self, widget: Any, name: str = 'TestWrapper', c: Cmdr = None) -> None:
+    def __init__(self, *, widget: Any, name: str = 'TestWrapper', c: Cmdr) -> None:
         """Ctor for QTextEditWrapper class. widget is a QTextEdit/QTextBrowser."""
         super().__init__(c)
         # Make sure all ivars are set.

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -1636,7 +1636,7 @@ class QTextEditWrapper(QTextMixin):
     """A wrapper for a QTextEdit/QTextBrowser supporting the high-level interface."""
 
     # @+others
-    # @+node:ekr.20110605121601.18073: *3* QTextEditWrapper.ctor & helpers
+    # @+node:ekr.20110605121601.18073: *3* QTextEditWrapper.__init__ & helpers
     def __init__(self, *, widget: Any, name: str = 'TestWrapper', c: Cmdr) -> None:
         """Ctor for QTextEditWrapper class. widget is a QTextEdit/QTextBrowser."""
         super().__init__(c)

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -2027,7 +2027,7 @@ class QTextEditWrapper(QTextMixin):
         s: Optional[str] = None,
     ) -> None:
         """Set the selection range and the insert point."""
-        #
+        c = self.c
         # Part 1
         w = self.widget
         if i is None:
@@ -2068,9 +2068,12 @@ class QTextEditWrapper(QTextMixin):
         if hasattr(g.app.gui, 'setClipboardSelection'):
             if s[i:j]:
                 g.app.gui.setClipboardSelection(s[i:j])
-        #
         # Remember the values for v.restoreCursorAndScroll.
-        v = self.c.p.v  # Always accurate.
+        if not c:
+            return
+        v = c.p.v
+        if not v:
+            return
         v.insertSpot = ins
         if i > j:
             i, j = j, i

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -1671,7 +1671,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         w.setObjectName(text_name)
         w.setReadOnly(True)
         # Create the standard Leo bindings in a wrapper widget.
-        wrapper = qt_text.QTextEditWrapper(w, 'rendering-pane-wrapper', c)
+        wrapper = qt_text.QTextEditWrapper(widget=w, name='rendering-pane-wrapper', c=c)
         c.k.completeAllBindingsForWidget(wrapper)
         w.setWordWrapMode(WrapMode.WrapAtWordBoundaryOrAnywhere)
 
@@ -1686,7 +1686,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         w.customContextMenuRequested.connect(contextMenuCallback)
 
         def handleClick(url: str, w: QWidget = w) -> None:
-            wrapper = qt_text.QTextEditWrapper(w, name='vr-body', c=c)
+            wrapper = qt_text.QTextEditWrapper(widget=w, name='vr-body', c=c)
             event = g.Bunch(c=c, w=wrapper)
             g.openUrlOnClick(event, url=url)
 

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -3358,7 +3358,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             # self.setBackgroundColor(self.background_color, text_name, w)
             w.setReadOnly(True)
             # Create the standard Leo bindings in a wrapper widget.
-            wrapper_widget = qt_text.QTextEditWrapper(w, 'rendering-pane-wrapper', c)
+            wrapper_widget = qt_text.QTextEditWrapper(widget=w, name='rendering-pane-wrapper', c=c)
             c.k.completeAllBindingsForWidget(wrapper_widget)
             w.setWordWrapMode(WrapMode.WrapAtWordBoundaryOrAnywhere)
 
@@ -4871,7 +4871,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             w = QtWidgets.QTextBrowser()
 
             def handleClick(url, w=w):
-                wrapper = qt_text.QTextEditWrapper(w, name='vr3-body', c=c)
+                wrapper = qt_text.QTextEditWrapper(widget=w, name='vr3-body', c=c)
                 event = g.Bunch(c=c, w=wrapper)
                 g.openUrlOnClick(event, url=url)
 


### PR DESCRIPTION
The bug arises from confusions between wrappers and widgets.

There are only a few places left in Leo's code where using `event.widget` is correct.
Almost all parts of Leo's *core* code should use the `event.w`.
`event.w` will always be some kind of wrapper, but *not* necessarily a *text* wrapper.

- [x] (The fix) `LeoKeyEvent.__init__`: make `event.w` a wrapper if necessary.
   The Aha! Make new wrappers *only* for Qt widgets. 
   Testing for `isTextWrapper` would be very wrong.
- [x] At last! `k.checkKeyEvent`: checks `event.w` correctly!
- [x] Use 'event.w' instead of 'event.widget` in the following methods:
   - `c.insertCharFromEvent`.
   - `g.openUrlHelper`.  Also, add guards.
   - `k.fullCommand`.
   -  `LeoFrame`:`cut/copy/pasteText`.
   - `LeoTree.onHeadlineKey`.
- [x] `QTextEditWrapper.mouseReleaseEvent`: allocate a `QTextEditWrapper` to replace the `QMouseEvent`.
    How did the old code ever work??
- [x] `k.callAltXFunction`: reset `event.w` and `event.widget` separately.
- [x] Remove the evil method called by `k.masterKeyHandler`.
- [x] **Won't do**: rename `x.edit_widget` to `x.edit_wrapper`.
    Global renames are surprisingly dangerous, as we have seen in the buggy PR.

**Other changes**

- [x] In four files: annotate `w` and `self.w` as a `QTextMixin`.
- [x] In class `QTextEditWrapper`: annotate (correctly!) the `widget` arg as `Any`.
    The widget may be other Qt objects besides `QWidget`.
- [x] `QTextEditWrapper.__init__`: All args must be kwargs. Require the `c` kwarg.
- [x] `QTextEditWrapper.setSelectionRange`: Add some guards.
- [x] Transfer the testing checklist to #1585.

**Changes for new PRs**

As the result of this work, I have opened the following issues:

- #4641.
- #4642.
- #4643.
- #4644.

**Testing checklist**

To be done regularly, especially just before merging:

- [x] Test copy/paste from the menu.
- [x] Test copy/paste from all text panes, including the 'Completion' tab.
- [x] Test copy/paste within headlines from the menu.
- [x] Test clicking URLs in body text.
- [x] Test typing in 'Log' and 'Completion' panes.
- [x] Test console gui.

