### PR TITLE
PR fixes #4647: crashes in Find and Task (Nav) panes

### DIFF
--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -366,6 +366,7 @@ class LeoKeyEvent:
         The cursesGui2 plugin calls this ctor only with with
         w = LeoBody(StringTextWrapper), whose name is 'body'.
         """
+        trace = 'keys' in g.app.debug
         self.c = c
         self.char = char or ''
         self.x = x
@@ -396,7 +397,7 @@ class LeoKeyEvent:
         if c.widget_name(w).startswith('log'):
             self.w = self.widget = c.frame.log.logCtrl
             return
-        if isinstance(w, QTextMixin):
+        if isinstance(w, QTextMixin):  # This will always succeed when using the console gui.
             self.w = self.widget = w  # A wrapper that handles text.
             return
         if wrapper := getattr(w, 'wrapper', None):
@@ -410,18 +411,21 @@ class LeoKeyEvent:
         if isinstance(w, QtWidgets.QTextEdit):
             self.widget = w
             self.w = w.leo_wrapper = QTextEditWrapper(widget=w, name=c.widget_name(w), c=c)
-            g.trace(f"New wrapper for {w.objectName() or repr(w)}")
+            if trace:
+                g.trace(f"New wrapper for {w.objectName() or repr(w)}")
             return
         if isinstance(w, QtWidgets.QLineEdit):
             self.widget = w
             self.w = w.leo_wrapper = QLineEditWrapper(widget=w, name=c.widget_name(w), c=c)
-            g.trace(f"New wrapper for {w.objectName() or repr(w)}")
+            if trace:
+                g.trace(f"New wrapper for {w.objectName() or repr(w)}")
             return
         # Anything should be valid here: we don't expect the wrapper to do key handling.
         self.w = self.widget = w
         if not isinstance(w, QtWidgets.QWidget):
-            # Should be a wrapper.
+            # Should be a wrapper, but we don't much care.
             name = c.widget_name(w)
+            # For now, let's leave this trace in.
             if not name.startswith(('body', 'canvas', 'head', 'mini')):
                 print(f"LeoKeyEvent: unusual w: {w.__class__.__name__} name: {name}")
 

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -367,6 +367,7 @@ class LeoKeyEvent:
         w = LeoBody(StringTextWrapper), whose name is 'body'.
         """
         trace = 'keys' in g.app.debug
+        tag = 'LeoKeyEvent.__init__:'
         self.c = c
         self.char = char or ''
         self.x = x
@@ -385,6 +386,17 @@ class LeoKeyEvent:
         # https://github.com/leo-editor/leo-editor/pull/4646/
         self.w: QTextMixin
         self.widget: Any  # The best we can do.
+
+        def obj_name(obj: Any) -> str:
+            if obj is None:
+                return 'None'
+            name = None
+            if hasattr(obj, 'objectName'):
+                name = obj.objectName()
+            return name or repr(obj)
+
+        if trace:
+            print(f"{tag} {id(w)} {w.__class__.__name__} {obj_name(w)}")
         if w is None:
             # Special case for headlines.
             if edit_wrapper := c.edit_widget(c.p):
@@ -412,22 +424,22 @@ class LeoKeyEvent:
             self.widget = w
             self.w = w.leo_wrapper = QTextEditWrapper(widget=w, name=c.widget_name(w), c=c)
             if trace:
-                g.trace(f"New wrapper for {w.objectName() or repr(w)}")
+                print(f"{tag} New wrapper: {self.w.__class__.__name__} for {obj_name(w)}")
             return
         if isinstance(w, QtWidgets.QLineEdit):
             self.widget = w
             self.w = w.leo_wrapper = QLineEditWrapper(widget=w, name=c.widget_name(w), c=c)
             if trace:
-                g.trace(f"New wrapper for {w.objectName() or repr(w)}")
+                print(f"{tag} New wrapper: {self.w.__class__.__name__} for {obj_name(w)}")
             return
         # Anything should be valid here: we don't expect the wrapper to do key handling.
         self.w = self.widget = w
         if not isinstance(w, QtWidgets.QWidget):
             # Should be a wrapper, but we don't much care.
-            name = c.widget_name(w)
-            # For now, let's leave this trace in.
-            if not name.startswith(('body', 'canvas', 'head', 'mini')):
-                print(f"LeoKeyEvent: unusual w: {w.__class__.__name__} name: {name}")
+            if trace:
+                name = obj_name(w)
+                if not name.startswith(('body', 'canvas', 'head', 'mini')):
+                    print(f"{tag} Unusual w: {w.__class__.__name__} name: {name}")
 
     # @+node:ekr.20140907103315.18774: *3* LeoKeyEvent.__repr__
     def __repr__(self) -> str:

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -18,7 +18,7 @@ from leo.core import leoGlobals as g
 from leo.core import leoFrame
 from leo.core.leoAPI import StringTextWrapper
 from leo.core.leoQt import QtWidgets
