### PR TITLE
PR fixes #4643: clean Leo's gui code

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -262,7 +262,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
         # Verbose only for *both* 'abbrev' and 'verbose'.
         verbose = all(z in g.app.debug for z in ('abbrev', 'verbose'))
         c, p = self.c, self.c.p
-        w = self.editWidget(event, forceFocus=False)
+        w = event.w if event else None
         w_name = g.app.gui.widget_name(w)
         if not w:
             if trace and verbose:

--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -264,7 +264,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
         c, p = self.c, self.c.p
         w = event.w if event else None
         w_name = g.app.gui.widget_name(w)
-        if not w:
+        if not g.isTextWrapper(w):
             if trace and verbose:
                 g.trace('no w')
             return False
@@ -650,7 +650,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
         """
         c, p = self.c, self.c.p
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         s = w.getAllText()
         ins = ins1 = w.getInsertPoint()
@@ -685,7 +685,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
         all possible completions if the prefix is the same as the word.
         """
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         s = w.getAllText()
         ins = ins1 = w.getInsertPoint()

--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -649,7 +649,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
         This corresponds to C-M-/ in Emacs.
         """
         c, p = self.c, self.c.p
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         s = w.getAllText()
@@ -684,7 +684,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
         Inserts the longest common prefix of the word at the cursor. Displays
         all possible completions if the prefix is the same as the word.
         """
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         s = w.getAllText()

--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -408,7 +408,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
                 p.h = new_s
                 c.redraw(p)
                 c.editHeadline()
-                w = c.edit_widget(p)
+                w = c.headline_wrapper(p)
                 w.setSelectionRange(i, j, insert=j)
                 return True
         s = p.b

--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -57,8 +57,11 @@ class BaseEditCommandsClass:
         Do the common processing at the end of each command.
         Handles undo only if we are in the body pane.
         """
-        k, p, u = self.c.k, self.c.p, self.c.undoer
-        w = self.editWidget(event=None)
+        c = self.c
+        k, p, u = c.k, c.p, c.undoer
+        w = c.frame.body and c.frame.body.wrapper
+        if not w:
+            return
         bunch = self.undoData
         if bunch and bunch.name.startswith('body') and changed:
             newText = w.getAllText()

--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -87,16 +87,33 @@ class BaseEditCommandsClass:
         """Return the edit widget for the event. Also sets self.w"""
         c = self.c
         w = event.widget if event else None  # event.widget is correct.
-        if w and g.isTextWrapper(w):
-            pass
-        else:
-            w = c.frame.body and c.frame.body.wrapper
-        if w and forceFocus:
-            c.widgetWantsFocusNow(w)
+        trace = False
+        if event:  ### Temp.
+            if trace:
+                print('')
+                if event.widget != event.w:
+                    g.trace(
+                        f"event.w: {event.w.__class__.__name__} event.widget {event.widget.__class__.__name__}"
+                    )
+                else:
+                    g.trace('No EVENT', g.callers())
+        if not g.isTextWrapper(w):
+            if trace:
+                old_w = w  ###
+                w = c.frame.body and c.frame.body.wrapper
+                g.trace(f"{old_w.__class__.__name__} ==> {w.__class__.__name__}")
+            else:
+                w = c.frame.body and c.frame.body.wrapper
+        # if w and g.isTextWrapper(w):
+        #     pass
+        # else:
+        #     w = c.frame.body and c.frame.body.wrapper
+        # if w and forceFocus:
+        #     c.widgetWantsFocusNow(w)
         self.w = w
         return w
 
-    # @+node:ekr.20150514043714.11: *3* BaseEdit._check_selection
+    # @+node:ekr.20150514043714.11: *3* BaseEdit._checkSelection
     def _checkSelection(self, event: LeoKeyEvent, warning: str = 'no selection') -> bool:
         """Return True if there is a selection in the edit widget."""
         w = self.editWidget(event)

--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -85,37 +85,6 @@ class BaseEditCommandsClass:
             else:
                 k.resetLabel()
 
-    # @+node:ekr.20150514043714.7: *3* BaseEdit.editWidget (to be deleted)
-    def editWidget(self, event: LeoKeyEvent, forceFocus: bool = True) -> QTextMixin:
-        """Return the edit widget for the event. Also sets self.w"""
-        c = self.c
-        w = event.widget if event else None  # event.widget is correct.
-        trace = False
-        if event:  ### Temp.
-            if trace:
-                print('')
-                if event.widget != event.w:
-                    g.trace(
-                        f"event.w: {event.w.__class__.__name__} event.widget {event.widget.__class__.__name__}"
-                    )
-                else:
-                    g.trace('No EVENT', g.callers())
-        if not g.isTextWrapper(w):
-            if trace:
-                old_w = w  ###
-                w = c.frame.body and c.frame.body.wrapper
-                g.trace(f"{old_w.__class__.__name__} ==> {w.__class__.__name__}")
-            else:
-                w = c.frame.body and c.frame.body.wrapper
-        # if w and g.isTextWrapper(w):
-        #     pass
-        # else:
-        #     w = c.frame.body and c.frame.body.wrapper
-        # if w and forceFocus:
-        #     c.widgetWantsFocusNow(w)
-        self.w = w
-        return w
-
     # @+node:ekr.20150514043714.11: *3* BaseEdit._checkSelection
     def _checkSelection(self, event: LeoKeyEvent, warning: str = 'no selection') -> bool:
         """Return True if there is a selection in the edit widget."""

--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -116,7 +116,7 @@ class BaseEditCommandsClass:
     # @+node:ekr.20150514043714.11: *3* BaseEdit._checkSelection
     def _checkSelection(self, event: LeoKeyEvent, warning: str = 'no selection') -> bool:
         """Return True if there is a selection in the edit widget."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         val = bool(w and w.hasSelection())
         if warning and not val:  # pragma: no cover
             g.es(warning, color='red')

--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -96,8 +96,8 @@ class BaseEditCommandsClass:
         self.w = w
         return w
 
-    # @+node:ekr.20150514043714.11: *3* BaseEdit._chckSel (to be deleted/moved)
-    def _chckSel(self, event: LeoKeyEvent, warning: str = 'no selection') -> bool:
+    # @+node:ekr.20150514043714.11: *3* BaseEdit._check_selection
+    def _checkSelection(self, event: LeoKeyEvent, warning: str = 'no selection') -> bool:
         """Return True if there is a selection in the edit widget."""
         w = self.editWidget(event)
         val = bool(w and w.hasSelection())

--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -83,7 +83,7 @@ class BaseEditCommandsClass:
             else:
                 k.resetLabel()
 
-    # @+node:ekr.20150514043714.7: *3* BaseEdit.editWidget
+    # @+node:ekr.20150514043714.7: *3* BaseEdit.editWidget (to be deleted)
     def editWidget(self, event: LeoKeyEvent, forceFocus: bool = True) -> QTextMixin:
         """Return the edit widget for the event. Also sets self.w"""
         c = self.c
@@ -97,13 +97,12 @@ class BaseEditCommandsClass:
         self.w = w
         return w
 
-    # @+node:ekr.20150514043714.8: *3* BaseEdit.getWSString
+    # @+node:ekr.20150514043714.8: *3* BaseEdit.getWSString (to be deleted)
     def getWSString(self, s: str) -> str:  # pragma: no cover
         """Return s with all characters replaced by tab or space."""
         return ''.join([ch if ch == '\t' else ' ' for ch in s])
 
-    # @+node:ekr.20150514043714.10: *3* BaseEdit.Helpers
-    # @+node:ekr.20150514043714.11: *4* BaseEdit._chckSel
+    # @+node:ekr.20150514043714.11: *3* BaseEdit._chckSel (to be deleted/moved)
     def _chckSel(self, event: LeoKeyEvent, warning: str = 'no selection') -> bool:
         """Return True if there is a selection in the edit widget."""
         w = self.editWidget(event)
@@ -112,18 +111,7 @@ class BaseEditCommandsClass:
             g.es(warning, color='red')
         return val
 
-    # @+node:ekr.20150514043714.13: *4* BaseEdit.getRectanglePoints
-    def getRectanglePoints(self, w: QTextMixin) -> tuple[int, int, int, int]:
-        """Return the rectangle corresponding to the selection range."""
-        c = self.c
-        c.widgetWantsFocusNow(w)
-        s = w.getAllText()
-        i, j = w.getSelectionRange()
-        r1, r2 = g.convertPythonIndexToRowCol(s, i)
-        r3, r4 = g.convertPythonIndexToRowCol(s, j)
-        return r1 + 1, r2, r3 + 1, r4
-
-    # @+node:ekr.20150514043714.14: *4* BaseEdit.keyboardQuit
+    # @+node:ekr.20150514043714.14: *3* BaseEdit.keyboardQuit (to be deleted)
     def keyboardQuit(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
         """Clear the state and the minibuffer label."""
         self.c.k.keyboardQuit()

--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -105,11 +105,6 @@ class BaseEditCommandsClass:
             g.es(warning, color='red')
         return val
 
-    # @+node:ekr.20150514043714.14: *3* BaseEdit.keyboardQuit (to be deleted)
-    def keyboardQuit(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
-        """Clear the state and the minibuffer label."""
-        self.c.k.keyboardQuit()
-
     # @-others
 
 

--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -22,7 +22,7 @@ class BaseEditCommandsClass:
     """The base class for all edit command classes"""
 
     # @+others
-    # @+node:ekr.20150516040334.1: *3* BaseEdit.ctor
+    # @+node:ekr.20150516040334.1: *3* BaseEdit.__init__
     def __init__(self, c: Cmdr) -> None:
         """
         Ctor for the BaseEditCommandsClass class.
@@ -32,8 +32,7 @@ class BaseEditCommandsClass:
         """
         self.c = c
 
-    # @+node:ekr.20150514043714.3: *3* BaseEdit.begin/endCommand (handles undo)
-    # @+node:ekr.20150514043714.4: *4* BaseEdit.beginCommand
+    # @+node:ekr.20150514043714.4: *3* BaseEdit.beginCommand
     def beginCommand(self, w: QTextMixin, undoType: str = 'Typing') -> QTextMixin:
         """Do the common processing at the start of each command."""
         c, p, u = self.c, self.c.p, self.c.undoer
@@ -52,7 +51,7 @@ class BaseEditCommandsClass:
             self.undoData = None  # pragma: no cover
         return w
 
-    # @+node:ekr.20150514043714.6: *4* BaseEdit.endCommand
+    # @+node:ekr.20150514043714.6: *3* BaseEdit.endCommand
     def endCommand(self, label: str = None, changed: bool = True, setLabel: bool = True) -> None:
         """
         Do the common processing at the end of each command.
@@ -96,11 +95,6 @@ class BaseEditCommandsClass:
             c.widgetWantsFocusNow(w)
         self.w = w
         return w
-
-    # @+node:ekr.20150514043714.8: *3* BaseEdit.getWSString (to be deleted)
-    def getWSString(self, s: str) -> str:  # pragma: no cover
-        """Return s with all characters replaced by tab or space."""
-        return ''.join([ch if ch == '\t' else ' ' for ch in s])
 
     # @+node:ekr.20150514043714.11: *3* BaseEdit._chckSel (to be deleted/moved)
     def _chckSel(self, event: LeoKeyEvent, warning: str = 'no selection') -> bool:

--- a/leo/commands/bufferCommands.py
+++ b/leo/commands/bufferCommands.py
@@ -49,7 +49,7 @@ class BufferCommandsClass(BaseEditCommandsClass):
     @cmd('buffer-append-to')
     def appendToBuffer(self, event: LeoKeyEvent) -> None:
         """Add the selected body text to the end of the body text of a named buffer (node)."""
-        self.w = self.editWidget(event)
+        self.w = event.w if event else None
         if self.w:
             self.c.k.setLabelBlue('Append to buffer: ')
             self.getBufferName(event, self.appendToBuffer1)
@@ -73,7 +73,7 @@ class BufferCommandsClass(BaseEditCommandsClass):
     @cmd('buffer-copy')
     def copyToBuffer(self, event: LeoKeyEvent) -> None:
         """Add the selected body text to the end of the body text of a named buffer (node)."""
-        self.w = self.editWidget(event)
+        self.w = event.w if event else None
         if self.w:
             self.c.k.setLabelBlue('Copy to buffer: ')
             self.getBufferName(event, self.copyToBuffer1)
@@ -94,7 +94,7 @@ class BufferCommandsClass(BaseEditCommandsClass):
     @cmd('buffer-insert')
     def insertToBuffer(self, event: LeoKeyEvent) -> None:
         """Add the selected body text at the insert point of the body text of a named buffer (node)."""
-        self.w = self.editWidget(event)
+        self.w = event.w if event else None
         if self.w:
             self.c.k.setLabelBlue('Insert to buffer: ')
             self.getBufferName(event, self.insertToBuffer1)
@@ -115,7 +115,7 @@ class BufferCommandsClass(BaseEditCommandsClass):
     @cmd('buffer-kill')
     def killBuffer(self, event: LeoKeyEvent) -> None:
         """Delete a buffer (node) and all its descendants."""
-        self.w = self.editWidget(event)
+        self.w = event.w if event else None
         if self.w:
             self.c.k.setLabelBlue('Kill buffer: ')
             self.getBufferName(event, self.killBuffer1)
@@ -161,7 +161,7 @@ class BufferCommandsClass(BaseEditCommandsClass):
     @cmd('buffer-prepend-to')
     def prependToBuffer(self, event: LeoKeyEvent) -> None:
         """Add the selected body text to the start of the body text of a named buffer (node)."""
-        self.w = self.editWidget(event)
+        self.w = event.w if event else None
         if self.w:
             self.c.k.setLabelBlue('Prepend to buffer: ')
             self.getBufferName(event, self.prependToBuffer1)

--- a/leo/commands/controlCommands.py
+++ b/leo/commands/controlCommands.py
@@ -108,7 +108,7 @@ class ControlCommandsClass(BaseEditCommandsClass):
     def shellCommandOnRegion(self, event: LeoKeyEvent) -> None:
         """Execute a command taken from the selected text in a separate process."""
         k = self.c.k
-        w = self.editWidget(event)
+        w = event.w if event else None
         if w:
             if w.hasSelection():
                 command = w.getSelectedText()
@@ -149,7 +149,7 @@ class ControlCommandsClass(BaseEditCommandsClass):
     @cmd('suspend')
     def suspend(self, event: LeoKeyEvent) -> None:
         """Minimize the present Leo window."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         self.c.frame.top.iconify()

--- a/leo/commands/controlCommands.py
+++ b/leo/commands/controlCommands.py
@@ -109,7 +109,7 @@ class ControlCommandsClass(BaseEditCommandsClass):
         """Execute a command taken from the selected text in a separate process."""
         k = self.c.k
         w = event.w if event else None
-        if w:
+        if g.isTextWrapper(w):
             if w.hasSelection():
                 command = w.getSelectedText()
                 self.executeSubprocess(event, command)

--- a/leo/commands/controlCommands.py
+++ b/leo/commands/controlCommands.py
@@ -149,9 +149,6 @@ class ControlCommandsClass(BaseEditCommandsClass):
     @cmd('suspend')
     def suspend(self, event: LeoKeyEvent) -> None:
         """Minimize the present Leo window."""
-        w = event.w if event else None
-        if not w:
-            return
         self.c.frame.top.iconify()
 
     @cmd('iconify-frame')

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -495,7 +495,8 @@ class EditCommandsClass(BaseEditCommandsClass):
         text, if there is any, or any path like text immediately preceding the
         cursor.
         """
-        c, u, w = self.c, self.c.undoer, self.editWidget(event)
+        c, u = self.c, self.c.undoer
+        w = event.w if event else None
         if not w:
             return
 
@@ -539,7 +540,6 @@ class EditCommandsClass(BaseEditCommandsClass):
         if g.app.batchMode:
             c.notValidInBatchMode("Insert Headline Time")
             return
-        # #131: Do not get w from self.editWidget()!
         w = c.frame.tree.edit_widget(p)
         if w and not g.app.inBridge:
             # Fix bug https://bugs.launchpad.net/leo-editor/+bug/1185933
@@ -711,7 +711,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Capitalize Entire Body Or Selection."""
         frame = self
         c, p, u = frame.c, self.c.p, self.c.undoer
-        w = frame.editWidget(event)
+        w = event.w if event else None
         s = w.getAllText()
         if not s:
             return
@@ -908,7 +908,8 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('center-line')
     def centerLine(self, event: LeoKeyEvent) -> None:
         """Centers line within current fill column"""
-        c, w = self.c, self.editWidget(event)
+        c = self.c
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         if self.fillColumn > 0:
@@ -955,7 +956,8 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('center-region')
     def centerRegion(self, event: LeoKeyEvent) -> None:
         """Centers the selected text within the fill column"""
-        c, w = self.c, self.editWidget(event)
+        c = self.c
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         s = w.getAllText()
@@ -1882,7 +1884,8 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('delete-char')
     def deleteNextChar(self, event: LeoKeyEvent) -> None:
         """Delete the character to the right of the cursor."""
-        c, w = self.c, self.editWidget(event)
+        c = self.c
+        w = event.w if event else None
         if not w:
             return
         wname = c.widget_name(w)
@@ -2054,15 +2057,13 @@ class EditCommandsClass(BaseEditCommandsClass):
 
         Select all lines if there is no existing selection.
         """
-        c, p, u, w = self.c, self.c.p, self.c.undoer, self.editWidget(event)
-        #
+        c, p, u = self.c, self.c.p, self.c.undoer
+        w = event.w if event else None
         # "Before" snapshot.
         bunch = u.beforeChangeBody(p)
-        #
         # Initial data.
         oldYview = w.getYScrollPosition()
         lines = g.splitLines(w.getAllText())
-        #
         # Calculate the result.
         result_list = []
         changed = False
@@ -2073,7 +2074,6 @@ class EditCommandsClass(BaseEditCommandsClass):
                 changed = True
         if not changed:
             return  # pragma: no cover (defensive)
-        #
         # Set p.b and w's text first.
         result = ''.join(result_list)
         p.b = result
@@ -2081,7 +2081,6 @@ class EditCommandsClass(BaseEditCommandsClass):
         i, j = 0, max(0, len(result) - 1)
         w.setSelectionRange(i, j, insert=j)
         w.setYScrollPosition(oldYview)
-        #
         # "after" snapshot.
         c.undoer.afterChangeBody(p, 'remove-blank-lines', bunch)
 
@@ -2127,7 +2126,8 @@ class EditCommandsClass(BaseEditCommandsClass):
         It handles undo, bodykey events, tabs, back-spaces and bracket matching.
         """
         trace = 'keys' in g.app.debug
-        c, p, u, w = self.c, self.c.p, self.c.undoer, self.editWidget(event)
+        c, p, u = self.c, self.c.p, self.c.undoer
+        w = event.w if event else None
         undoType = 'Typing'
         if not w:
             return  # pragma: no cover (defensive)

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -3053,8 +3053,9 @@ class EditCommandsClass(BaseEditCommandsClass):
         w: QTextMixin = None,
     ) -> tuple[int, int]:
         """Compute the word at the cursor. Select it if select arg is True."""
-        if not w:
-            w = self.editWidget(event)
+        w = event.w if event else None
+        # if not w:
+        #     w = self.editWidget(event)
         if not w:
             return 0, 0  # pragma: no cover (defensive)
         s = w.getAllText()

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -2575,7 +2575,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """
         c, k = self.c, self.c.k
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         c.widgetWantsFocusNow(w)
         # Put the request in the proper range.
@@ -2590,7 +2590,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.305: *5* ec.moveWithinLineHelper
     def moveWithinLineHelper(self, event: LeoKeyEvent, spot: str, extend: bool) -> None:
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         # Bug fix: 2012/02/28: don't use the Qt end-line logic:
         # it apparently does not work for wrapped lines.
@@ -2640,7 +2640,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         c.widgetWantsFocusNow(w)
         s = w.getAllText()
@@ -2759,7 +2759,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         or the start of the line if already there.
         """
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         s = w.getAllText()
         ins = w.getInsertPoint()
@@ -2781,7 +2781,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def backToIndentation(self, event: LeoKeyEvent) -> None:
         """Position the point at the first non-blank character on the line."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         s = w.getAllText()
         ins = w.getInsertPoint()
@@ -2850,7 +2850,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.293: *5* ec.moveUpOrDownHelper
     def moveUpOrDownHelper(self, event: LeoKeyEvent, direction: str, extend: bool) -> None:
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         ins = w.getInsertPoint()
         s = w.getAllText()
@@ -2896,7 +2896,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.295: *5* ec.moveToBufferHelper
     def moveToBufferHelper(self, event: LeoKeyEvent, spot: str, extend: bool) -> None:
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         if hasattr(w, 'leoMoveCursorHelper'):
             extend = extend or self.extendMode
@@ -2934,7 +2934,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.297: *5* ec.moveToCharacterHelper
     def moveToCharacterHelper(self, event: LeoKeyEvent, spot: str, extend: bool) -> None:
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         if hasattr(w, 'leoMoveCursorHelper'):
             extend = extend or self.extendMode
@@ -2996,7 +2996,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         if hasattr(w, 'leoMoveCursorHelper'):
             w.leoMoveCursorHelper(kind='exchange', extend=False)
@@ -3015,7 +3015,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def extendToLine(self, event: LeoKeyEvent) -> None:
         """Select the line at the cursor."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         s = w.getAllText()
         n = len(s)
@@ -3033,7 +3033,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def extendToSentence(self, event: LeoKeyEvent) -> None:
         """Select the line at the cursor."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         s = w.getAllText()
         n = len(s)
@@ -3054,7 +3054,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     ) -> tuple[int, int]:
         """Compute the word at the cursor. Select it if select arg is True."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return 0, 0  # pragma: no cover (defensive)
         s = w.getAllText()
         n = len(s)
@@ -3142,7 +3142,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def movePastCloseHelper(self, event: LeoKeyEvent, extend: bool) -> None:
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         c.widgetWantsFocusNow(w)
         s = w.getAllText()
@@ -3208,7 +3208,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     ) -> None:  # kind in back/forward.
         """Move the cursor up/down one page, possibly extending the selection."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         linesPerPage = 15  # To do.
         if hasattr(w, 'leoMoveCursorHelper'):
@@ -3259,7 +3259,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.309: *5* ec.backwardParagraphHelper
     def backwardParagraphHelper(self, event: LeoKeyEvent, extend: bool) -> None:
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         s = w.getAllText()
         i, j = w.getSelectionRange()
@@ -3284,7 +3284,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.310: *5* ec.forwardParagraphHelper
     def forwardParagraphHelper(self, event: LeoKeyEvent, extend: bool) -> None:
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         s = w.getAllText()
         ins = w.getInsertPoint()
@@ -3343,7 +3343,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Select all text."""
         k = self.c.k
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         # Bug fix 2013/12/13: Special case the minibuffer.
         if w == k.w:
@@ -3376,7 +3376,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def backSentenceHelper(self, event: LeoKeyEvent, extend: bool) -> None:
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         c.widgetWantsFocusNow(w)
         s = w.getAllText()
@@ -3442,7 +3442,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def forwardSentenceHelper(self, event: LeoKeyEvent, extend: bool) -> None:
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         c.widgetWantsFocusNow(w)
         s = w.getAllText()
@@ -3520,7 +3520,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Kill the previous paragraph."""
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         self.beginCommand(w, undoType='backward-kill-paragraph')
         try:
@@ -3567,7 +3567,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def fillParagraph(self, event: LeoKeyEvent) -> None:
         """Fill the selected paragraph"""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         # Clear the selection range.
         i, j = w.getSelectionRange()
@@ -3580,7 +3580,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Kill the present paragraph."""
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         self.beginCommand(w, undoType='kill-paragraph')
         try:
@@ -3596,7 +3596,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def extendToParagraph(self, event: LeoKeyEvent) -> None:
         """Select the paragraph surrounding the cursor."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         s = w.getAllText()
         ins = w.getInsertPoint()
@@ -3665,7 +3665,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Print the number of lines and characters in the selected text."""
         k = self.c.k
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         txt = w.getSelectedText()
         lines = 1
@@ -3685,7 +3685,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         s = w.getAllText()
         sel_1, sel_2 = w.getSelectionRange()
@@ -3729,7 +3729,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         s = w.getAllText()
         sel_1, sel_2 = w.getSelectionRange()
@@ -4028,7 +4028,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def transposeLines(self, event: LeoKeyEvent) -> None:
         """Transpose the line containing the cursor with the preceding line."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         ins = w.getInsertPoint()
         s = w.getAllText()
@@ -4060,7 +4060,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         transposes into ‘BAR, FOO’.
         """
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         self.beginCommand(w, undoType='transpose-words')
         s = w.getAllText()
@@ -4088,7 +4088,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def transposeCharacters(self, event: LeoKeyEvent) -> None:
         """Swap the characters at the cursor."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         self.beginCommand(w, undoType='swap-characters')
         s = w.getAllText()

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -497,7 +497,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """
         c, u = self.c, self.c.undoer
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
 
         def callback(arg: str, w: QTextMixin = w) -> None:
@@ -681,7 +681,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.194: *4* ec.capitalizeHelper
     def capitalizeHelper(self, event: LeoKeyEvent, which: str, undoType: str) -> None:
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         s = w.getAllText()
         ins = w.getInsertPoint()
@@ -854,7 +854,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def setCommentColumn(self, event: LeoKeyEvent) -> None:
         """Set the comment column for the indent-to-comment-column command."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         s = w.getAllText()
         ins = w.getInsertPoint()
@@ -869,7 +869,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         comment column.
         """
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         self.beginCommand(w, undoType='indent-to-comment-column')
         s = w.getAllText()
@@ -910,7 +910,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Centers line within current fill column"""
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         if self.fillColumn > 0:
             fillColumn = self.fillColumn
@@ -958,7 +958,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Centers the selected text within the fill column"""
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         s = w.getAllText()
         sel_1, sel_2 = w.getSelectionRange()
@@ -992,7 +992,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def setFillPrefix(self, event: LeoKeyEvent) -> None:
         """Make the selected text the fill prefix."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         s = w.getAllText()
         i, j = w.getSelectionRange()
@@ -1518,7 +1518,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def deleteIndentation(self, event: LeoKeyEvent) -> None:
         """Delete indentation in the presently line."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         s = w.getAllText()
         ins = w.getInsertPoint()
@@ -1552,7 +1552,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         p, u = self.c.p, self.c.undoer
         undoType = 'indent-relative'
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         s = w.getAllText()
         ins = w.getInsertPoint()
@@ -1607,7 +1607,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Print the character, line number, column number and total number of characters."""
         k = self.c.k
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         s = w.getAllText()
         i = w.getInsertPoint()
@@ -1672,7 +1672,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def addRemoveHelper(self, event: LeoKeyEvent, ch: str, add: bool, undoType: str) -> None:
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         if w.hasSelection():
             s = w.getSelectedText()
@@ -1707,7 +1707,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Delete the character to the left of the cursor."""
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         wname = c.widget_name(w)
         ins = w.getInsertPoint()
@@ -1774,7 +1774,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         c = self.c
         u = c.undoer
         w = c.frame.body.wrapper
-        if not w:
+        if not g.isTextWrapper(w):
             return
         tag = 'clean-all-lines'
         roots = g.findRootsWithPredicate(c, c.p)
@@ -1807,7 +1807,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         Not recommended: reindent is better.
         """
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         s = w.getAllText()
         lines = []
@@ -1829,7 +1829,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def clearSelectedText(self, event: LeoKeyEvent) -> None:
         """Delete the selected text."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         i, j = w.getSelectionRange()
         if i == j:
@@ -1865,7 +1865,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def deleteWordHelper(self, event: LeoKeyEvent, forward: bool, smart: bool = False) -> None:
         # c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         self.beginCommand(w, undoType="delete-word")
         if w.hasSelection():
@@ -1886,7 +1886,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Delete the character to the right of the cursor."""
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         wname = c.widget_name(w)
         if wname.startswith('body'):
@@ -1920,7 +1920,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def deleteSpaces(self, event: LeoKeyEvent, insertspace: bool = False) -> None:
         """Delete all whitespace surrounding the cursor."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         undoType = 'insert-space' if insertspace else 'delete-spaces'
         s = w.getAllText()
@@ -1950,7 +1950,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Insert one hard tab."""
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         if not g.isTextWrapper(w):
             return
@@ -1977,7 +1977,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         # Note: insertNewlineHelper already exists.
         c, k = self.c, self.c.k
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
@@ -1999,7 +1999,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         c, k = self.c, self.c.k
         p = c.p
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         if not g.isTextWrapper(w):
             return
@@ -2034,7 +2034,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Insert spaces equivalent to one tab."""
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         if not g.isTextWrapper(w):
             return
@@ -2127,9 +2127,9 @@ class EditCommandsClass(BaseEditCommandsClass):
         """
         trace = 'keys' in g.app.debug
         c, p, u = self.c, self.c.p, self.c.undoer
-        w = event.w if event else None
         undoType = 'Typing'
-        if not w:
+        w = event.w if event else None
+        if not g.isTextWrapper(w):
             return  # pragma: no cover (defensive)
         # @+<< set local vars >>
         # @+node:ekr.20150514063305.269: *5* << set local vars >> (selfInsertCommand)
@@ -2469,7 +2469,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         if not c.p.threadNext():
             return
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         s = w.getAllText()
         sel_1, sel_2 = w.getSelectionRange()

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -936,7 +936,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Set the fill column used by the center-line and center-region commands."""
         k = self.c.k
         self.w = event.w if event else None
-        if not self.w:
+        if not g.isTextWrapper(self.w):
             return  # pragma: no cover (defensive)
         k.setLabelBlue('Set Fill Column: ')
         k.get1Arg(event, handler=self.setFillColumn1)
@@ -1025,7 +1025,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Put the cursor at the next occurrence of a character on a line."""
         k = self.c.k
         self.w = event.w if event else None
-        if not self.w:
+        if not g.isTextWrapper(self.w):
             return
         self.event = event
         self.backward = backward

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -3558,7 +3558,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def fillRegionAsParagraph(self, event: LeoKeyEvent) -> None:
         """Fill the selected text."""
         w = self.editWidget(event)
-        if not w or not self._chckSel(event):
+        if not w or not self._checkSelection(event):
             return  # pragma: no cover (defensive)
         self.beginCommand(w, undoType='fill-region-as-paragraph')
         self.endCommand(changed=True, setLabel=True)
@@ -3644,7 +3644,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def tabIndentRegion(self, event: LeoKeyEvent) -> None:
         """Insert a hard tab at the start of each line of the selected text."""
         w = self.editWidget(event)
-        if not w or not self._chckSel(event):
+        if not w or not self._checkSelection(event):
             return  # pragma: no cover (defensive)
         self.beginCommand(w, undoType='indent-rigidly')
         s = w.getAllText()
@@ -3768,7 +3768,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def reverseRegion(self, event: LeoKeyEvent) -> None:
         """Reverse the order of lines in the selected text."""
         w = self.editWidget(event)
-        if not w or not self._chckSel(event):
+        if not w or not self._checkSelection(event):
             return  # pragma: no cover (defensive)
         self.beginCommand(w, undoType='reverse-region')
         s = w.getAllText()
@@ -3939,7 +3939,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         comparison.
         """
         w = self.editWidget(event)
-        if not self._chckSel(event):
+        if not self._checkSelection(event):
             return  # pragma: no cover (defensive)
         s = w.getAllText()
 
@@ -3995,7 +3995,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     ) -> None:
         """Sort the selected lines."""
         w = self.editWidget(event)
-        if not self._chckSel(event):
+        if not self._checkSelection(event):
             return
         undoType = 'reverse-sort-lines' if reverse else 'sort-lines'
         self.beginCommand(w, undoType=undoType)

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -643,7 +643,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self.tabifyHelper(event, which='untabify')
 
     def tabifyHelper(self, event: LeoKeyEvent, which: str) -> None:
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w or not w.hasSelection():
             return
         self.beginCommand(w, undoType=which)
@@ -680,7 +680,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.194: *4* ec.capitalizeHelper
     def capitalizeHelper(self, event: LeoKeyEvent, which: str, undoType: str) -> None:
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         s = w.getAllText()
@@ -853,7 +853,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('set-comment-column')
     def setCommentColumn(self, event: LeoKeyEvent) -> None:
         """Set the comment column for the indent-to-comment-column command."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         s = w.getAllText()
@@ -868,7 +868,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         Insert whitespace to indent the line containing the insert point to the
         comment column.
         """
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         self.beginCommand(w, undoType='indent-to-comment-column')
@@ -934,7 +934,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def setFillColumn(self, event: LeoKeyEvent) -> None:
         """Set the fill column used by the center-line and center-region commands."""
         k = self.c.k
-        self.w = self.editWidget(event)
+        self.w = event.w if event else None
         if not self.w:
             return  # pragma: no cover (defensive)
         k.setLabelBlue('Set Fill Column: ')
@@ -989,7 +989,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('set-fill-prefix')
     def setFillPrefix(self, event: LeoKeyEvent) -> None:
         """Make the selected text the fill prefix."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         s = w.getAllText()
@@ -1022,7 +1022,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def findCharacterHelper(self, event: LeoKeyEvent, backward: bool, extend: bool) -> None:
         """Put the cursor at the next occurrence of a character on a line."""
         k = self.c.k
-        self.w = self.editWidget(event)
+        self.w = event.w if event else None
         if not self.w:
             return
         self.event = event
@@ -1073,7 +1073,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.224: *5* ec.findWordHelper
     def findWordHelper(self, event: LeoKeyEvent, oneLine: bool) -> None:
         k = self.c.k
-        self.w = self.editWidget(event)
+        self.w = event.w if event else None
         if self.w:
             self.oneLineFlag = oneLine
             k.setLabelBlue(f"Find word {'in line ' if oneLine else ''}starting with: ")
@@ -1121,7 +1121,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def gotoCharacter(self, event: LeoKeyEvent) -> None:
         """Put the cursor at the n'th character of the buffer."""
         k = self.c.k
-        self.w = self.editWidget(event)
+        self.w = event.w if event else None
         if self.w:
             k.setLabelBlue("Goto n'th character: ")
             k.get1Arg(event, handler=self.gotoCharacter1)
@@ -1158,7 +1158,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         # Improved docstring for #253: Goto Global line (Alt-G) is inconsistent.
         # https://github.com/leo-editor/leo-editor/issues/253
         k = self.c.k
-        self.w = self.editWidget(event)
+        self.w = event.w if event else None
         if self.w:
             k.setLabelBlue('Goto global line: ')
             k.get1Arg(event, handler=self.gotoGlobalLine1)
@@ -1177,7 +1177,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def gotoLine(self, event: LeoKeyEvent) -> None:
         """Put the cursor at the n'th line of the buffer."""
         k = self.c.k
-        self.w = self.editWidget(event)
+        self.w = event.w if event else None
         if self.w:
             k.setLabelBlue('Goto line: ')
             k.get1Arg(event, handler=self.gotoLine1)
@@ -1515,7 +1515,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('delete-indentation')
     def deleteIndentation(self, event: LeoKeyEvent) -> None:
         """Delete indentation in the presently line."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         s = w.getAllText()
@@ -1549,7 +1549,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """
         p, u = self.c.p, self.c.undoer
         undoType = 'indent-relative'
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         s = w.getAllText()
@@ -1604,7 +1604,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def lineNumber(self, event: LeoKeyEvent) -> None:
         """Print the character, line number, column number and total number of characters."""
         k = self.c.k
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         s = w.getAllText()
@@ -1635,7 +1635,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def whatLine(self, event: LeoKeyEvent) -> None:
         """Print the line number of the line containing the cursor."""
         k = self.c.k
-        w = self.editWidget(event)
+        w = event.w if event else None
         if w:
             s = w.getAllText()
             i = w.getInsertPoint()
@@ -1669,7 +1669,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.252: *5* ec.addRemoveHelper
     def addRemoveHelper(self, event: LeoKeyEvent, ch: str, add: bool, undoType: str) -> None:
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         if w.hasSelection():
@@ -1704,7 +1704,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def backwardDeleteCharacter(self, event: LeoKeyEvent = None) -> None:
         """Delete the character to the left of the cursor."""
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         wname = c.widget_name(w)
@@ -1804,7 +1804,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
         Not recommended: reindent is better.
         """
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         s = w.getAllText()
@@ -1826,7 +1826,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('clear-selected-text')
     def clearSelectedText(self, event: LeoKeyEvent) -> None:
         """Delete the selected text."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         i, j = w.getSelectionRange()
@@ -1862,7 +1862,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     def deleteWordHelper(self, event: LeoKeyEvent, forward: bool, smart: bool = False) -> None:
         # c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         self.beginCommand(w, undoType="delete-word")
