### PR TITLE
Add publish.yml GHA workflow for GitHub Release + PyPI uploads

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,64 @@
+name: Publish
+
+on:
+  release:
+    types: [published, created]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to build and upload assets for (e.g. v6.8.5)'
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - run: python -m pip install --upgrade build
+      - run: python -m build
+      - run: ls -la dist/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  github-release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.inputs.tag || github.event.release.tag_name }}"
+          gh release upload "$TAG" dist/*.whl dist/*.tar.gz \
+            --clobber --repo ${{ github.repository }}
+
+  pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Adds a `Publish` GitHub Actions workflow that fires when a GitHub Release is created/published (via UI or `gh release create`). It builds an sdist and a wheel and:

1. Attaches them to the GitHub Release as downloadable assets.
2. Uploads them to PyPI via Trusted Publishing (OIDC, no API tokens).

This was discussed and agreed in earlier PR comments.

## Triggers

- `release: [published, created]` — the natural trigger; works for both `gh release create` and the web UI, draft or non-draft.
- `workflow_dispatch` — manual re-run against an existing release tag if a build fails.

## Required one-time setup before PyPI upload works

A PyPI owner of the `leo` project (e.g. Edward) needs to configure a Trusted Publisher:

1. Go to https://pypi.org/manage/project/leo/settings/publishing/
2. Add a publisher with:
   - **PyPI Project Name:** `leo`
   - **Owner:** `leo-editor`
   - **Repository name:** `leo-editor`
   - **Workflow name:** `publish.yml`
   - **Environment name:** `pypi`

The `pypi` GitHub environment is auto-created on first workflow run — no manual repo setup needed.

Until PyPI is configured, the `pypi` job will fail with an OIDC error, but the `github-release` job still succeeds and attaches assets to the Release. After PyPI is configured, just re-run the workflow.

## Test plan

- [ ] Edward configures the PyPI trusted publisher.
- [ ] Cut a test/pre-release via `gh release create` and verify assets appear on the Release page and on PyPI.