-from leo.plugins.qt_text import QTextEditWrapper
+from leo.plugins.qt_text import QLineEditWrapper, QTextEditWrapper
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
@@ -383,14 +383,23 @@ class LeoKeyEvent:
                 self.widget = widget
                 name = c.widget_name(widget) if widget else 'dummy-wrapper'
                 self.w = QTextEditWrapper(widget=widget, name=name, c=c)
-                # print(f"LeoKeyEvent: new {self.w.__class__.__name__} from {widget.__class__.__name__}"
         elif c.widget_name(w).startswith('log'):
             self.w = self.widget = c.frame.log.logCtrl
-        elif isinstance(w, QtWidgets.QWidget):
+        elif isinstance(w, QTextEditWrapper):
+            self.w = self.widget = w
+        elif isinstance(w, QtWidgets.QTextEdit):
             self.widget = w
             self.w = QTextEditWrapper(widget=w, name=c.widget_name(w), c=c)
-            # print(f"LeoKeyEvent: new {self.w.__class__.__name__} from {w.__class__.__name__}")
+        elif isinstance(w, QtWidgets.QLineEdit):
+            self.widget = w
+            self.w = QLineEditWrapper(widget=w, name=c.widget_name(w), c=c)
+        elif isinstance(w, QtWidgets.QWidget):
+            self.w = self.widget = w  # type:ignore
         else:
+            # Should be a wrapper.
+            name = c.widget_name(w)
+            if not name.startswith(('body', 'canvas', 'head', 'mini')):
+                print(f"LeoKeyEvent: unusual w: {w.__class__.__name__} name: {name}")
             self.w = self.widget = w
 
         # Optional ivars

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -18,13 +18,12 @@ from leo.core import leoGlobals as g
 from leo.core import leoFrame
 from leo.core.leoAPI import StringTextWrapper
 from leo.core.leoQt import QtWidgets
-from leo.plugins.qt_text import QLineEditWrapper, QTextEditWrapper
+from leo.plugins.qt_text import QLineEditWrapper, QTextEditWrapper, QTextMixin
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoNodes import Position
     from leo.plugins.qt_frame import FindTabManager
-    from leo.plugins.qt_text import QTextMixin
 
     Widget = Any  # 'Any' is the correct annotation for base class widgets.
 
@@ -361,53 +360,70 @@ class LeoKeyEvent:
         x_root: int = None,
         y_root: int = None,
     ) -> None:
-        """Ctor for LeoKeyEvent class."""
+        """
+        Ctor for LeoKeyEvent class.
+
+        The cursesGui2 plugin calls this ctor only with with
+        w = LeoBody(StringTextWrapper), whose name is 'body'.
+        """
         self.c = c
         self.char = char or ''
+        self.x = x
+        self.y = y
+        self.x_root = x_root
+        self.y_root = y_root
+
+        # Compute self.stroke.
         self.stroke: Any = (
             binding if g.isStroke(binding) else g.KeyStroke(binding) if binding else None
         )
         assert g.isStrokeOrNone(self.stroke), f"(LeoKeyEvent) {self.stroke!r} {g.callers()}"
 
+        # Compute self.w and self.widget.
+        # Coming soon: PR # 4646 will eliminate the widget ivar!
+        # https://github.com/leo-editor/leo-editor/pull/4646/
         self.w: QTextMixin
         self.widget: Any  # The best we can do.
         if w is None:
             # Special case for headlines.
-            edit_wrapper = c.edit_widget(c.p)
-            if edit_wrapper:
+            if edit_wrapper := c.edit_widget(c.p):
                 self.w = edit_wrapper
                 self.widget = self.w.widget
-            else:
-                focus_widget = g.app.gui.get_focus()
-                widget = focus_widget if g.isTextWrapper(focus_widget) else c.frame.body.widget
-                self.widget = widget
-                name = c.widget_name(widget) if widget else 'dummy-wrapper'
-                self.w = QTextEditWrapper(widget=widget, name=name, c=c)
-        elif c.widget_name(w).startswith('log'):
+                return
+            w = g.app.gui.get_focus()
+            if w is None:
+                return
+        if c.widget_name(w).startswith('log'):
             self.w = self.widget = c.frame.log.logCtrl
-        elif isinstance(w, QTextEditWrapper):
-            self.w = self.widget = w
-        elif isinstance(w, QtWidgets.QTextEdit):
+            return
+        if isinstance(w, QTextMixin):
+            self.w = self.widget = w  # A wrapper that handles text.
+            return
+        if wrapper := getattr(w, 'wrapper', None):
+            # g.trace(f"Use w.wrapper: {wrapper!r}")
+            self.w = self.widget = wrapper
+            return
+        if wrapper := getattr(w, 'leo_wrapper', None):
+            # g.trace(f"Use w.leo_wrapper: {wrapper!r}")
+            self.w = self.widget = wrapper
+            return
+        if isinstance(w, QtWidgets.QTextEdit):
             self.widget = w