@@ -1916,7 +1916,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('delete-spaces')
     def deleteSpaces(self, event: LeoKeyEvent, insertspace: bool = False) -> None:
         """Delete all whitespace surrounding the cursor."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         undoType = 'insert-space' if insertspace else 'delete-spaces'
@@ -1946,7 +1946,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def insertHardTab(self, event: LeoKeyEvent) -> None:
         """Insert one hard tab."""
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         if not g.isTextWrapper(w):
@@ -1973,7 +1973,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """A helper that can be monkey-patched by tables.py plugin."""
         # Note: insertNewlineHelper already exists.
         c, k = self.c, self.c.k
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         if not g.isTextWrapper(w):
@@ -1995,7 +1995,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         trace = 'keys' in g.app.debug
         c, k = self.c, self.c.k
         p = c.p
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         if not g.isTextWrapper(w):
@@ -2017,7 +2017,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('insert-parentheses')
     def insertParentheses(self, event: LeoKeyEvent) -> None:
         """Insert () at the cursor."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if w:
             self.beginCommand(w, undoType='insert-parenthesis')
             i = w.getInsertPoint()
@@ -2030,7 +2030,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def insertSoftTab(self, event: LeoKeyEvent) -> None:
         """Insert spaces equivalent to one tab."""
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         if not g.isTextWrapper(w):
@@ -2090,7 +2090,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def replaceCurrentCharacter(self, event: LeoKeyEvent) -> None:
         """Replace the current character with the next character typed."""
         k = self.c.k
-        self.w = self.editWidget(event)
+        self.w = event.w if event else None
         if self.w:
             k.setLabelBlue('Replace Character: ')
             k.get1Arg(event, handler=self.replaceCurrentCharacter1)
@@ -2468,7 +2468,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         c = self.c
         if not c.p.threadNext():
             return
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         s = w.getAllText()
@@ -2493,7 +2493,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('split-line')
     def splitLine(self, event: LeoKeyEvent) -> None:
         """Split a line at the cursor position."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if w:
             self.beginCommand(w, undoType='split-line')
             s = w.getAllText()
@@ -2574,7 +2574,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         in a way that can be described by a Tk Text expression.
         """
         c, k = self.c, self.c.k
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         c.widgetWantsFocusNow(w)
@@ -2589,7 +2589,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.305: *5* ec.moveWithinLineHelper
     def moveWithinLineHelper(self, event: LeoKeyEvent, spot: str, extend: bool) -> None:
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         # Bug fix: 2012/02/28: don't use the Qt end-line logic:
@@ -2639,7 +2639,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         The cursor is placed at the start of the word unless end=True
         """
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         c.widgetWantsFocusNow(w)
@@ -2758,7 +2758,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         Position the point at the first non-blank character on the line,
         or the start of the line if already there.
         """
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         s = w.getAllText()
@@ -2780,7 +2780,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('back-to-indentation')
     def backToIndentation(self, event: LeoKeyEvent) -> None:
         """Position the point at the first non-blank character on the line."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         s = w.getAllText()
@@ -2849,7 +2849,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.293: *5* ec.moveUpOrDownHelper
     def moveUpOrDownHelper(self, event: LeoKeyEvent, direction: str, extend: bool) -> None:
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         ins = w.getInsertPoint()
@@ -2895,7 +2895,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.295: *5* ec.moveToBufferHelper
     def moveToBufferHelper(self, event: LeoKeyEvent, spot: str, extend: bool) -> None:
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         if hasattr(w, 'leoMoveCursorHelper'):
@@ -2933,7 +2933,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.297: *5* ec.moveToCharacterHelper
     def moveToCharacterHelper(self, event: LeoKeyEvent, spot: str, extend: bool) -> None:
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         if hasattr(w, 'leoMoveCursorHelper'):
@@ -2968,7 +2968,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     def extendModeHelper(self, event: LeoKeyEvent, val: bool) -> None:
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if w:
             self.extendMode = val
             if not g.unitTesting:
@@ -2995,7 +2995,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         selected text).
         """
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         if hasattr(w, 'leoMoveCursorHelper'):
@@ -3014,7 +3014,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('extend-to-line')
     def extendToLine(self, event: LeoKeyEvent) -> None:
         """Select the line at the cursor."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         s = w.getAllText()
@@ -3032,7 +3032,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('extend-to-sentence')
     def extendToSentence(self, event: LeoKeyEvent) -> None:
         """Select the line at the cursor."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         s = w.getAllText()
@@ -3054,8 +3054,6 @@ class EditCommandsClass(BaseEditCommandsClass):
     ) -> tuple[int, int]:
         """Compute the word at the cursor. Select it if select arg is True."""
         w = event.w if event else None
-        # if not w:
-        #     w = self.editWidget(event)
         if not w:
             return 0, 0  # pragma: no cover (defensive)
         s = w.getAllText()
@@ -3143,7 +3141,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.304: *5* ec.movePastCloseHelper
     def movePastCloseHelper(self, event: LeoKeyEvent, extend: bool) -> None:
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         c.widgetWantsFocusNow(w)
@@ -3209,7 +3207,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self, event: LeoKeyEvent, kind: str, extend: bool
     ) -> None:  # kind in back/forward.
         """Move the cursor up/down one page, possibly extending the selection."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         linesPerPage = 15  # To do.
@@ -3260,7 +3258,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.309: *5* ec.backwardParagraphHelper
     def backwardParagraphHelper(self, event: LeoKeyEvent, extend: bool) -> None:
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         s = w.getAllText()
@@ -3285,7 +3283,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.310: *5* ec.forwardParagraphHelper
     def forwardParagraphHelper(self, event: LeoKeyEvent, extend: bool) -> None:
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         s = w.getAllText()
@@ -3311,7 +3309,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def popCursor(self, event: LeoKeyEvent = None) -> None:
         """Restore the node, selection range and insert point from the stack."""
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if w and self.cursorStack:
             p, i, j, ins = self.cursorStack.pop()
             if c.positionExists(p):
@@ -3328,7 +3326,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def pushCursor(self, event: LeoKeyEvent = None) -> None:
         """Push the selection range and insert point on the stack."""
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if w:
             p = c.p.copy()
             i, j = w.getSelectionRange()
@@ -3344,7 +3342,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def selectAllText(self, event: LeoKeyEvent) -> None:
         """Select all text."""
         k = self.c.k
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         # Bug fix 2013/12/13: Special case the minibuffer.
@@ -3377,7 +3375,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.313: *5* ec.backSentenceHelper
     def backSentenceHelper(self, event: LeoKeyEvent, extend: bool) -> None:
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         c.widgetWantsFocusNow(w)
@@ -3443,7 +3441,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.314: *5* ec.forwardSentenceHelper
     def forwardSentenceHelper(self, event: LeoKeyEvent, extend: bool) -> None:
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         c.widgetWantsFocusNow(w)
@@ -3521,7 +3519,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def backwardKillParagraph(self, event: LeoKeyEvent) -> None:
         """Kill the previous paragraph."""
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         self.beginCommand(w, undoType='backward-kill-paragraph')
@@ -3541,7 +3539,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Fill all paragraphs in the selected text."""
         c, p = self.c, self.c.p
         undoType = 'fill-region'
-        w = self.editWidget(event)
+        w = event.w if event else None
         i, j = w.getSelectionRange()
         c.undoer.beforeChangeGroup(p, undoType)
         while 1:
@@ -3558,7 +3556,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('fill-region-as-paragraph')
     def fillRegionAsParagraph(self, event: LeoKeyEvent) -> None:
         """Fill the selected text."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w or not self._checkSelection(event):
             return  # pragma: no cover (defensive)
         self.beginCommand(w, undoType='fill-region-as-paragraph')
@@ -3568,7 +3566,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('fill-paragraph')
     def fillParagraph(self, event: LeoKeyEvent) -> None:
         """Fill the selected paragraph"""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         # Clear the selection range.
@@ -3581,7 +3579,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def killParagraph(self, event: LeoKeyEvent) -> None:
         """Kill the present paragraph."""
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         self.beginCommand(w, undoType='kill-paragraph')
@@ -3597,7 +3595,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('extend-to-paragraph')
     def extendToParagraph(self, event: LeoKeyEvent) -> None:
         """Select the paragraph surrounding the cursor."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         s = w.getAllText()
@@ -3644,7 +3642,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('indent-rigidly')
     def tabIndentRegion(self, event: LeoKeyEvent) -> None:
         """Insert a hard tab at the start of each line of the selected text."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w or not self._checkSelection(event):
             return  # pragma: no cover (defensive)
         self.beginCommand(w, undoType='indent-rigidly')
@@ -3666,7 +3664,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def countRegion(self, event: LeoKeyEvent) -> None:
         """Print the number of lines and characters in the selected text."""
         k = self.c.k
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         txt = w.getSelectedText()
@@ -3686,7 +3684,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         Move all lines containing any selected text down one line.
         """
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         s = w.getAllText()
@@ -3730,7 +3728,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         Move all lines containing any selected text up one line.
         """
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         s = w.getAllText()
@@ -3768,7 +3766,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('reverse-region')
     def reverseRegion(self, event: LeoKeyEvent) -> None:
         """Reverse the order of lines in the selected text."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w or not self._checkSelection(event):
             return  # pragma: no cover (defensive)
         self.beginCommand(w, undoType='reverse-region')
@@ -3802,7 +3800,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self.caseHelper(event, 'up', 'upcase-region')
 
     def caseHelper(self, event: LeoKeyEvent, way: str, undoType: str) -> None:
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w or not w.hasSelection():
             return  # pragma: no cover (defensive)
         self.beginCommand(w, undoType=undoType)
@@ -3939,7 +3937,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         Sort lines of selected text using the selected columns to do the
         comparison.
         """
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not self._checkSelection(event):
             return  # pragma: no cover (defensive)
         s = w.getAllText()
@@ -3995,7 +3993,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self, event: LeoKeyEvent, ignoreCase: bool = False, reverse: bool = False
     ) -> None:
         """Sort the selected lines."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not self._checkSelection(event):
             return
         undoType = 'reverse-sort-lines' if reverse else 'sort-lines'
@@ -4029,7 +4027,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('transpose-lines')
     def transposeLines(self, event: LeoKeyEvent) -> None:
         """Transpose the line containing the cursor with the preceding line."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         ins = w.getInsertPoint()
@@ -4061,7 +4059,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         Punctuation between words does not move. For example, ‘FOO, BAR’
         transposes into ‘BAR, FOO’.
         """
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         self.beginCommand(w, undoType='transpose-words')
@@ -4089,7 +4087,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('transpose-chars')
     def transposeCharacters(self, event: LeoKeyEvent) -> None:
         """Swap the characters at the cursor."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return  # pragma: no cover (defensive)
         self.beginCommand(w, undoType='swap-characters')
@@ -4165,7 +4163,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def setUa(self, event: LeoKeyEvent) -> None:
         """Prompt for the name and value of a uA, then set the uA in the present node."""
         k = self.c.k
-        self.w = self.editWidget(event)
+        self.w = event.w if event else None
         if self.w:
             k.setLabelBlue('Set uA: ')
             k.get1Arg(event, handler=self.setUa1)

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1638,7 +1638,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Print the line number of the line containing the cursor."""
         k = self.c.k
         w = event.w if event else None
-        if w:
+        if g.isTextWrapper(w):
             s = w.getAllText()
             i = w.getInsertPoint()
             row, col = g.convertPythonIndexToRowCol(s, i)
@@ -2021,7 +2021,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def insertParentheses(self, event: LeoKeyEvent) -> None:
         """Insert () at the cursor."""
         w = event.w if event else None
-        if w:
+        if g.isTextWrapper(w):
             self.beginCommand(w, undoType='insert-parenthesis')
             i = w.getInsertPoint()
             w.insert(i, '()')
@@ -2494,7 +2494,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def splitLine(self, event: LeoKeyEvent) -> None:
         """Split a line at the cursor position."""
         w = event.w if event else None
-        if w:
+        if g.isTextWrapper(w):
             self.beginCommand(w, undoType='split-line')
             s = w.getAllText()
             ins = w.getInsertPoint()
@@ -2969,7 +2969,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def extendModeHelper(self, event: LeoKeyEvent, val: bool) -> None:
         c = self.c
         w = event.w if event else None
-        if w:
+        if g.isTextWrapper(w):
             self.extendMode = val
             if not g.unitTesting:
                 # g.red('extend mode','on' if val else 'off'))
@@ -3327,7 +3327,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Push the selection range and insert point on the stack."""
         c = self.c
         w = event.w if event else None
-        if w:
+        if g.isTextWrapper(w):
             p = c.p.copy()
             i, j = w.getSelectionRange()
             ins = w.getInsertPoint()

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -644,7 +644,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     def tabifyHelper(self, event: LeoKeyEvent, which: str) -> None:
         w = event.w if event else None
-        if not w or not w.hasSelection():
+        if not g.isTextWrapper(w):
             return
         self.beginCommand(w, undoType=which)
         i, end = w.getSelectionRange()

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -798,17 +798,17 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('focus-to-log')
     def focusToLog(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
         """Put the keyboard focus in Leo's log pane."""
-        self.c.logWantsFocus()
+        self.c.logWantsFocusNow()
 
     @cmd('focus-to-minibuffer')
     def focusToMinibuffer(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
         """Put the keyboard focus in Leo's minibuffer."""
-        self.c.minibufferWantsFocus()
+        self.c.minibufferWantsFocusNow()
 
     @cmd('focus-to-tree')
     def focusToTree(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
         """Put the keyboard focus in Leo's outline pane."""
-        self.c.treeWantsFocus()
+        self.c.treeWantsFocusNow()
 
     # @+node:ekr.20150514063305.201: *4* ec.clicks in the icon box
     # These call the actual event handlers so as to trigger hooks.

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -540,7 +540,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         if g.app.batchMode:
             c.notValidInBatchMode("Insert Headline Time")
             return
-        w = c.frame.tree.edit_widget(p)
+        w = c.frame.tree.headline_wrapper(p)
         if w and not g.app.inBridge:
             # Fix bug https://bugs.launchpad.net/leo-editor/+bug/1185933
             # insert-headline-time should insert at cursor.

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -572,7 +572,7 @@ class EditFileCommandsClass(BaseEditCommandsClass):
         Insert the file's contents in the body at the insertion point.
         """
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         fn = self.getReadableTextFile()
         if not fn:
@@ -630,7 +630,7 @@ class EditFileCommandsClass(BaseEditCommandsClass):
         """Prompt for the name of a file and put the body text of the selected node into it.."""
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         fileName = g.app.gui.runSaveFileDialog(
             c,

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -571,7 +571,7 @@ class EditFileCommandsClass(BaseEditCommandsClass):
         Prompt for the name of a file.
         Insert the file's contents in the body at the insertion point.
         """
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         fn = self.getReadableTextFile()
@@ -629,7 +629,7 @@ class EditFileCommandsClass(BaseEditCommandsClass):
     def saveFile(self, event: LeoKeyEvent) -> None:
         """Prompt for the name of a file and put the body text of the selected node into it.."""
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         fileName = g.app.gui.runSaveFileDialog(

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -533,7 +533,7 @@ def show_file_line(event: LeoKeyEvent) -> None:
     if not c:
         return
     w = c.frame.body.wrapper
-    if not w:
+    if not g.isTextWrapper(w):
         return
     # n0 is the 1-based line number of the first line of p.b.
     n0 = GoToCommands(c).find_node_start(p=c.p)  # 1-based.

--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -107,11 +107,10 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
 
     def killWordHelper(self, event: LeoKeyEvent) -> None:
         c = self.c
-        e = c.editCommands
-        w = e.editWidget(event)
+        w = event.w if event else None
         if w:
             # self.killWs(event)
-            e.extendToWord(event)
+            c.editCommands.extendToWord(event)
             i, j = w.getSelectionRange()
             self.killHelper(event, i, j, w)
             self.endCommand(changed=True, setLabel=True)

--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -72,7 +72,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     def backwardKillSentence(self, event: LeoKeyEvent) -> None:
         """Kill the previous sentence."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         s = w.getAllText()
         ins = w.getInsertPoint()
@@ -185,7 +185,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         """
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         # Extend (frm, to) if it spans a line.
         i, j = w.getSelectionRange()
@@ -213,7 +213,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     ) -> None:
         """A helper method for kill-paragraph commands."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         s = w.get(frm, to)
         if undoType:
@@ -230,7 +230,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     def killToEndOfLine(self, event: LeoKeyEvent) -> None:
         """Kill from the cursor to end of the line."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         s = w.getAllText()
         ins = w.getInsertPoint()
@@ -254,7 +254,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     def killLine(self, event: LeoKeyEvent) -> None:
         """Kill the line containing the cursor."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         s = w.getAllText()
         ins = w.getInsertPoint()
@@ -275,7 +275,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     def killRegion(self, event: LeoKeyEvent) -> None:
         """Kill the text selection."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         i, j = w.getSelectionRange()
         if i == j:
@@ -291,7 +291,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     def killRegionSave(self, event: LeoKeyEvent) -> None:
         """Add the selected text to the kill ring, but do not delete it."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         i, j = w.getSelectionRange()
         if i == j:
@@ -305,7 +305,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     def killSentence(self, event: LeoKeyEvent) -> None:
         """Kill the sentence containing the cursor."""
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         s = w.getAllText()
         ins = w.getInsertPoint()
@@ -325,7 +325,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         """Kill whitespace."""
         ws = ''
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         s = w.getAllText()
         i = j = ins = w.getInsertPoint()
@@ -364,7 +364,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         """
         c = self.c
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         current = c.p
         if not current:
@@ -405,7 +405,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         """Kill characters from the insertion point to a given character."""
         k = self.c.k
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         state = k.getState('zap-to-char')
         if state == 0:

--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -71,7 +71,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     @cmd('backward-kill-sentence')
     def backwardKillSentence(self, event: LeoKeyEvent) -> None:
         """Kill the previous sentence."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         s = w.getAllText()
@@ -91,7 +91,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     def backwardKillWord(self, event: LeoKeyEvent) -> None:
         """Kill the previous word."""
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if w:
             self.beginCommand(w, undoType='backward-kill-word')
             c.editCommands.backwardWord(event)
@@ -100,7 +100,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     @cmd('kill-word')
     def killWord(self, event: LeoKeyEvent) -> None:
         """Kill the word containing the cursor."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if w:
             self.beginCommand(w, undoType='kill-word')
             self.killWordHelper(event)
@@ -185,7 +185,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         A helper method for all kill commands except kill-paragraph commands.
         """
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         # Extend (frm, to) if it spans a line.
@@ -213,7 +213,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         undoType: str = None,
     ) -> None:
         """A helper method for kill-paragraph commands."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         s = w.get(frm, to)
@@ -230,7 +230,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     @cmd('kill-to-end-of-line')
     def killToEndOfLine(self, event: LeoKeyEvent) -> None:
         """Kill from the cursor to end of the line."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         s = w.getAllText()
@@ -254,7 +254,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     @cmd('kill-line')
     def killLine(self, event: LeoKeyEvent) -> None:
         """Kill the line containing the cursor."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         s = w.getAllText()
@@ -275,7 +275,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     @cmd('kill-region')
     def killRegion(self, event: LeoKeyEvent) -> None:
         """Kill the text selection."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         i, j = w.getSelectionRange()
@@ -291,7 +291,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     @cmd('kill-region-save')
     def killRegionSave(self, event: LeoKeyEvent) -> None:
         """Add the selected text to the kill ring, but do not delete it."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         i, j = w.getSelectionRange()
@@ -305,7 +305,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     @cmd('kill-sentence')
     def killSentence(self, event: LeoKeyEvent) -> None:
         """Kill the sentence containing the cursor."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         s = w.getAllText()
@@ -325,7 +325,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     def killWs(self, event: LeoKeyEvent, undoType: str = 'kill-ws') -> None:
         """Kill whitespace."""
         ws = ''
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         s = w.getAllText()
@@ -364,7 +364,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         pop = True:  insert the next entry of the kill ring.
         """
         c = self.c
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         current = c.p
@@ -405,7 +405,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     def zapToCharacter(self, event: LeoKeyEvent) -> None:
         """Kill characters from the insertion point to a given character."""
         k = self.c.k
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         state = k.getState('zap-to-char')

--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -92,7 +92,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         """Kill the previous word."""
         c = self.c
         w = event.w if event else None
-        if w:
+        if g.isTextWrapper(w):
             self.beginCommand(w, undoType='backward-kill-word')
             c.editCommands.backwardWord(event)
             self.killWordHelper(event)
@@ -101,14 +101,14 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     def killWord(self, event: LeoKeyEvent) -> None:
         """Kill the word containing the cursor."""
         w = event.w if event else None
-        if w:
+        if g.isTextWrapper(w):
             self.beginCommand(w, undoType='kill-word')
             self.killWordHelper(event)
 
     def killWordHelper(self, event: LeoKeyEvent) -> None:
         c = self.c
         w = event.w if event else None
-        if w:
+        if g.isTextWrapper(w):
             # self.killWs(event)
             c.editCommands.extendToWord(event)
             i, j = w.getSelectionRange()

--- a/leo/commands/rectangleCommands.py
+++ b/leo/commands/rectangleCommands.py
@@ -26,7 +26,7 @@ def cmd(name: str) -> Callable:
 # @+node:ekr.20160514120751.1: ** class RectangleCommandsClass
 class RectangleCommandsClass(BaseEditCommandsClass):
     # @+others
-    # @+node:ekr.20150514063305.448: *3* rectangle.__init__
+    # @+node:ekr.20150514063305.448: *3* RectangleCommandsClass.__init__
     def __init__(self, c: Cmdr) -> None:
         """Ctor for RectangleCommandsClass."""
         # pylint: disable=super-init-not-called
@@ -44,7 +44,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
         }
         self.w: QTextMixin = None
 
-    # @+node:ekr.20150514063305.451: *3* check
+    # @+node:ekr.20150514063305.451: *3* RectangleCommandsClass.check
     def check(self, event: LeoKeyEvent, warning: str = 'No rectangle selected') -> bool:
         """
         Return True if there is a selection.
@@ -52,8 +52,19 @@ class RectangleCommandsClass(BaseEditCommandsClass):
         """
         return self._chckSel(event, warning)
 
-    # @+node:ekr.20150514063305.453: *3* rectangle.Entries
-    # @+node:ekr.20150514063305.454: *4* clearRectangle
+    # @+node:ekr.20150514043714.13: *3* RectangleCommandsClass.getRectanglePoints
+    def getRectanglePoints(self, w: QTextMixin) -> tuple[int, int, int, int]:
+        """Return the rectangle corresponding to the selection range."""
+        c = self.c
+        c.widgetWantsFocusNow(w)
+        s = w.getAllText()
+        i, j = w.getSelectionRange()
+        r1, r2 = g.convertPythonIndexToRowCol(s, i)
+        r3, r4 = g.convertPythonIndexToRowCol(s, j)
+        return r1 + 1, r2, r3 + 1, r4
+
+    # @+node:ekr.20150514063305.453: *3* RectangleCommandsClass.Entries
+    # @+node:ekr.20150514063305.454: *4* RectangleCommandsClass.clearRectangle
     @cmd('rectangle-clear')
     def clearRectangle(self, event: LeoKeyEvent) -> None:
         """Clear the rectangle defined by the start and end of selected text."""
@@ -74,7 +85,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
         w.setSelectionRange(toInt(f"{r1}.{r2}"), toInt(f"{r3}.{r2 + len(fill)}"))
         self.endCommand()
 
-    # @+node:ekr.20150514063305.455: *4* closeRectangle
+    # @+node:ekr.20150514063305.455: *4* RectangleCommandsClass.closeRectangle
     @cmd('rectangle-close')
     def closeRectangle(self, event: LeoKeyEvent) -> None:
         """Delete the rectangle if it contains nothing but whitespace.."""
@@ -100,7 +111,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
         w.setSelectionRange(i, j, insert=j)
         self.endCommand()
 
-    # @+node:ekr.20150514063305.456: *4* deleteRectangle
+    # @+node:ekr.20150514063305.456: *4* RectangleCommandsClass.deleteRectangle
     @cmd('rectangle-delete')
     def deleteRectangle(self, event: LeoKeyEvent) -> None:
         """Delete the rectangle defined by the start and end of selected text."""
@@ -120,7 +131,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
         w.setSelectionRange(i, j, insert=j)
         self.endCommand()
 
-    # @+node:ekr.20150514063305.457: *4* killRectangle
+    # @+node:ekr.20150514063305.457: *4* RectangleCommandsClass.killRectangle
     @cmd('rectangle-kill')
     def killRectangle(self, event: LeoKeyEvent) -> None:
         """Kill the rectangle defined by the start and end of selected text."""
@@ -144,7 +155,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
             w.setSelectionRange(ins, ins, insert=ins)
         self.endCommand()
 
-    # @+node:ekr.20150514063305.458: *4* openRectangle
+    # @+node:ekr.20150514063305.458: *4* RectangleCommandsClass.openRectangle
     @cmd('rectangle-open')
     def openRectangle(self, event: LeoKeyEvent) -> None:
         """
@@ -168,7 +179,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
         w.setSelectionRange(i, j, insert=j)
         self.endCommand()
 
-    # @+node:ekr.20150514063305.459: *4* stringRectangle
+    # @+node:ekr.20150514063305.459: *4* RectangleCommandsClass.stringRectangle
     @cmd('rectangle-string')
     def stringRectangle(self, event: LeoKeyEvent) -> None:
         """
@@ -210,7 +221,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
         # string-rectangle kills syntax highlighting.
         c.recolor(c.p)
 
-    # @+node:ekr.20150514063305.460: *4* yankRectangle
+    # @+node:ekr.20150514063305.460: *4* RectangleCommandsClass.yankRectangle
     @cmd('rectangle-yank')
     def yankRectangle(self, event: LeoKeyEvent) -> None:
         """Yank into the rectangle defined by the start and end of selected text."""

--- a/leo/commands/rectangleCommands.py
+++ b/leo/commands/rectangleCommands.py
@@ -60,7 +60,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
     @cmd('rectangle-clear')
     def clearRectangle(self, event: LeoKeyEvent) -> None:
         """Clear the rectangle defined by the start and end of selected text."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w or not self._checkSelection(event):
             return
 
@@ -81,7 +81,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
     @cmd('rectangle-close')
     def closeRectangle(self, event: LeoKeyEvent) -> None:
         """Delete the rectangle if it contains nothing but whitespace.."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w or not self._checkSelection(event):
             return
 
@@ -107,7 +107,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
     @cmd('rectangle-delete')
     def deleteRectangle(self, event: LeoKeyEvent) -> None:
         """Delete the rectangle defined by the start and end of selected text."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w or not self._checkSelection(event):
             return
 
@@ -127,7 +127,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
     @cmd('rectangle-kill')
     def killRectangle(self, event: LeoKeyEvent) -> None:
         """Kill the rectangle defined by the start and end of selected text."""
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w or not self._checkSelection(event):
             return
 
@@ -154,7 +154,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
         Insert blanks in the rectangle defined by the start and end of selected
         text. This pushes the previous contents of the rectangle rightward.
         """
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w or not self._checkSelection(event):
             return
 
@@ -181,11 +181,11 @@ class RectangleCommandsClass(BaseEditCommandsClass):
         k = self.c.k
         if g.unitTesting:
             k.arg = 's...s'  # This string is known to the unit test.
-            self.w = self.editWidget(event)
+            self.w = event.w if event else None
             self.stringRect = self.getRectanglePoints(self.w)
             self.stringRectangle1(event)
             return
-        self.w = self.editWidget(event)
+        self.w = event.w if event else None
         if self.w and self._checkSelection(event):
             self.stringRect = self.getRectanglePoints(self.w)
             k.setLabelBlue('String rectangle: ')
@@ -219,7 +219,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
         """Yank into the rectangle defined by the start and end of selected text."""
         # c = self.c
         k = self.c.k
-        w = self.editWidget(event)
+        w = event.w if event else None
         if not w:
             return
         killRect = self.theKillRectangle

--- a/leo/commands/rectangleCommands.py
+++ b/leo/commands/rectangleCommands.py
@@ -44,14 +44,6 @@ class RectangleCommandsClass(BaseEditCommandsClass):
         }
         self.w: QTextMixin = None
 
-    # @+node:ekr.20150514063305.451: *3* RectangleCommandsClass.check
-    def check(self, event: LeoKeyEvent, warning: str = 'No rectangle selected') -> bool:
-        """
-        Return True if there is a selection.
-        Otherwise, return False and issue a warning.
-        """
-        return self._chckSel(event, warning)
-
     # @+node:ekr.20150514043714.13: *3* RectangleCommandsClass.getRectanglePoints
     def getRectanglePoints(self, w: QTextMixin) -> tuple[int, int, int, int]:
         """Return the rectangle corresponding to the selection range."""
@@ -69,7 +61,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
     def clearRectangle(self, event: LeoKeyEvent) -> None:
         """Clear the rectangle defined by the start and end of selected text."""
         w = self.editWidget(event)
-        if not w or not self.check(event):
+        if not w or not self._checkSelection(event):
             return
 
         def toInt(index: str) -> int:
@@ -90,7 +82,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
     def closeRectangle(self, event: LeoKeyEvent) -> None:
         """Delete the rectangle if it contains nothing but whitespace.."""
         w = self.editWidget(event)
-        if not w or not self.check(event):
+        if not w or not self._checkSelection(event):
             return
 
         def toInt(index: str) -> int:
@@ -116,7 +108,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
     def deleteRectangle(self, event: LeoKeyEvent) -> None:
         """Delete the rectangle defined by the start and end of selected text."""
         w = self.editWidget(event)
-        if not w or not self.check(event):
+        if not w or not self._checkSelection(event):
             return
 
         def toInt(index: str) -> int:
@@ -136,7 +128,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
     def killRectangle(self, event: LeoKeyEvent) -> None:
         """Kill the rectangle defined by the start and end of selected text."""
         w = self.editWidget(event)
-        if not w or not self.check(event):
+        if not w or not self._checkSelection(event):
             return
 
         def toInt(index: str) -> int:
@@ -163,7 +155,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
         text. This pushes the previous contents of the rectangle rightward.
         """
         w = self.editWidget(event)
-        if not w or not self.check(event):
+        if not w or not self._checkSelection(event):
             return
 
         def toInt(index: str) -> int:
@@ -194,7 +186,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
             self.stringRectangle1(event)
             return
         self.w = self.editWidget(event)
-        if self.w and self.check(event):
+        if self.w and self._checkSelection(event):
             self.stringRect = self.getRectanglePoints(self.w)
             k.setLabelBlue('String rectangle: ')
             k.get1Arg(event, handler=self.stringRectangle1)

--- a/leo/commands/rectangleCommands.py
+++ b/leo/commands/rectangleCommands.py
@@ -220,7 +220,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
         # c = self.c
         k = self.c.k
         w = event.w if event else None
-        if not w:
+        if not g.isTextWrapper(w):
             return
         killRect = self.theKillRectangle
 

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -103,7 +103,7 @@ class StringTextWrapper(QTextMixin):
     """A class that represents Leo's body pane as a Python string."""
 
     # @+others
-    # @+node:ekr.20070228074228.2: *3* StringTextWrapper.__init__
+    # @+node:ekr.20070228074228.2: *3* StringTextWrapper.__init__, __repr__ & getName
     def __init__(self, c: Cmdr, name: str) -> None:
         """Ctor for the StringTextWrapper class."""
         super().__init__(c)

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -317,7 +317,7 @@ class TreeAPI:
     ) -> tuple[Widget, QTextMixin]:
         return None, None
 
-    def edit_widget(self, p: Position) -> None:
+    def headline_wrapper(self, p: Position) -> None:
         return None
 
     def redraw(self, p: Position = None) -> None:

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -120,7 +120,7 @@ class StringTextWrapper(QTextMixin):
 
     def getName(self) -> str:
         """StringTextWrapper."""
-        return self.name  # Essential.
+        return self.name or ''  # Essential.
 
     # @+node:ekr.20140903172510.18578: *3* StringTextWrapper: Clipboard
     def clipboard_clear(self) -> None:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4464,8 +4464,7 @@ class Commands:
 
     # @+node:ekr.20080514131122.17: *5* c.widget_name
     def widget_name(self, widget: Widget) -> str:
-        # c = self
-        return g.app.gui.widget_name(widget) if g.app.gui else '<no widget>'
+        return g.app.gui.widget_name(widget) if g.app.gui else ''
 
     # @+node:ekr.20171124101045.1: *4* c.Events
     # @+node:ekr.20060923202156: *5* c.onCanvasKey

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1607,10 +1607,12 @@ class Commands:
             if p.v.expandedPositions:
                 g.printObj(p.v.expandedPositions, indent=p.level(), tag=p.h)
 
-    # @+node:ekr.20040306220230.1: *5* c.edit_widget
-    def edit_widget(self, p: Position) -> Widget:
+    # @+node:ekr.20040306220230.1: *5* c.headline_wrapper
+    def headline_wrapper(self, p: Position) -> Widget:
         c = self
-        return c.frame.tree.edit_widget(p) if p else None
+        return c.frame.tree.headline_wrapper(p) if p else None
+
+    edit_widget = headline_wrapper  # Compatibility.
 
     # @+node:ekr.20031218072017.2986: *5* c.fileName & relativeFileName & shortFileName
     # Compatibility with scripts

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -883,11 +883,11 @@ class LeoFind:
         c, p = self.c, self.c.p
         #
         # The gui widget may not exist for headlines.
-        gui_w = c.headline_wrapper(p) if self.in_headline else c.frame.body.wrapper
+        w = c.headline_wrapper(p) if self.in_headline else c.frame.body.wrapper
         #
         # Init the work widget, so we don't get stuck.
         s = p.h if self.in_headline else p.b
-        ins = gui_w.getInsertPoint() if gui_w else 0
+        ins = w.getInsertPoint() if w else 0
         self.work_s = s
         self.work_sel = (ins, ins, ins)
         #
@@ -2452,13 +2452,13 @@ class LeoFind:
         """Replace selection with self.change_text."""
         c, u = self.c, self.c.undoer
         wrapper = c.frame.body and c.frame.body.wrapper
-        gui_w = c.headline_wrapper(p) if self.in_headline else wrapper
-        if not gui_w:  # pragma: no cover
+        w = c.headline_wrapper(p) if self.in_headline else wrapper
+        if not w:  # pragma: no cover
             self.in_headline = False
-            gui_w = wrapper
-        if not gui_w:  # pragma: no cover
+            w = wrapper
+        if not w:  # pragma: no cover
             return False
-        oldSel = sel = gui_w.getSelectionRange()
+        oldSel = sel = w.getSelectionRange()
         start, end = sel
         if start > end:  # pragma: no cover
             start, end = end, start
@@ -2477,25 +2477,25 @@ class LeoFind:
         # Update both the gui widget and the work "widget"
         new_ins = start if self.reverse else start + len(change_text)
         if start != end:
-            gui_w.delete(start, end)
-        gui_w.insert(start, change_text)
-        gui_w.setInsertPoint(new_ins)
-        self.work_s = gui_w.getAllText()  # #2220.
+            w.delete(start, end)
+        w.insert(start, change_text)
+        w.setInsertPoint(new_ins)
+        self.work_s = w.getAllText()  # #2220.
         self.work_sel = (new_ins, new_ins, new_ins)
         # Update the selection for the next match.
-        gui_w.setSelectionRange(start, start + len(change_text))
-        c.widgetWantsFocus(gui_w)
+        w.setSelectionRange(start, start + len(change_text))
+        c.widgetWantsFocus(w)
         # No redraws here: they would destroy the headline selection.
         if self.in_headline:
             # #2220: Let onHeadChanged handle undo, etc.
             c.frame.tree.onHeadChanged(p, undoType='Change Headline')
-            # gui_w will change after a redraw.
-            gui_w = c.headline_wrapper(p)
-            if gui_w:
+            # w will change after a redraw.
+            w = c.headline_wrapper(p)
+            if w:
                 # find-next and find-prev work regardless of insert point.
-                gui_w.setSelectionRange(start, start + len(change_text))
+                w.setSelectionRange(start, start + len(change_text))
         else:
-            p.v.b = gui_w.getAllText()
+            p.v.b = w.getAllText()
             u.afterChangeBody(p, 'Change Body', bunch)
 
         if self.mark_changes and not p.isMarked():  # pragma: no cover
@@ -3139,9 +3139,9 @@ class LeoFind:
         if len(self.stack) <= 1:
             self.in_headline = False
         # Init the work widget from the gui widget.
-        gui_w = self.set_widget()
-        s = gui_w.getAllText()
-        i, j = gui_w.getSelectionRange()
+        w = self.set_widget()
+        s = w.getAllText()
+        i, j = w.getSelectionRange()
         if again:
             ins = i if reverse else j + len(pattern)
         else:

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -3350,7 +3350,7 @@ class LeoFind:
         if not c.config.getBool('preload-find-pattern', default=False):
             # Make *sure* we don't preload the find pattern if it is not wanted.
             return
-        if not w:
+        if not g.isTextWrapper(w):
             return
         #
         # #1436: Don't create a selection if there isn't one.

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -97,16 +97,13 @@ class LeoFind:
     def __init__(self, c: Cmdr) -> None:
         """Ctor for LeoFind class."""
         self.c = c
-        self.expert_mode = False  # Set in finishCreate.
         # Created by dw.createFindTab.
         self.ftm: FindTabManager = None
         self.k: KeyHandler = c.k
         self.re_obj: re.Pattern = None
-        #
         # The work "widget".
         self.work_s = ''  # p.b or p.c.
         self.work_sel: tuple[int, int, int] = None  # pos, newpos, insert.
-        #
         # Options ivars: set by FindTabManager.init.
         # These *must* be initially None, not False.
         self.ignore_case: bool = None

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -883,7 +883,7 @@ class LeoFind:
         c, p = self.c, self.c.p
         #
         # The gui widget may not exist for headlines.
-        gui_w = c.edit_widget(p) if self.in_headline else c.frame.body.wrapper
+        gui_w = c.headline_wrapper(p) if self.in_headline else c.frame.body.wrapper
         #
         # Init the work widget, so we don't get stuck.
         s = p.h if self.in_headline else p.b
@@ -2452,7 +2452,7 @@ class LeoFind:
         """Replace selection with self.change_text."""
         c, u = self.c, self.c.undoer
         wrapper = c.frame.body and c.frame.body.wrapper
-        gui_w = c.edit_widget(p) if self.in_headline else wrapper
+        gui_w = c.headline_wrapper(p) if self.in_headline else wrapper
         if not gui_w:  # pragma: no cover
             self.in_headline = False
             gui_w = wrapper
@@ -2490,7 +2490,7 @@ class LeoFind:
             # #2220: Let onHeadChanged handle undo, etc.
             c.frame.tree.onHeadChanged(p, undoType='Change Headline')
             # gui_w will change after a redraw.
-            gui_w = c.edit_widget(p)
+            gui_w = c.headline_wrapper(p)
             if gui_w:
                 # find-next and find-prev work regardless of insert point.
                 gui_w.setSelectionRange(start, start + len(change_text))
@@ -2972,7 +2972,7 @@ class LeoFind:
             c.endEditing()
             c.redraw(p)
             c.frame.tree.editLabel(p)
-            w = c.edit_widget(p)  # #2220
+            w = c.headline_wrapper(p)  # #2220
             if w:
                 w.setSelectionRange(pos, newpos, insert)  # #2220
         else:
@@ -3240,12 +3240,12 @@ class LeoFind:
         c, p = self.c, self.c.p
         wrapper = c.frame.body.wrapper
         if self.in_headline:
-            w = c.edit_widget(p)
+            w = c.headline_wrapper(p)
             if not w:
                 # Selecting the minibuffer can kill the edit widget.
                 selection = 0, 0, 0
                 c.redrawAndEdit(p, selectAll=False, selection=selection, keepMinibuffer=True)
-                w = c.edit_widget(p)
+                w = c.headline_wrapper(p)
             if not w:  # Should never happen.
                 g.trace('**** no edit widget!')
                 self.in_headline = False

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2491,7 +2491,7 @@ class LeoFind:
             c.frame.tree.onHeadChanged(p, undoType='Change Headline')
             # w will change after a redraw.
             w = c.headline_wrapper(p)
-            if w:
+            if g.isTextWrapper(w):
                 # find-next and find-prev work regardless of insert point.
                 w.setSelectionRange(start, start + len(change_text))
         else:
@@ -2973,7 +2973,7 @@ class LeoFind:
             c.redraw(p)
             c.frame.tree.editLabel(p)
             w = c.headline_wrapper(p)  # #2220
-            if w:
+            if g.isTextWrapper(w):
                 w.setSelectionRange(pos, newpos, insert)  # #2220
         else:
             # Tricky code.  Do not change without careful thought.

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -962,7 +962,7 @@ class LeoTree:
         Officially change a headline.
         Set the old undo text to the previous revert point.
         """
-        c, u, w = self.c, self.c.undoer, self.edit_widget(p)
+        c, u, w = self.c, self.c.undoer, self.headline_wrapper(p)
         if not w:
             g.trace('no w')
             return
@@ -1110,7 +1110,7 @@ class LeoTree:
     ) -> tuple[Widget, Any]:  # Any is the best possible annotation.
         raise NotImplementedError
 
-    def edit_widget(self, p: Position) -> Widget:
+    def headline_wrapper(self, p: Position) -> Widget:
         raise NotImplementedError
 
     # @+node:ekr.20040803072955.128: *3* LeoTree.select & helpers
@@ -1698,8 +1698,8 @@ class NullTree(LeoTree):
         self.c = frame.c
         self.editWidgetsDict: dict[VNode, StringTextWrapper] = {}
 
-    # @+node:ekr.20070228163350.2: *3* NullTree.edit_widget
-    def edit_widget(self, p: Position) -> QTextMixin:
+    # @+node:ekr.20070228163350.2: *3* NullTree.headline_wrapper
+    def headline_wrapper(self, p: Position) -> QTextMixin:
         d = self.editWidgetsDict
         if not p or not p.v:
             return None
@@ -1750,7 +1750,7 @@ class NullTree(LeoTree):
         """Set the actual text of the headline widget.
 
         This is called from the undo/redo logic to change the text before redrawing."""
-        w = self.edit_widget(p)
+        w = self.headline_wrapper(p)
         if w:
             w.delete(0, w.getLastIndex())
             if s.endswith('\n') or s.endswith('\r'):

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -131,7 +131,7 @@ class LeoBody:
         # Init user settings.
         self.use_chapters = False  # May be overridden in subclasses.
 
-    # @+node:ekr.20031218072017.3677: *3* LeoBody.Coloring
+    # @+node:ekr.20031218072017.3677: *3* LeoBody: Coloring
     def forceFullRecolor(self) -> None:
         pass
 
@@ -148,7 +148,7 @@ class LeoBody:
 
     recolor_now = recolor
 
-    # @+node:ekr.20060528100747: *3* LeoBody.Editors
+    # @+node:ekr.20060528100747: *3* LeoBody: Editors
     # @+node:ekr.20070424053629.1: *4* LeoBody.utils
     # @+node:ekr.20060530204135: *5* LeoBody.recolorWidget (QScintilla only)
     def recolorWidget(self, p: Position, w: QTextMixin) -> None:
@@ -163,7 +163,7 @@ class LeoBody:
             finally:
                 c.frame.body.wrapper = old_wrapper
 
-    # @+node:ekr.20031218072017.4018: *3* LeoBody.Text
+    # @+node:ekr.20031218072017.4018: *3* LeoBody: Text
     # @+node:ekr.20031218072017.4030: *4* LeoBody.getInsertLines
     def getInsertLines(self) -> tuple[str, str, str]:
         """
@@ -254,7 +254,7 @@ class LeoFrame:
     instances = 0
 
     # @+others
-    # @+node:ekr.20031218072017.3679: *3* LeoFrame.__init__
+    # @+node:ekr.20031218072017.3679: *3*  LeoFrame.__init__
     def __init__(self, c: Cmdr, gui: LeoGui) -> None:
         self.c = c
         self.gui = gui
@@ -298,7 +298,7 @@ class LeoFrame:
         p._linkAsRoot()
         return v
 
-    # @+node:ekr.20061109125528: *3* LeoFrame.May be defined in subclasses
+    # @+node:ekr.20061109125528: *3* LeoFrame: May be defined in subclasses
     # @+node:ekr.20031218072017.3688: *4* LeoFrame.getTitle & setTitle
     def getTitle(self) -> str:
         return self.title
@@ -324,7 +324,7 @@ class LeoFrame:
     def compute_secondary_ratio(self) -> float:
         return 0.5
 
-    # @+node:ekr.20061109125528.1: *3* LeoFrame.Must be defined in base class
+    # @+node:ekr.20061109125528.1: *3* LeoFrame: Must be defined in base class
     # @+node:ekr.20031218072017.3689: *4* LeoFrame.initialRatios
     def initialRatios(self) -> tuple[bool, float, float]:
         c = self.c
@@ -603,7 +603,7 @@ class LeoFrame:
             k.setDefaultInputState()
             k.showStateAndMode()
 
-    # @+node:ekr.20031218072017.3680: *3* LeoFrame.Must be defined in subclasses
+    # @+node:ekr.20031218072017.3680: *3* LeoFrame: Must be defined in subclasses
     def bringToFront(self) -> None:
         raise NotImplementedError
 
@@ -705,8 +705,7 @@ class LeoLog:
     """The base class for the log pane in Leo windows."""
 
     # @+others
-    # @+node:ekr.20150509054436.1: *3* LeoLog.Birth
-    # @+node:ekr.20031218072017.3695: *4* LeoLog.__init__
+    # @+node:ekr.20031218072017.3695: *3*  LeoLog.__init__
     def __init__(self, frame: LeoLog | LeoQtFrame | NullFrame) -> None:
         """Ctor for LeoLog class."""
         g._assert(frame is None or issubclass(frame.__class__, LeoFrame))
@@ -940,67 +939,7 @@ class LeoTree:
     """The base class for the outline pane in Leo windows."""
 
     # @+others
-    # @+node:ekr.20081005065934.8: *3* LeoTree.May be defined in subclasses
-    # These are new in Leo 4.6.
-
-    def initAfterLoad(self) -> None:
-        """Do late initialization. Called in g.openWithFileName after a successful load."""
-
-    # Hints for optimization. The proper default is c.redraw()
-
-    def redraw_after_head_changed(self) -> None:
-        self.c.redraw()
-
-    def redraw_after_select(self, p: Position = None) -> None:
-        self.c.redraw()
-
-    # @+node:ekr.20040803072955.91: *4* LeoTree.onHeadChanged
-    # Tricky code: do not change without careful thought and testing.
-    # Important: This code *is* used by the leoBridge module.
-    def onHeadChanged(self, p: Position, undoType: str = 'Typing') -> None:
-        """
-        Officially change a headline.
-        Set the old undo text to the previous revert point.
-        """
-        c, u, w = self.c, self.c.undoer, self.headline_wrapper(p)
-        if not w:
-            g.trace('no w')
-            return
-        ch = '\n'  # We only report the final keystroke.
-        s = w.getAllText()
-        # @+<< truncate s if it has multiple lines >>
-        # @+node:ekr.20040803072955.94: *5* << truncate s if it has multiple lines >>
-        # #3633: Replace newlines with a blank.
-        if '\n' in s:
-            s = re.sub(r'\s*\n\s*', ' ', s).replace('  ', ' ').rstrip()
-        limit = 1000
-        if len(s) > limit:
-            g.warning("truncating headline to", limit, "characters")
-            s = s[:limit]
-        s = g.checkUnicode(s or '')
-        # @-<< truncate s if it has multiple lines >>
-        # Make the change official, but undo to the *old* revert point.
-        changed = s != p.h
-        if not changed:
-            return  # Leo 6.4: only call the hooks if the headline has actually changed.
-        if g.doHook("headkey1", c=c, p=p, ch=ch, changed=changed):
-            return  # The hook claims to have handled the event.
-        # Handle undo.
-        undoData = u.beforeChangeHeadline(p)
-        p.initHeadString(s)  # change p.h *after* calling undoer's before method.
-        if not c.changed:
-            c.setChanged()
-        # New in Leo 4.4.5: we must recolor the body because
-        # the headline may contain directives.
-        c.frame.scanForTabWidth(p)
-        c.recolor(p)
-        p.setDirty()
-        u.afterChangeHeadline(p, undoType, undoData)
-        # Fix bug 1280689: don't call the non-existent c.treeEditFocusHelper
-        c.redraw_after_head_changed()
-        g.doHook("headkey2", c=c, p=p, ch=ch, changed=changed)
-
-    # @+node:ekr.20031218072017.3705: *3* LeoTree.__init__
+    # @+node:ekr.20031218072017.3705: *3*  LeoTree.__init__
     def __init__(self, frame: Widget) -> None:
         """Ctor for the LeoTree class."""
         self.frame = frame
@@ -1013,105 +952,6 @@ class LeoTree:
         self.use_chapters = False  # May be overridden in subclasses.
         # Define these here to keep pylint happy.
         self.canvas: Any = None
-
-    # @+node:ekr.20061109165848: *3* LeoTree.Must be defined in base class
-    # @+node:ekr.20040803072955.126: *4* LeoTree.endEditLabel
-    def endEditLabel(self) -> None:
-        """End editing of a headline and update p.h."""
-        # Important: this will redraw if necessary.
-        self.onHeadChanged(self.c.p)
-        # Do *not* call setDefaultUnboundKeyAction here: it might put us in ignore mode!
-        # k.setDefaultInputState()
-        # k.showStateAndMode()
-        # This interferes with the find command and interferes with focus generally!
-        # c.bodyWantsFocus()
-
-    # @+node:ekr.20031218072017.3716: *4* LeoTree.getEditTextDict
-    def getEditTextDict(self, v: VNode) -> Widget:
-        # New in 4.2: the default is an empty list.
-        return self.edit_text_dict.get(v, [])
-
-    # @+node:ekr.20040803072955.88: *4* LeoTree.onHeadlineKey
-    def onHeadlineKey(self, event: LeoKeyEvent) -> None:
-        """Handle a key event in a headline."""
-        if not event:
-            return
-        w = event.w
-        ch = event.char
-        # This test prevents flashing in the headline when the control key is held down.
-        if ch and w:
-            self.updateHead(event, w)
-
-    # @+node:ekr.20120314064059.9739: *4* LeoTree.OnIconCtrlClick (@url)
-    def OnIconCtrlClick(self, p: Position) -> None:
-        g.openUrl(p)
-
-    # @+node:ekr.20031218072017.2312: *4* LeoTree.OnIconDoubleClick (do nothing)
-    def OnIconDoubleClick(self, p: Position) -> None:
-        pass
-
-    # @+node:ekr.20051026083544.2: *4* LeoTree.updateHead
-    def updateHead(self, event: LeoKeyEvent, w: QTextMixin) -> None:
-        """
-        Update a headline from an event.
-
-        The headline officially changes only when editing ends.
-        """
-        k = self.c.k
-        ch = event.char if event else ''
-        i, j = w.getSelectionRange()
-        ins = w.getInsertPoint()
-        if i != j:
-            ins = i
-        if ch in ('\b', 'BackSpace'):
-            if i != j:
-                w.delete(i, j)
-                # Bug fix: 2018/04/19.
-                w.setSelectionRange(i, i, insert=i)
-            elif i > 0:
-                i -= 1
-                w.delete(i)
-                w.setSelectionRange(i, i, insert=i)
-            else:
-                w.setSelectionRange(0, 0, insert=0)
-        elif ch and ch not in ('\n', '\r'):
-            if i != j:
-                w.delete(i, j)
-            elif k.unboundKeyAction == 'overwrite':
-                w.delete(i, i + 1)
-            w.insert(ins, ch)
-            w.setSelectionRange(ins + 1, ins + 1, insert=ins + 1)
-        s = w.getAllText()
-        if s.endswith('\n'):
-            s = s[:-1]
-        # 2011/11/14: Not used at present.
-        # w.setWidth(self.headWidth(s=s))
-        if ch in ('\n', '\r'):
-            self.endEditLabel()
-
-    # @+node:ekr.20031218072017.3706: *3* LeoTree.Must be defined in subclasses
-    # Drawing & scrolling.
-
-    def redraw(self, p: Position = None) -> None:
-        raise NotImplementedError
-
-    redraw_now = redraw
-
-    def scrollTo(self, p: Position) -> None:
-        raise NotImplementedError
-
-    # Headlines.
-
-    def editLabel(
-        self,
-        p: Position,
-        selectAll: bool = False,
-        selection: tuple = None,
-    ) -> tuple[Widget, Any]:  # Any is the best possible annotation.
-        raise NotImplementedError
-
-    def headline_wrapper(self, p: Position) -> Widget:
-        raise NotImplementedError
 
     # @+node:ekr.20040803072955.128: *3* LeoTree.select & helpers
     tree_select_lockout = False
@@ -1271,6 +1111,165 @@ class LeoTree:
             s = c.frame.computeStatusUnl(p)
             c.frame.putStatusLine(s)
 
+    # @+node:ekr.20081005065934.8: *3* LeoTree: May be defined in subclasses
+    # These are new in Leo 4.6.
+
+    def initAfterLoad(self) -> None:
+        """Do late initialization. Called in g.openWithFileName after a successful load."""
+
+    # Hints for optimization. The proper default is c.redraw()
+
+    def redraw_after_head_changed(self) -> None:
+        self.c.redraw()
+
+    def redraw_after_select(self, p: Position = None) -> None:
+        self.c.redraw()
+
+    # @+node:ekr.20040803072955.91: *4* LeoTree.onHeadChanged
+    # Tricky code: do not change without careful thought and testing.
+    # Important: This code *is* used by the leoBridge module.
+    def onHeadChanged(self, p: Position, undoType: str = 'Typing') -> None:
+        """
+        Officially change a headline.
+        Set the old undo text to the previous revert point.
+        """
+        c, u, w = self.c, self.c.undoer, self.headline_wrapper(p)
+        if not w:
+            g.trace('no w')
+            return
+        ch = '\n'  # We only report the final keystroke.
+        s = w.getAllText()
+        # @+<< truncate s if it has multiple lines >>
+        # @+node:ekr.20040803072955.94: *5* << truncate s if it has multiple lines >>
+        # #3633: Replace newlines with a blank.
+        if '\n' in s:
+            s = re.sub(r'\s*\n\s*', ' ', s).replace('  ', ' ').rstrip()
+        limit = 1000
+        if len(s) > limit:
+            g.warning("truncating headline to", limit, "characters")
+            s = s[:limit]
+        s = g.checkUnicode(s or '')
+        # @-<< truncate s if it has multiple lines >>
+        # Make the change official, but undo to the *old* revert point.
+        changed = s != p.h
+        if not changed:
+            return  # Leo 6.4: only call the hooks if the headline has actually changed.
+        if g.doHook("headkey1", c=c, p=p, ch=ch, changed=changed):
+            return  # The hook claims to have handled the event.
+        # Handle undo.
+        undoData = u.beforeChangeHeadline(p)
+        p.initHeadString(s)  # change p.h *after* calling undoer's before method.
+        if not c.changed:
+            c.setChanged()
+        # New in Leo 4.4.5: we must recolor the body because
+        # the headline may contain directives.
+        c.frame.scanForTabWidth(p)
+        c.recolor(p)
+        p.setDirty()
+        u.afterChangeHeadline(p, undoType, undoData)
+        # Fix bug 1280689: don't call the non-existent c.treeEditFocusHelper
+        c.redraw_after_head_changed()
+        g.doHook("headkey2", c=c, p=p, ch=ch, changed=changed)
+
+    # @+node:ekr.20061109165848: *3* LeoTree: Must be defined in base class
+    # @+node:ekr.20040803072955.126: *4* LeoTree.endEditLabel
+    def endEditLabel(self) -> None:
+        """End editing of a headline and update p.h."""
+        # Important: this will redraw if necessary.
+        self.onHeadChanged(self.c.p)
+        # Do *not* call setDefaultUnboundKeyAction here: it might put us in ignore mode!
+        # k.setDefaultInputState()
+        # k.showStateAndMode()
+        # This interferes with the find command and interferes with focus generally!
+        # c.bodyWantsFocus()
+
+    # @+node:ekr.20031218072017.3716: *4* LeoTree.getEditTextDict
+    def getEditTextDict(self, v: VNode) -> Widget:
+        # New in 4.2: the default is an empty list.
+        return self.edit_text_dict.get(v, [])
+
+    # @+node:ekr.20040803072955.88: *4* LeoTree.onHeadlineKey
+    def onHeadlineKey(self, event: LeoKeyEvent) -> None:
+        """Handle a key event in a headline."""
+        if not event:
+            return
+        w = event.w
+        ch = event.char
+        # This test prevents flashing in the headline when the control key is held down.
+        if ch and w:
+            self.updateHead(event, w)
+
+    # @+node:ekr.20120314064059.9739: *4* LeoTree.OnIconCtrlClick (@url)
+    def OnIconCtrlClick(self, p: Position) -> None:
+        g.openUrl(p)
+
+    # @+node:ekr.20031218072017.2312: *4* LeoTree.OnIconDoubleClick (do nothing)
+    def OnIconDoubleClick(self, p: Position) -> None:
+        pass
+
+    # @+node:ekr.20051026083544.2: *4* LeoTree.updateHead
+    def updateHead(self, event: LeoKeyEvent, w: QTextMixin) -> None:
+        """
+        Update a headline from an event.
+
+        The headline officially changes only when editing ends.
+        """
+        k = self.c.k
+        ch = event.char if event else ''
+        i, j = w.getSelectionRange()
+        ins = w.getInsertPoint()
+        if i != j:
+            ins = i
+        if ch in ('\b', 'BackSpace'):
+            if i != j:
+                w.delete(i, j)
+                # Bug fix: 2018/04/19.
+                w.setSelectionRange(i, i, insert=i)
+            elif i > 0:
+                i -= 1
+                w.delete(i)
+                w.setSelectionRange(i, i, insert=i)
+            else:
+                w.setSelectionRange(0, 0, insert=0)
+        elif ch and ch not in ('\n', '\r'):
+            if i != j:
+                w.delete(i, j)
+            elif k.unboundKeyAction == 'overwrite':
+                w.delete(i, i + 1)
+            w.insert(ins, ch)
+            w.setSelectionRange(ins + 1, ins + 1, insert=ins + 1)
+        s = w.getAllText()
+        if s.endswith('\n'):
+            s = s[:-1]
+        # 2011/11/14: Not used at present.
+        # w.setWidth(self.headWidth(s=s))
+        if ch in ('\n', '\r'):
+            self.endEditLabel()
+
+    # @+node:ekr.20031218072017.3706: *3* LeoTree: Must be defined in subclasses
+    # Drawing & scrolling.
+
+    def redraw(self, p: Position = None) -> None:
+        raise NotImplementedError
+
+    redraw_now = redraw
+
+    def scrollTo(self, p: Position) -> None:
+        raise NotImplementedError
+
+    # Headlines.
+
+    def editLabel(
+        self,
+        p: Position,
+        selectAll: bool = False,
+        selection: tuple = None,
+    ) -> tuple[Widget, Any]:  # Any is the best possible annotation.
+        raise NotImplementedError
+
+    def headline_wrapper(self, p: Position) -> Widget:
+        raise NotImplementedError
+
     # @-others
 
 
@@ -1345,7 +1344,12 @@ class NullFrame(LeoFrame):
         self.x = 40
         self.y = 40
 
-    # @+node:ekr.20061109124552: *3* NullFrame.do nothings
+    # @+node:ekr.20171112115045.1: *3*  NullFrame.finishCreate
+    def finishCreate(self) -> None:
+        # 2017/11/12: For #503: Use string/null gui for unit tests.
+        self.createFirstTreeNode()  # Call the base LeoFrame method.
+
+    # @+node:ekr.20061109124552: *3* NullFrame: do nothings
     def bringToFront(self) -> None:
         pass
 
@@ -1462,11 +1466,6 @@ class NullFrame(LeoFrame):
     def update(self) -> None:
         pass
 
-    # @+node:ekr.20171112115045.1: *3* NullFrame.finishCreate
-    def finishCreate(self) -> None:
-        # 2017/11/12: For #503: Use string/null gui for unit tests.
-        self.createFirstTreeNode()  # Call the base LeoFrame method.
-
     # @-others
 
 
@@ -1479,31 +1478,6 @@ class NullIconBarClass:
     def __init__(self, c: Cmdr) -> None:
         """Ctor for NullIconBarClass."""
         self.c = c
-
-    # @+node:ekr.20070301165343: *3*  NullIconBarClass.Do nothing
-    def addRow(self, height: str = None) -> None:
-        pass
-
-    def addRowIfNeeded(self) -> None:
-        pass
-
-    def addWidget(self, w: QTextMixin) -> None:
-        pass
-
-    def createChaptersIcon(self) -> None:
-        pass
-
-    def deleteButton(self, w: QTextMixin) -> None:
-        pass
-
-    def getNewFrame(self) -> None:
-        return None
-
-    def hide(self) -> None:
-        pass
-
-    def show(self) -> None:
-        pass
 
     # @+node:ekr.20070301164543.2: *3* NullIconBarClass.add
     def add(self, *args: Any, **keys: Any) -> Widget:
@@ -1555,6 +1529,31 @@ class NullIconBarClass:
         except Exception:
             pass
 
+    # @+node:ekr.20070301165343: *3* NullIconBarClass: Do nothing
+    def addRow(self, height: str = None) -> None:
+        pass
+
+    def addRowIfNeeded(self) -> None:
+        pass
+
+    def addWidget(self, w: QTextMixin) -> None:
+        pass
+
+    def createChaptersIcon(self) -> None:
+        pass
+
+    def deleteButton(self, w: QTextMixin) -> None:
+        pass
+
+    def getNewFrame(self) -> None:
+        return None
+
+    def hide(self) -> None:
+        pass
+
+    def show(self) -> None:
+        pass
+
     # @-others
 
 
@@ -1563,8 +1562,7 @@ class NullLog(LeoLog):
     """A do-nothing log class."""
 
     # @+others
-    # @+node:ekr.20070302095500: *3* NullLog.Birth
-    # @+node:ekr.20041012083237: *4* NullLog.__init__
+    # @+node:ekr.20041012083237: *3*  NullLog.__init__
     def __init__(self, *, frame: NullFrame = None) -> None:
         super().__init__(frame)
         c = self.c
@@ -1572,7 +1570,7 @@ class NullLog(LeoLog):
         # self.logCtrl is now a property of the base LeoLog class.
         self.widget = StringTextWrapper(c=c, name='null-log')
 
-    # @+node:ekr.20120216123546.10951: *4* NullLog.finishCreate
+    # @+node:ekr.20120216123546.10951: *3*  NullLog.finishCreate
     def finishCreate(self) -> None:
         pass
 
@@ -1652,7 +1650,7 @@ class NullStatusLineClass:
         self.textWidget = StringTextWrapper(c, name='status-line')
 
     # @+others
-    # @+node:ekr.20070302171917: *3* NullStatusLineClass.methods
+    # @+node:ekr.20070302171917: *3* NullStatusLineClass: methods
     def computeStatusUnl(self, p: Position) -> str:
         return ''
 
@@ -1732,7 +1730,7 @@ class NullTree(LeoTree):
             w = d.get(key)
             g.pr('w', w, 'v.h:', key.headString, 's:', repr(w.s))
 
-    # @+node:ekr.20070228163350.1: *3* NullTree.Drawing & scrolling
+    # @+node:ekr.20070228163350.1: *3* NullTree.redraw and scrollTo
     def redraw(self, p: Position = None) -> None:
         self.redrawCount += 1
 

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -730,7 +730,7 @@ class LeoLog:
     def clearTab(self, tabName: str, wrap: str = 'none') -> None:
         self.selectTab(tabName, wrap=wrap)
         w = self.logCtrl
-        if w:
+        if g.isTextWrapper(w):
             w.delete(0, w.getLastIndex())
 
     # @+node:ekr.20070302094848.2: *3* LeoLog.createTab

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1804,13 +1804,13 @@ class SettingsDict(dict):
     __str__ = __repr__
 
     # @+others
-    # @+node:ekr.20120223062418.10422: *4* td.copy
+    # @+node:ekr.20120223062418.10422: *4* SettingsDict.copy
     def copy(self, name: str = None) -> Value:
         """Return a new dict with the same contents."""
         # The result is a g.SettingsDict.
         return copy.deepcopy(self)
 
-    # @+node:ekr.20190904052828.1: *4* td.add_to_list
+    # @+node:ekr.20190904052828.1: *4* SettingsDict.add_to_list
     def add_to_list(self, key: str, val: BindingInfo) -> None:
         """Update the *list*, self.d [key]"""
         if key is None:
@@ -1821,7 +1821,7 @@ class SettingsDict(dict):
             aList.append(val)
             self[key] = aList
 
-    # @+node:ekr.20190903181030.1: *4* td.get_setting & get_string_setting
+    # @+node:ekr.20190903181030.1: *4* SettingsDict.get_setting & get_string_setting
     def get_setting(self, key: str) -> Optional[str]:
         """Return the canonical setting name."""
         key = key.replace('-', '').replace('_', '')
@@ -1833,7 +1833,7 @@ class SettingsDict(dict):
         val = self.get_setting(key)
         return val if val and isinstance(val, str) else None
 
-    # @+node:ekr.20190904103552.1: *4* td.name & setName
+    # @+node:ekr.20190904103552.1: *4* SettingsDict.name & setName
     def name(self) -> str:
         return self._name
 

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -370,28 +370,22 @@ class LeoKeyEvent:
         assert g.isStrokeOrNone(self.stroke), f"(LeoKeyEvent) {self.stroke!r} {g.callers()}"
 
         self.w: QTextMixin
-        self.widget: Any  # The best we can do.
         if w is None:
             # Special case for headlines.
             edit_wrapper = c.edit_widget(c.p)
             if edit_wrapper:
                 self.w = edit_wrapper
-                self.widget = self.w.widget
             else:
                 focus_widget = g.app.gui.get_focus()
                 widget = focus_widget if g.isTextWrapper(focus_widget) else c.frame.body.widget
-                self.widget = widget
                 name = c.widget_name(widget) if widget else 'dummy-wrapper'
                 self.w = QTextEditWrapper(widget=widget, name=name, c=c)
-                # print(f"LeoKeyEvent: new {self.w.__class__.__name__} from {widget.__class__.__name__}"
         elif c.widget_name(w).startswith('log'):
-            self.w = self.widget = c.frame.log.logCtrl
+            self.w = c.frame.log.logCtrl
         elif isinstance(w, QtWidgets.QWidget):
-            self.widget = w
             self.w = QTextEditWrapper(widget=w, name=c.widget_name(w), c=c)
-            # print(f"LeoKeyEvent: new {self.w.__class__.__name__} from {w.__class__.__name__}")
         else:
-            self.w = self.widget = w
+            self.w = w
 
         # Optional ivars
         self.x = x

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -65,14 +65,7 @@ class LeoGui:
 
     # @+node:ekr.20051206103652: *3* LeoGui.widget_name
     def widget_name(self, w: Widget) -> str:
-        # First try the widget's getName method.
-        if not w:
-            return '<no widget>'
-        if hasattr(w, 'getName'):
-            return w.getName()
-        if hasattr(w, '_name'):
-            return w._name
-        return repr(w)
+        return w.getName() or '' if hasattr(w, 'getName') else ''
 
     # @+node:ekr.20070228154059: *3* LeoGui: May be defined in subclasses
     def dismiss_splash_screen(self) -> None:

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -370,7 +370,7 @@ class LeoKeyEvent:
         - The "before" part is Qt's event handling, controlled by eventFiler methods.
         - The "after" part consists of Leo's command handlers.
         """
-        trace = 'keys' in g.app.debug
+        # trace = 'keys' in g.app.debug
         tag = 'LeoKeyEvent.__init__:'
         self.c = c
         self.char = char or ''
@@ -388,15 +388,10 @@ class LeoKeyEvent:
         self.w: QTextMixin
 
         def obj_name(obj: Any) -> str:
-            if obj is None:
-                return 'None'
-            name = None
-            if hasattr(obj, 'objectName'):
-                name = obj.objectName()
-            return name or repr(obj)
+            return g.app.gui.widget_name(obj)
 
-        if trace:
-            print(f"{tag} {id(w)} {w.__class__.__name__} {obj_name(w)}")
+        # print(f"{tag} {id(w):>16} {w.__class__.__name__} {obj_name(w)}")
+
         if w is None:
             # Special case for headlines.
             if headline_wrapper := c.headline_wrapper(c.p):
@@ -411,32 +406,31 @@ class LeoKeyEvent:
         if c.widget_name(w).startswith('log'):
             self.w = c.frame.log.logCtrl
             return
-        if isinstance(w, QTextMixin):  # This will always succeed when using the console gui.
-            self.w = w  # A wrapper that handles text.
+        if isinstance(w, QTextMixin):
+            # print(f"{tag} Use QTextMixin: {w.__class__.__name__}")
+            self.w = w
             return
         if wrapper := getattr(w, 'wrapper', None):
-            # g.trace(f"Use w.wrapper: {wrapper!r}")
+            # print(f"{tag} Use w.wrapper: {wrapper.__class__.__name__}")
             self.w = wrapper
             return
         if wrapper := getattr(w, 'leo_wrapper', None):
-            # g.trace(f"Use w.leo_wrapper: {wrapper!r}")
+            # print(f"{tag} Use w.leo_wrapper: {wrapper.__class__.__name__}")
             self.w = wrapper
             return
         if isinstance(w, QtWidgets.QTextEdit):
             # Inject the `leo_wrapper` ivar into the widget so that this method
             # will never reallocate another wrapper for this widget.
             self.w = w.leo_wrapper = QTextEditWrapper(widget=w, name=c.widget_name(w), c=c)
-            if trace:
-                print(f"{tag} New wrapper: {self.w.__class__.__name__} for {obj_name(w)}")
+            print(f"{tag} New wrapper: {self.w.__class__.__name__} for {obj_name(w)}")
             return
         if isinstance(w, QtWidgets.QLineEdit):
             self.w = w.leo_wrapper = QLineEditWrapper(widget=w, name=c.widget_name(w), c=c)
-            if trace:
-                print(f"{tag} New wrapper: {self.w.__class__.__name__} for {obj_name(w)}")
+            print(f"{tag} New wrapper: {self.w.__class__.__name__} for {obj_name(w)}")
             return
         # Anything should be valid here: we don't expect the wrapper to do key handling.
         self.w = w
-        if trace and not isinstance(w, QtWidgets.QWidget):
+        if not isinstance(w, QtWidgets.QWidget):
             # We expect that w is a wrapper, but we don't much care.
             name = obj_name(w)
             if not name.startswith(('body', 'canvas', 'head', 'mini')):

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -406,8 +406,8 @@ class LeoKeyEvent:
             print(f"{tag} {id(w)} {w.__class__.__name__} {obj_name(w)}")
         if w is None:
             # Special case for headlines.
-            if edit_wrapper := c.edit_widget(c.p):
-                self.w = edit_wrapper
+            if headline_wrapper := c.headline_wrapper(c.p):
+                self.w = headline_wrapper
                 return
             # Default to the widget with focus, if any.
             w = g.app.gui.get_focus()

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -387,59 +387,62 @@ class LeoKeyEvent:
         def obj_name(obj: Any) -> str:
             return g.app.gui.widget_name(obj)
 
-        def trace(message: str) -> None:
+        def trace(prefix: str, message: str) -> None:
             if 'keys' in g.app.debug:
-                print('')
-                print(message)
+                trace_always(prefix, message)
+
+        def trace_always(prefix: str, message: str) -> None:
+            print('')
+            print(f"{tag} {prefix:>14}: {message}")
 
         if w is None:
             # Special case for headlines.
             if headline_wrapper := c.headline_wrapper(c.p):
-                trace(f"{tag} no w: headline")
+                trace('no w', 'headline')
                 self.w = headline_wrapper
                 return
             # Default to the widget with focus, if any.
             w = g.app.gui.get_focus()
-            trace(f"{tag} no w: focus: {w.__class__.__name__}")
+            trace('no w: focus', w.__class__.__name__)
             if w is None:
                 return
         else:
-            trace(f"{tag} w: text? {isinstance(w, QTextMixin):1} {w.__class__.__name__}")
+            trace(f" text? {isinstance(w, QTextMixin):1} w", w.__class__.__name__)
 
         # Ensure that self.w is a wrapper for all key-related Qt widgets.
         if c.widget_name(w).startswith('log'):
             self.w = c.frame.log.logCtrl
             return
         if isinstance(w, QTextMixin):
-            trace(f"{tag} Use QTextMixin: {w.__class__.__name__}")
+            trace('QTextMixin', 'w.__class__.__name__')
             self.w = w
             return
         if wrapper := getattr(w, 'wrapper', None):
-            trace(f"{tag} Use w.wrapper: {wrapper.__class__.__name__}")
+            trace('w.wrapper', wrapper.__class__.__name__)
             self.w = wrapper
             return
         if wrapper := getattr(w, 'leo_wrapper', None):
-            trace(f"{tag} Use w.leo_wrapper: {wrapper.__class__.__name__}")
+            trace('w.leo_wrapper', wrapper.__class__.__name__)
             self.w = wrapper
             return
         if isinstance(w, QtWidgets.QTextEdit):
             # Inject the `leo_wrapper` ivar into the widget so that this method
             # will never reallocate another wrapper for this widget.
             self.w = w.leo_wrapper = QTextEditWrapper(widget=w, name=c.widget_name(w), c=c)
-            print(f"{tag} New wrapper: {self.w.__class__.__name__} for {obj_name(w)}")
+            trace_always('new wrapper', f"{self.w.__class__.__name__} for {obj_name(w)}")
             return
         if isinstance(w, QtWidgets.QLineEdit):
             self.w = w.leo_wrapper = QLineEditWrapper(widget=w, name=c.widget_name(w), c=c)
-            print(f"{tag} New wrapper: {self.w.__class__.__name__} for {obj_name(w)}")
+            trace_always('New wrapper', f"{self.w.__class__.__name__} for {obj_name(w)}")
             return
         # Anything should be valid here: we don't expect the wrapper to do key handling.
         self.w = w
-        trace(f"{tag} unknown: {w.__class__.__name__}")
+        trace_always('unknown w', w.__class__.__name__)
         if not isinstance(w, QtWidgets.QWidget):
             # We expect that w is a wrapper, but we don't much care.
             name = obj_name(w)
             if not name.startswith(('body', 'canvas', 'head', 'mini')):
-                print(f"{tag} Unusual w: {w.__class__.__name__} name: {name}")
+                trace_always('unusual w', f"{w.__class__.__name__} name: {name}")
 
     # @+node:ekr.20140907103315.18774: *3*  LeoKeyEvent.__repr__
     def __repr__(self) -> str:

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -370,7 +370,6 @@ class LeoKeyEvent:
         - The "before" part is Qt's event handling, controlled by eventFiler methods.
         - The "after" part consists of Leo's command handlers.
         """