-            self.w = QTextEditWrapper(widget=w, name=c.widget_name(w), c=c)
-        elif isinstance(w, QtWidgets.QLineEdit):
+            self.w = w.leo_wrapper = QTextEditWrapper(widget=w, name=c.widget_name(w), c=c)
+            g.trace(f"New wrapper for {w.objectName() or repr(w)}")
+            return
+        if isinstance(w, QtWidgets.QLineEdit):
             self.widget = w
-            self.w = QLineEditWrapper(widget=w, name=c.widget_name(w), c=c)
-        elif isinstance(w, QtWidgets.QWidget):
-            self.w = self.widget = w  # type:ignore
-        else:
+            self.w = w.leo_wrapper = QLineEditWrapper(widget=w, name=c.widget_name(w), c=c)
+            g.trace(f"New wrapper for {w.objectName() or repr(w)}")
+            return
+        # Anything should be valid here: we don't expect the wrapper to do key handling.
+        self.w = self.widget = w
+        if not isinstance(w, QtWidgets.QWidget):
             # Should be a wrapper.
             name = c.widget_name(w)
             if not name.startswith(('body', 'canvas', 'head', 'mini')):
                 print(f"LeoKeyEvent: unusual w: {w.__class__.__name__} name: {name}")
-            self.w = self.widget = w
-
-        # Optional ivars
-        self.x = x
-        self.y = y
-        # Support for fastGotoNode plugin
-        self.x_root = x_root
-        self.y_root = y_root
 
     # @+node:ekr.20140907103315.18774: *3* LeoKeyEvent.__repr__
     def __repr__(self) -> str:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -3454,8 +3454,6 @@ class KeyHandlerClass:
         assert hasattr(event, 'w'), repr(event)
         assert hasattr(event, 'widget'), repr(event)
         assert g.isStrokeOrNone(event.stroke)
-        # See LeoKeyEvent.__init__ for why the following test is correct.
-        assert not isinstance(event.w, QtWidgets.QWidget), repr(event.w)
 
         # A continuous unit test.
         assert event.stroke.s not in g.app.gui.ignoreChars, repr(event.stroke.s)

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -1292,13 +1292,10 @@ class KeyHandler:
         if isinstance(ch, int):
             g.trace('can not happen: ch: %r binding: %r' % (ch, binding))
         elif (
-            ch
-            and len(ch) == 1
-            and binding
-            and len(binding) == 1
-            and ch.isalpha()
-            and binding.isalpha()
-        ):
+            ch and len(ch) == 1
+            and binding and len(binding) == 1
+            and ch.isalpha() and binding.isalpha()
+        ):  # fmt: skip
             if ch != binding:
                 if trace:
                     g.trace('caps-lock')

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -55,6 +55,7 @@ from leo.core.leoQt import (
 )
 from leo.plugins import qt_events, qt_text
 from leo.plugins.mod_scripting import build_rclick_tree
+from leo.plugins.qt_text import QTextEditWrapper
 from leo.plugins.qt_tree import LeoQtTree
 from leo.plugins.qt_layout import LayoutCacheWidget
 
@@ -69,7 +70,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoNodes import Position
     from leo.plugins.leoFrame import LeoLog
     from leo.plugins.mod_scripting import ScriptingController
-    from leo.plugins.qt_text import LeoQTextBrowser, QScintillaWrapper, QTextEditWrapper
+    from leo.plugins.qt_text import LeoQTextBrowser, QScintillaWrapper
 
     QBoxLayout = QtWidgets.QBoxLayout
     QComboBox = QtWidgets.QComboBox
@@ -762,6 +763,8 @@ class DynamicWindow(QtWidgets.QMainWindow):
             w.setFrameShadow(shadow)
             w.setLineWidth(lineWidth)
             self.setName(w, name)
+        if not hasattr(w, 'leo_wrapper'):
+            w.leo_wrapper = QTextEditWrapper(widget=w, name=name, c=c)
         return w
 
     # @+node:ekr.20110605121601.18164: *4* dw.createTreeWidget

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -596,7 +596,7 @@ if QtWidgets:
 
         # @+node:ekr.20110605121601.18007: *3* LeoQTextBrowser. __repr__ & __str__
         def __repr__(self) -> str:
-            return f"(LeoQTextBrowser) {id(self)}"
+            return f"<LeoQTextBrowser: {id(self)} {self.objectName() or 'no name'}>"
 
         __str__ = __repr__
 


### PR DESCRIPTION
See #4647:

- [x] Add cases to `LeoKeyEvent.__init__`.
- [x] Automatically allocate a wrapper in `DynamicWindow.createText`.
- [x] Remove an assert from `k.checkKeyEvent`.

**Other changes**

- [x] `cursesGui.py`: Reformat a statement.
- [x] Improve `LeoQTextBrowser. __repr__`.

**Testing**

- [x] Test copy/paste from the menu.
- [x] Test copy/paste from all text panes, including the 'Completion' tab and VR pane.
- [x] Test copy/paste within headlines from the menu.
- [x] Test clicking URLs in body text.
- [x] Test typing in 'Log'  and 'Completion' panes.
- [x] Test typing in the `Find` and `Task` (Nav) panes.
- [x] Test console gui.