-        # trace = 'keys' in g.app.debug
         tag = 'LeoKeyEvent.__init__:'
         self.c = c
         self.char = char or ''
@@ -385,37 +384,42 @@ class LeoKeyEvent:
         )
         assert g.isStrokeOrNone(self.stroke), f"(LeoKeyEvent) {self.stroke!r} {g.callers()}"
 
-        self.w: QTextMixin
-
         def obj_name(obj: Any) -> str:
             return g.app.gui.widget_name(obj)
 
-        # print(f"{tag} {id(w):>16} {w.__class__.__name__} {obj_name(w)}")
+        def trace(message: str) -> None:
+            if 'keys' in g.app.debug:
+                print('')
+                print(message)
 
         if w is None:
             # Special case for headlines.
             if headline_wrapper := c.headline_wrapper(c.p):
+                trace(f"{tag} no w: headline")
                 self.w = headline_wrapper
                 return
             # Default to the widget with focus, if any.
             w = g.app.gui.get_focus()
+            trace(f"{tag} no w: focus: {w.__class__.__name__}")
             if w is None:
                 return
+        else:
+            trace(f"{tag} w: text? {isinstance(w, QTextMixin):1} {w.__class__.__name__}")
 
         # Ensure that self.w is a wrapper for all key-related Qt widgets.
         if c.widget_name(w).startswith('log'):
             self.w = c.frame.log.logCtrl
             return
         if isinstance(w, QTextMixin):
-            # print(f"{tag} Use QTextMixin: {w.__class__.__name__}")
+            trace(f"{tag} Use QTextMixin: {w.__class__.__name__}")
             self.w = w
             return
         if wrapper := getattr(w, 'wrapper', None):
-            # print(f"{tag} Use w.wrapper: {wrapper.__class__.__name__}")
+            trace(f"{tag} Use w.wrapper: {wrapper.__class__.__name__}")
             self.w = wrapper
             return
         if wrapper := getattr(w, 'leo_wrapper', None):
-            # print(f"{tag} Use w.leo_wrapper: {wrapper.__class__.__name__}")
+            trace(f"{tag} Use w.leo_wrapper: {wrapper.__class__.__name__}")
             self.w = wrapper
             return
         if isinstance(w, QtWidgets.QTextEdit):

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -434,6 +434,7 @@ class LeoKeyEvent:
             return
         # Anything should be valid here: we don't expect the wrapper to do key handling.
         self.w = w
+        trace(f"{tag} unknown: {w.__class__.__name__}")
         if not isinstance(w, QtWidgets.QWidget):
             # We expect that w is a wrapper, but we don't much care.
             name = obj_name(w)

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -38,7 +38,7 @@ class LeoGui:
     """
 
     # @+others
-    # @+node:ekr.20031218072017.3722: *3* LeoGui.__init__
+    # @+node:ekr.20031218072017.3722: *3*  LeoGui.__init__
     def __init__(self, guiName: str) -> None:
         """Ctor for the LeoGui class."""
         self.active = False  # Used only by qt_gui.
@@ -342,7 +342,7 @@ class LeoKeyEvent:
     __slots__ = ('c', 'char', 'stroke', 'w', 'x', 'x_root', 'y', 'y_root')
 
     # @+others
-    # @+node:ekr.20110605121601.18846: *3* LeoKeyEvent.__init__
+    # @+node:ekr.20110605121601.18846: *3*  LeoKeyEvent.__init__
     def __init__(
         self,
         c: Cmdr,
@@ -442,7 +442,7 @@ class LeoKeyEvent:
             if not name.startswith(('body', 'canvas', 'head', 'mini')):
                 print(f"{tag} Unusual w: {w.__class__.__name__} name: {name}")
 
-    # @+node:ekr.20140907103315.18774: *3* LeoKeyEvent.__repr__
+    # @+node:ekr.20140907103315.18774: *3*  LeoKeyEvent.__repr__
     def __repr__(self) -> str:
         d = {'c': self.c.shortFileName()}
         for ivar in ('char', 'stroke', 'w'):
@@ -470,7 +470,7 @@ class NullGui(LeoGui):
     """Null gui class."""
 
     # @+others
-    # @+node:ekr.20031218072017.2225: *3* NullGui.__init__
+    # @+node:ekr.20031218072017.2225: *3*  NullGui.__init__
     def __init__(self, guiName: str = 'nullGui') -> None:
         """ctor for the NullGui class."""
         super().__init__(guiName)
@@ -646,7 +646,7 @@ class NullGui(LeoGui):
         """Return True if w is a Text widget suitable for text-oriented commands."""
         return issubclass(w.__class__, StringTextWrapper)
 
-    # @+node:ekr.20070301172456: *3* NullGui.panels
+    # @+node:ekr.20070301172456: *3* NullGui: panels
     def createComparePanel(self, c: Cmdr) -> None:
         """Create Compare panel."""
 
@@ -716,7 +716,7 @@ class StringFindTabManager:
     """A string-based FindTabManager class for unit tests."""
 
     # @+others
-    # @+node:ekr.20210221130549.2: *3*  sftm.ctor
+    # @+node:ekr.20210221130549.2: *3*  sftm.__init__
 
     def __init__(self, c: Cmdr) -> None:
         """Ctor for the FindTabManager class."""
@@ -864,7 +864,7 @@ class StringFindTabManager:
         if not w.isChecked():
             w.toggle()
 
-    # @+node:ekr.20210221130549.3: *3* sftm.text getters/setters
+    # @+node:ekr.20210221130549.3: *3* sftm: getters/setters
     def get_find_text(self) -> str:
         s = self.find_findbox.text()
         if s and s[-1] in ('\r', '\n'):

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -18,13 +18,12 @@ from leo.core import leoGlobals as g
 from leo.core import leoFrame
 from leo.core.leoAPI import StringTextWrapper
 from leo.core.leoQt import QtWidgets
-from leo.plugins.qt_text import QTextEditWrapper
+from leo.plugins.qt_text import QLineEditWrapper, QTextEditWrapper, QTextMixin
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoNodes import Position
     from leo.plugins.qt_frame import FindTabManager
-    from leo.plugins.qt_text import QTextMixin
 
     Widget = Any  # 'Any' is the correct annotation for base class widgets.
 
@@ -347,6 +346,8 @@ class LeoGui:
 class LeoKeyEvent:
     """A gui-independent wrapper for gui events."""
 
+    __slots__ = ('c', 'char', 'stroke', 'w', 'x', 'x_root', 'y', 'y_root')
+
     # @+others
     # @+node:ekr.20110605121601.18846: *3* LeoKeyEvent.__init__
     def __init__(
@@ -355,44 +356,98 @@ class LeoKeyEvent:
         *,
         binding: Any = None,
         char: str = None,
-        w: Any = None,
+        w: Any = None,  # w can be either a Qt widget or one of Leo's wrappers.
         x: int = None,
         y: int = None,
         x_root: int = None,
         y_root: int = None,
     ) -> None:
-        """Ctor for LeoKeyEvent class."""
+        """
+        Ctor for LeoKeyEvent class.
+
+        The `w` kwarg can be either a (Qt) widget or an instance of one of
+        Leo's wrapper classes.
+
+        This method *computes* `event.w`. When `w` is a text-related Qt *widget*,
+        this method ensures that `event.w` is the correct text *wrapper*.
+
+        For the console gui (cursesGui2.py), `w` is always a StringTextWrapper.
+
+        This method is the "midpoint" of Leo's key-handling code:
+        - The "before" part is Qt's event handling, controlled by eventFiler methods.
+        - The "after" part consists of Leo's command handlers.
+        """
+        trace = 'keys' in g.app.debug
+        tag = 'LeoKeyEvent.__init__:'
         self.c = c
         self.char = char or ''
+        self.x = x
+        self.y = y
+        self.x_root = x_root
+        self.y_root = y_root
+
+        # Compute self.stroke.
         self.stroke: Any = (
             binding if g.isStroke(binding) else g.KeyStroke(binding) if binding else None
         )
         assert g.isStrokeOrNone(self.stroke), f"(LeoKeyEvent) {self.stroke!r} {g.callers()}"
 
         self.w: QTextMixin
+
+        def obj_name(obj: Any) -> str:
+            if obj is None:
+                return 'None'
+            name = None
+            if hasattr(obj, 'objectName'):
+                name = obj.objectName()
+            return name or repr(obj)
+
+        if trace:
+            print(f"{tag} {id(w)} {w.__class__.__name__} {obj_name(w)}")
         if w is None:
             # Special case for headlines.
-            edit_wrapper = c.edit_widget(c.p)
-            if edit_wrapper:
+            if edit_wrapper := c.edit_widget(c.p):
                 self.w = edit_wrapper
-            else:
-                focus_widget = g.app.gui.get_focus()
-                widget = focus_widget if g.isTextWrapper(focus_widget) else c.frame.body.widget
-                name = c.widget_name(widget) if widget else 'dummy-wrapper'
-                self.w = QTextEditWrapper(widget=widget, name=name, c=c)
-        elif c.widget_name(w).startswith('log'):
-            self.w = c.frame.log.logCtrl
-        elif isinstance(w, QtWidgets.QWidget):
-            self.w = QTextEditWrapper(widget=w, name=c.widget_name(w), c=c)
-        else:
-            self.w = w
+                return
+            # Default to the widget with focus, if any.
+            w = g.app.gui.get_focus()
+            if w is None:
+                return
 
-        # Optional ivars
-        self.x = x
-        self.y = y
-        # Support for fastGotoNode plugin
-        self.x_root = x_root
-        self.y_root = y_root
+        # Ensure that self.w is a wrapper for all key-related Qt widgets.
+        if c.widget_name(w).startswith('log'):
+            self.w = c.frame.log.logCtrl
+            return
+        if isinstance(w, QTextMixin):  # This will always succeed when using the console gui.
+            self.w = w  # A wrapper that handles text.
+            return
+        if wrapper := getattr(w, 'wrapper', None):
+            # g.trace(f"Use w.wrapper: {wrapper!r}")
+            self.w = wrapper
+            return
+        if wrapper := getattr(w, 'leo_wrapper', None):
+            # g.trace(f"Use w.leo_wrapper: {wrapper!r}")
+            self.w = wrapper
+            return
+        if isinstance(w, QtWidgets.QTextEdit):
+            # Inject the `leo_wrapper` ivar into the widget so that this method
+            # will never reallocate another wrapper for this widget.
+            self.w = w.leo_wrapper = QTextEditWrapper(widget=w, name=c.widget_name(w), c=c)
+            if trace:
+                print(f"{tag} New wrapper: {self.w.__class__.__name__} for {obj_name(w)}")
+            return
+        if isinstance(w, QtWidgets.QLineEdit):
+            self.w = w.leo_wrapper = QLineEditWrapper(widget=w, name=c.widget_name(w), c=c)
+            if trace:
+                print(f"{tag} New wrapper: {self.w.__class__.__name__} for {obj_name(w)}")
+            return
+        # Anything should be valid here: we don't expect the wrapper to do key handling.
+        self.w = w
+        if trace and not isinstance(w, QtWidgets.QWidget):
+            # We expect that w is a wrapper, but we don't much care.
+            name = obj_name(w)
+            if not name.startswith(('body', 'canvas', 'head', 'mini')):
+                print(f"{tag} Unusual w: {w.__class__.__name__} name: {name}")
 
     # @+node:ekr.20140907103315.18774: *3* LeoKeyEvent.__repr__
     def __repr__(self) -> str:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -247,7 +247,7 @@ class AutoCompleterClass:
         if not c.widget_name(w).lower().startswith('body'):
             return
         self.language = c.getLanguage(c.p)
-        if w:
+        if g.isTextWrapper(w):
             self.w = w
             self.start(event)
 
@@ -4015,7 +4015,7 @@ class KeyHandlerClass:
         c, w = k.c, k.w
         k.setLabelGrey('')
         k.mb_prefix = ''
-        if w:
+        if g.isTextWrapper(w):
             w.setSelectionRange(0, 0, insert=0)
             state = k.unboundKeyAction
             if c.vim_mode and c.vimCommands:
@@ -4034,7 +4034,7 @@ class KeyHandlerClass:
     def setLabel(self, s: str, protect: bool = False) -> None:
         """Set the label of the minibuffer."""
         c, k, w = self.c, self, self.w
-        if w:
+        if g.isTextWrapper(w):
             # Support for the curses gui.
             if hasattr(g.app.gui, 'set_minibuffer_label'):
                 g.app.gui.set_minibuffer_label(c, s)

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -292,8 +292,9 @@ class AutoCompleterClass:
     @ac_cmd('show-calltips')
     def showCalltips(self, event: LeoKeyEvent = None) -> None:
         """Show the calltips at the cursor."""
-        c, k, w = self.c, self.c.k, event and event.w
-        if not w:
+        c, k = self.c, self.c.k
+        w = event.w if event else None
+        if not g.isTextWrapper(w):
             return
         is_headline = c.widget_name(w).startswith('head')
         if k.enable_calltips and not is_headline:
@@ -306,8 +307,9 @@ class AutoCompleterClass:
     @ac_cmd('show-calltips-force')
     def showCalltipsForce(self, event: LeoKeyEvent = None) -> None:
         """Show the calltips at the cursor, even if calltips are not presently enabled."""
-        c, w = self.c, event and event.w
-        if not w:
+        c = self.c
+        w = event.w if event else None
+        if not g.isTextWrapper(w):
             return
         is_headline = c.widget_name(w).startswith('head')
         if not is_headline:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2597,16 +2597,15 @@ class KeyHandlerClass:
             k.resetLabel()
             if commandName != 'repeat-complex-command':
                 k.mb_history.insert(0, commandName)
-            w = event and event.widget
+            w = event and event.w
             if hasattr(w, 'permanent') and not w.permanent:
                 # In a headline that is being edited.
                 c.endEditing()
                 c.bodyWantsFocusNow()
                 # Change the event widget so we don't refer to the to-be-deleted headline widget.
                 event.w = c.frame.body.wrapper
-                event.widget = c.frame.body.wrapper.widget
-            else:
-                c.widgetWantsFocusNow(event and event.widget)  # So cut-text works, e.g.
+            elif event:
+                c.widgetWantsFocusNow(event.w)
             try:
                 func(event)
             except Exception:
@@ -3452,7 +3451,7 @@ class KeyHandlerClass:
         assert hasattr(event, 'char'), repr(event)
         assert hasattr(event, 'stroke'), repr(event)
         assert hasattr(event, 'w'), repr(event)
-        assert hasattr(event, 'widget'), repr(event)
+        ### assert hasattr(event, 'widget'), repr(event)
         assert g.isStrokeOrNone(event.stroke)
         # See LeoKeyEvent.__init__ for why the following test is correct.
         assert not isinstance(event.w, QtWidgets.QWidget), repr(event.w)
@@ -4218,7 +4217,7 @@ class KeyHandlerClass:
         if state == 0:
             k.inputModeName = modeName
             k.modePrompt = prompt or modeName
-            k.modeWidget = event.widget if event else None
+            k.modeWidget = event.w if event else None
             k.setState(modeName, 1, handler=k.generalModeHandler)
             self.initMode(event, modeName)
             # Careful: k.initMode can execute commands that will destroy a commander.
@@ -4238,7 +4237,7 @@ class KeyHandlerClass:
                 self.endMode()
                 # New in 4.4.1: pass an event describing the original widget.
                 if event:
-                    event.w = event.widget = k.modeWidget
+                    event.w = k.modeWidget
                 else:
                     event = g.app.gui.create_key_event(c, w=k.modeWidget)
                 func(event)

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -3451,7 +3451,6 @@ class KeyHandlerClass:
         assert hasattr(event, 'char'), repr(event)
         assert hasattr(event, 'stroke'), repr(event)
         assert hasattr(event, 'w'), repr(event)
-        ### assert hasattr(event, 'widget'), repr(event)
         assert g.isStrokeOrNone(event.stroke)
         # See LeoKeyEvent.__init__ for why the following test is correct.
         assert not isinstance(event.w, QtWidgets.QWidget), repr(event.w)

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -121,7 +121,7 @@ class LeoMenu:
     def error(self, s: str) -> None:
         g.error('', s)
 
-    # @+node:ekr.20031218072017.3781: *3* LeoMenu.Gui-independent menu routines
+    # @+node:ekr.20031218072017.3781: *3* LeoMenu: Gui-independent menu routines
     # @+node:ekr.20060926213642: *4* LeoMenu.capitalizeMinibufferMenuName
     def capitalizeMinibufferMenuName(self, s: str, removeHyphens: bool) -> str:
         result = []
@@ -273,7 +273,7 @@ class LeoMenu:
             return first != last
         return False
 
-    # @+node:ekr.20051022053758.1: *3* LeoMenu.Helpers
+    # @+node:ekr.20051022053758.1: *3* LeoMenu: Helpers
     # @+node:ekr.20031218072017.3783: *4* LeoMenu.canonicalize*
     def canonicalizeMenuName(self, name: str) -> str:
         # #1121 & #1188. Allow Chinese characters in command names
@@ -657,7 +657,7 @@ class LeoMenu:
         cmn = self.canonicalizeMenuName(menuName)
         del self.menus[cmn]
 
-    # @+node:ekr.20031218072017.3808: *3* LeoMenu.Must be overridden in menu subclasses
+    # @+node:ekr.20031218072017.3808: *3* LeoMenu: Must be overridden in menu subclasses
     # @+node:ekr.20031218072017.3809: *4* LeoMenu.9 Routines with Tk spellings
     def add_cascade(self, parent: Widget, label: str, menu: QtMenuWrapper, underline: int) -> None:
         pass

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -338,7 +338,7 @@ class LeoMenu:
                 # Redirect (MacOS only).
                 wname = c.widget_name(w)
                 if wname.startswith('head'):
-                    w = c.frame.tree.edit_widget(c.p)
+                    w = c.frame.tree.headline_wrapper(c.p)
             return w if g.isTextWidget(w) else None
 
         if isinstance(command, str):

--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -2,7 +2,7 @@
 # @+node:ekr.20140810053602.18074: * @file leoQt.py
 """Leo's Qt import wrapper, specialized for Qt6."""
 
-# pylint: disable=no-name-in-module,unused-import)
+# pylint: disable=no-name-in-module,unused-import
 from typing import Any
 from PyQt6 import QtCore, QtGui, QtWidgets
 from PyQt6.QtCore import Qt, QUrl

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -1052,7 +1052,7 @@ class LeoServer:
         if not hasattr(self, 'c') or not self.c:
             return
         try:
-            gui_w = self.c.edit_widget(self.c.p)
+            gui_w = self.c.headline_wrapper(self.c.p)
             gui_w.setSelectionRange(0, 0, insert=0)
         except Exception:
             print("Could not reset headline cursor")
@@ -2177,12 +2177,7 @@ class LeoServer:
             fc.in_headline = False
             c.bodyWantsFocus()
             c.bodyWantsFocusNow()
-        #
-        # if fc.in_headline:
-        #     ins = len(p.h)
-        #     gui_w = c.edit_widget(p)
-        #     gui_w.setSelectionRange(ins, ins, insert=ins)
-        #
+
         try:
             settings = fc.ftm.get_settings()
             p, pos, newpos = fc.do_find_next(settings)
@@ -2221,11 +2216,6 @@ class LeoServer:
             fc.in_headline = False
             c.bodyWantsFocus()
             c.bodyWantsFocusNow()
-        #
-        # if fc.in_headline:
-        #     gui_w = c.edit_widget(p)
-        #     gui_w.setSelectionRange(0, 0, insert=0)
-        #
         try:
             settings = fc.ftm.get_settings()
             p, pos, newpos = fc.do_find_prev(settings)
@@ -5300,7 +5290,7 @@ class LeoServer:
             if hasattr(w, "sel"):
                 return w.sel[0], w.sel[1]
             c = self.c
-            gui_w = c.edit_widget(c.p)
+            gui_w = c.headline_wrapper(c.p)
             selRange = gui_w.getSelectionRange()
             return selRange
         except Exception:

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -1052,8 +1052,8 @@ class LeoServer:
         if not hasattr(self, 'c') or not self.c:
             return
         try:
-            gui_w = self.c.headline_wrapper(self.c.p)
-            gui_w.setSelectionRange(0, 0, insert=0)
+            w = self.c.headline_wrapper(self.c.p)
+            w.setSelectionRange(0, 0, insert=0)
         except Exception:
             print("Could not reset headline cursor")
         # Important: this will redraw if necessary.
@@ -5290,8 +5290,8 @@ class LeoServer:
             if hasattr(w, "sel"):
                 return w.sel[0], w.sel[1]
             c = self.c
-            gui_w = c.headline_wrapper(c.p)
-            selRange = gui_w.getSelectionRange()
+            w = c.headline_wrapper(c.p)
+            selRange = w.getSelectionRange()
             return selRange
         except Exception:
             print("Error retrieving current focused widget selection range.")

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -550,11 +550,11 @@ class textTree(leoFrame.LeoTree):
         w.setAllText(p.b)
         # and something to do with undo?
 
-    # @+node:ekr.20150107090324.66: *3* editLabel & edit_widget (cursesGui)
+    # @+node:ekr.20150107090324.66: *3* editLabel & headline_wrapper (cursesGui)
     def editLabel(self, v, selectAll: bool = False, selection: tuple = None) -> tuple[None, None]:
         return None, None
 
-    def edit_widget(self, p):
+    def headline_wrapper(self, p):
         return None
 
     # @+node:ekr.20150107090324.67: *3* text_draw_tree & helper

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -177,7 +177,7 @@ class textGui(leoGui.LeoGui):
         elif s in ('q', 'quit'):
             self.killed = True
 
-    # @+node:ekr.20150107090324.20: *3* widget_name
+    # @+node:ekr.20150107090324.20: *3* widget_name (cursesGui.py)
     def widget_name(self, w):
         if isinstance(w, textBodyCtrl):
             return 'body'

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -271,10 +271,6 @@ class TextFrame(leoFrame.LeoFrame):
                 self.leoWidget = w
                 self.widget = w
 
-        # Leo uses widget_name(event.widget) to decide if a 'default' keystroke belongs
-        # to typing in the body text, in the tree control, or whereever.
-        # Canonicalize the setting.
-
         char = key
         stroke = c.k.shortcutFromSetting(char)
         g.trace('char', repr(char), 'stroke', repr(stroke))

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2663,7 +2663,7 @@ class CoreTree(leoFrame.LeoTree):
             if trace:
                 g.trace('NO wrapper')
             return  # Startup.
-        w = self.edit_widget(p)
+        w = self.headline_wrapper(p)
         if not w:
             if trace:
                 g.trace('****** no w for p: %s', repr(p))
@@ -2734,8 +2734,8 @@ class CoreTree(leoFrame.LeoTree):
         # vScroll.setValue(vPos)
 
     # @+node:ekr.20170511105355.1: *4* CTree.Selecting & editing
-    # @+node:ekr.20170511105355.4: *5* CTree.edit_widget
-    def edit_widget(self, p: Position) -> HeadWrapper:
+    # @+node:ekr.20170511105355.4: *5* CTree.headline_wrapper
+    def headline_wrapper(self, p: Position) -> HeadWrapper:
         """Returns the edit widget for position p."""
         return HeadWrapper(c=self.c, name='head', p=p)
 
@@ -2772,7 +2772,7 @@ class CoreTree(leoFrame.LeoTree):
             return
         # Don't do this here: the caller should do it.
         # p.setHeadString(s)
-        e = self.edit_widget(p)
+        e = self.headline_wrapper(p)
         assert isinstance(e, HeadWrapper), repr(e)
         e.setAllText(s)
         if trace:
@@ -4351,7 +4351,7 @@ class BodyWrapper(StringTextWrapper):
 # @+node:ekr.20170522002403.1: *3* class HeadWrapper (StringTextWrapper) cursesGui2.py
 class HeadWrapper(StringTextWrapper):
     """
-    A Wrapper class for headline widgets, returned by c.edit_widget(p)
+    A Wrapper class for headline widgets, returned by c.headline_wrapper(p)
     """
 
     def __init__(self, c: Cmdr, name: str, p: Position) -> None:

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -4171,7 +4171,7 @@ class TextMixin:
     """A minimal mixin class for QTextEditWrapper and QScintillaWrapper classes."""
 
     # @+others
-    # @+node:ekr.20170511053143.2: *4* tm.ctor & helper
+    # @+node:ekr.20170511053143.2: *4* TextMixin.__init__ & helper
     def __init__(self, c: Cmdr = None) -> None:
         """Ctor for TextMixin class"""
         self.c = c
@@ -4179,7 +4179,7 @@ class TextMixin:
         if c:
             self.injectIvars(c)
 
-    # @+node:ekr.20170511053143.3: *5* tm.injectIvars (cursesGui2)
+    # @+node:ekr.20170511053143.3: *5* TextMixin.injectIvars (cursesGui2)
     def injectIvars(self, c: Cmdr) -> Any:
         """Inject standard leo ivars into the QTextEdit or QsciScintilla widget."""
         self.leo_active = True
@@ -4190,20 +4190,20 @@ class TextMixin:
         self.leo_frame = None
         return self
 
-    # @+node:ekr.20170511053143.4: *4* tm.getName
+    # @+node:ekr.20170511053143.4: *4* TextMixin.getName
     def getName(self) -> str:
         return self.name  # Essential.
 
-    # @+node:ekr.20170511053143.8: *4* tm.Generic high-level interface
+    # @+node:ekr.20170511053143.8: *4* TextMixin: Generic high-level interface
     # These call only wrapper methods.
-    # @+node:ekr.20170511053143.13: *5* tm.appendText
+    # @+node:ekr.20170511053143.13: *5* TextMixin.appendText
     def appendText(self, s: str) -> None:
         """TextMixin"""
         s2 = self.getAllText()
         self.setAllText(s2 + s)
         self.setInsertPoint(len(s2))
 
-    # @+node:ekr.20170511053143.10: *5* tm.clipboard_clear/append
+    # @+node:ekr.20170511053143.10: *5* TextMixin.clipboard_clear/append
     def clipboard_append(self, s: str) -> None:
         s1 = g.app.gui.getTextFromClipboard()
         g.app.gui.replaceClipboardWith(s1 + s)
@@ -4211,7 +4211,7 @@ class TextMixin:
     def clipboard_clear(self) -> None:
         g.app.gui.replaceClipboardWith('')
 
-    # @+node:ekr.20170511053143.14: *5* tm.delete
+    # @+node:ekr.20170511053143.14: *5* TextMixin.delete
     def delete(self, i: int, j: int = None) -> None:
         """TextMixin"""
         s = self.getAllText()
@@ -4224,20 +4224,20 @@ class TextMixin:
         # Bug fix: Significant in external tests.
         self.setSelectionRange(i, i, insert=i)
 
-    # @+node:ekr.20170511053143.15: *5* tm.deleteTextSelection
+    # @+node:ekr.20170511053143.15: *5* TextMixin.deleteTextSelection
     def deleteTextSelection(self) -> None:
         """TextMixin"""
         i, j = self.getSelectionRange()
         self.delete(i, j)
 
-    # @+node:ekr.20170511053143.9: *5* tm.Enable/disable
+    # @+node:ekr.20170511053143.9: *5* TextMixin.Enable/disable
     def disable(self) -> None:
         self.enabled = False
 
     def enable(self, enabled: bool = True) -> None:
         self.enabled = enabled
 
-    # @+node:ekr.20170511053143.16: *5* tm.get
+    # @+node:ekr.20170511053143.16: *5* TextMixin.get
     def get(self, i: int, j: int = None) -> str:
         """TextMixin"""
         # 2012/04/12: fix the following two bugs by using the vanilla code:
@@ -4248,7 +4248,7 @@ class TextMixin:
             j = i + 1
         return all_s[i:j]
 
-    # @+node:ekr.20170511053143.17: *5* tm.getLastIndex & getLength
+    # @+node:ekr.20170511053143.17: *5* TextMixin.getLastIndex & getLength
     def getLastIndex(self) -> int:
         """TextMixin"""
         return len(self.getAllText())
@@ -4257,7 +4257,7 @@ class TextMixin:
         """TextMixin"""
         return len(self.getAllText())
 
-    # @+node:ekr.20170511053143.18: *5* tm.getSelectedText
+    # @+node:ekr.20170511053143.18: *5* TextMixin.getSelectedText
     def getSelectedText(self) -> str:
         """TextMixin"""
         i, j = self.getSelectionRange()
@@ -4266,7 +4266,7 @@ class TextMixin:
         s = self.getAllText()
         return s[i:j]
 
-    # @+node:ekr.20170511053143.19: *5* tm.insert
+    # @+node:ekr.20170511053143.19: *5* TextMixin.insert
     def insert(self, i: int, s: str) -> int:
         """TextMixin"""
         all_s = self.getAllText()
@@ -4274,7 +4274,7 @@ class TextMixin:
         self.setInsertPoint(i + len(s))
         return i
 
-    # @+node:ekr.20170511053143.24: *5* tm.rememberSelectionAndScroll
+    # @+node:ekr.20170511053143.24: *5* TextMixin.rememberSelectionAndScroll
     def rememberSelectionAndScroll(self) -> None:
         v = self.c.p.v  # Always accurate.
         v.insertSpot = self.getInsertPoint()
@@ -4286,23 +4286,23 @@ class TextMixin:
         v.selectionLength = j - i
         v.scrollBarSpot = self.getYScrollPosition()
 
-    # @+node:ekr.20170511053143.20: *5* tm.seeInsertPoint
+    # @+node:ekr.20170511053143.20: *5* TextMixin.seeInsertPoint
     def seeInsertPoint(self) -> None:
         """Ensure the insert point is visible."""
         # getInsertPoint defined in client classes.
         self.see(self.getInsertPoint())
 
-    # @+node:ekr.20170511053143.21: *5* tm.selectAllText
+    # @+node:ekr.20170511053143.21: *5* TextMixin.selectAllText
     def selectAllText(self) -> None:
         """TextMixin."""
         self.setSelectionRange(0, self.getLength())
 
-    # @+node:ekr.20170511053143.11: *5* tm.setFocus
+    # @+node:ekr.20170511053143.11: *5* TextMixin.setFocus
     def setFocus(self) -> None:
         """TextMixin.setFocus"""
         g.app.gui.set_focus(self)
 
-    # @+node:ekr.20170511053143.23: *5* tm.toPythonIndexRowCol
+    # @+node:ekr.20170511053143.23: *5* TextMixin.toPythonIndexRowCol
     def toPythonIndexRowCol(self, index: int) -> tuple[int, int]:
         """TextMixin"""
         s = self.getAllText()

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2469,7 +2469,7 @@ class CoreFrame(leoFrame.LeoFrame):
         """
         trace = False and not g.unitTesting
         c, p, u = self.c, self.c.p, self.c.undoer
-        w = event and event.widget
+        w = event and event.w
         if not isinstance(w, StringTextWrapper):
             g.trace('not a StringTextWrapper', repr(w))
             return

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2328,22 +2328,18 @@ class CoreFrame(leoFrame.LeoFrame):
     # @+node:ekr.20171128052121.4: *6* CFrame.create_find_findbox
     def create_find_findbox(self) -> None:
         """Create the Find: label and text area."""
-        c = self.c
-        fc = c.findCommands
         ftm = self.ftm
         assert ftm
         assert ftm.find_findbox is None
-        ftm.find_findbox = self.createLineEdit('findPattern', disabled=fc.expert_mode)
+        ftm.find_findbox = self.createLineEdit('findPattern')
 
     # @+node:ekr.20171128052121.5: *6* CFrame.create_find_replacebox
     def create_find_replacebox(self) -> None:
         """Create the Replace: label and text area."""
-        c = self.c
-        fc = c.findCommands
         ftm = self.ftm
         assert ftm
         assert ftm.find_replacebox is None
-        ftm.find_replacebox = self.createLineEdit('findChange', disabled=fc.expert_mode)
+        ftm.find_replacebox = self.createLineEdit('findChange')
 
     # @+node:ekr.20171128052121.6: *6* CFrame.create_find_checkboxes
     def create_find_checkboxes(self) -> None:

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2764,19 +2764,14 @@ class CoreTree(leoFrame.LeoTree):
     # @+node:ekr.20170511105355.9: *5* CTree.setHeadline
     def setHeadline(self, p: Position, s: str) -> None:
         """Force the actual text of the headline widget to p.h."""
-        trace = False and not g.unitTesting
         # This is used by unit tests to force the headline and p into alignment.
         if not p:
-            if trace:
-                g.trace('*** no p')
             return
         # Don't do this here: the caller should do it.
         # p.setHeadString(s)
-        e = self.headline_wrapper(p)
-        assert isinstance(e, HeadWrapper), repr(e)
-        e.setAllText(s)
-        if trace:
-            g.trace(e)
+        w = self.headline_wrapper(p)
+        assert isinstance(w, HeadWrapper), repr(w)
+        w.setAllText(s)
 
     # @+node:ekr.20170523115818.1: *5* CTree.set_body_text_after_select
     def set_body_text_after_select(self, p: Position, old_p: Position) -> None:

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -4192,7 +4192,7 @@ class TextMixin:
 
     # @+node:ekr.20170511053143.4: *4* TextMixin.getName
     def getName(self) -> str:
-        return self.name  # Essential.
+        return self.name or ''  # Essential.
 
     # @+node:ekr.20170511053143.8: *4* TextMixin: Generic high-level interface
     # These call only wrapper methods.

--- a/leo/plugins/demo.py
+++ b/leo/plugins/demo.py
@@ -455,7 +455,7 @@ class Demo:
         tree = c.frame.tree
         p.h = ''
         c.editHeadline()
-        w = tree.edit_widget(p)
+        w = tree.headline_wrapper(p)
         if undo:
             undoData = c.undoer.beforeChangeNodeContents(p)
             p.setDirty()

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -73,7 +73,7 @@ class LossageData:
 # @+node:ekr.20141028061518.17: ** class LeoQtEventFilter
 class LeoQtEventFilter(QtCore.QObject):
     # @+others
-    # @+node:ekr.20110605121601.18539: *3* LeoQtEventFilter.__init__
+    # @+node:ekr.20110605121601.18539: *3*  LeoQtEventFilter.__init__
     def __init__(self, c, w, tag=''):
         """Ctor for LeoQtEventFilter class."""
         super().__init__()
@@ -387,7 +387,7 @@ class LeoQtEventFilter(QtCore.QObject):
         mods = [b for a, b in mod_table if (modifiers & a)]
         return mods
 
-    # @+node:ekr.20140907103315.18767: *3* LeoQtEventFilter:Tracing
+    # @+node:ekr.20140907103315.18767: *3* LeoQtEventFilter: Tracing
     # @+node:ekr.20190922075339.1: *4* LeoQtEventFilter.traceKeys
     def traceKeys(self, obj, event):
         if g.unitTesting:

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -186,7 +186,7 @@ class LeoQtEventFilter(QtCore.QObject):
         """
         c = self.c
         t = event.type()
-        isEditWidget = obj == c.frame.tree.edit_widget(c.p)
+        isEditWidget = obj == c.frame.tree.headline_wrapper(c.p)
         if isEditWidget:
             # QLineEdit: ignore all key events except keyRelease events.
             return t != Type.KeyRelease

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1671,7 +1671,7 @@ class LeoQtBody(leoFrame.LeoBody):
         self.set_widget()  # Sets self.widget and self.wrapper.
         self.setWrap(c.p)
 
-    # @+node:ekr.20110605121601.18185: *4* LeoQtBody.get_name
+    # @+node:ekr.20110605121601.18185: *4* LeoQtBody.getName
     def getName(self) -> str:
         return 'body-widget'
 

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -3826,7 +3826,7 @@ class QtIconBarClass:
     def add(self, *args: Any, **keys: Any) -> QAction:
         """Add a button to the icon bar."""
         c = self.c
-        if not self.w:
+        if not g.isTextWrapper(self.w):
             return None
         command: Callable = keys.get('command')
         text: str = keys.get('text')

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1657,7 +1657,7 @@ class LeoQtBody(leoFrame.LeoBody):
     """A class that represents the body pane of a Qt window."""
 
     # @+others
-    # @+node:ekr.20110605121601.18182: *3* LeoQtBody.ctor & helpers
+    # @+node:ekr.20110605121601.18182: *3*  LeoQtBody.__init__ & helpers
     def __init__(self, frame: LeoQtFrame) -> None:
         """Ctor for LeoQtBody class."""
         # Call the base class constructor.
@@ -1912,7 +1912,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
         """A kludge: called to enable text changed events."""
         self.initComplete = True
 
-    # @+node:ekr.20110605121601.18274: *3* LeoQtFrame.Configuration
+    # @+node:ekr.20110605121601.18274: *3* LeoQtFrame: Configuration
     # @+node:ekr.20240510092709.1: *4* LeoQtFrame.compute_ratio & compute_secondary_ratio
     # @+node:ekr.20240510093119.1: *5* LeoQtFrame.compute_ratio
     def compute_ratio(self) -> float:
@@ -2035,7 +2035,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
         s2 = s - s1
         splitter.setSizes([s1, s2])
 
-    # @+node:ekr.20110605121601.18285: *3* LeoQtFrame.Event handlers
+    # @+node:ekr.20110605121601.18285: *3* LeoQtFrame: Event handlers
     # @+node:ekr.20110605121601.18286: *4* LeoQtFrame.OnCloseLeoEvent
     # Called from quit logic and when user closes the window.
     # Returns True if the close happened.
@@ -2059,7 +2059,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
     def OnActivateTree(self, event: QEvent = None) -> None:
         pass
 
-    # @+node:ekr.20110605121601.18293: *3* LeoQtFrame.Gui-dependent commands
+    # @+node:ekr.20110605121601.18293: *3* LeoQtFrame: Gui-dependent commands
     # @+node:ekr.20110605121601.18301: *4* LeoQtFrame.Window Menu...
     # @+node:ekr.20110605121601.18302: *5* LeoQtFrame.toggleActivePane
     @frame_cmd('toggle-active-pane')
@@ -2162,7 +2162,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
             else:
                 w.setWindowState(WindowState.WindowMaximized)
 
-    # @+node:ekr.20110605121601.18311: *3* LeoQtFrame.Qt bindings...
+    # @+node:ekr.20110605121601.18311: *3* LeoQtFrame: Qt bindings
     # @+node:ekr.20190611053431.1: *4* LeoQtFrame.bringToFront
     def bringToFront(self) -> None:
         if 'size' in g.app.debug:
@@ -2322,7 +2322,7 @@ class LeoQtLog(leoFrame.LeoLog):
     def getName(self) -> str:
         return 'log'  # Required for proper pane bindings.
 
-    # @+node:ekr.20150717102728.1: *3* LeoQtLog: clear-log & dump-log
+    # @+node:ekr.20150717102728.1: *3* LeoQtLog.clear-log & dump-log
     @log_cmd('clear-log')
     @log_cmd('log-clear')
     def clearLog(self, event: LeoKeyEvent = None) -> None:
@@ -2350,12 +2350,11 @@ class LeoQtLog(leoFrame.LeoLog):
         g.printObj([dump(z) for z in w.toPlainText().split('\n')], tag=f"{fn}: w.toPlainText")
         g.printObj([f"{dump(z)}<br />" for z in w.toHtml().split('<br />')], tag=f"{fn}: w.toHtml")
 
-    # @+node:ekr.20110605121601.18333: *3* LeoQtLog.color tab stuff
+    # @+node:ekr.20110605121601.18333: *3* LeoQtLog.createColorPicker
     def createColorPicker(self, tabName: str) -> None:
         g.warning('color picker not ready for qt')
 
-    # @+node:ekr.20110605121601.18334: *3* LeoQtLog.font tab stuff
-    # @+node:ekr.20110605121601.18335: *4* LeoQtLog.createFontPicker
+    # @+node:ekr.20110605121601.18335: *3* LeoQtLog.createFontPicker
     def createFontPicker(self, tabName: str) -> None:
         # log = self
         font, ok = QtWidgets.QFontDialog.getFont()
@@ -2395,7 +2394,7 @@ class LeoQtLog(leoFrame.LeoLog):
             if val3:
                 g.es(key3, val3, tabName='Fonts')
 
-    # @+node:ekr.20110605121601.18339: *4* LeoQtLog.hideFontTab
+    # @+node:ekr.20110605121601.18339: *3* LeoQtLog.hideFontTab
     def hideFontTab(self, event: LeoKeyEvent = None) -> None:
         c = self.c
         c.frame.log.selectTab('Log')
@@ -2552,7 +2551,7 @@ class LeoQtLog(leoFrame.LeoLog):
         sb.setSliderPosition(pos)
         w.repaint()  # Slow, but essential.
 
-    # @+node:ekr.20110605121601.18324: *3* LeoQtLog.Tab
+    # @+node:ekr.20110605121601.18324: *3* LeoQtLog: Tab
     # @+node:ekr.20110605121601.18325: *4* LeoQtLog.clearTab
     def clearTab(self, tabName: str, wrap: str = 'none') -> None:
         w = self.logDict.get(tabName)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -55,7 +55,7 @@ from leo.core.leoQt import (
 )
 from leo.plugins import qt_events, qt_text
 from leo.plugins.mod_scripting import build_rclick_tree
-from leo.plugins.qt_text import QTextEditWrapper
+from leo.plugins.qt_text import QLineEditWrapper, QTextEditWrapper
 from leo.plugins.qt_tree import LeoQtTree
 from leo.plugins.qt_layout import LayoutCacheWidget
 
@@ -356,6 +356,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         ftm = fc.ftm
         assert ftm.find_findbox is None
         ftm.find_findbox = w = dw.createLineEdit(parent, 'findPattern', disabled=fc.expert_mode)
+        w.leo_wrapper = QLineEditWrapper(widget=w, name='find-wrapper', c=c)
         lab2 = self.createLabel(parent, 'findLabel', 'Find:')
         grid.addWidget(lab2, row, 0)
         grid.addWidget(w, row, 1, 1, 2)
@@ -370,6 +371,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         ftm = fc.ftm
         assert ftm.find_replacebox is None
         ftm.find_replacebox = w = dw.createLineEdit(parent, 'findChange', disabled=fc.expert_mode)
+        w.leo_wrapper = QLineEditWrapper(widget=w, name='replace-wrapper', c=c)
         lab3 = dw.createLabel(parent, 'changeLabel', 'Replace:')
         grid.addWidget(lab3, row, 0)
         grid.addWidget(w, row, 1, 1, 2)
@@ -691,7 +693,9 @@ class DynamicWindow(QtWidgets.QMainWindow):
         return w
 
     # @+node:ekr.20110605121601.18159: *4* dw.createLineEdit
-    def createLineEdit(self, parent: QWidget, name: str, disabled: bool = True) -> QWidget:
+    def createLineEdit(
+        self, parent: QWidget, name: str, disabled: bool = True
+    ) -> QtWidgets.QLineEdit:
         w = QtWidgets.QLineEdit(parent)
         w.setObjectName(name)
         w.leo_disabled = disabled  # Inject the ivar.

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -355,7 +355,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         fc = c.findCommands
         ftm = fc.ftm
         assert ftm.find_findbox is None
-        ftm.find_findbox = w = dw.createLineEdit(parent, 'findPattern', disabled=fc.expert_mode)
+        ftm.find_findbox = w = dw.createLineEdit(parent, 'findPattern')
         w.leo_wrapper = QLineEditWrapper(widget=w, name='find-wrapper', c=c)
         lab2 = self.createLabel(parent, 'findLabel', 'Find:')
         grid.addWidget(lab2, row, 0)
@@ -370,7 +370,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         fc = c.findCommands
         ftm = fc.ftm
         assert ftm.find_replacebox is None
-        ftm.find_replacebox = w = dw.createLineEdit(parent, 'findChange', disabled=fc.expert_mode)
+        ftm.find_replacebox = w = dw.createLineEdit(parent, 'findChange')
         w.leo_wrapper = QLineEditWrapper(widget=w, name='replace-wrapper', c=c)
         lab3 = dw.createLabel(parent, 'changeLabel', 'Replace:')
         grid.addWidget(lab3, row, 0)
@@ -488,20 +488,6 @@ class DynamicWindow(QtWidgets.QMainWindow):
         row += max_row2
         row += 2
         return row
-
-    # @+node:ekr.20150618072619.1: *5* dw.create_find_status
-    if 0:
-
-        def create_find_status(self, grid: QGridLayout, parent: QWidget, row: int) -> None:
-            """Create the status line."""
-            dw = self
-            status_label = dw.createLabel(parent, 'status-label', 'Status')
-            status_line = dw.createLineEdit(parent, 'find-status', disabled=True)
-            grid.addWidget(status_label, row, 0)
-            grid.addWidget(status_line, row, 1, 1, 2)
-            # Official ivars.
-            dw.find_status_label = status_label
-            dw.find_status_edit = status_line
 
     # @+node:ekr.20131118172620.16891: *5* dw.override_events
     def override_events(self) -> None:
@@ -693,12 +679,9 @@ class DynamicWindow(QtWidgets.QMainWindow):
         return w
 
     # @+node:ekr.20110605121601.18159: *4* dw.createLineEdit
-    def createLineEdit(
-        self, parent: QWidget, name: str, disabled: bool = True
-    ) -> QtWidgets.QLineEdit:
+    def createLineEdit(self, parent: QWidget, name: str) -> QtWidgets.QLineEdit:
         w = QtWidgets.QLineEdit(parent)
         w.setObjectName(name)
-        w.leo_disabled = disabled  # Inject the ivar.
         return w
 
     # @+node:ekr.20110605121601.18160: *4* dw.createRadioButton

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -233,7 +233,326 @@ class LeoQtGui(leoGui.LeoGui):
             g.pr('LeoQtGui.destroySelf: calling qtApp.Quit')
         self.qtApp.quit()
 
-    # @+node:ekr.20110605121601.18485: *3* LeoQtGui.Clipboard
+    # @+node:ekr.20110605121601.18510: *3* LeoQtGui.getFontFromParams
+    size_warnings: list[str] = []
+    font_ids: list[int] = []  # id's of traced fonts.
+
+    def getFontFromParams(
+        self,
+        family: str,
+        size: str,
+        slant: str,
+        weight: str,
+        defaultSize: int = 12,
+        tag='',
+    ) -> Optional[QFont]:
+        """Required to handle syntax coloring."""
+        if isinstance(size, str):
+            if size.endswith('pt'):
+                size = size[:-2].strip()
+            elif size.endswith('px'):
+                if size not in self.size_warnings:
+                    self.size_warnings.append(size)
+                    g.es(f"px ignored in font setting: {size}")
+                size = size[:-2].strip()
+        try:
+            i_size = int(size)
+        except Exception:
+            i_size = 0
+        if i_size < 1:
+            i_size = defaultSize
+        d = {
+            'black': Weight.Black,
+            'bold': Weight.Bold,
+            'demibold': Weight.DemiBold,
+            'light': Weight.Light,
+            'normal': Weight.Normal,
+        }
+        weight_val = d.get(weight.lower(), Weight.Normal)
+        italic = slant == 'italic'
+        if not family:
+            family = 'DejaVu Sans Mono'
+        try:
+            font = QtGui.QFont(family, i_size, weight_val, italic)
+            if sys.platform.startswith('linux'):
+                try:
+                    font.setHintingPreference(font.PreferFullHinting)
+                except AttributeError:
+                    pass
+            return font
+        except Exception:
+            g.es_print("exception setting font", g.callers(4))
+            g.es_print(f"family: {family}\n  size: {i_size}\n slant: {slant}\nweight: {weight}")
+            # g.es_exception() # Confusing for most users.
+            return None
+
+    # @+node:ekr.20110605121601.18511: *3* LeoQtGui.getFullVersion
+    def getFullVersion(self, c: Cmdr = None) -> str:
+        """Return the PyQt version (for signon)"""
+        try:
+            qtLevel = f"version {QtCore.qVersion()}"
+        except Exception:
+            # g.es_exception()
+            qtLevel = '<qtLevel>'
+        return f"PyQt {qtLevel}"
+
+    # @+node:ekr.20110605121601.18528: *3* LeoQtGui.makeScriptButton
+    def makeScriptButton(
+        self,
+        c: Cmdr,
+        args: Any = None,
+        p: Position = None,  # A node containing the script.
+        script: str = None,  # The script itself.
+        buttonText: str = None,
+        balloonText: str = 'Script Button',
+        shortcut: str = None,
+        bg: str = 'LightSteelBlue1',
+        define_g: bool = True,
+        define_name: str = '__main__',
+        silent: bool = False,  # Passed on to c.executeScript.
+    ) -> None:
+        """
+        Create a script button for the script in node p.
+        The button's text defaults to p.headString."""
+        # pylint: disable=line-too-long
+        k = c.k
+        if p and not buttonText:
+            buttonText = p.h.strip()
+        if not buttonText:
+            buttonText = 'Unnamed Script Button'
+        # @+<< create the button b >>
+        # @+node:ekr.20110605121601.18529: *4* << create the button b >>
+        iconBar = c.frame.getIconBarObject()
+        b = iconBar.add(text=buttonText)
+
+        # @-<< create the button b >>
+        # @+<< define the callbacks for b >>
+        # @+node:ekr.20110605121601.18530: *4* << define the callbacks for b >>
+        def deleteButtonCallback(
+            event: LeoKeyEvent = None, b: QPushButton = b, c: Cmdr = c
+        ) -> None:
+            if b:
+                b.pack_forget()
+            c.bodyWantsFocus()
+
+        def executeScriptCallback(
+            event: LeoKeyEvent = None,
+            b: QPushButton = b,
+            c: Cmdr = c,
+            buttonText: str = buttonText,
+            p: Position = p and p.copy(),
+            script: str = script,
+        ) -> None:
+            if c.disableCommandsMessage:
+                g.blue('', c.disableCommandsMessage)
+            else:
+                g.app.scriptDict = {'script_gnx': p.gnx}
+                c.executeScript(
+                    args=args,
+                    p=p,
+                    script=script,
+                    define_g=define_g,
+                    define_name=define_name,
+                    silent=silent,
+                )
+                # Remove the button if the script asks to be removed.
+                if g.app.scriptDict.get('removeMe'):
+                    g.es('removing', f"'{buttonText}'", 'button at its request')
+                    b.pack_forget()
+            # Do not assume the script will want to remain in this commander.
+
+        # @-<< define the callbacks for b >>
+
+        b.configure(command=executeScriptCallback)
+        if shortcut:
+            # @+<< bind the shortcut to executeScriptCallback >>
+            # @+node:ekr.20110605121601.18531: *4* << bind the shortcut to executeScriptCallback >>
+            # In LeoQtGui.makeScriptButton.
+            func = executeScriptCallback
+            if shortcut:
+                shortcut = g.KeyStroke(shortcut)  # type:ignore
+            ok = k.bindKey('button', shortcut, func, buttonText)
+            if ok:
+                g.blue('bound @button', buttonText, 'to', shortcut)
+            # @-<< bind the shortcut to executeScriptCallback >>
+        # @+<< create press-buttonText-button command >>
+        # @+node:ekr.20110605121601.18532: *4* << create press-buttonText-button command >> LeoQtGui.makeScriptButton
+        # #1121. Like sc.cleanButtonText
+        buttonCommandName = f"press-{buttonText.replace(' ', '-').strip('-')}-button"
+        #
+        # This will use any shortcut defined in an @shortcuts node.
+        k.registerCommand(buttonCommandName, executeScriptCallback, pane='button')
+        # @-<< create press-buttonText-button command >>
+
+    # @+node:ekr.20200304125716.1: *3* LeoQtGui.onContextMenu
+    def onContextMenu(self, c: Cmdr, w: QTextMixin, point: QPoint) -> None:
+        """LeoQtGui: Common context menu handling."""
+        # #1286.
+        handlers = g.tree_popup_handlers
+        if not handlers:
+            return  # #4164: The "No popup handlers" message is annoying.
+        menu = QtWidgets.QMenu(c.frame.top)  # #1995.
+        menuPos = w.mapToGlobal(point)
+        p = c.p.copy()
+        done: set[Callable] = set()
+        for handler in handlers:
+            # every handler has to add it's QActions by itself
+            if handler in done:
+                # do not run the same handler twice
+                continue
+            try:
+                handler(c, p, menu)
+                done.add(handler)
+            except Exception:
+                g.es_print('Exception executing right-click handler')
+                g.es_exception()
+        menu.popup(menuPos)
+        self._contextmenu = menu
+
+    # @+node:ekr.20170612065255.1: *3* LeoQtGui.put_help
+    def put_help(self, c: Cmdr, s: str, short_title: str = '') -> Any:
+        """Put the help command."""
+        s = textwrap.dedent(s.rstrip())
+        if s.startswith('<') and not s.startswith('<<'):
+            pass  # how to do selective replace??
+        pc = g.app.pluginsController
+        table = (
+            'viewrendered3.py',
+            'viewrendered.py',
+        )
+        for name in table:
+            if pc.isLoaded(name):
+                vr = pc.loadOnePlugin(name)
+                break
+        else:
+            vr = pc.loadOnePlugin('viewrendered.py')
+        if vr:
+            kw = {
+                'c': c,
+                'flags': 'rst',
+                'kind': 'rst',
+                'label': '',
+                'msg': s,
+                'name': 'Apropos',
+                'short_title': short_title,
+                'title': '',
+            }
+            vr.show_scrolled_message(tag='Apropos', kw=kw)
+            c.bodyWantsFocus()
+            if g.unitTesting:
+                vr.close_rendering_pane(event={'c': c})
+        elif g.unitTesting:
+            pass
+        else:
+            g.es(s)
+        return vr  # For unit tests
+
+    # @+node:ekr.20110605121601.18521: *3* LeoQtGui.runAtIdle
+    def runAtIdle(self, aFunc: Callable) -> None:
+        """This can not be called in some contexts."""
+        QtCore.QTimer.singleShot(0, aFunc)
+
+    # @+node:ekr.20130930062914.16000: *3* LeoQtGui.runMainLoop
+    def runMainLoop(self) -> None:
+        """Start the Qt main loop."""
+        try:  # #2127: A crash here hard-crashes Leo: There is no main loop!
+            g.app.gui.dismiss_splash_screen()
+            c = g.app.log and g.app.log.c
+            if c and c.config.getBool('show-tips', default=False):
+                g.app.gui.show_tips(c)
+        except Exception:
+            g.es_exception()
+        if self.script:
+            log = g.app.log
+            if log:
+                g.pr('Start of batch script...\n')
+                log.c.executeScript(script=self.script)
+                g.pr('End of batch script')
+            else:
+                g.pr('no log, no commander for executeScript in LeoQtGui.runMainLoop')
+        else:
+            # This can be alarming when using Python's -i option.
+            sys.exit(self.qtApp.exec())
+
+    # @+node:ekr.20180117053546.1: *3* LeoQtGui.show_tips & helpers
+    @g.command('show-tips')
+    def show_next_tip(self, event: LeoKeyEvent = None) -> None:
+        c = g.app.log and g.app.log.c
+        if c:
+            g.app.gui.show_tips(c)
+
+    # @+<< define DialogWithCheckBox >>
+    # @+node:ekr.20220123052350.1: *4* << define DialogWithCheckBox >>
+    class DialogWithCheckBox(QtWidgets.QMessageBox):
+        def __init__(self, controller: LeoQtGui, checked: bool, tip: UserTip) -> None:
+            super().__init__()
+            c = g.app.log.c
+            self.leo_checked = True
+            self.setObjectName('TipMessageBox')
+            self.setIcon(Icon.Information)  # #2127.
+            # self.setMinimumSize(5000, 4000)
+            # Doesn't work.
+            # Prevent the dialog from jumping around when
+            # selecting multiple tips.
+            self.setWindowTitle('Leo Tips')
+            self.setText(repr(tip))
+            self.next_tip_button = self.addButton('Show Next Tip', ButtonRole.ActionRole)
+            self.addButton('Ok', ButtonRole.YesRole)
+            c.styleSheetManager.set_style_sheets(w=self)
+            # Workaround #693.
+            layout = self.layout()
+            cb = QtWidgets.QCheckBox()
+            cb.setObjectName('TipCheckbox')
+            cb.setText('Show Tip On Startup')
+            # #2383: State is a tri-state, so use the official constants.
+            state = Checked if checked else Unchecked
+            cb.setCheckState(state)  # #2127.
+            cb.stateChanged.connect(controller.onClick)
+            layout.addWidget(cb, 4, 0, -1, -1)  # type:ignore
+            if 0:  # Does not work well.
+                sizePolicy = QtWidgets.QSizePolicy
+                vSpacer = QtWidgets.QSpacerItem(200, 200, sizePolicy.Minimum, sizePolicy.Expanding)
+                layout.addItem(vSpacer)
+
+    # @-<< define DialogWithCheckBox >>
+
+    def show_tips(self, c: Cmdr) -> None:
+        if g.unitTesting:
+            return
+        from leo.core import leoTips
+
+        tm = leoTips.TipManager()
+        self.show_tips_flag = c.config.getBool('show-tips', default=False)  # 2390.
+        while True:  # QMessageBox is always a modal dialog.
+            tip = tm.get_next_tip()
+            m = self.DialogWithCheckBox(controller=self, checked=self.show_tips_flag, tip=tip)
+            try:
+                c.in_qt_dialog = True
+                m.exec()
+            finally:
+                c.in_qt_dialog = False
+            b = m.clickedButton()
+            if b != m.next_tip_button:
+                break
+
+    # @+node:ekr.20180117080131.1: *4* onButton (not used)
+    def onButton(self, m: QPushButton) -> None:
+        m.hide()
+
+    # @+node:ekr.20180117073603.1: *4* onClick
+    def onClick(self, state: str) -> None:
+        c = g.app.log.c
+        self.show_tips_flag = bool(state)
+        if c:  # #2390: The setting *has* changed.
+            c.config.setUserSetting('@bool show-tips', self.show_tips_flag)
+            c.redraw()  # #2390: Show the change immediately.
+
+    # @+node:ekr.20180127103142.1: *4* onNext (not used)
+    def onNext(self, *args: Any, **keys: Any) -> bool:
+        g.trace(args, keys)
+        return True
+
+    # @+node:ekr.20110605121601.18485: *3* LeoQtGui: Clipboard
     # @+node:ekr.20160917125946.1: *4* LeoQtGui.replaceClipboardWith
     def replaceClipboardWith(self, s: str) -> None:
         """Replace the clipboard with the string s."""
@@ -267,7 +586,7 @@ class LeoQtGui(leoGui.LeoGui):
         # Alas, returning s reopens #218.
         return
 
-    # @+node:ekr.20110605121601.18487: *3* LeoQtGui.Dialogs & panels
+    # @+node:ekr.20110605121601.18487: *3* LeoQtGui: Dialogs & panels
     # @+node:ekr.20231010004932.1: *4* LeoQtGui._save/_restore_focus
     def _save_focus(self, c):
         """
@@ -997,7 +1316,7 @@ class LeoQtGui(leoGui.LeoGui):
             c.in_qt_dialog = False
         # @-<< emergency fallback >>
 
-    # @+node:ekr.20110607182447.16456: *3* LeoQtGui.Event handlers
+    # @+node:ekr.20110607182447.16456: *3* LeoQtGui: Event handlers
     # @+node:ekr.20190824094650.1: *4* LeoQtGui.close_event
     def close_event(self, event: QEvent) -> None:
         # Save session data.
@@ -1097,7 +1416,7 @@ class LeoQtGui(leoGui.LeoGui):
         obj.installEventFilter(theFilter)
         w.ev_filter = theFilter  # Set the official ivar in w.
 
-    # @+node:ekr.20110605121601.18508: *3* LeoQtGui.Focus
+    # @+node:ekr.20110605121601.18508: *3* LeoQtGui: Focus
     # @+node:ekr.20190601055031.1: *4* LeoQtGui.ensure_commander_visible
     def ensure_commander_visible(self, c1: Cmdr) -> None:
         """
@@ -1137,70 +1456,7 @@ class LeoQtGui(leoGui.LeoGui):
             g.trace('(LeoQtGui)', name)
         w.setFocus()
 
-    # @+node:ekr.20110605121601.18510: *3* LeoQtGui.getFontFromParams
-    size_warnings: list[str] = []
-    font_ids: list[int] = []  # id's of traced fonts.
-
-    def getFontFromParams(
-        self,
-        family: str,
-        size: str,
-        slant: str,
-        weight: str,
-        defaultSize: int = 12,
-        tag='',
-    ) -> Optional[QFont]:
-        """Required to handle syntax coloring."""
-        if isinstance(size, str):
-            if size.endswith('pt'):
-                size = size[:-2].strip()
-            elif size.endswith('px'):
-                if size not in self.size_warnings:
-                    self.size_warnings.append(size)
-                    g.es(f"px ignored in font setting: {size}")
-                size = size[:-2].strip()
-        try:
-            i_size = int(size)
-        except Exception:
-            i_size = 0
-        if i_size < 1:
-            i_size = defaultSize
-        d = {
-            'black': Weight.Black,
-            'bold': Weight.Bold,
-            'demibold': Weight.DemiBold,
-            'light': Weight.Light,
-            'normal': Weight.Normal,
-        }
-        weight_val = d.get(weight.lower(), Weight.Normal)
-        italic = slant == 'italic'
-        if not family:
-            family = 'DejaVu Sans Mono'
-        try:
-            font = QtGui.QFont(family, i_size, weight_val, italic)
-            if sys.platform.startswith('linux'):
-                try:
-                    font.setHintingPreference(font.PreferFullHinting)
-                except AttributeError:
-                    pass
-            return font
-        except Exception:
-            g.es_print("exception setting font", g.callers(4))
-            g.es_print(f"family: {family}\n  size: {i_size}\n slant: {slant}\nweight: {weight}")
-            # g.es_exception() # Confusing for most users.
-            return None
-
-    # @+node:ekr.20110605121601.18511: *3* LeoQtGui.getFullVersion
-    def getFullVersion(self, c: Cmdr = None) -> str:
-        """Return the PyQt version (for signon)"""
-        try:
-            qtLevel = f"version {QtCore.qVersion()}"
-        except Exception:
-            # g.es_exception()
-            qtLevel = '<qtLevel>'
-        return f"PyQt {qtLevel}"
-
-    # @+node:ekr.20110605121601.18514: *3* LeoQtGui.Icons
+    # @+node:ekr.20110605121601.18514: *3* LeoQtGui: Icons
     # @+node:ekr.20110605121601.18515: *4* LeoQtGui.attachLeoIcon
     def attachLeoIcon(self, window: QMainWindow | QDialog) -> None:
         """Attach a Leo icon to the window."""
@@ -1308,263 +1564,7 @@ class LeoQtGui(leoGui.LeoGui):
             return image, image.height()
         return None, None
 
-    # @+node:ekr.20110605121601.18528: *3* LeoQtGui.makeScriptButton
-    def makeScriptButton(
-        self,
-        c: Cmdr,
-        args: Any = None,
-        p: Position = None,  # A node containing the script.
-        script: str = None,  # The script itself.
-        buttonText: str = None,
-        balloonText: str = 'Script Button',
-        shortcut: str = None,
-        bg: str = 'LightSteelBlue1',
-        define_g: bool = True,
-        define_name: str = '__main__',
-        silent: bool = False,  # Passed on to c.executeScript.
-    ) -> None:
-        """
-        Create a script button for the script in node p.
-        The button's text defaults to p.headString."""
-        # pylint: disable=line-too-long
-        k = c.k
-        if p and not buttonText:
-            buttonText = p.h.strip()
-        if not buttonText:
-            buttonText = 'Unnamed Script Button'
-        # @+<< create the button b >>
-        # @+node:ekr.20110605121601.18529: *4* << create the button b >>
-        iconBar = c.frame.getIconBarObject()
-        b = iconBar.add(text=buttonText)
-
-        # @-<< create the button b >>
-        # @+<< define the callbacks for b >>
-        # @+node:ekr.20110605121601.18530: *4* << define the callbacks for b >>
-        def deleteButtonCallback(
-            event: LeoKeyEvent = None, b: QPushButton = b, c: Cmdr = c
-        ) -> None:
-            if b:
-                b.pack_forget()
-            c.bodyWantsFocus()
-
-        def executeScriptCallback(
-            event: LeoKeyEvent = None,
-            b: QPushButton = b,
-            c: Cmdr = c,
-            buttonText: str = buttonText,
-            p: Position = p and p.copy(),
-            script: str = script,
-        ) -> None:
-            if c.disableCommandsMessage:
-                g.blue('', c.disableCommandsMessage)
-            else:
-                g.app.scriptDict = {'script_gnx': p.gnx}
-                c.executeScript(
-                    args=args,
-                    p=p,
-                    script=script,
-                    define_g=define_g,
-                    define_name=define_name,
-                    silent=silent,
-                )
-                # Remove the button if the script asks to be removed.
-                if g.app.scriptDict.get('removeMe'):
-                    g.es('removing', f"'{buttonText}'", 'button at its request')
-                    b.pack_forget()
-            # Do not assume the script will want to remain in this commander.
-
-        # @-<< define the callbacks for b >>
-
-        b.configure(command=executeScriptCallback)
-        if shortcut:
-            # @+<< bind the shortcut to executeScriptCallback >>
-            # @+node:ekr.20110605121601.18531: *4* << bind the shortcut to executeScriptCallback >>
-            # In LeoQtGui.makeScriptButton.
-            func = executeScriptCallback
-            if shortcut:
-                shortcut = g.KeyStroke(shortcut)  # type:ignore
-            ok = k.bindKey('button', shortcut, func, buttonText)
-            if ok:
-                g.blue('bound @button', buttonText, 'to', shortcut)
-            # @-<< bind the shortcut to executeScriptCallback >>
-        # @+<< create press-buttonText-button command >>
-        # @+node:ekr.20110605121601.18532: *4* << create press-buttonText-button command >> LeoQtGui.makeScriptButton
-        # #1121. Like sc.cleanButtonText
-        buttonCommandName = f"press-{buttonText.replace(' ', '-').strip('-')}-button"
-        #
-        # This will use any shortcut defined in an @shortcuts node.
-        k.registerCommand(buttonCommandName, executeScriptCallback, pane='button')
-        # @-<< create press-buttonText-button command >>
-
-    # @+node:ekr.20200304125716.1: *3* LeoQtGui.onContextMenu
-    def onContextMenu(self, c: Cmdr, w: QTextMixin, point: QPoint) -> None:
-        """LeoQtGui: Common context menu handling."""
-        # #1286.
-        handlers = g.tree_popup_handlers
-        if not handlers:
-            return  # #4164: The "No popup handlers" message is annoying.
-        menu = QtWidgets.QMenu(c.frame.top)  # #1995.
-        menuPos = w.mapToGlobal(point)
-        p = c.p.copy()
-        done: set[Callable] = set()
-        for handler in handlers:
-            # every handler has to add it's QActions by itself
-            if handler in done:
-                # do not run the same handler twice
-                continue
-            try:
-                handler(c, p, menu)
-                done.add(handler)
-            except Exception:
-                g.es_print('Exception executing right-click handler')
-                g.es_exception()
-        menu.popup(menuPos)
-        self._contextmenu = menu
-
-    # @+node:ekr.20170612065255.1: *3* LeoQtGui.put_help
-    def put_help(self, c: Cmdr, s: str, short_title: str = '') -> Any:
-        """Put the help command."""
-        s = textwrap.dedent(s.rstrip())
-        if s.startswith('<') and not s.startswith('<<'):
-            pass  # how to do selective replace??
-        pc = g.app.pluginsController
-        table = (
-            'viewrendered3.py',
-            'viewrendered.py',
-        )
-        for name in table:
-            if pc.isLoaded(name):
-                vr = pc.loadOnePlugin(name)
-                break
-        else:
-            vr = pc.loadOnePlugin('viewrendered.py')
-        if vr:
-            kw = {
-                'c': c,
-                'flags': 'rst',
-                'kind': 'rst',
-                'label': '',
-                'msg': s,
-                'name': 'Apropos',
-                'short_title': short_title,
-                'title': '',
-            }
-            vr.show_scrolled_message(tag='Apropos', kw=kw)
-            c.bodyWantsFocus()
-            if g.unitTesting:
-                vr.close_rendering_pane(event={'c': c})
-        elif g.unitTesting:
-            pass
-        else:
-            g.es(s)
-        return vr  # For unit tests
-
-    # @+node:ekr.20110605121601.18521: *3* LeoQtGui.runAtIdle
-    def runAtIdle(self, aFunc: Callable) -> None:
-        """This can not be called in some contexts."""
-        QtCore.QTimer.singleShot(0, aFunc)
-
-    # @+node:ekr.20130930062914.16000: *3* LeoQtGui.runMainLoop
-    def runMainLoop(self) -> None:
-        """Start the Qt main loop."""
-        try:  # #2127: A crash here hard-crashes Leo: There is no main loop!
-            g.app.gui.dismiss_splash_screen()
-            c = g.app.log and g.app.log.c
-            if c and c.config.getBool('show-tips', default=False):
-                g.app.gui.show_tips(c)
-        except Exception:
-            g.es_exception()
-        if self.script:
-            log = g.app.log
-            if log:
-                g.pr('Start of batch script...\n')
-                log.c.executeScript(script=self.script)
-                g.pr('End of batch script')
-            else:
-                g.pr('no log, no commander for executeScript in LeoQtGui.runMainLoop')
-        else:
-            # This can be alarming when using Python's -i option.
-            sys.exit(self.qtApp.exec())
-
-    # @+node:ekr.20180117053546.1: *3* LeoQtGui.show_tips & helpers
-    @g.command('show-tips')
-    def show_next_tip(self, event: LeoKeyEvent = None) -> None:
-        c = g.app.log and g.app.log.c
-        if c:
-            g.app.gui.show_tips(c)
-
-    # @+<< define DialogWithCheckBox >>
-    # @+node:ekr.20220123052350.1: *4* << define DialogWithCheckBox >>
-    class DialogWithCheckBox(QtWidgets.QMessageBox):
-        def __init__(self, controller: LeoQtGui, checked: bool, tip: UserTip) -> None:
-            super().__init__()
-            c = g.app.log.c
-            self.leo_checked = True
-            self.setObjectName('TipMessageBox')
-            self.setIcon(Icon.Information)  # #2127.
-            # self.setMinimumSize(5000, 4000)
-            # Doesn't work.
-            # Prevent the dialog from jumping around when
-            # selecting multiple tips.
-            self.setWindowTitle('Leo Tips')
-            self.setText(repr(tip))
-            self.next_tip_button = self.addButton('Show Next Tip', ButtonRole.ActionRole)
-            self.addButton('Ok', ButtonRole.YesRole)
-            c.styleSheetManager.set_style_sheets(w=self)
-            # Workaround #693.
-            layout = self.layout()
-            cb = QtWidgets.QCheckBox()
-            cb.setObjectName('TipCheckbox')
-            cb.setText('Show Tip On Startup')
-            # #2383: State is a tri-state, so use the official constants.
-            state = Checked if checked else Unchecked
-            cb.setCheckState(state)  # #2127.
-            cb.stateChanged.connect(controller.onClick)
-            layout.addWidget(cb, 4, 0, -1, -1)  # type:ignore
-            if 0:  # Does not work well.
-                sizePolicy = QtWidgets.QSizePolicy
-                vSpacer = QtWidgets.QSpacerItem(200, 200, sizePolicy.Minimum, sizePolicy.Expanding)
-                layout.addItem(vSpacer)
-
-    # @-<< define DialogWithCheckBox >>
-
-    def show_tips(self, c: Cmdr) -> None:
-        if g.unitTesting:
-            return
-        from leo.core import leoTips
-
-        tm = leoTips.TipManager()
-        self.show_tips_flag = c.config.getBool('show-tips', default=False)  # 2390.
-        while True:  # QMessageBox is always a modal dialog.
-            tip = tm.get_next_tip()
-            m = self.DialogWithCheckBox(controller=self, checked=self.show_tips_flag, tip=tip)
-            try:
-                c.in_qt_dialog = True
-                m.exec()
-            finally:
-                c.in_qt_dialog = False
-            b = m.clickedButton()
-            if b != m.next_tip_button:
-                break
-
-    # @+node:ekr.20180117080131.1: *4* onButton (not used)
-    def onButton(self, m: QPushButton) -> None:
-        m.hide()
-
-    # @+node:ekr.20180117073603.1: *4* onClick
-    def onClick(self, state: str) -> None:
-        c = g.app.log.c
-        self.show_tips_flag = bool(state)
-        if c:  # #2390: The setting *has* changed.
-            c.config.setUserSetting('@bool show-tips', self.show_tips_flag)
-            c.redraw()  # #2390: Show the change immediately.
-
-    # @+node:ekr.20180127103142.1: *4* onNext (not used)
-    def onNext(self, *args: Any, **keys: Any) -> bool:
-        g.trace(args, keys)
-        return True
-
-    # @+node:ekr.20111215193352.10220: *3* LeoQtGui.Splash Screen
+    # @+node:ekr.20111215193352.10220: *3* LeoQtGui: Splash Screen
     # @+node:ekr.20110605121601.18479: *4* LeoQtGui.createSplashScreen
     def createSplashScreen(self) -> QWidget:
         """Put up a splash screen with Leo's logo."""
@@ -1628,7 +1628,7 @@ class LeoQtGui(leoGui.LeoGui):
             # gui.splashScreen.deleteLater()
             gui.splashScreen = None
 
-    # @+node:ekr.20140825042850.18411: *3* LeoQtGui:Utils...
+    # @+node:ekr.20140825042850.18411: *3* LeoQtGui: Utils
     # @+node:ekr.20240519114809.1: *4* LeoQtGui._self_and_subtree
     def _self_and_subtree(self, qt_obj: QObject) -> Generator:
         """Yield w and all of w's descendants."""
@@ -1707,7 +1707,7 @@ class LeoQtGui(leoGui.LeoGui):
             else ''
         )  # fmt: skip
 
-    # @+node:ekr.20190819091957.1: *3* LeoQtGui:Widget constructors
+    # @+node:ekr.20190819091957.1: *3* LeoQtGui: Widget constructors
     # @+node:ekr.20190819094016.1: *4* LeoQtGui.createButton
     def createButton(self, parent: QWidget, name: str, label: str) -> QPushButton:
         w = QtWidgets.QPushButton(parent)
@@ -1809,7 +1809,7 @@ class StyleClassManager:
     style_sclass_property = 'style_class'  # name of QObject property for styling
 
     # @+others
-    # @+node:tbrown.20150724090431.2: *3* update_view
+    # @+node:tbrown.20150724090431.2: *3* StyleClassManager.update_view
     def update_view(self, w: QTextMixin) -> None:
         """update_view - Make Qt apply w's style
 
@@ -1818,7 +1818,7 @@ class StyleClassManager:
 
         w.setStyleSheet("/* */")  # forces visual update
 
-    # @+node:tbrown.20150724090431.3: *3* add_sclass
+    # @+node:tbrown.20150724090431.3: *3* StyleClassManager.add_sclass
     def add_sclass(self, w: QTextMixin, prop: str) -> None:
         """Add style class to QWidget w"""
         if not prop:
@@ -1828,12 +1828,12 @@ class StyleClassManager:
             props.append(prop)
             self.set_sclasses(w, props)
 
-    # @+node:tbrown.20150724090431.4: *3* clear_sclasses
+    # @+node:tbrown.20150724090431.4: *3* StyleClassManager.clear_sclasses
     def clear_sclasses(self, w: QTextMixin) -> None:
         """Remove all style classes from QWidget w"""
         w.setProperty(self.style_sclass_property, '')
 
-    # @+node:tbrown.20150724090431.5: *3* has_sclass
+    # @+node:tbrown.20150724090431.5: *3* StyleClassManager.has_sclass
     def has_sclass(self, w: QTextMixin, prop: str) -> bool:
         """Check for style class or list of classes prop on QWidget w"""
         if not prop:
@@ -1845,7 +1845,7 @@ class StyleClassManager:
             ans = [i in props for i in prop]
         return all(ans)
 
-    # @+node:tbrown.20150724090431.6: *3* remove_sclass
+    # @+node:tbrown.20150724090431.6: *3* StyleClassManager.remove_sclass
     def remove_sclass(self, w: QTextMixin, prop: str) -> None:
         """Remove style class or list of classes prop from QWidget w"""
         if not prop:
@@ -1858,12 +1858,12 @@ class StyleClassManager:
 
         self.set_sclasses(w, props)
 
-    # @+node:tbrown.20150724090431.8: *3* sclasses
+    # @+node:tbrown.20150724090431.8: *3* StyleClassManager.sclasses
     def sclasses(self, w: QTextMixin) -> list[str]:
         """return list of style classes for QWidget w"""
         return str(w.property(self.style_sclass_property) or '').split()
 
-    # @+node:tbrown.20150724090431.9: *3* set_sclasses
+    # @+node:tbrown.20150724090431.9: *3* StyleClassManager.set_sclasses
     def set_sclasses(self, w: QTextMixin, classes: list[str]) -> None:
         """Set style classes for QWidget w to list in classes"""
         w.setProperty(self.style_sclass_property, f" {' '.join(set(classes))} ")
@@ -1876,8 +1876,7 @@ class StyleSheetManager:
     """A class to manage (reload) Qt style sheets."""
 
     # @+others
-    # @+node:ekr.20180316091829.1: *3*  ssm.Birth
-    # @+node:ekr.20140912110338.19371: *4* ssm.__init__
+    # @+node:ekr.20140912110338.19371: *3*  StyleSheetManager.__init__
     def __init__(self, c: Cmdr, safe: bool = False) -> None:
         """Ctor the ReloadStyle class."""
         self.c = c
@@ -1890,7 +1889,7 @@ class StyleSheetManager:
         # g.es("No '@settings' node found in outline.  See:")
         # g.es("https://leo-editor.github.io/leo-editor/tutorial-basics.html#configuring-leo")
 
-    # @+node:ekr.20170222051716.1: *4* ssm.reload_settings
+    # @+node:ekr.20170222051716.1: *3*  StyleSheetManager.reload_settings
     def reload_settings(self, sheet: str = None) -> None:
         """
         Recompute and apply the stylesheet.
@@ -1905,8 +1904,8 @@ class StyleSheetManager:
 
     reloadSettings = reload_settings
 
-    # @+node:ekr.20180316091500.1: *3* ssm.Paths...
-    # @+node:ekr.20180316065346.1: *4* ssm.compute_icon_directories
+    # @+node:ekr.20180316091500.1: *3* StyleSheetManager: Paths...
+    # @+node:ekr.20180316065346.1: *4* StyleSheetManager.compute_icon_directories
     def compute_icon_directories(self) -> list[str]:
         """
         Return a list of *existing* directories that could contain theme-related icons.
@@ -1931,7 +1930,7 @@ class StyleSheetManager:
                 table.append(directory2)
         return [g.os_path_normslashes(z) for z in table if g.os_path_exists(z)]
 
-    # @+node:ekr.20180315101238.1: *4* ssm.compute_theme_directories
+    # @+node:ekr.20180315101238.1: *4* StyleSheetManager.compute_theme_directories
     def compute_theme_directories(self) -> list[str]:
         """
         Return a list of *existing* directories that could contain theme .leo files.
@@ -1944,7 +1943,7 @@ class StyleSheetManager:
         # All entries are known to exist and have normalized slashes.
         return table
 
-    # @+node:ekr.20170307083738.1: *4* ssm.find_icon_path
+    # @+node:ekr.20170307083738.1: *4* StyleSheetManager.find_icon_path
     def find_icon_path(self, setting: str) -> Optional[str]:
         """Return the path to the open/close indicator icon."""
         c = self.c
@@ -1958,8 +1957,8 @@ class StyleSheetManager:
         g.es_print('no icon found for:', setting)
         return None
 
-    # @+node:ekr.20180316091920.1: *3* ssm.Settings
-    # @+node:ekr.20110605121601.18176: *4* ssm.default_style_sheet
+    # @+node:ekr.20180316091920.1: *3* StyleSheetManager: Settings
+    # @+node:ekr.20110605121601.18176: *4* StyleSheetManager.default_style_sheet
     def default_style_sheet(self) -> str:
         """Return a reasonable default style sheet."""
         # Valid color names: http://www.w3.org/TR/SVG/types.html#ColorKeywords
@@ -1984,13 +1983,13 @@ class StyleSheetManager:
     }
     '''
 
-    # @+node:ekr.20140916170549.19551: *4* ssm.get_data
+    # @+node:ekr.20140916170549.19551: *4* StyleSheetManager.get_data
     def get_data(self, setting: str) -> list:
         """Return the value of the @data node for the setting."""
         c = self.c
         return c.config.getData(setting, strip_comments=False, strip_data=False) or []
 
-    # @+node:ekr.20140916170549.19552: *4* ssm.get_style_sheet_from_settings
+    # @+node:ekr.20140916170549.19552: *4* StyleSheetManager.get_style_sheet_from_settings
     def get_style_sheet_from_settings(self) -> str:
         """
         Scan for themes or @data qt-gui-plugin-style-sheet nodes.
@@ -2004,14 +2003,14 @@ class StyleSheetManager:
         sheet = self.expand_css_constants(sheet)
         return sheet
 
-    # @+node:ekr.20140915194122.19476: *4* ssm.print_style_sheet
+    # @+node:ekr.20140915194122.19476: *4* StyleSheetManager.print_style_sheet
     def print_style_sheet(self) -> None:
         """Show the top-level style sheet."""
         w = self.get_master_widget()
         sheet = w.styleSheet()
         print(f"style sheet for: {w}...\n\n{sheet}")
 
-    # @+node:ekr.20110605121601.18175: *4* ssm.set_style_sheets
+    # @+node:ekr.20110605121601.18175: *4* StyleSheetManager.set_style_sheets
     def set_style_sheets(self, all: bool = True, top: QWidget = None, w: QWidget = None) -> None:
         """Set the master style sheet for all widgets using config settings."""
         c = self.c
@@ -2045,9 +2044,9 @@ class StyleSheetManager:
                 w = self.get_master_widget(top)
             w.setStyleSheet(sheet)
 
-    # @+node:ekr.20180316091943.1: *3* ssm.Stylesheet
+    # @+node:ekr.20180316091943.1: *3* StyleSheetManager: Stylesheets
     # Computations on stylesheets themselves.
-    # @+node:ekr.20140915062551.19510: *4* ssm.expand_css_constants & helpers
+    # @+node:ekr.20140915062551.19510: *4* StyleSheetManager.expand_css_constants & helpers
     css_warning_given = False  # For do_pass.
 
     def expand_css_constants(self, sheet: str, settingsDict: g.SettingsDict = None) -> str:
@@ -2079,7 +2078,7 @@ class StyleSheetManager:
         sheet = sheet.replace('\\\n', '')  # join lines ending in \
         return sheet
 
-    # @+node:ekr.20150617085045.1: *5* ssm.adjust_sizes
+    # @+node:ekr.20150617085045.1: *5* StyleSheetManager.adjust_sizes
     def adjust_sizes(self, settingsDict: dict) -> tuple[dict, Any]:
         """Adjust constants to reflect c._style_deltas."""
         c = self.c
@@ -2103,7 +2102,7 @@ class StyleSheetManager:
                 constants['@' + delta] = f"{size}{units}"
         return constants, deltas
 
-    # @+node:ekr.20180316093159.1: *5* ssm.do_pass
+    # @+node:ekr.20180316093159.1: *5* StyleSheetManager.do_pass
     def do_pass(
         self,
         constants: dict,
@@ -2155,7 +2154,7 @@ class StyleSheetManager:
                 # So rely on whoever calls .setStyleSheet() to do the right thing.
         return sheet
 
-    # @+node:tbrown.20131120093739.27085: *5* ssm.find_constants_referenced
+    # @+node:tbrown.20131120093739.27085: *5* StyleSheetManager.find_constants_referenced
     def find_constants_referenced(self, text: str) -> list[str]:
         """find_constants - Return a list of constants referenced in the supplied text,
         constants match::
@@ -2173,7 +2172,7 @@ class StyleSheetManager:
                 aList.remove(s)
         return aList
 
-    # @+node:ekr.20150617090104.1: *5* ssm.replace_indicator_constants
+    # @+node:ekr.20150617090104.1: *5* StyleSheetManager.replace_indicator_constants
     def replace_indicator_constants(self, sheet: str) -> str:
         """
         In the stylesheet, replace (if they exist)::
@@ -2211,7 +2210,7 @@ class StyleSheetManager:
                 sheet = sheet.replace(old, new)
         return sheet
 
-    # @+node:ekr.20180320054305.1: *5* ssm.resolve_urls
+    # @+node:ekr.20180320054305.1: *5* StyleSheetManager.resolve_urls
     def resolve_urls(self, sheet: str) -> str:
         """Resolve all relative url's so they use absolute paths."""
         trace = 'themes' in g.app.debug
@@ -2255,7 +2254,7 @@ class StyleSheetManager:
             sheet = sheet.replace(old, new)
         return sheet
 
-    # @+node:ekr.20140912110338.19372: *4* ssm.munge
+    # @+node:ekr.20140912110338.19372: *4* StyleSheetManager.munge
     def munge(self, stylesheet: str) -> str:
         """
         Return the stylesheet without extra whitespace.
@@ -2268,7 +2267,7 @@ class StyleSheetManager:
         )
         return s.rstrip()  # Don't care about ending newline.
 
-    # @+node:tom.20220310224019.1: *4* ssm.rescale_sizes
+    # @+node:tom.20220310224019.1: *4* StyleSheetManager.rescale_sizes
     def rescale_sizes(self, sheet: str, factor: float) -> str:
         """
         # @+<< docstring >>
@@ -2320,8 +2319,8 @@ class StyleSheetManager:
         newsheet = re.sub(RE, scale, sheet)
         return newsheet
 
-    # @+node:ekr.20180316092116.1: *3* ssm.Widgets
-    # @+node:ekr.20140913054442.19390: *4* ssm.get_master_widget
+    # @+node:ekr.20180316092116.1: *3* StyleSheetManager: Widgets
+    # @+node:ekr.20140913054442.19390: *4* StyleSheetManager.get_master_widget
     def get_master_widget(self, top: QWidget = None) -> QWidget:
         """
         Carefully return the master widget.
@@ -2332,7 +2331,7 @@ class StyleSheetManager:
         master = top.leo_master or top
         return master
 
-    # @+node:ekr.20140913054442.19391: *4* ssm.set selected_style_sheet
+    # @+node:ekr.20140913054442.19391: *4* StyleSheetManager.set selected_style_sheet
     def set_selected_style_sheet(self) -> None:
         """For manual testing: update the stylesheet using c.p.b."""
         if not g.unitTesting:

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -1701,21 +1701,11 @@ class LeoQtGui(leoGui.LeoGui):
 
     # @+node:ekr.20110605121601.18527: *4* LeoQtGui.widget_name
     def widget_name(self, w: QWidget) -> str:
-        if not w:
-            return '<no widget>'
-        try:
-            if name := w.getName():
-                return name
-        except AttributeError:
-            pass
-        try:
-            if name := w.objectName():
-                return name
-        except AttributeError:
-            pass
-        if name := getattr(w, '_name', None):
-            return name
-        return w.__class__.__name__
+        return (
+                 w.getName()    or '' if hasattr(w, 'getName')
+            else w.objectName() or '' if hasattr(w, 'objectName')
+            else ''
+        )  # fmt: skip
 
     # @+node:ekr.20190819091957.1: *3* LeoQtGui:Widget constructors
     # @+node:ekr.20190819094016.1: *4* LeoQtGui.createButton

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -180,7 +180,7 @@ class QTextMixin:
 
     # @+node:ekr.20140901062324.18825: *3* QTextMixin.getName
     def getName(self) -> str:
-        return self.name  # Essential.
+        return self.name or ''  # Essential.
 
     # @+node:ekr.20140901122110.18733: *3* QTextMixin.Event handlers
     # These are independent of the kind of Qt widget.

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -1146,8 +1146,8 @@ class LeoQtTree(leoFrame.LeoTree):
         vScroll.setValue(vPos)
 
     # @+node:ekr.20110605121601.17905: *3* LeoQtTree:Selecting & editing
-    # @+node:ekr.20110605121601.17908: *4* LeoQtTree.edit_widget
-    def edit_widget(self, p: Position) -> QHeadlineWrapper:
+    # @+node:ekr.20110605121601.17908: *4* LeoQtTree.headline_wrapper
+    def headline_wrapper(self, p: Position) -> QHeadlineWrapper:
         """Returns the edit widget (A QLineEdit) for position p."""
         item = self.position2item(p)
         if item:
@@ -1160,6 +1160,8 @@ class LeoQtTree(leoFrame.LeoTree):
             # But warning: calling this method twice might not work!
             return None
         return None
+
+    edit_widget = headline_wrapper  # Compatibility.
 
     # @+node:ekr.20110605121601.17909: *4* LeoQtTree.editLabel and helper
     def editLabel(
@@ -1269,7 +1271,7 @@ class LeoQtTree(leoFrame.LeoTree):
             return
         # Don't do this here: the caller should do it.
         # p.setHeadString(s)
-        e = self.edit_widget(p)
+        e = self.headline_wrapper(p)
         if e:
             e.setAllText(s)
         else:

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -1021,18 +1021,15 @@ class LeoQtTree(leoFrame.LeoTree):
     def getWrapper(self, e: QLineEdit, item: QTreeWidgetItem) -> QHeadlineWrapper:
         """Return the QHeadlineWrapper that wraps e (a QLineEdit)."""
         c = self.c
-        if e:
-            wrapper = self.editWidgetsDict.get(e)
-            if wrapper:
-                pass
-            else:
-                if item:
-                    # 2011/02/12: item can be None.
-                    wrapper = qt_text.QHeadlineWrapper(c, item, name='head', widget=e)
-                    self.editWidgetsDict[e] = wrapper
+        if not e:
+            return None
+        if wrapper := self.editWidgetsDict.get(e):
             return wrapper
-        g.trace('no e')
-        return None
+        if not item:
+            return None
+        wrapper = qt_text.QHeadlineWrapper(c, item, name='head', widget=e)
+        self.editWidgetsDict[e] = wrapper
+        return wrapper
 
     # @+node:ekr.20110605121601.18429: *4* LeoQtTree.nthChildItem
     def nthChildItem(self, n: int, parent_item: QTreeWidgetItem) -> QTreeWidgetItem:

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -42,8 +42,7 @@ class LeoQtTree(leoFrame.LeoTree):
     """Leo Qt tree class"""
 
     # @+others
-    # @+node:ekr.20110605121601.18404: *3* LeoQtTree:Birth
-    # @+node:ekr.20110605121601.18405: *4* LeoQtTree.__init__
+    # @+node:ekr.20110605121601.18405: *3*  LeoQtTree.__init__
     def __init__(self, c: Cmdr, frame: LeoQtFrame) -> None:  # Frame is a LeoQtFrame.
         """Ctor for the LeoQtTree class."""
         super().__init__(frame)
@@ -76,7 +75,7 @@ class LeoQtTree(leoFrame.LeoTree):
 
         if 0:  # None of this works.
             # @+<< Drag and drop >>
-            # @+node:ekr.20220913074246.1: *5* << Drag and drop >>
+            # @+node:ekr.20220913074246.1: *4* << Drag and drop >>
             w.setDragEnabled(True)
             w.viewport().setAcceptDrops(True)
             w.showDropIndicator = True
@@ -103,12 +102,7 @@ class LeoQtTree(leoFrame.LeoTree):
         n = c.config.getInt('icon-height') or 16
         w.setIconSize(QtCore.QSize(160, n))
 
-    # @+node:ekr.20110605121601.17866: *4* LeoQtTree.getName
-    def getName(self) -> str:
-        """Return the name of this widget: must start with "canvas"."""
-        return 'canvas(tree)'
-
-    # @+node:ekr.20110605121601.18406: *4* LeoQtTree.initAfterLoad
+    # @+node:ekr.20110605121601.18406: *3*  LeoQtTree.initAfterLoad
     def initAfterLoad(self) -> None:
         """Do late-state inits."""
         # Called by Leo's core.
@@ -130,7 +124,7 @@ class LeoQtTree(leoFrame.LeoTree):
         # The read logic sets c.changed to indicate nodes have changed.
         # c.clearChanged()
 
-    # @+node:ekr.20110605121601.17871: *4* LeoQtTree.reloadSettings
+    # @+node:ekr.20110605121601.17871: *3*  LeoQtTree.reloadSettings
     def reloadSettings(self) -> None:
         """LeoQtTree."""
         c = self.c
@@ -146,7 +140,12 @@ class LeoQtTree(leoFrame.LeoTree):
             'use-mouse-expand-gestures', default=False
         )
 
-    # @+node:ekr.20110605121601.17868: *3* LeoQtTree:Debugging & tracing
+    # @+node:ekr.20110605121601.17866: *3* LeoQtTree.getName
+    def getName(self) -> str:
+        """Return the name of this widget: must start with "canvas"."""
+        return 'canvas(tree)'
+
+    # @+node:ekr.20110605121601.17868: *3* LeoQtTree: Debugging & tracing
     def error(self, s: str) -> None:
         if not g.unitTesting:
             g.trace('LeoQtTree Error: ', s, g.callers())
@@ -157,7 +156,7 @@ class LeoQtTree(leoFrame.LeoTree):
             return f"item {id(item)}: {self.getItemText(item)}"
         return '<no item>'
 
-    # @+node:ekr.20110605121601.17872: *3* LeoQtTree:Drawing
+    # @+node:ekr.20110605121601.17872: *3* LeoQtTree: Drawing
     # @+node:ekr.20110605121601.18408: *4* LeoQtTree.clear
     def clear(self) -> None:
         """Clear all widgets in the tree."""
@@ -204,8 +203,7 @@ class LeoQtTree(leoFrame.LeoTree):
     redraw = full_redraw  # type:ignore
     redraw_now = full_redraw  # type:ignore
 
-    # @+node:vitalije.20200329160945.1: *5* tree declutter code
-    # @+node:tbrown.20150807090639.1: *6* LeoQtTree.declutter_node & helpers
+    # @+node:tbrown.20150807090639.1: *5* LeoQtTree.declutter_node & helpers
     def declutter_node(self, c: Cmdr, v: VNode, item: QTreeWidgetItem) -> QIcon:
         """declutter_node - change the appearance of a node
 
@@ -221,7 +219,7 @@ class LeoQtTree(leoFrame.LeoTree):
         loaded_images = self.loaded_images
 
         # @+others
-        # @+node:vitalije.20200329153544.1: *7* sorted_icons
+        # @+node:vitalije.20200329153544.1: *6* sorted_icons
         def sorted_icons(v: VNode) -> list[str]:
             """
             Returns a list of icon filenames for this node.
@@ -233,7 +231,7 @@ class LeoQtTree(leoFrame.LeoTree):
             a.extend(x['file'] for x in icons if x['where'] == 'beforeHeadline')
             return a
 
-        # @+node:ekr.20171122064635.1: *7* declutter_replace
+        # @+node:ekr.20171122064635.1: *6* declutter_replace
         def declutter_replace(arg: str, cmd: Callable, pattern: str) -> tuple[Callable, str]:
             """
             Executes cmd if cmd is any replace command and returns
@@ -270,7 +268,7 @@ class LeoQtTree(leoFrame.LeoTree):
 
             return None, s
 
-        # @+node:ekr.20171122055719.1: *7* declutter_style
+        # @+node:ekr.20171122055719.1: *6* declutter_style
         def declutter_style(arg: str, cmd: Callable) -> tuple[Callable, str]:
             """
             Handles style options and returns pair '(commander, param)',
@@ -354,7 +352,7 @@ class LeoQtTree(leoFrame.LeoTree):
                 modifier(item, param)
             return modifier, param
 
-        # @+node:vitalije.20200327163522.1: *7* apply_declutter_rules
+        # @+node:vitalije.20200327163522.1: *6* apply_declutter_rules
         def apply_declutter_rules(
             cmds: list[tuple[Callable, str]], pattern: str
         ) -> list[tuple[Any, str]]:
@@ -371,7 +369,7 @@ class LeoQtTree(leoFrame.LeoTree):
                     modifiers.append((modifier, param))
             return modifiers
 
-        # @+node:vitalije.20200329162015.1: *7* preload_images
+        # @+node:vitalije.20200329162015.1: *6* preload_images
         def preload_images() -> None:
             for f in new_icons:
                 if f not in loaded_images:
@@ -405,39 +403,6 @@ class LeoQtTree(leoFrame.LeoTree):
             g.app.gui.iconimages[h] = icon
         # There is always at least a box icon.
         return icon
-
-    # @+node:vitalije.20200327162532.1: *6* LeoQtTree.get_declutter_patterns
-    def get_declutter_patterns(self) -> list[tuple[Any, Any]]:
-        "Initializes self.declutter_patterns from configuration and returns it"
-        if self.declutter_patterns is not None:
-            return self.declutter_patterns
-        c = self.c
-        patterns: list[Any] = []
-        warned = False
-        lines = c.config.getData("tree-declutter-patterns")
-        for line in lines:
-            try:
-                cmd, arg = line.split(None, 1)
-            except ValueError:
-                # Allow empty arg, and guard against user errors.
-                cmd = line.strip()
-                arg = ''
-            if cmd.startswith('#'):
-                pass
-            elif cmd == 'RULE':
-                try:
-                    patterns.append((re.compile(arg), []))
-                except re.error:
-                    g.app.log('Invalid declutter pattern: %r' % (arg,), color='error')
-                    patterns.append((re.compile('a^'), []))  # create a rule that matches nothing
-            else:
-                if patterns:
-                    patterns[-1][1].append((cmd, arg))
-                elif not warned:
-                    warned = True
-                    g.app.log('Declutter patterns must start with RULE*', color='error')
-        self.declutter_patterns = patterns
-        return patterns
 
     # @+node:ekr.20110605121601.17874: *5* LeoQtTree.drawChildren
     def drawChildren(self, p: Position, parent_item: QTreeWidgetItem) -> None:
@@ -529,6 +494,39 @@ class LeoQtTree(leoFrame.LeoTree):
         # Draw all the visible children.
         self.drawChildren(p, parent_item=item)
 
+    # @+node:vitalije.20200327162532.1: *5* LeoQtTree.get_declutter_patterns
+    def get_declutter_patterns(self) -> list[tuple[Any, Any]]:
+        "Initializes self.declutter_patterns from configuration and returns it"
+        if self.declutter_patterns is not None:
+            return self.declutter_patterns
+        c = self.c
+        patterns: list[Any] = []
+        warned = False
+        lines = c.config.getData("tree-declutter-patterns")
+        for line in lines:
+            try:
+                cmd, arg = line.split(None, 1)
+            except ValueError:
+                # Allow empty arg, and guard against user errors.
+                cmd = line.strip()
+                arg = ''
+            if cmd.startswith('#'):
+                pass
+            elif cmd == 'RULE':
+                try:
+                    patterns.append((re.compile(arg), []))
+                except re.error:
+                    g.app.log('Invalid declutter pattern: %r' % (arg,), color='error')
+                    patterns.append((re.compile('a^'), []))  # create a rule that matches nothing
+            else:
+                if patterns:
+                    patterns[-1][1].append((cmd, arg))
+                elif not warned:
+                    warned = True
+                    g.app.log('Declutter patterns must start with RULE*', color='error')
+        self.declutter_patterns = patterns
+        return patterns
+
     # @+node:ekr.20110605121601.17878: *5* LeoQtTree.initData
     def initData(self) -> None:
         self.item2positionDict = {}
@@ -570,8 +568,8 @@ class LeoQtTree(leoFrame.LeoTree):
         w.repaint()
         w.resizeColumnToContents(0)  # 2009/12/22
 
-    # @+node:ekr.20110605121601.17885: *3* LeoQtTree:Event handlers
-    # @+node:ekr.20110605121601.17887: *4*  LeoQtTree.Click Box
+    # @+node:ekr.20110605121601.17885: *3* LeoQtTree: Event handlers
+    # @+node:ekr.20110605121601.17887: *4*  LeoQtTree: Click box event handlers
     # @+node:ekr.20110605121601.17888: *5* LeoQtTree.onClickBoxClick
     def onClickBoxClick(self, event: LeoKeyEvent, p: Position = None) -> None:
         if self.busy:
@@ -598,7 +596,7 @@ class LeoQtTree(leoFrame.LeoTree):
         g.doHook('rclick-popup', c=c, p=p, event=event, context_menu='plusbox')
         c.outerUpdate()
 
-    # @+node:ekr.20110605121601.17891: *4*  LeoQtTree.Icon Box
+    # @+node:ekr.20110605121601.17891: *4*  LeoQtTree: Icon box event handlers
     # For Qt, there seems to be no way to trigger these events.
     # @+node:ekr.20110605121601.17892: *5* LeoQtTree.onIconBoxClick
     def onIconBoxClick(self, event: LeoKeyEvent, p: Position = None) -> None:
@@ -632,14 +630,14 @@ class LeoQtTree(leoFrame.LeoTree):
         g.doHook("icondclick2", c=c, p=p, event=event)
         c.outerUpdate()
 
-    # @+node:ekr.20110605121601.18437: *4* LeoQtTree.onContextMenu
+    # @+node:ekr.20110605121601.18437: *5* LeoQtTree.onContextMenu
     def onContextMenu(self, point: QPoint) -> None:
         """LeoQtTree: Callback for customContextMenuRequested events."""
         # #1286.
         c, w = self.c, self.treeWidget
         g.app.gui.onContextMenu(c, w, point)
 
-    # @+node:ekr.20110605121601.17896: *4* LeoQtTree.onItemClicked
+    # @+node:ekr.20110605121601.17896: *5* LeoQtTree.onItemClicked
     def onItemClicked(self, item: QTreeWidgetItem, col: int) -> None:  # Col not used.
         """Handle a click in a BaseNativeTree widget item."""
         # This is called after an item is selected.
@@ -682,7 +680,7 @@ class LeoQtTree(leoFrame.LeoTree):
         finally:
             self.busy = False
 
-    # @+node:ekr.20110605121601.17895: *4* LeoQtTree.onItemCollapsed
+    # @+node:ekr.20110605121601.17895: *5* LeoQtTree.onItemCollapsed
     def onItemCollapsed(self, item: QTreeWidgetItem) -> None:
         """Handle Qt tree-collapsed events."""
         if self.busy:
@@ -701,7 +699,7 @@ class LeoQtTree(leoFrame.LeoTree):
             p.contract()
         c.redraw()
 
-    # @+node:ekr.20110605121601.17897: *4* LeoQtTree.onItemDoubleClicked
+    # @+node:ekr.20110605121601.17897: *5* LeoQtTree.onItemDoubleClicked
     def onItemDoubleClicked(self, item: QTreeWidgetItem, col: int) -> None:  # col not used.
         """Handle a double click in a BaseNativeTree widget item."""
         if self.busy:  # Required.
@@ -723,7 +721,7 @@ class LeoQtTree(leoFrame.LeoTree):
         g.doHook("headclick2", c=c, p=p, event=None)
         c.outerUpdate()
 
-    # @+node:tom.20230324155453.1: *4* LeoQtTree.onItemEntered
+    # @+node:tom.20230324155453.1: *5* LeoQtTree.onItemEntered
     def onItemEntered(self, item: QTreeWidgetItem, col: int):
         """Expand/Contract a node when mouse moves over it.
 
@@ -742,7 +740,7 @@ class LeoQtTree(leoFrame.LeoTree):
             elif isShift and not isCtrl:
                 self.contractItem(item)
 
-    # @+node:ekr.20110605121601.17898: *4* LeoQtTree.onItemExpanded
+    # @+node:ekr.20110605121601.17898: *5* LeoQtTree.onItemExpanded
     def onItemExpanded(self, item: QTreeWidgetItem) -> None:
         """Handle Qt tree-expansion events."""
         if self.busy:  # Required
@@ -761,7 +759,7 @@ class LeoQtTree(leoFrame.LeoTree):
             p.expand()
         c.redraw()
 
-    # @+node:ekr.20110605121601.17899: *4* LeoQtTree.onTreeSelect
+    # @+node:ekr.20110605121601.17899: *5* LeoQtTree.onTreeSelect
     def onTreeSelect(self) -> None:
         """Select the proper position when a tree node is selected."""
         if self.busy:  # Required
@@ -777,7 +775,7 @@ class LeoQtTree(leoFrame.LeoTree):
         self.select(p)  # This is a call to LeoTree.select(!!)
         c.outerUpdate()
 
-    # @+node:ekr.20110605121601.17944: *3* LeoQtTree:Focus
+    # @+node:ekr.20110605121601.17944: *3* LeoQtTree: Focus
     def getFocus(self) -> QWidget:
         return g.app.gui.get_focus(self.c)  # Bug fix: 2009/6/30
 
@@ -786,7 +784,7 @@ class LeoQtTree(leoFrame.LeoTree):
     def setFocus(self) -> None:
         g.app.gui.set_focus(self.c, self.treeWidget)
 
-    # @+node:ekr.20110605121601.18409: *3* LeoQtTree:Icons
+    # @+node:ekr.20110605121601.18409: *3* LeoQtTree: Icons
     # @+node:ekr.20110605121601.18411: *4* LeoQtTree.getIcon & helpers
     def getIcon(self, v: VNode) -> QIcon:
         """Return the proper icon for position p."""
@@ -860,7 +858,7 @@ class LeoQtTree(leoFrame.LeoTree):
             # but there is no itemChanged event handler.
             item.setIcon(0, icon)
 
-    # @+node:ekr.20110605121601.18414: *3* LeoQtTree:Items
+    # @+node:ekr.20110605121601.18414: *3* LeoQtTree: Items
     # @+node:ekr.20110605121601.17943: *4*  LeoQtTree.item dict getters
     def itemHash(self, item: QTreeWidgetItem) -> str:
         return f"{repr(item)} at {str(id(item))}"
@@ -1083,7 +1081,7 @@ class LeoQtTree(leoFrame.LeoTree):
         # limit width to available space
         editor.resize(space - used, editor.size().height())
 
-    # @+node:ekr.20110605121601.18433: *3* LeoQtTree:Scroll bars
+    # @+node:ekr.20110605121601.18433: *3* LeoQtTree: Scroll bars
     # @+node:ekr.20110605121601.18434: *4* LeoQtTree.getSCroll
     def getScroll(self) -> tuple[int, int]:
         """Return the hPos,vPos for the tree's scrollbars."""
@@ -1144,7 +1142,7 @@ class LeoQtTree(leoFrame.LeoTree):
         vScroll = w.verticalScrollBar()
         vScroll.setValue(vPos)
 
-    # @+node:ekr.20110605121601.17905: *3* LeoQtTree:Selecting & editing
+    # @+node:ekr.20110605121601.17905: *3* LeoQtTree: Selecting & editing
     # @+node:ekr.20110605121601.17908: *4* LeoQtTree.headline_wrapper
     def headline_wrapper(self, p: Position) -> QHeadlineWrapper:
         """Returns the edit widget (A QLineEdit) for position p."""

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -103,7 +103,7 @@ class LeoQtTree(leoFrame.LeoTree):
         n = c.config.getInt('icon-height') or 16
         w.setIconSize(QtCore.QSize(160, n))
 
-    # @+node:ekr.20110605121601.17866: *4* LeoQtTree.get_name
+    # @+node:ekr.20110605121601.17866: *4* LeoQtTree.getName
     def getName(self) -> str:
         """Return the name of this widget: must start with "canvas"."""
         return 'canvas(tree)'

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -1270,9 +1270,9 @@ class LeoQtTree(leoFrame.LeoTree):
             return
         # Don't do this here: the caller should do it.
         # p.setHeadString(s)
-        e = self.headline_wrapper(p)
-        if e:
-            e.setAllText(s)
+        w = self.headline_wrapper(p)
+        if w:
+            w.setAllText(s)
         else:
             item = self.position2item(p)
             if item:

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -911,9 +911,9 @@ class LeoQtTree(leoFrame.LeoTree):
         return items
 
     # @+node:ekr.20110605121601.18418: *4* LeoQtTree.connectEditorWidget & callback
-    def connectEditorWidget(self, e: QLineEdit, item: QTreeWidgetItem) -> QHeadlineWrapper:
+    def connectEditorWidget(self, w: QLineEdit, item: QTreeWidgetItem) -> QHeadlineWrapper:
         """
-        Connect QLineEdit e to QTreeItem item.
+        Connect QLineEdit w to QTreeItem item.
 
         Also callback for when the editor ends.
 
@@ -925,7 +925,7 @@ class LeoQtTree(leoFrame.LeoTree):
         # @+node:ekr.20201109043641.1: *5* function: editingFinished_callback
         def editingFinished_callback() -> None:
             """Called when Qt emits the editingFinished signal."""
-            s = e.text()
+            s = w.text()
             # #3633: Replace newlines with a blank.
             if '\n' in s:
                 s = re.sub(r'\s*\n\s*', ' ', s).replace('  ', ' ').rstrip()
@@ -946,12 +946,11 @@ class LeoQtTree(leoFrame.LeoTree):
             c.outerUpdate()
 
         # @-others
-        if e:
+        if w:
             # Hook up the widget.
-            wrapper = self.getWrapper(e, item)
-            e.editingFinished.connect(editingFinished_callback)
+            wrapper = self.getWrapper(w, item)
+            w.editingFinished.connect(editingFinished_callback)
             return wrapper  # 2011/02/12
-        # g.trace('can not happen: no e')
         return None
 
     # @+node:ekr.20110605121601.18419: *4* LeoQtTree.contractItem & expandItem

--- a/leo/plugins/screencast.py
+++ b/leo/plugins/screencast.py
@@ -452,7 +452,7 @@ class ScreenCastController:
             n2 = 0.095
         p.h = ''
         c.editHeadline()
-        w = tree.edit_widget(p)
+        w = tree.headline_wrapper(p)
         # Support undo.
         undoData = c.undoer.beforeChangeNodeContents(p)
         p.setDirty()

--- a/leo/plugins/tables.py
+++ b/leo/plugins/tables.py
@@ -83,7 +83,7 @@ class TableController:
 
         Important: the code must use event.ch, not stroke.
         """
-        w = self.ec.editWidget(event)
+        w = event.w if event else None
         ch = event.char
         i, s, lines = self.get_table(ch, w)
         if lines:
@@ -144,7 +144,7 @@ class TableController:
     # @+node:ekr.20170218075243.1: *3* table.insert_newline
     def insert_newline(self, event):
         """TableController: override c.editCommands.insertNewLine."""
-        w = self.ec.editWidget(event)
+        w = event.w if event else None
         i, s, lines = self.get_table('return', w)
         if lines:
             self.put('\n', event)

--- a/leo/unittests/commands/test_editCommands.py
+++ b/leo/unittests/commands/test_editCommands.py
@@ -4195,7 +4195,8 @@ class TestEditCommands(LeoUnitTest):
         )  # fmt: skip
         for which, result in table:
             w.setInsertPoint(5)  # Must be inside the target.
-            c.editCommands.capitalizeHelper(event=None, which=which, undoType='X')
+            event = LeoKeyEvent(c, w=w)  # Leo 6.8.9.
+            c.editCommands.capitalizeHelper(event=event, which=which, undoType='X')
             s = w.getAllText()
             word = s[2:12]
             self.assertEqual(word, result, msg=which)
@@ -4361,7 +4362,7 @@ class TestEditCommands(LeoUnitTest):
             # ('1.0','4.5',False),
             (5, 50, True),
         ):
-            event = None
+            event = LeoKeyEvent(c, w=w)  # Leo 6.8.9.
             extend = True
             ec.moveSpot = None
             w.setInsertPoint(i)

--- a/leo/unittests/commands/test_editCommands.py
+++ b/leo/unittests/commands/test_editCommands.py
@@ -4232,7 +4232,7 @@ class TestEditCommands(LeoUnitTest):
         c.selectPosition(p)
         c.redraw(p)  # To make node visible
         c.frame.tree.editLabel(p)
-        w = c.edit_widget(p)
+        w = c.headline_wrapper(p)
         try:
             assert w
             end = w.getLastIndex()
@@ -4399,7 +4399,7 @@ class TestEditCommands(LeoUnitTest):
         p.h = h
         c.selectPosition(p)
         c.frame.tree.editLabel(p)
-        w = c.edit_widget(p)
+        w = c.headline_wrapper(p)
         assert w
         end = w.getLastIndex()
         w.setSelectionRange(end, end)
@@ -4420,7 +4420,7 @@ class TestEditCommands(LeoUnitTest):
         p.h = h
         c.selectPosition(p)
         c.frame.tree.editLabel(p)
-        w = c.edit_widget(p)
+        w = c.headline_wrapper(p)
         assert w
         paste = 'ABC'
         g.app.gui.replaceClipboardWith(paste)
@@ -4439,7 +4439,7 @@ class TestEditCommands(LeoUnitTest):
         p.h = h
         c.selectPosition(p)
         c.frame.tree.editLabel(p)
-        w = c.edit_widget(p)
+        w = c.headline_wrapper(p)
         assert w
         end = w.getLastIndex()
         g.app.gui.set_focus(c, w)
@@ -4460,7 +4460,7 @@ class TestEditCommands(LeoUnitTest):
         c.selectPosition(p)
         c.selectPosition(p)
         c.frame.tree.editLabel(p)
-        w = c.edit_widget(p)
+        w = c.headline_wrapper(p)
         end = w.getLastIndex()
         w.setSelectionRange(end, end, insert=end)
         paste = 'ABC'
@@ -4487,7 +4487,7 @@ class TestEditCommands(LeoUnitTest):
         c.selectPosition(p)
         c.redraw(p)  # To make node visible
         c.frame.tree.editLabel(p)
-        w = c.edit_widget(p)
+        w = c.headline_wrapper(p)
         wName = g.app.gui.widget_name(w)
         assert wName.startswith('head'), 'w.name:%s' % wName
         g.app.gui.event_generate(c, '\n', 'Return', w)
@@ -4514,7 +4514,7 @@ class TestEditCommands(LeoUnitTest):
         c.selectPosition(p)
         c.redraw(p)  # To make node visible
         c.frame.tree.editLabel(p)
-        w = c.edit_widget(p)
+        w = c.headline_wrapper(p)
         end = w.getLastIndex()
         w.setSelectionRange(end, end)
         paste = 'ABC'
@@ -4536,7 +4536,7 @@ class TestEditCommands(LeoUnitTest):
         c.selectPosition(p)
         c.redraw(p)  # Required
         c.frame.tree.editLabel(p)
-        w = c.edit_widget(p)
+        w = c.headline_wrapper(p)
         end = w.getLastIndex()
         w.setSelectionRange(end, end)
         # char, shortcut.
@@ -4625,7 +4625,7 @@ class TestEditCommands(LeoUnitTest):
         p = c.rootPosition().insertAfter()
         p.h = h
         c.redrawAndEdit(p)  # Required
-        w = c.edit_widget(p)
+        w = c.headline_wrapper(p)
         assert w
         end = w.getLastIndex()
         wName = g.app.gui.widget_name(w)

--- a/leo/unittests/commands/test_editCommands.py
+++ b/leo/unittests/commands/test_editCommands.py
@@ -4267,26 +4267,26 @@ class TestEditCommands(LeoUnitTest):
     # @+node:ekr.20210905064816.7: *4* test_findWord
     def test_findWord(self):
         c = self.c
-        e, k, w = c.editCommands, c.k, c.frame.body.wrapper
+        ec, k, w = c.editCommands, c.k, c.frame.body.wrapper
         w.setAllText('start\ntargetWord\n')
         w.setInsertPoint(0)
         k.arg = 't'  # 'targetWord'
-        e.w = w
-        e.oneLineFlag = False
-        e.findWord1(event=None)
+        ec.w = w
+        ec.oneLineFlag = False
+        ec.findWord1(event=None)
         i, j = w.getSelectionRange()
         self.assertEqual(i, 6)
 
     # @+node:ekr.20210905064816.8: *4* test_findWordInLine
     def test_findWordInLine(self):
         c = self.c
-        e, k, w = c.editCommands, c.k, c.frame.body.wrapper
+        ec, k, w = c.editCommands, c.k, c.frame.body.wrapper
         w.setAllText('abc\ntargetWord\n')
         k.arg = 't'  # 'targetWord'
         w.setInsertPoint(0)
-        e.w = w
-        e.oneLineFlag = False
-        e.findWord1(event=None)
+        ec.w = w
+        ec.oneLineFlag = False
+        ec.findWord1(event=None)
         i, j = w.getSelectionRange()
         self.assertEqual(i, 4)
 

--- a/leo/unittests/commands/test_editCommands.py
+++ b/leo/unittests/commands/test_editCommands.py
@@ -6,6 +6,7 @@
 import textwrap
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest
+from leo.core.leoGui import LeoKeyEvent
 
 
 # @+others
@@ -59,7 +60,8 @@ class TestEditCommands(LeoUnitTest):
         i, j = toInt(i), toInt(j)
         w.setSelectionRange(i, j, insert=j)
         # Run the command!
-        c.doCommandByName(command_name)
+        event = LeoKeyEvent(c, w=w)  # Leo 6.8.9.
+        c.doCommandByName(command_name, event)
         self.assertEqual(self.tempNode.b, self.after_p.b, msg=command_name)
 
     # @+node:ekr.20201201084621.1: *3* TestEditCommands.setUp

--- a/leo/unittests/commands/test_editCommands.py
+++ b/leo/unittests/commands/test_editCommands.py
@@ -84,7 +84,7 @@ class TestEditCommands(LeoUnitTest):
     # self.c = None
     # @+node:ekr.20201130091020.1: *3* TestEditCommands: Commands...
     # @+node:ekr.20210829061326.1: *4* Commands A-B
-    # @+node:ekr.20201130090918.1: *5* add-space-to-lines
+    # @+node:ekr.20201130090918.1: *5* test_add-space-to-lines
     def test_add_space_to_lines(self):
         """Test case for add-space-to-lines"""
         before_b = """\
@@ -109,7 +109,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="add-space-to-lines",
         )
 
-    # @+node:ekr.20201130090918.2: *5* add-tab-to-lines
+    # @+node:ekr.20201130090918.2: *5* test_add-tab-to-lines
     def test_add_tab_to_lines(self):
         """Test case for add-tab-to-lines"""
         before_b = """\
@@ -136,7 +136,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="add-tab-to-lines",
         )
 
-    # @+node:ekr.20201130090918.3: *5* back-char
+    # @+node:ekr.20201130090918.3: *5* test_back-char
     def test_back_char(self):
         """Test case for back-char"""
         before_b = """\
@@ -163,7 +163,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="back-char",
         )
 
-    # @+node:ekr.20201130090918.4: *5* back-char-extend-selection
+    # @+node:ekr.20201130090918.4: *5* test_back-char-extend-selection
     def test_back_char_extend_selection(self):
         """Test case for back-char-extend-selection"""
         before_b = """\
@@ -190,7 +190,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="back-char-extend-selection",
         )
 
-    # @+node:ekr.20201130090918.5: *5* back-paragraph
+    # @+node:ekr.20201130090918.5: *5* test_back-paragraph
     def test_back_paragraph(self):
         """Test case for back-paragraph"""
         before_b = """\
@@ -241,7 +241,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="back-paragraph",
         )
 
-    # @+node:ekr.20201130090918.6: *5* back-paragraph-extend-selection
+    # @+node:ekr.20201130090918.6: *5* test_back-paragraph-extend-selection
     def test_back_paragraph_extend_selection(self):
         """Test case for back-paragraph-extend-selection"""
         before_b = """\
@@ -292,7 +292,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="back-paragraph-extend-selection",
         )
 
-    # @+node:ekr.20201130090918.7: *5* back-sentence
+    # @+node:ekr.20201130090918.7: *5* test_back-sentence
     def test_back_sentence(self):
         """Test case for back-sentence"""
         before_b = """\
@@ -317,7 +317,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="back-sentence",
         )
 
-    # @+node:ekr.20201130090918.8: *5* back-sentence-extend-selection
+    # @+node:ekr.20201130090918.8: *5* test_back-sentence-extend-selection
     def test_back_sentence_extend_selection(self):
         """Test case for back-sentence-extend-selection"""
         before_b = """\
@@ -342,7 +342,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="back-sentence-extend-selection",
         )
 
-    # @+node:ekr.20201130090918.12: *5* back-to-home (at end of line)
+    # @+node:ekr.20201130090918.12: *5* test_back-to-home (at end of line)
     def test_back_to_home_at_end_of_line(self):
         """Test case for back-to-home (at end of line)"""
         before_b = """\
@@ -361,7 +361,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="back-to-home",
         )
 
-    # @+node:ekr.20201130090918.11: *5* back-to-home (at indentation
+    # @+node:ekr.20201130090918.11: *5* test_back-to-home (at indentation
     def test_back_to_home_at_indentation(self):
         """Test case for back-to-home (at indentation"""
         before_b = """\
@@ -380,7 +380,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="back-to-home",
         )
 
-    # @+node:ekr.20201130090918.10: *5* back-to-home (at start of line)
+    # @+node:ekr.20201130090918.10: *5* test_back-to-home (at start of line)
     def test_back_to_home_at_start_of_line(self):
         """Test case for back-to-home (at start of line)"""
         before_b = """\
@@ -399,7 +399,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="back-to-home",
         )
 
-    # @+node:ekr.20201130090918.9: *5* back-to-indentation
+    # @+node:ekr.20201130090918.9: *5* test_back-to-indentation
     def test_back_to_indentation(self):
         """Test case for back-to-indentation"""
         before_b = """\
@@ -426,7 +426,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="back-to-indentation",
         )
 
-    # @+node:ekr.20201130090918.13: *5* back-word
+    # @+node:ekr.20201130090918.13: *5* test_back-word
     def test_back_word(self):
         """Test case for back-word"""
         before_b = """\
@@ -451,7 +451,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="back-word",
         )
 
-    # @+node:ekr.20201130090918.14: *5* back-word-extend-selection
+    # @+node:ekr.20201130090918.14: *5* test_back-word-extend-selection
     def test_back_word_extend_selection(self):
         """Test case for back-word-extend-selection"""
         before_b = """\
@@ -476,7 +476,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="back-word-extend-selection",
         )
 
-    # @+node:ekr.20201130090918.15: *5* backward-delete-char
+    # @+node:ekr.20201130090918.15: *5* test_backward-delete-char
     def test_backward_delete_char(self):
         """Test case for backward-delete-char"""
         before_b = """\
@@ -503,7 +503,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="backward-delete-char",
         )
 
-    # @+node:ekr.20201130090918.16: *5* backward-delete-char  (middle of line)
+    # @+node:ekr.20201130090918.16: *5* test_backward-delete-char  (middle of line)
     def test_backward_delete_char__middle_of_line(self):
         """Test case for backward-delete-char  (middle of line)"""
         before_b = """\
@@ -522,7 +522,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="backward-delete-char",
         )
 
-    # @+node:ekr.20201130090918.17: *5* backward-delete-char (last char)
+    # @+node:ekr.20201130090918.17: *5* test_backward-delete-char (last char)
     def test_backward_delete_char_last_char(self):
         """Test case for backward-delete-char (last char)"""
         before_b = """\
@@ -541,7 +541,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="backward-delete-char",
         )
 
-    # @+node:ekr.20201130090918.18: *5* backward-delete-word (no selection)
+    # @+node:ekr.20201130090918.18: *5* test_backward-delete-word (no selection)
     def test_backward_delete_word_no_selection(self):
         """Test case for backward-delete-word (no selection)"""
         before_b = """\
@@ -558,7 +558,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="backward-delete-word",
         )
 
-    # @+node:ekr.20201130090918.19: *5* backward-delete-word (selection)
+    # @+node:ekr.20201130090918.19: *5* test_backward-delete-word (selection)
     def test_backward_delete_word_selection(self):
         """Test case for backward-delete-word (selection)"""
         before_b = """\
@@ -575,7 +575,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="backward-delete-word",
         )
 
-    # @+node:ekr.20201130090918.20: *5* backward-kill-paragraph
+    # @+node:ekr.20201130090918.20: *5* test_backward-kill-paragraph
     def test_backward_kill_paragraph(self):
         """Test case for backward-kill-paragraph"""
         before_b = """\
@@ -624,7 +624,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="backward-kill-paragraph",
         )
 
-    # @+node:ekr.20201130090918.21: *5* backward-kill-sentence
+    # @+node:ekr.20201130090918.21: *5* test_backward-kill-sentence
     def test_backward_kill_sentence(self):
         """Test case for backward-kill-sentence"""
         before_b = """\
@@ -644,7 +644,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="backward-kill-sentence",
         )
 
-    # @+node:ekr.20201130090918.22: *5* backward-kill-word
+    # @+node:ekr.20201130090918.22: *5* test_backward-kill-word
     def test_backward_kill_word(self):
         """Test case for backward-kill-word"""
         before_b = """\
@@ -665,7 +665,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="backward-kill-word",
         )
 
-    # @+node:ekr.20201130090918.23: *5* beginning-of-buffer
+    # @+node:ekr.20201130090918.23: *5* test_beginning-of-buffer
     def test_beginning_of_buffer(self):
         """Test case for beginning-of-buffer"""
         before_b = """\
@@ -690,7 +690,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="beginning-of-buffer",
         )
 
-    # @+node:ekr.20201130090918.24: *5* beginning-of-buffer-extend-selection
+    # @+node:ekr.20201130090918.24: *5* test_beginning-of-buffer-extend-selection
     def test_beginning_of_buffer_extend_selection(self):
         """Test case for beginning-of-buffer-extend-selection"""
         before_b = """\
@@ -715,7 +715,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="beginning-of-buffer-extend-selection",
         )
 
-    # @+node:ekr.20201130090918.25: *5* beginning-of-line
+    # @+node:ekr.20201130090918.25: *5* test_beginning-of-line
     def test_beginning_of_line(self):
         """Test case for beginning-of-line"""
         before_b = """\
@@ -742,7 +742,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="beginning-of-line",
         )
 
-    # @+node:ekr.20201130090918.26: *5* beginning-of-line-extend-selection
+    # @+node:ekr.20201130090918.26: *5* test_beginning-of-line-extend-selection
     def test_beginning_of_line_extend_selection(self):
         """Test case for beginning-of-line-extend-selection"""
         before_b = """\
@@ -770,7 +770,7 @@ class TestEditCommands(LeoUnitTest):
         )
 
     # @+node:ekr.20210829061337.1: *4* Commands C-E
-    # @+node:ekr.20201130090918.27: *5* capitalize-word
+    # @+node:ekr.20201130090918.27: *5* test_capitalize-word
     def test_capitalize_word(self):
         """Test case for capitalize-word"""
         before_b = """\
@@ -797,7 +797,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="capitalize-word",
         )
 
-    # @+node:ekr.20201130090918.28: *5* center-line
+    # @+node:ekr.20201130090918.28: *5* test_center-line
     def test_center_line(self):
         """Test case for center-line"""
         before_b = """\
@@ -832,7 +832,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="center-line",
         )
 
-    # @+node:ekr.20201130090918.29: *5* center-region
+    # @+node:ekr.20201130090918.29: *5* test_center-region
     def test_center_region(self):
         """Test case for center-region"""
         before_b = """\
@@ -860,7 +860,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@pagewidth 70",
         )
 
-    # @+node:ekr.20201130090918.30: *5* clean-lines
+    # @+node:ekr.20201130090918.30: *5* test_clean-lines
     def test_clean_lines(self):
         """Test case for clean-lines"""
         before_b = self.prep(
@@ -889,7 +889,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="clean-lines",
         )
 
-    # @+node:ekr.20201130090918.31: *5* clear-selected-text
+    # @+node:ekr.20201130090918.31: *5* test_clear-selected-text
     def test_clear_selected_text(self):
         """Test case for clear-selected-text"""
         before_b = """\
@@ -914,7 +914,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="clear-selected-text",
         )
 
-    # @+node:ekr.20201130090918.32: *5* count-region
+    # @+node:ekr.20201130090918.32: *5* test_count-region
     def test_count_region(self):
         """Test case for count-region"""
         before_b = """\
@@ -941,7 +941,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="count-region",
         )
 
-    # @+node:ekr.20201130090918.33: *5* delete-char
+    # @+node:ekr.20201130090918.33: *5* test_delete-char
     def test_delete_char(self):
         """Test case for delete-char"""
         before_b = """\
@@ -968,7 +968,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="delete-char",
         )
 
-    # @+node:ekr.20201130090918.34: *5* delete-indentation
+    # @+node:ekr.20201130090918.34: *5* test_delete-indentation
     def test_delete_indentation(self):
         """Test case for delete-indentation"""
         before_b = """\
@@ -989,7 +989,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="delete-indentation",
         )
 
-    # @+node:ekr.20201130090918.35: *5* delete-spaces
+    # @+node:ekr.20201130090918.35: *5* test_delete-spaces
     def test_delete_spaces(self):
         """Test case for delete-spaces"""
         before_b = """\
@@ -1016,7 +1016,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="delete-spaces",
         )
 
-    # @+node:ekr.20201130090918.36: *5* do-nothing
+    # @+node:ekr.20201130090918.36: *5* test_do-nothing
     def test_do_nothing(self):
         """Test case for do-nothing"""
         before_b = """\
@@ -1043,7 +1043,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="do-nothing",
         )
 
-    # @+node:ekr.20201130090918.37: *5* downcase-region
+    # @+node:ekr.20201130090918.37: *5* test_downcase-region
     def test_downcase_region(self):
         """Test case for downcase-region"""
         before_b = """\
@@ -1068,7 +1068,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="downcase-region",
         )
 
-    # @+node:ekr.20201130090918.38: *5* downcase-word
+    # @+node:ekr.20201130090918.38: *5* test_downcase-word
     def test_downcase_word(self):
         """Test case for downcase-word"""
         before_b = """\
@@ -1095,7 +1095,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="downcase-word",
         )
 
-    # @+node:ekr.20201130090918.39: *5* end-of-buffer
+    # @+node:ekr.20201130090918.39: *5* test_end-of-buffer
     def test_end_of_buffer(self):
         """Test case for end-of-buffer"""
         before_b = """\
@@ -1122,7 +1122,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="end-of-buffer",
         )
 
-    # @+node:ekr.20201130090918.40: *5* end-of-buffer-extend-selection
+    # @+node:ekr.20201130090918.40: *5* test_end-of-buffer-extend-selection
     def test_end_of_buffer_extend_selection(self):
         """Test case for end-of-buffer-extend-selection"""
         before_b = """\
@@ -1149,7 +1149,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="end-of-buffer-extend-selection",
         )
 
-    # @+node:ekr.20201130090918.41: *5* end-of-line
+    # @+node:ekr.20201130090918.41: *5* test_end-of-line
     def test_end_of_line(self):
         """Test case for end-of-line"""
         before_b = """\
@@ -1176,7 +1176,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="end-of-line",
         )
 
-    # @+node:ekr.20201130090918.44: *5* end-of-line (blank last line)
+    # @+node:ekr.20201130090918.44: *5* test_end-of-line (blank last line)
     def test_end_of_line_blank_last_line(self):
         """Test case for end-of-line (blank last line)"""
         before_b = """\
@@ -1203,7 +1203,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="end-of-line",
         )
 
-    # @+node:ekr.20201130090918.43: *5* end-of-line (internal blank line)
+    # @+node:ekr.20201130090918.43: *5* test_end-of-line (internal blank line)
     def test_end_of_line_internal_blank_line(self):
         """Test case for end-of-line (internal blank line)"""
         before_b = """\
@@ -1232,7 +1232,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="end-of-line",
         )
 
-    # @+node:ekr.20201130090918.45: *5* end-of-line (single char last line)
+    # @+node:ekr.20201130090918.45: *5* test_end-of-line (single char last line)
     def test_end_of_line_single_char_last_line(self):
         """Test case for end-of-line (single char last line)"""
         before_b = """\
@@ -1261,7 +1261,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="end-of-line",
         )
 
-    # @+node:ekr.20201130090918.42: *5* end-of-line 2
+    # @+node:ekr.20201130090918.42: *5* test_end-of-line 2
     def test_end_of_line_2(self):
         """Test case for end-of-line 2"""
         before_b = """\
@@ -1288,7 +1288,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="end-of-line",
         )
 
-    # @+node:ekr.20201130090918.46: *5* end-of-line-extend-selection
+    # @+node:ekr.20201130090918.46: *5* test_end-of-line-extend-selection
     def test_end_of_line_extend_selection(self):
         """Test case for end-of-line-extend-selection"""
         before_b = """\
@@ -1315,7 +1315,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="end-of-line-extend-selection",
         )
 
-    # @+node:ekr.20201130090918.47: *5* end-of-line-extend-selection (blank last line)
+    # @+node:ekr.20201130090918.47: *5* test_end-of-line-extend-selection (blank last line)
     def test_end_of_line_extend_selection_blank_last_line(self):
         """Test case for end-of-line-extend-selection (blank last line)"""
         before_b = """\
@@ -1342,7 +1342,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="end-of-line-extend-selection",
         )
 
-    # @+node:ekr.20201130090918.48: *5* exchange-point-mark
+    # @+node:ekr.20201130090918.48: *5* test_exchange-point-mark
     def test_exchange_point_mark(self):
         """Test case for exchange-point-mark"""
         before_b = """\
@@ -1369,7 +1369,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="exchange-point-mark",
         )
 
-    # @+node:ekr.20201130090918.49: *5* extend-to-line
+    # @+node:ekr.20201130090918.49: *5* test_extend-to-line
     def test_extend_to_line(self):
         """Test case for extend-to-line"""
         before_b = """\
@@ -1396,7 +1396,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="extend-to-line",
         )
 
-    # @+node:ekr.20201130090918.50: *5* extend-to-paragraph
+    # @+node:ekr.20201130090918.50: *5* test_extend-to-paragraph
     def test_extend_to_paragraph(self):
         """Test case for extend-to-paragraph"""
         before_b = """\
@@ -1447,7 +1447,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="extend-to-paragraph",
         )
 
-    # @+node:ekr.20201130090918.51: *5* extend-to-sentence
+    # @+node:ekr.20201130090918.51: *5* test_extend-to-sentence
     def test_extend_to_sentence(self):
         """Test case for extend-to-sentence"""
         before_b = """\
@@ -1472,7 +1472,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="extend-to-sentence",
         )
 
-    # @+node:ekr.20201130090918.52: *5* extend-to-word
+    # @+node:ekr.20201130090918.52: *5* test_extend-to-word
     def test_extend_to_word(self):
         """Test case for extend-to-word"""
         before_b = """\
@@ -1500,7 +1500,7 @@ class TestEditCommands(LeoUnitTest):
         )
 
     # @+node:ekr.20210829062134.1: *4* Commands F-L
-    # @+node:ekr.20201130090918.56: *5* fill-paragraph
+    # @+node:ekr.20201130090918.56: *5* test_fill-paragraph
     def test_fill_paragraph(self):
         """Test case for fill-paragraph"""
         before_b = """\
@@ -1542,7 +1542,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@pagewidth 80",
         )
 
-    # @+node:ekr.20201130090918.53: *5* finish-of-line
+    # @+node:ekr.20201130090918.53: *5* test_finish-of-line
     def test_finish_of_line(self):
         """Test case for finish-of-line"""
         before_b = """\
@@ -1569,7 +1569,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="finish-of-line",
         )
 
-    # @+node:ekr.20201130090918.54: *5* finish-of-line (2)
+    # @+node:ekr.20201130090918.54: *5* test_finish-of-line (2)
     def test_finish_of_line_2(self):
         """Test case for finish-of-line (2)"""
         before_b = """\
@@ -1596,7 +1596,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="finish-of-line",
         )
 
-    # @+node:ekr.20201130090918.55: *5* finish-of-line-extend-selection
+    # @+node:ekr.20201130090918.55: *5* test_finish-of-line-extend-selection
     def test_finish_of_line_extend_selection(self):
         """Test case for finish-of-line-extend-selection"""
         before_b = """\
@@ -1623,7 +1623,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="finish-of-line-extend-selection",
         )
 
-    # @+node:ekr.20201130090918.57: *5* forward-char
+    # @+node:ekr.20201130090918.57: *5* test_forward-char
     def test_forward_char(self):
         """Test case for forward-char"""
         before_b = """\
@@ -1650,7 +1650,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="forward-char",
         )
 
-    # @+node:ekr.20201130090918.58: *5* forward-char-extend-selection
+    # @+node:ekr.20201130090918.58: *5* test_forward-char-extend-selection
     def test_forward_char_extend_selection(self):
         """Test case for forward-char-extend-selection"""
         before_b = """\
@@ -1677,7 +1677,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="forward-char-extend-selection",
         )
 
-    # @+node:ekr.20201130090918.59: *5* forward-end-word (end of line)
+    # @+node:ekr.20201130090918.59: *5* test_forward-end-word (end of line)
     def test_forward_end_word_end_of_line(self):
         """Test case for forward-end-word (end of line)"""
         before_b = """\
@@ -1702,7 +1702,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="forward-end-word",
         )
 
-    # @+node:ekr.20201130090918.60: *5* forward-end-word (start of word)
+    # @+node:ekr.20201130090918.60: *5* test_forward-end-word (start of word)
     def test_forward_end_word_start_of_word(self):
         """Test case for forward-end-word (start of word)"""
         before_b = """\
@@ -1727,7 +1727,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="forward-end-word",
         )
 
-    # @+node:ekr.20201130090918.61: *5* forward-end-word-extend-selection
+    # @+node:ekr.20201130090918.61: *5* test_forward-end-word-extend-selection
     def test_forward_end_word_extend_selection(self):
         """Test case for forward-end-word-extend-selection"""
         before_b = """\
@@ -1752,7 +1752,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="forward-end-word-extend-selection",
         )
 
-    # @+node:ekr.20201130090918.62: *5* forward-paragraph
+    # @+node:ekr.20201130090918.62: *5* test_forward-paragraph
     def test_forward_paragraph(self):
         """Test case for forward-paragraph"""
         before_b = """\
@@ -1803,7 +1803,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="forward-paragraph",
         )
 
-    # @+node:ekr.20201130090918.63: *5* forward-paragraph-extend-selection
+    # @+node:ekr.20201130090918.63: *5* test_forward-paragraph-extend-selection
     def test_forward_paragraph_extend_selection(self):
         """Test case for forward-paragraph-extend-selection"""
         before_b = """\
@@ -1854,7 +1854,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="forward-paragraph-extend-selection",
         )
 
-    # @+node:ekr.20201130090918.64: *5* forward-sentence
+    # @+node:ekr.20201130090918.64: *5* test_forward-sentence
     def test_forward_sentence(self):
         """Test case for forward-sentence"""
         before_b = """\
@@ -1879,7 +1879,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="forward-sentence",
         )
 
-    # @+node:ekr.20201130090918.65: *5* forward-sentence-extend-selection
+    # @+node:ekr.20201130090918.65: *5* test_forward-sentence-extend-selection
     def test_forward_sentence_extend_selection(self):
         """Test case for forward-sentence-extend-selection"""
         before_b = """\
@@ -1904,7 +1904,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="forward-sentence-extend-selection",
         )
 
-    # @+node:ekr.20201130090918.66: *5* forward-word
+    # @+node:ekr.20201130090918.66: *5* test_forward-word
     def test_forward_word(self):
         """Test case for forward-word"""
         before_b = """\
@@ -1929,7 +1929,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="forward-word",
         )
 
-    # @+node:ekr.20201130090918.67: *5* forward-word-extend-selection
+    # @+node:ekr.20201130090918.67: *5* test_forward-word-extend-selection
     def test_forward_word_extend_selection(self):
         """Test case for forward-word-extend-selection"""
         before_b = """\
@@ -1954,7 +1954,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="forward-word-extend-selection",
         )
 
-    # @+node:ekr.20201130090918.68: *5* indent-relative
+    # @+node:ekr.20201130090918.68: *5* test_indent-relative
     def test_indent_relative(self):
         """Test case for indent-relative"""
         before_b = """\
@@ -1981,7 +1981,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="indent-relative",
         )
 
-    # @+node:ekr.20201130090918.69: *5* indent-rigidly
+    # @+node:ekr.20201130090918.69: *5* test_indent-rigidly
     def test_indent_rigidly(self):
         """Test case for indent-rigidly"""
         before_b = """\
@@ -2008,7 +2008,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="indent-rigidly",
         )
 
-    # @+node:ekr.20201130090918.70: *5* indent-to-comment-column
+    # @+node:ekr.20201130090918.70: *5* test_indent-to-comment-column
     def test_indent_to_comment_column(self):
         """Test case for indent-to-comment-column"""
         before_b = """\
@@ -2030,7 +2030,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="indent-to-comment-column",
         )
 
-    # @+node:ekr.20201130090918.71: *5* insert-newline
+    # @+node:ekr.20201130090918.71: *5* test_insert-newline
     def test_insert_newline(self):
         """Test case for insert-newline"""
         before_b = """\
@@ -2058,7 +2058,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="insert-newline",
         )
 
-    # @+node:ekr.20210926144000.1: *5* insert-newline-bug-2230
+    # @+node:ekr.20210926144000.1: *5* test_insert-newline-bug-2230
     def test_insert_newline_bug_2230(self):
         """Test case for insert-newline"""
         before_b = self.prep("""
@@ -2086,7 +2086,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="insert-newline",
         )
 
-    # @+node:ekr.20201130090918.72: *5* insert-parentheses
+    # @+node:ekr.20201130090918.72: *5* test_insert-parentheses
     def test_insert_parentheses(self):
         """Test case for insert-parentheses"""
         before_b = """\
@@ -2113,7 +2113,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="insert-parentheses",
         )
 
-    # @+node:ekr.20201130090918.76: *5* kill-line end-body-text
+    # @+node:ekr.20201130090918.76: *5* test_kill-line end-body-text
     def test_kill_line_end_body_text(self):
         """Test case for kill-line end-body-text"""
         before_b = """\
@@ -2133,7 +2133,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="kill-line",
         )
 
-    # @+node:ekr.20201130090918.77: *5* kill-line end-line-text
+    # @+node:ekr.20201130090918.77: *5* test_kill-line end-line-text
     def test_kill_line_end_line_text(self):
         """Test case for kill-line end-line-text"""
         before_b = """\
@@ -2154,7 +2154,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="kill-line",
         )
 
-    # @+node:ekr.20201130090918.79: *5* kill-line start-blank-line
+    # @+node:ekr.20201130090918.79: *5* test_kill-line start-blank-line
     def test_kill_line_start_blank_line(self):
         """Test case for kill-line start-blank-line"""
         before_b = """\
@@ -2176,7 +2176,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="kill-line",
         )
 
-    # @+node:ekr.20201130090918.78: *5* kill-line start-line
+    # @+node:ekr.20201130090918.78: *5* test_kill-line start-line
     def test_kill_line_start_line(self):
         """Test case for kill-line start-line"""
         before_b = """\
@@ -2199,7 +2199,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="kill-line",
         )
 
-    # @+node:ekr.20201130090918.73: *5* kill-paragraph
+    # @+node:ekr.20201130090918.73: *5* test_kill-paragraph
     def test_kill_paragraph(self):
         """Test case for kill-paragraph"""
         before_b = """\
@@ -2245,7 +2245,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="kill-paragraph",
         )
 
-    # @+node:ekr.20201130090918.74: *5* kill-sentence
+    # @+node:ekr.20201130090918.74: *5* test_kill-sentence
     def test_kill_sentence(self):
         """Test case for kill-sentence"""
         before_b = """\
@@ -2265,7 +2265,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="kill-sentence",
         )
 
-    # @+node:ekr.20201130090918.82: *5* kill-to-end-of-line after last visible char
+    # @+node:ekr.20201130090918.82: *5* test_kill-to-end-of-line after last visible char
     def test_kill_to_end_of_line_after_last_visible_char(self):
         """Test case for kill-to-end-of-line after last visible char"""
         before_b = """\
@@ -2287,7 +2287,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="kill-to-end-of-line",
         )
 
-    # @+node:ekr.20201130090918.80: *5* kill-to-end-of-line end-body-text
+    # @+node:ekr.20201130090918.80: *5* test_kill-to-end-of-line end-body-text
     def test_kill_to_end_of_line_end_body_text(self):
         """Test case for kill-to-end-of-line end-body-text"""
         before_b = """\
@@ -2307,7 +2307,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="kill-to-end-of-line",
         )
 
-    # @+node:ekr.20201130090918.81: *5* kill-to-end-of-line end-line
+    # @+node:ekr.20201130090918.81: *5* test_kill-to-end-of-line end-line
     def test_kill_to_end_of_line_end_line(self):
         """Test case for kill-to-end-of-line end-line"""
         before_b = """\
@@ -2327,7 +2327,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="kill-to-end-of-line",
         )
 
-    # @+node:ekr.20201130090918.85: *5* kill-to-end-of-line middle-line
+    # @+node:ekr.20201130090918.85: *5* test_kill-to-end-of-line middle-line
     def test_kill_to_end_of_line_middle_line(self):
         """Test case for kill-to-end-of-line middle-line"""
         before_b = """\
@@ -2348,7 +2348,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="kill-to-end-of-line",
         )
 
-    # @+node:ekr.20201130090918.84: *5* kill-to-end-of-line start-blank-line
+    # @+node:ekr.20201130090918.84: *5* test_kill-to-end-of-line start-blank-line
     def test_kill_to_end_of_line_start_blank_line(self):
         """Test case for kill-to-end-of-line start-blank-line"""
         before_b = """\
@@ -2370,7 +2370,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="kill-to-end-of-line",
         )
 
-    # @+node:ekr.20201130090918.83: *5* kill-to-end-of-line start-line
+    # @+node:ekr.20201130090918.83: *5* test_kill-to-end-of-line start-line
     def test_kill_to_end_of_line_start_line(self):
         """Test case for kill-to-end-of-line start-line"""
         before_b = """\
@@ -2393,7 +2393,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="kill-to-end-of-line",
         )
 
-    # @+node:ekr.20201130090918.75: *5* kill-word
+    # @+node:ekr.20201130090918.75: *5* test_kill-word
     def test_kill_word(self):
         """Test case for kill-word"""
         before_b = """\
@@ -2415,7 +2415,7 @@ class TestEditCommands(LeoUnitTest):
         )
 
     # @+node:ekr.20210829062149.1: *4* Commands M-R
-    # @+node:ekr.20220517064432.1: *5* merge-node-with-next-node
+    # @+node:ekr.20220517064432.1: *5* test_merge-node-with-next-node
     def test_merge_node_with_next_node(self):
         c, u = self.c, self.c.undoer
         prev_b = self.prep(
@@ -2454,7 +2454,7 @@ class TestEditCommands(LeoUnitTest):
         self.assertEqual(c.p.b, result_b)
         self.assertFalse(c.p.next())
 
-    # @+node:ekr.20220517064507.1: *5* merge-node-with-prev-node
+    # @+node:ekr.20220517064507.1: *5* test_merge-node-with-prev-node
     def test_merge_node_with_prev_node(self):
         c, u = self.c, self.c.undoer
         prev_b = self.prep(
@@ -2497,7 +2497,7 @@ class TestEditCommands(LeoUnitTest):
         self.assertEqual(c.p.b, result_b)
         self.assertFalse(c.p.next())
 
-    # @+node:ekr.20201130090918.86: *5* move-lines-down
+    # @+node:ekr.20201130090918.86: *5* test_move-lines-down
     def test_move_lines_down(self):
         """Test case for move-lines-down"""
         before_b = """\
@@ -2524,7 +2524,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="move-lines-down",
         )
 
-    # @+node:ekr.20201130090918.87: *5* move-lines-up
+    # @+node:ekr.20201130090918.87: *5* test_move-lines-up
     def test_move_lines_up(self):
         """Test case for move-lines-up"""
         before_b = """\
@@ -2551,7 +2551,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="move-lines-up",
         )
 
-    # @+node:ekr.20201130090918.88: *5* move-lines-up (into docstring)
+    # @+node:ekr.20201130090918.88: *5* test_move-lines-up (into docstring)
     def test_move_lines_up_into_docstring(self):
         """Test case for move-lines-up (into docstring)"""
         before_b = '''\
@@ -2584,7 +2584,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="move-lines-up",
         )
 
-    # @+node:ekr.20201130090918.89: *5* move-past-close
+    # @+node:ekr.20201130090918.89: *5* test_move-past-close
     def test_move_past_close(self):
         """Test case for move-past-close"""
         before_b = """\
@@ -2611,7 +2611,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="move-past-close",
         )
 
-    # @+node:ekr.20201130090918.90: *5* move-past-close-extend-selection
+    # @+node:ekr.20201130090918.90: *5* test_move-past-close-extend-selection
     def test_move_past_close_extend_selection(self):
         """Test case for move-past-close-extend-selection"""
         before_b = """\
@@ -2638,7 +2638,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="move-past-close-extend-selection",
         )
 
-    # @+node:ekr.20201130090918.91: *5* newline-and-indent
+    # @+node:ekr.20201130090918.91: *5* test_newline-and-indent
     def test_newline_and_indent(self):
         """Test case for newline-and-indent"""
         before_b = self.prep(
@@ -2668,7 +2668,7 @@ class TestEditCommands(LeoUnitTest):
             dedent=False,
         )
 
-    # @+node:ekr.20201130090918.92: *5* next-line
+    # @+node:ekr.20201130090918.92: *5* test_next-line
     def test_next_line(self):
         """Test case for next-line"""
         before_b = """\
@@ -2689,7 +2689,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="next-line",
         )
 
-    # @+node:ekr.20201130090918.93: *5* previous-line
+    # @+node:ekr.20201130090918.93: *5* test_previous-line
     def test_previous_line(self):
         """Test case for previous-line"""
         before_b = """\
@@ -2710,7 +2710,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="previous-line",
         )
 
-    # @+node:ekr.20201130090918.94: *5* rectangle-clear
+    # @+node:ekr.20201130090918.94: *5* test_rectangle-clear
     def test_rectangle_clear(self):
         """Test case for rectangle-clear"""
         before_b = """\
@@ -2737,7 +2737,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="rectangle-clear",
         )
 
-    # @+node:ekr.20201130090918.95: *5* rectangle-close
+    # @+node:ekr.20201130090918.95: *5* test_rectangle-close
     def test_rectangle_close(self):
         """Test case for rectangle-close"""
         before_b = """\
@@ -2764,7 +2764,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="rectangle-close",
         )
 
-    # @+node:ekr.20201130090918.96: *5* rectangle-delete
+    # @+node:ekr.20201130090918.96: *5* test_rectangle-delete
     def test_rectangle_delete(self):
         """Test case for rectangle-delete"""
         before_b = """\
@@ -2791,7 +2791,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="rectangle-delete",
         )
 
-    # @+node:ekr.20201130090918.97: *5* rectangle-kill
+    # @+node:ekr.20201130090918.97: *5* test_rectangle-kill
     def test_rectangle_kill(self):
         """Test case for rectangle-kill"""
         before_b = """\
@@ -2818,7 +2818,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="rectangle-kill",
         )
 
-    # @+node:ekr.20201130090918.98: *5* rectangle-open
+    # @+node:ekr.20201130090918.98: *5* test_rectangle-open
     def test_rectangle_open(self):
         """Test case for rectangle-open"""
         before_b = """\
@@ -2845,7 +2845,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="rectangle-open",
         )
 
-    # @+node:ekr.20201130090918.99: *5* test_rectangle-string
+    # @+node:ekr.20201130090918.99: *5* test_test_rectangle-string
     def test_rectangle_string(self):
         """Test case for rectangle-string"""
         before_b = self.prep(
@@ -2878,7 +2878,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="rectangle-string",
         )
 
-    # @+node:ekr.20201130090918.100: *5* test_rectangle-yank
+    # @+node:ekr.20201130090918.100: *5* test_test_rectangle-yank
     def test_rectangle_yank(self):
         """Test case for rectangle-yank"""
         before_b = self.prep(
@@ -2911,7 +2911,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="rectangle-yank",
         )
 
-    # @+node:ekr.20201130090918.122: *5* reformat-paragraph list 1 of 5
+    # @+node:ekr.20201130090918.122: *5* test_reformat-paragraph list 1 of 5
     def test_reformat_paragraph_list_1_of_5(self):
         """Test case for reformat-paragraph list 1 of 5"""
         before_b = """\
@@ -2955,7 +2955,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.123: *5* reformat-paragraph list 2 of 5
+    # @+node:ekr.20201130090918.123: *5* test_reformat-paragraph list 2 of 5
     def test_reformat_paragraph_list_2_of_5(self):
         """Test case for reformat-paragraph list 2 of 5"""
         before_b = """\
@@ -2999,7 +2999,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.124: *5* reformat-paragraph list 3 of 5
+    # @+node:ekr.20201130090918.124: *5* test_reformat-paragraph list 3 of 5
     def test_reformat_paragraph_list_3_of_5(self):
         """Test case for reformat-paragraph list 3 of 5"""
         before_b = """\
@@ -3043,7 +3043,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.125: *5* reformat-paragraph list 4 of 5
+    # @+node:ekr.20201130090918.125: *5* test_reformat-paragraph list 4 of 5
     def test_reformat_paragraph_list_4_of_5(self):
         """Test case for reformat-paragraph list 4 of 5"""
         before_b = """\
@@ -3087,7 +3087,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.126: *5* reformat-paragraph list 5 of 5
+    # @+node:ekr.20201130090918.126: *5* test_reformat-paragraph list 5 of 5
     def test_reformat_paragraph_list_5_of_5(self):
         """Test case for reformat-paragraph list 5 of 5"""
         before_b = """\
@@ -3131,7 +3131,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.127: *5* reformat-paragraph new code 1 of 8
+    # @+node:ekr.20201130090918.127: *5* test_reformat-paragraph new code 1 of 8
     def test_reformat_paragraph_new_code_1_of_8(self):
         """Test case for reformat-paragraph new code 1 of 8"""
         before_b = """\
@@ -3155,7 +3155,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.128: *5* reformat-paragraph new code 2 of 8
+    # @+node:ekr.20201130090918.128: *5* test_reformat-paragraph new code 2 of 8
     def test_reformat_paragraph_new_code_2_of_8(self):
         """Test case for reformat-paragraph new code 2 of 8"""
         before_b = """\
@@ -3179,7 +3179,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.129: *5* reformat-paragraph new code 3 of 8
+    # @+node:ekr.20201130090918.129: *5* test_reformat-paragraph new code 3 of 8
     def test_reformat_paragraph_new_code_3_of_8(self):
         """Test case for reformat-paragraph new code 3 of 8"""
         before_b = """\
@@ -3204,7 +3204,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.130: *5* reformat-paragraph new code 4 of 8
+    # @+node:ekr.20201130090918.130: *5* test_reformat-paragraph new code 4 of 8
     def test_reformat_paragraph_new_code_4_of_8(self):
         """Test case for reformat-paragraph new code 4 of 8"""
         before_b = """\
@@ -3226,7 +3226,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.131: *5* reformat-paragraph new code 5 of 8
+    # @+node:ekr.20201130090918.131: *5* test_reformat-paragraph new code 5 of 8
     def test_reformat_paragraph_new_code_5_of_8(self):
         """Test case for reformat-paragraph new code 5 of 8"""
         before_b = """\
@@ -3248,7 +3248,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.132: *5* reformat-paragraph new code 6 of 8
+    # @+node:ekr.20201130090918.132: *5* test_reformat-paragraph new code 6 of 8
     def test_reformat_paragraph_new_code_6_of_8(self):
         """Test case for reformat-paragraph new code 6 of 8"""
         before_b = """\
@@ -3272,7 +3272,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.133: *5* reformat-paragraph new code 7 of 8
+    # @+node:ekr.20201130090918.133: *5* test_reformat-paragraph new code 7 of 8
     def test_reformat_paragraph_new_code_7_of_8(self):
         """Test case for reformat-paragraph new code 7 of 8"""
         before_b = """\
@@ -3298,7 +3298,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.134: *5* reformat-paragraph new code 8 of 8
+    # @+node:ekr.20201130090918.134: *5* test_reformat-paragraph new code 8 of 8
     def test_reformat_paragraph_new_code_8_of_8(self):
         """Test case for reformat-paragraph new code 8 of 8"""
         before_b = """\
@@ -3318,7 +3318,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.135: *5* reformat-paragraph paragraph 1 of 3
+    # @+node:ekr.20201130090918.135: *5* test_reformat-paragraph paragraph 1 of 3
     def test_reformat_paragraph_paragraph_1_of_3(self):
         """Test case for reformat-paragraph paragraph 1 of 3"""
         before_b = """\
@@ -3358,7 +3358,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.136: *5* reformat-paragraph paragraph 2 of 3
+    # @+node:ekr.20201130090918.136: *5* test_reformat-paragraph paragraph 2 of 3
     def test_reformat_paragraph_paragraph_2_of_3(self):
         """Test case for reformat-paragraph paragraph 2 of 3"""
         before_b = """\
@@ -3418,7 +3418,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.137: *5* reformat-paragraph paragraph 3 of 3
+    # @+node:ekr.20201130090918.137: *5* test_reformat-paragraph paragraph 3 of 3
     def test_reformat_paragraph_paragraph_3_of_3(self):
         """Test case for reformat-paragraph paragraph 3 of 3"""
         before_b = """\
@@ -3495,7 +3495,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.138: *5* reformat-paragraph simple hanging indent
+    # @+node:ekr.20201130090918.138: *5* test_reformat-paragraph simple hanging indent
     def test_reformat_paragraph_simple_hanging_indent(self):
         """Test case for reformat-paragraph simple hanging indent"""
         before_b = """\
@@ -3522,7 +3522,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.139: *5* reformat-paragraph simple hanging indent 2
+    # @+node:ekr.20201130090918.139: *5* test_reformat-paragraph simple hanging indent 2
     def test_reformat_paragraph_simple_hanging_indent_2(self):
         """Test case for reformat-paragraph simple hanging indent 2"""
         before_b = """\
@@ -3550,7 +3550,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.140: *5* reformat-paragraph simple hanging indent 3
+    # @+node:ekr.20201130090918.140: *5* test_reformat-paragraph simple hanging indent 3
     def test_reformat_paragraph_simple_hanging_indent_3(self):
         """Test case for reformat-paragraph simple hanging indent 3"""
         before_b = """\
@@ -3581,7 +3581,7 @@ class TestEditCommands(LeoUnitTest):
             directives="@language plain\n@pagewidth 40\n@tabwidth 8",
         )
 
-    # @+node:ekr.20201130090918.101: *5* remove-blank-lines
+    # @+node:ekr.20201130090918.101: *5* test_remove-blank-lines
     def test_remove_blank_lines(self):
         """Test case for remove-blank-lines"""
         before_b = """\
@@ -3610,7 +3610,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="remove-blank-lines",
         )
 
-    # @+node:ekr.20201130090918.102: *5* remove-space-from-lines
+    # @+node:ekr.20201130090918.102: *5* test_remove-space-from-lines
     def test_remove_space_from_lines(self):
         """Test case for remove-space-from-lines"""
         before_b = """\
@@ -3641,7 +3641,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="remove-space-from-lines",
         )
 
-    # @+node:ekr.20201130090918.103: *5* remove-tab-from-lines
+    # @+node:ekr.20201130090918.103: *5* test_remove-tab-from-lines
     def test_remove_tab_from_lines(self):
         """Test case for remove-tab-from-lines"""
         before_b = """\
@@ -3668,7 +3668,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="remove-tab-from-lines",
         )
 
-    # @+node:ekr.20201130090918.104: *5* reverse-region
+    # @+node:ekr.20201130090918.104: *5* test_reverse-region
     def test_reverse_region(self):
         """Test case for reverse-region"""
         before_b = """\
@@ -3696,7 +3696,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="reverse-region",
         )
 
-    # @+node:ekr.20201130090918.105: *5* reverse-sort-lines
+    # @+node:ekr.20201130090918.105: *5* test_reverse-sort-lines
     def test_reverse_sort_lines(self):
         """Test case for reverse-sort-lines"""
         before_b = """\
@@ -3721,7 +3721,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="reverse-sort-lines",
         )
 
-    # @+node:ekr.20201130090918.106: *5* reverse-sort-lines-ignoring-case
+    # @+node:ekr.20201130090918.106: *5* test_reverse-sort-lines-ignoring-case
     def test_reverse_sort_lines_ignoring_case(self):
         """Test case for reverse-sort-lines-ignoring-case"""
         before_b = """\
@@ -3749,7 +3749,7 @@ class TestEditCommands(LeoUnitTest):
         )
 
     # @+node:ekr.20210829062731.1: *4* Commands S-Z
-    # @+node:ekr.20201130090918.107: *5* sort-columns
+    # @+node:ekr.20201130090918.107: *5* test_sort-columns
     def test_sort_columns(self):
         """Test case for sort-columns"""
         before_b = """\
@@ -3776,7 +3776,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="sort-columns",
         )
 
-    # @+node:ekr.20201130090918.108: *5* sort-lines
+    # @+node:ekr.20201130090918.108: *5* test_sort-lines
     def test_sort_lines(self):
         """Test case for sort-lines"""
         before_b = """\
@@ -3803,7 +3803,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="sort-lines",
         )
 
-    # @+node:ekr.20201130090918.109: *5* sort-lines-ignoring-case
+    # @+node:ekr.20201130090918.109: *5* test_sort-lines-ignoring-case
     def test_sort_lines_ignoring_case(self):
         """Test case for sort-lines-ignoring-case"""
         before_b = """\
@@ -3828,7 +3828,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="sort-lines-ignoring-case",
         )
 
-    # @+node:ekr.20201130090918.110: *5* split-line
+    # @+node:ekr.20201130090918.110: *5* test_split-line
     def test_split_line(self):
         """Test case for split-line"""
         before_b = """\
@@ -3856,7 +3856,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="split-line",
         )
 
-    # @+node:ekr.20201130090918.111: *5* start-of-line
+    # @+node:ekr.20201130090918.111: *5* test_start-of-line
     def test_start_of_line(self):
         """Test case for start-of-line"""
         before_b = """\
@@ -3883,7 +3883,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="start-of-line",
         )
 
-    # @+node:ekr.20201130090918.112: *5* start-of-line (2)
+    # @+node:ekr.20201130090918.112: *5* test_start-of-line (2)
     def test_start_of_line_2(self):
         """Test case for start-of-line (2)"""
         before_b = """\
@@ -3910,7 +3910,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="start-of-line",
         )
 
-    # @+node:ekr.20201130090918.113: *5* start-of-line-extend-selection
+    # @+node:ekr.20201130090918.113: *5* test_start-of-line-extend-selection
     def test_start_of_line_extend_selection(self):
         """Test case for start-of-line-extend-selection"""
         before_b = """\
@@ -3937,7 +3937,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="start-of-line-extend-selection",
         )
 
-    # @+node:ekr.20201130090918.114: *5* start-of-line-extend-selection (2)
+    # @+node:ekr.20201130090918.114: *5* test_start-of-line-extend-selection (2)
     def test_start_of_line_extend_selection_2(self):
         """Test case for start-of-line-extend-selection (2)"""
         before_b = """\
@@ -3964,7 +3964,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="start-of-line-extend-selection",
         )
 
-    # @+node:ekr.20201130090918.115: *5* tabify
+    # @+node:ekr.20201130090918.115: *5* test_tabify
     def test_tabify(self):
         """Test case for tabify"""
         before_b = """\
@@ -3991,7 +3991,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="tabify",
         )
 
-    # @+node:ekr.20201130090918.116: *5* transpose-chars
+    # @+node:ekr.20201130090918.116: *5* test_transpose-chars
     def test_transpose_chars(self):
         """Test case for transpose-chars"""
         before_b = """\
@@ -4018,7 +4018,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="transpose-chars",
         )
 
-    # @+node:ekr.20201130090918.117: *5* transpose-lines
+    # @+node:ekr.20201130090918.117: *5* test_transpose-lines
     def test_transpose_lines(self):
         """Test case for transpose-lines"""
         before_b = """\
@@ -4045,7 +4045,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="transpose-lines",
         )
 
-    # @+node:ekr.20201130090918.118: *5* transpose-words
+    # @+node:ekr.20201130090918.118: *5* test_transpose-words
     def test_transpose_words(self):
         """Test case for transpose-words"""
         before_b = """\
@@ -4066,7 +4066,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="transpose-words",
         )
 
-    # @+node:ekr.20201130090918.119: *5* untabify
+    # @+node:ekr.20201130090918.119: *5* test_untabify
     def test_untabify(self):
         """Test case for untabify"""
         before_b = """\
@@ -4093,7 +4093,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="untabify",
         )
 
-    # @+node:ekr.20201130090918.120: *5* upcase-region
+    # @+node:ekr.20201130090918.120: *5* test_upcase-region
     def test_upcase_region(self):
         """Test case for upcase-region"""
         before_b = """\
@@ -4118,7 +4118,7 @@ class TestEditCommands(LeoUnitTest):
             command_name="upcase-region",
         )
 
-    # @+node:ekr.20201130090918.121: *5* upcase-word
+    # @+node:ekr.20201130090918.121: *5* test_upcase-word
     def test_upcase_word(self):
         """Test case for upcase-word"""
         before_b = """\
@@ -4146,7 +4146,7 @@ class TestEditCommands(LeoUnitTest):
         )
 
     # @+node:ekr.20210905064816.1: *3* TestEditCommands: Others
-    # @+node:ekr.20210905064816.2: *4* TestEditCommands.test_abbrevCommands_next_place
+    # @+node:ekr.20210905064816.2: *4* test_abbrevCommands_next_place
     def test_abbrevCommands_next_place(self):
         c = self.c
         ac = c.abbrevCommands
@@ -4157,7 +4157,7 @@ class TestEditCommands(LeoUnitTest):
         new_s, i, j = ac.next_place(s, offset=0)
         assert new_s == s.replace('<|', '').replace('|>', '')
 
-    # @+node:ekr.20210905064816.3: *4* TestEditCommands.test_addAbbrevHelper
+    # @+node:ekr.20210905064816.3: *4* test_addAbbrevHelper
     def test_addAbbrevHelper(self):
         c = self.c
         f = c.abbrevCommands.addAbbrevHelper
@@ -4184,7 +4184,7 @@ class TestEditCommands(LeoUnitTest):
                 )
                 self.assertEqual(result, expected, msg=kind)
 
-    # @+node:ekr.20210905064816.4: *4* TestEditCommands.test_capitalizeHelper
+    # @+node:ekr.20210905064816.4: *4* test_capitalizeHelper
     def test_capitalizeHelper(self):
         c, w = self.c, self.c.frame.body.wrapper
         w.setAllText('# TARGETWORD\n')
@@ -4202,7 +4202,7 @@ class TestEditCommands(LeoUnitTest):
             i = w.getInsertPoint()
             self.assertEqual(i, 5, msg=which)
 
-    # @+node:ekr.20210905064816.16: *4* TestEditCommands.test_delete_key_sticks_in_body
+    # @+node:ekr.20210905064816.16: *4* test_delete_key_sticks_in_body
     def test_delete_key_sticks_in_body(self):
         c = self.c
         w = c.frame.body.wrapper
@@ -4221,7 +4221,7 @@ class TestEditCommands(LeoUnitTest):
         c.selectPosition(p)
         self.assertEqual(p.b, s[:-1])
 
-    # @+node:ekr.20210905064816.17: *4* TestEditCommands.test_delete_key_sticks_in_headline
+    # @+node:ekr.20210905064816.17: *4* test_delete_key_sticks_in_headline
     def test_delete_key_sticks_in_headline(self):
         c = self.c
         h = 'Test headline abc'
@@ -4240,7 +4240,7 @@ class TestEditCommands(LeoUnitTest):
                 c.setHeadString(p, h)  # Essential
                 c.redraw(p)
 
-    # @+node:ekr.20210905064816.5: *4* TestEditCommands.test_dynamicExpandHelper
+    # @+node:ekr.20210905064816.5: *4* test_dynamicExpandHelper
     def test_dynamicExpandHelper(self):
         c = self.c
         # A totally wimpy test.
@@ -4248,7 +4248,7 @@ class TestEditCommands(LeoUnitTest):
         if 0:
             c.abbrevCommands.dynamicExpandHelper(event=None, prefix='', aList=[], w=None)
 
-    # @+node:ekr.20210905064816.6: *4* TestEditCommands.test_extendHelper
+    # @+node:ekr.20210905064816.6: *4* test_extendHelper
     def test_extendHelper(self):
         c = self.c
         ec = c.editCommands
@@ -4262,7 +4262,7 @@ class TestEditCommands(LeoUnitTest):
             ec.extendHelper(w, extend, j)
             i2, j2 = w.getSelectionRange()
 
-    # @+node:ekr.20210905064816.7: *4* TestEditCommands.test_findWord
+    # @+node:ekr.20210905064816.7: *4* test_findWord
     def test_findWord(self):
         c = self.c
         e, k, w = c.editCommands, c.k, c.frame.body.wrapper
@@ -4275,7 +4275,7 @@ class TestEditCommands(LeoUnitTest):
         i, j = w.getSelectionRange()
         self.assertEqual(i, 6)
 
-    # @+node:ekr.20210905064816.8: *4* TestEditCommands.test_findWordInLine
+    # @+node:ekr.20210905064816.8: *4* test_findWordInLine
     def test_findWordInLine(self):
         c = self.c
         e, k, w = c.editCommands, c.k, c.frame.body.wrapper
@@ -4288,19 +4288,19 @@ class TestEditCommands(LeoUnitTest):
         i, j = w.getSelectionRange()
         self.assertEqual(i, 4)
 
-    # @+node:ekr.20210905064816.9: *4* TestEditCommands.test_helpForMinibuffer
+    # @+node:ekr.20210905064816.9: *4* test_helpForMinibuffer
     def test_helpForMinibuffer(self):
         c = self.c
         c.helpCommands.helpForMinibuffer()
 
-    # @+node:ekr.20210914154830.1: *4* TestEditCommands.test_helpForPython
+    # @+node:ekr.20210914154830.1: *4* test_helpForPython
     def test_helpForPthon(self):
         c, k = self.c, self.c.k
         k.arg = 'os'
         s = c.helpCommands.pythonHelp1(event=None)
         self.assertTrue('Help on module os' in s)
 
-    # @+node:ekr.20210905064816.19: *4* TestEditCommands.test_insert_node_before_node_can_be_undone_and_redone
+    # @+node:ekr.20210905064816.19: *4* test_insert_node_before_node_can_be_undone_and_redone
     def test_insert_node_before_node_can_be_undone_and_redone(self):
         c = self.c
         u = c.undoer
@@ -4310,7 +4310,7 @@ class TestEditCommands(LeoUnitTest):
         c.undoer.undo()
         self.assertEqual(u.redoMenuLabel, 'Redo Insert Node Before')
 
-    # @+node:ekr.20210905064816.18: *4* TestEditCommands.test_insert_node_can_be_undone_and_redone
+    # @+node:ekr.20210905064816.18: *4* test_insert_node_can_be_undone_and_redone
     def test_insert_node_can_be_undone_and_redone(self):
         c = self.c
         u = c.undoer
@@ -4320,7 +4320,7 @@ class TestEditCommands(LeoUnitTest):
         c.undoer.undo()
         self.assertEqual(u.redoMenuLabel, 'Redo Insert Node')
 
-    # @+node:ekr.20210905064816.20: *4* TestEditCommands.test_inserting_a_new_node_draws_the_screen_exactly_once
+    # @+node:ekr.20210905064816.20: *4* test_inserting_a_new_node_draws_the_screen_exactly_once
     def test_inserting_a_new_node_draws_the_screen_exactly_once(self):
         c = self.c
         n = c.frame.tree.redrawCount
@@ -4329,7 +4329,7 @@ class TestEditCommands(LeoUnitTest):
         n2 = c.frame.tree.redrawCount
         self.assertEqual(n2, n + 1)
 
-    # @+node:ekr.20210905064816.15: *4* TestEditCommands.test_most_toggle_commands
+    # @+node:ekr.20210905064816.15: *4* test_most_toggle_commands
     def test_most_toggle_commands(self):
         c, k = self.c, self.c.k
         ed = c.editCommands
@@ -4352,7 +4352,7 @@ class TestEditCommands(LeoUnitTest):
             val3 = getattr(obj, ivar)
             self.assertEqual(val3, val1, msg=command)
 
-    # @+node:ekr.20210905064816.10: *4* TestEditCommands.test_moveToHelper
+    # @+node:ekr.20210905064816.10: *4* test_moveToHelper
     def test_moveToHelper(self):
         c = self.c
         ec = c.editCommands
@@ -4371,7 +4371,7 @@ class TestEditCommands(LeoUnitTest):
             self.assertEqual(j, j2)
             w.setSelectionRange(0, 0, insert=None)
 
-    # @+node:ekr.20210905064816.11: *4* TestEditCommands.test_moveUpOrDownHelper
+    # @+node:ekr.20210905064816.11: *4* test_moveUpOrDownHelper
     def test_moveUpOrDownHelper(self):
         c = self.c
         ec = c.editCommands
@@ -4389,7 +4389,7 @@ class TestEditCommands(LeoUnitTest):
             ec.moveUpOrDownHelper(event=None, direction=direction, extend=False)
             w.getSelectionRange()
 
-    # @+node:ekr.20210905064816.21: *4* TestEditCommands.test_paste_and_undo_in_headline__at_end
+    # @+node:ekr.20210905064816.21: *4* test_paste_and_undo_in_headline__at_end
     def test_paste_and_undo_in_headline__at_end(self):
         c, k = self.c, self.c.k
         h = 'Test headline abc'
@@ -4410,7 +4410,7 @@ class TestEditCommands(LeoUnitTest):
         k.manufactureKeyPressForCommandName(w, 'undo')
         self.assertEqual(p.h, h)
 
-    # @+node:ekr.20210905064816.22: *4* TestEditCommands.test_paste_and_undo_in_headline__with_selection
+    # @+node:ekr.20210905064816.22: *4* test_paste_and_undo_in_headline__with_selection
     def test_paste_and_undo_in_headline__with_selection(self):
         c, k = self.c, self.c.k
         h = 'Test headline abc'
@@ -4429,7 +4429,7 @@ class TestEditCommands(LeoUnitTest):
         k.manufactureKeyPressForCommandName(w, 'undo')
         self.assertEqual(p.h, h)
 
-    # @+node:ekr.20210905064816.23: *4* TestEditCommands.test_paste_at_end_of_headline
+    # @+node:ekr.20210905064816.23: *4* test_paste_at_end_of_headline
     def test_paste_at_end_of_headline(self):
         c = self.c
         h = 'Test headline abc'
@@ -4449,7 +4449,7 @@ class TestEditCommands(LeoUnitTest):
         g.app.gui.event_generate(c, '\n', 'Return', w)
         self.assertEqual(p.h, h + paste)
 
-    # @+node:ekr.20210905064816.24: *4* TestEditCommands.test_paste_from_menu_into_headline_sticks
+    # @+node:ekr.20210905064816.24: *4* test_paste_from_menu_into_headline_sticks
     def test_paste_from_menu_into_headline_sticks(self):
         c = self.c
         h = 'Test headline abc'
@@ -4476,7 +4476,7 @@ class TestEditCommands(LeoUnitTest):
                 c.setHeadString(p, h)  # Essential
                 c.redraw(p)
 
-    # @+node:ekr.20210905064816.25: *4* TestEditCommands.test_return_ends_editing_of_headline
+    # @+node:ekr.20210905064816.25: *4* test_return_ends_editing_of_headline
     def test_return_ends_editing_of_headline(self):
         c = self.c
         h = 'test that return ends editing of headline'
@@ -4492,7 +4492,7 @@ class TestEditCommands(LeoUnitTest):
         c.outerUpdate()
         assert w != c.get_focus(), 'oops2: focus in headline'
 
-    # @+node:ekr.20210905064816.12: *4* TestEditCommands.test_scrollHelper
+    # @+node:ekr.20210905064816.12: *4* test_scrollHelper
     def test_scrollHelper(self):
         c = self.c
         ec = c.editCommands
@@ -4503,7 +4503,7 @@ class TestEditCommands(LeoUnitTest):
                 event = g.app.gui.create_key_event(c, w=w)
                 ec.scrollHelper(event, direction, distance)
 
-    # @+node:ekr.20210905064816.26: *4* TestEditCommands.test_selecting_new_node_retains_paste_in_headline
+    # @+node:ekr.20210905064816.26: *4* test_selecting_new_node_retains_paste_in_headline
     def test_selecting_new_node_retains_paste_in_headline(self):
         c = self.c
         h = 'Test headline abc'
@@ -4524,7 +4524,7 @@ class TestEditCommands(LeoUnitTest):
         c.undoer.undo()
         self.assertEqual(p.h, h)
 
-    # @+node:ekr.20210905064816.27: *4* TestEditCommands.test_selecting_new_node_retains_typing_in_headline
+    # @+node:ekr.20210905064816.27: *4* test_selecting_new_node_retains_typing_in_headline
     def test_selecting_new_node_retains_typing_in_headline(self):
         c, k = self.c, self.c.k
         k.defaultUnboundKeyAction = 'insert'
@@ -4547,7 +4547,7 @@ class TestEditCommands(LeoUnitTest):
         k.manufactureKeyPressForCommandName(w, 'undo')
         self.assertEqual(p.h, h)
 
-    # @+node:ekr.20210905064816.13: *4* TestEditCommands.test_setMoveCol
+    # @+node:ekr.20210905064816.13: *4* test_setMoveCol
     def test_setMoveCol(self):
         c = self.c
         ec, w = c.editCommands, c.frame.body.wrapper
@@ -4561,7 +4561,7 @@ class TestEditCommands(LeoUnitTest):
             self.assertEqual(ec.moveSpot, result)
             self.assertEqual(ec.moveCol, result)
 
-    # @+node:ekr.20210905064816.14: *4* TestEditCommands.test_toggle_extend_mode
+    # @+node:ekr.20210905064816.14: *4* test_toggle_extend_mode
     def test_toggle_extend_mode(self):
         c = self.c
         # backward-find-character and find-character
@@ -4615,7 +4615,7 @@ class TestEditCommands(LeoUnitTest):
             # i, j = w.getSelectionRange()
             # self.assertNotEqual(i, j, msg=commandName)
 
-    # @+node:ekr.20210905064816.28: *4* TestEditCommands.test_typing_and_undo_in_headline_at_end
+    # @+node:ekr.20210905064816.28: *4* test_typing_and_undo_in_headline_at_end
     def test_typing_and_undo_in_headline_at_end(self):
         c, k = self.c, self.c.k
         k.defaultUnboundKeyAction = 'insert'
@@ -4639,7 +4639,7 @@ class TestEditCommands(LeoUnitTest):
         self.assertEqual(c.undoer.redoMenuLabel, 'Redo Typing')
         self.assertEqual(p.h, h)
 
-    # @+node:ekr.20210905064816.29: *4* TestEditCommands.test_typing_in_non_empty_body_text_does_not_redraw_the_screen
+    # @+node:ekr.20210905064816.29: *4* test_typing_in_non_empty_body_text_does_not_redraw_the_screen
     def test_typing_in_non_empty_body_text_does_not_redraw_the_screen(self):
         c = self.c
         w = c.frame.body.wrapper
@@ -4655,7 +4655,7 @@ class TestEditCommands(LeoUnitTest):
         n2 = c.frame.tree.redrawCount
         self.assertEqual(n2, n)
 
-    # @+node:ekr.20210905064816.30: *4* TestEditCommands.test_undoing_insert_node_restores_previous_node_s_body_text
+    # @+node:ekr.20210905064816.30: *4* test_undoing_insert_node_restores_previous_node_s_body_text
     def test_undoing_insert_node_restores_previous_node_s_body_text(self):
         c = self.c
         h = 'Test headline abc'

--- a/leo/unittests/commands/test_editCommands.py
+++ b/leo/unittests/commands/test_editCommands.py
@@ -4216,7 +4216,8 @@ class TestEditCommands(LeoUnitTest):
         c.bodyWantsFocus()
         w.setInsertPoint(2)
         c.outerUpdate()  # This fixed the problem.
-        c.doCommandByName('delete-char')
+        event = LeoKeyEvent(c, w=w)  # Leo 6.8.9.
+        c.doCommandByName('delete-char', event)
         self.assertEqual(p.b, s[:-1])
         c.selectPosition(p.threadBack())
         c.selectPosition(p)

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -362,7 +362,7 @@ class TestFind(LeoUnitTest):
         # Find test_p.
         p, pos, newpos = x.do_find_next(settings)
         self.assertEqual(p, test_p)
-        w = c.edit_widget(p)
+        w = c.headline_wrapper(p)
         self.assertEqual(test_p.h, w.getAllText())
         self.assertEqual(w.getSelectionRange(), (pos, newpos))
         # Do change-then-find.
@@ -449,7 +449,7 @@ class TestFind(LeoUnitTest):
         p, pos, newpos = x.do_find_next(settings)
         assert p
         self.assertEqual(p.h, settings.find_text)
-        w = self.c.edit_widget(p)
+        w = self.c.headline_wrapper(p)
         assert w
         s = p.h[pos:newpos]
         self.assertEqual(s, settings.find_text)

--- a/leo/unittests/core/test_leoUndo.py
+++ b/leo/unittests/core/test_leoUndo.py
@@ -294,7 +294,7 @@ class TestUndo(LeoUnitTest):
         node1 = p.copy().moveToFirstChild()
         c.selectPosition(node1)
         c.editHeadline()
-        w = c.frame.tree.edit_widget(node1)
+        w = c.frame.tree.headline_wrapper(node1)
         w.insert(0, 'changed - ')
         c.endEditing()
         self.assertEqual([p.h for p in p.subtree()], ['changed - node 1', 'node 2', 'node 3'])


### PR DESCRIPTION
This PR fixes the following issues:
- #4643.
- #4644.

OMG: `BaseEdit.editWidget` was the worst kind of faux helper!
OMG: Without `editWidget`, we can get rid of `event.widget`!!!.

`TestEditCommands.run_test` should call `c.doCommandByName` with a proper `event` arg!
```python
 event = LeoKeyEvent(c, w=w)  # Leo 6.8.9.
 c.doCommandByName(command_name, event)
```
After that, all edit commands can simply do:
```python
w = event.w if event else None
if not g.isTextWrapper(w):
    return <maybe some value>
```

**Significant Changes**

These three changes are milestones in Leo's codebase.

- [x] `TestEditCommands.run_test` calls  `c.doCommandByName` with a proper `event` arg!
- [x] Remove `LeoKeyEvent.widget`!
- [x] Replace all calls to `BaseEdit.editWidget` with the code shown above, with a few special cases.
 
**Other changes**

- [x] Create wrapper widgets for the find and change text in the Find tab.
- [x] Move `BaseEditCommandsClass.getRectanglePoints` to the `RectangleCommandsClass` class, where it belongs.
- [x] Remove unused `BaseEdit.getWSString`  and  `BaseEdit.keyboardQuit` methods.
- [x] Rename  `BaseEditCommandsClass._checkSel` to `_checkSelection`.
- [x] 'test_editCommands.py': The headlines of all tests start with `test_`.
- [x] Improve various other headlines.
- [x] Per [#4644](https://github.com/leo-editor/leo-editor/issues/4644), rename `c.edit_widget` to `headline_wrapper`, with aliases for compatibility.
- [x] Replace `gui_w` (or `e`) by `w` in several places. 
- [x] Improve headline comments of classes: Use the full class name, not some too-short abbreviation.
- [x] Simplify `x.widget_name` and ensure that `x.getName` returns a string, never 'None'.
    By default, these methods now return an empty string, not `repr(w)` or `<no name>`.
    This new convention helps when creating debugging traces.

**Testing**

- [x] Test copy/paste from the menu.
- [x] Test copy/paste from all text panes, including the 'Completion' tab and VR pane.
- [x] Test copy/paste within headlines from the menu.
- [x] Test clicking URLs in body text.
- [x] Test typing in 'Log'  and 'Completion' panes.
- [x] Test console gui.
