### PR TITLE
Add @language pug support clean

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -441,6 +441,8 @@ class LeoApp:
             "pro":      "prolog",
             "ps":       "postscript",
             "psp":      "psp",
+            "pug":      "pug",
+            "jade":     "pug",
             "ptl":      "ptl",
             "py":       "python",
             "pyx":      "cython",  # Other extensions, .pyd,.pyi
@@ -664,6 +666,7 @@ class LeoApp:
             "ptl"                : "#",
             "pvwave"             : ";",
             "pyrex"              : "#",
+            "pug"                : "//-",
             "python"             : "#",
             "r"                  : "#",
             "rapidq"             : "'",  # fil 2004-march-11
@@ -843,6 +846,7 @@ class LeoApp:
             "psp"           : "psp",
             "ptl"           : "ptl",
             "pyrex"         : "pyx",
+            "pug"           : "pug",
             "python"        : "py",
             "r"             : "r",
             "rapidq"        : "bas",  # fil 2004-march-11

--- a/leo/modes/pug.py
+++ b/leo/modes/pug.py
@@ -1,26 +1,33 @@
 # @+leo-ver=5-thin
-# @+node:ekr.20250501.1: * @file ../modes/pug.py
-"""
-leo/modes/pug.py: Leo's mode file for @language pug.
-
-Supports:
-- Comments: //- (non-output), // (output)
-- Tag names (div, p, a, etc.)
-- CSS selectors (#id, .class)
-- HTML attributes with double/single quoted strings
-- Backslash line continuation in double-quoted strings: "foo \\n  bar \\n  baz"
-- Interpolation: #{}, !{}
-- Pug directives: doctype, if/else/each/mixin/include/block/extends/case/when/default/append/prepend
-- Embedded script: and style: blocks delegating to javascript/css
-- Keywords: true/false/and/or/not/null/undefined
-
-Design notes on cross-line strings:
-  leo's match_span uses a 'dots' hack for continued strings which
-  suppresses setRestart.  This means lines after a backslash-\n
-  lose all colouring until the closing quote.  We therefore use a
-  custom matcher for "..." that calls setRestart explicitly.
-"""
-
+# @+node:swot.20260501212006.1: * @file /Users/swot/app/leo-editor/leo/modes/pug.py
+# @@language python
+# @+<< docs >>
+# @+node:swot.20260501212107.1: ** << docs >>
+# @+doc
+# leo/modes/pug.py: Leo's mode file for @language pug.
+#
+# Supports:
+#
+# - Comments: //- (non-output), // (output)
+# - Tag names (div, p, a, etc.)
+# - CSS selectors (#id, .class)
+# - HTML attributes with double/single quoted strings
+# - Backslash line continuation in double-quoted strings: "foo \\n  bar \\n  baz"
+# - Interpolation: #{}, !{}
+# - Pug directives: doctype, if/else/each/mixin/include/block/extends/case/when/default/append/prepend
+# - Embedded script: and style: blocks delegating to javascript/css
+# - Keywords: true/false/and/or/not/null/undefined
+#
+#
+# Design notes on cross-line strings:
+#
+#   leo's match_span uses a 'dots' hack for continued strings which
+#   suppresses setRestart.  This means lines after a backslash-\n
+#   lose all colouring until the closing quote.  We therefore use a
+#   custom matcher for "..." that calls setRestart explicitly.
+# @-<< docs >>
+# @+<< import >>
+# @+node:swot.20260501213739.1: ** << import >>
 from __future__ import annotations
 import re
 import string
@@ -28,40 +35,30 @@ from typing import Any
 from leo.core import leoGlobals as g
 
 assert g
-
-
-# @+<< pug.py: rules >>
-# @+node:ekr.20250501.2: ** << pug.py: rules >>
+# @-<< import >>
 # @+others
-# @+node:ekr.20250501.3: *3* pug_rule_comment_buf //-
+# @+node:swot.20260501214155.1: ** pug_rule
+# @+node:swot.20260501212231.1: *3* pug_rule_comment_buf
 def pug_rule_comment_buf(colorer: Any, s: str, i: int) -> int:
     """Match buffer-only (non-output) Pug comment: //-"""
     return colorer.match_eol_span(s, i, kind="comment1", seq="//-")
-
-
-# @+node:ekr.20250501.4: *3* pug_rule_comment // <!-- output comment -->
+# @+node:swot.20260501212428.1: *3* pug_rule_comment
 def pug_rule_comment(colorer: Any, s: str, i: int) -> int:
     """Match output Pug comment: //"""
     # Must not match //- (handled by pug_rule_comment_buf first).
     return colorer.match_eol_span(s, i, kind="comment1", seq="//")
-
-
-# @+node:ekr.20250501.5: *3* pug_rule_handlebar {{..}}
+# @+node:swot.20260501212453.1: *3* pug_rule_handlebar
 def pug_rule_handlebar(colorer: Any, s: str, i: int) -> int:
     """Match Vue/Pug handlebar expression: {{...}}"""
     return colorer.match_span(s, i, kind="keyword3", begin="{{", end="}}")
-
-
-# @+node:ekr.20250501.6: *3* pug_rule_interpolation
+# @+node:swot.20260501212551.1: *3* pug_rule_interpolation
 def pug_rule_interpolation(colorer: Any, s: str, i: int) -> int:
     """Match Pug interpolation: #{...} or !{...}"""
     n = colorer.match_span(s, i, kind="literal3", begin="#{", end="}")
     if n:
         return n
     return colorer.match_span(s, i, kind="literal3", begin="!{", end="}")
-
-
-# @+node:ekr.20250501.25: *3* pug_rule_component
+# @+node:swot.20260501212628.1: *3* pug_rule_component
 def pug_rule_component(colorer: Any, s: str, i: int) -> int:
     """Match Vue/Pug custom component names (PascalCase, no colouring)."""
     if i >= len(s) or not s[i].isupper():
@@ -72,9 +69,7 @@ def pug_rule_component(colorer: Any, s: str, i: int) -> int:
     if j > i:
         return j - i
     return 0
-
-
-# @+node:ekr.20250501.27: *3* pug_rule_vue_directive
+# @+node:swot.20260501212654.1: *3* pug_rule_vue_directive
 def pug_rule_vue_directive(colorer: Any, s: str, i: int) -> int:
     """Match Vue directives: v-if, v-else, v-for, v-model, etc."""
     if not s.startswith("v-", i):
@@ -86,9 +81,7 @@ def pug_rule_vue_directive(colorer: Any, s: str, i: int) -> int:
         colorer.colorRangeWithTag(s, i, j, tag="keyword1")
         return j - i
     return 0
-
-
-# @+node:ekr.20250501.28: *3* pug_rule_vue_bind
+# @+node:swot.20260501212707.1: *3* pug_rule_vue_bind
 def pug_rule_vue_bind(colorer: Any, s: str, i: int) -> int:
     """Match Vue bind shorthand: :class, :src, etc."""
     if s[i] != ":":
@@ -100,9 +93,7 @@ def pug_rule_vue_bind(colorer: Any, s: str, i: int) -> int:
         colorer.colorRangeWithTag(s, i, j, tag="keyword1")
         return j - i
     return 0
-
-
-# @+node:ekr.20250501.29: *3* pug_rule_vue_event
+# @+node:swot.20260501212723.1: *3* pug_rule_vue_event
 def pug_rule_vue_event(colorer: Any, s: str, i: int) -> int:
     """Match Vue event shorthand: @click, @submit, etc."""
     if s[i] != "@":
@@ -114,9 +105,7 @@ def pug_rule_vue_event(colorer: Any, s: str, i: int) -> int:
         colorer.colorRangeWithTag(s, i, j, tag="keyword1")
         return j - i
     return 0
-
-
-# @+node:ekr.20250501.30: *3* pug_rule_attribute
+# @+node:swot.20260501212738.1: *3* pug_rule_attribute
 def pug_rule_attribute(colorer: Any, s: str, i: int) -> int:
     """Match HTML attribute names inside attribute lists."""
     if not s[i].isalpha():
@@ -139,15 +128,11 @@ def pug_rule_attribute(colorer: Any, s: str, i: int) -> int:
             colorer.colorRangeWithTag(s, i, j, tag="keyword1")
             return j - i
     return 0
-
-
-# @+node:ekr.20250501.26: *3* pug_rule_keyword
+# @+node:swot.20260501212806.1: *3* pug_rule_keyword
 def pug_rule_keyword(colorer: Any, s: str, i: int) -> int:
     """Match keywords from keywordsDict (HTML tags, Pug directives, etc.)."""
     return colorer.match_keywords(s, i)
-
-
-# @+node:ekr.20250501.7: *3* pug_rule_css_id
+# @+node:swot.20260501212819.1: *3* pug_rule_css_id
 def pug_rule_css_id(colorer: Any, s: str, i: int) -> int:
     """Match CSS id selector: #id (no colouring – default white)."""
     if i > 0 and s[i - 1] not in (' ', '\t', '\n', '('):
@@ -156,9 +141,7 @@ def pug_rule_css_id(colorer: Any, s: str, i: int) -> int:
     if m:
         return m.end()
     return 0
-
-
-# @+node:ekr.20250501.8: *3* pug_rule_css_class
+# @+node:swot.20260501213001.1: *3* pug_rule_css_class
 def pug_rule_css_class(colorer: Any, s: str, i: int) -> int:
     """Match CSS class selector: .class (no colouring – default white)."""
     if i > 0 and s[i - 1] not in (' ', '\t', '\n', '('):
@@ -167,25 +150,19 @@ def pug_rule_css_class(colorer: Any, s: str, i: int) -> int:
     if m:
         return m.end()
     return 0
-
-
-# @+node:ekr.20250501.9: *3* pug_rule_paren_open
+# @+node:swot.20260501213014.1: *3* pug_rule_paren_open
 def pug_rule_paren_open(colorer: Any, s: str, i: int) -> int:
     """Match opening parenthesis: ( (no colouring)."""
     if i < len(s) and s[i] == "(":
         return 1
     return 0
-
-
-# @+node:ekr.20250501.10: *3* pug_rule_paren_close
+# @+node:swot.20260501213024.1: *3* pug_rule_paren_close
 def pug_rule_paren_close(colorer: Any, s: str, i: int) -> int:
     """Match closing parenthesis: ) (no colouring)."""
     if i < len(s) and s[i] == ")":
         return 1
     return 0
-
-
-# @+node:ekr.20250501.15: *3* pug_rule_dq_string
+# @+node:swot.20260501213038.1: *3* pug_rule_dq_string
 def pug_rule_dq_string(colorer: Any, s: str, i: int) -> int:
     """Match double-quoted string with backslash line continuation.
 
@@ -227,9 +204,7 @@ def pug_rule_dq_string(colorer: Any, s: str, i: int) -> int:
 
     colorer.setRestart(restart_dq_string)
     return len(s) - i
-
-
-# @+node:ekr.20250501.16: *3* pug_rule_sq_string
+# @+node:swot.20260501213057.1: *3* pug_rule_sq_string
 def pug_rule_sq_string(colorer: Any, s: str, i: int) -> int:
     """Match single-quoted string with backslash line continuation."""
     if i >= len(s) or s[i] != "'":
@@ -266,21 +241,15 @@ def pug_rule_sq_string(colorer: Any, s: str, i: int) -> int:
 
     colorer.setRestart(restart_sq_string)
     return len(s) - i
-
-
-# @+node:ekr.20250501.17: *3* pug_rule_equals
+# @+node:swot.20260501213117.1: *3* pug_rule_equals
 def pug_rule_equals(colorer: Any, s: str, i: int) -> int:
     """Match = operator in attribute."""
     return colorer.match_plain_seq(s, i, kind="operator", seq="=")
-
-
-# @+node:ekr.20250501.18: *3* pug_rule_comma
+# @+node:swot.20260501213126.1: *3* pug_rule_comma
 def pug_rule_comma(colorer: Any, s: str, i: int) -> int:
     """Match comma separator in attributes."""
     return colorer.match_seq(s, i, kind="operator", seq=",")
-
-
-# @+node:ekr.20250501.10: *3* pug_rule_script_block
+# @+node:swot.20260501213136.1: *3* pug_rule_script_block
 def pug_rule_script_block(colorer: Any, s: str, i: int) -> int:
     """
     Match script: block at start of line.
@@ -291,9 +260,7 @@ def pug_rule_script_block(colorer: Any, s: str, i: int) -> int:
         colorer.push_delegate('javascript')
         return len(s)
     return 0
-
-
-# @+node:ekr.20250501.11: *3* pug_rule_style_block
+# @+node:swot.20260501213146.1: *3* pug_rule_style_block
 def pug_rule_style_block(colorer: Any, s: str, i: int) -> int:
     """
     Match style: block at start of line.
@@ -304,40 +271,28 @@ def pug_rule_style_block(colorer: Any, s: str, i: int) -> int:
         colorer.push_delegate('css')
         return len(s)
     return 0
-
-
-# @+node:ekr.20250501.12: *3* pug_rule_doctype
+# @+node:swot.20260501213204.1: *3* pug_rule_doctype
 def pug_rule_doctype(colorer: Any, s: str, i: int) -> int:
     """Match doctype declaration."""
     if i == 0 and s.startswith("doctype"):
         colorer.match_seq(s, i, kind="keyword1", seq="doctype")
         return len(s)
     return 0
-
-
-# @+node:ekr.20250501.13: *3* pug_rule_pipe
+# @+node:swot.20260501213221.1: *3* pug_rule_pipe
 def pug_rule_pipe(colorer: Any, s: str, i: int) -> int:
     """Match pipe character | for raw text."""
     if i == 0 and s.startswith("|"):
         colorer.match_seq(s, i, kind="operator", seq="|")
         return len(s)
     return 0
+# @+node:swot.20260501213659.1: ** dicts
 
-
-# @-others
-# @-<< pug.py: rules >>
-
-
-# @+<< pug.py: dictionaries >>
-# @+node:ekr.20250501.19: ** << pug.py: dictionaries >>
-# @+others
-# @+node:ekr.20250501.20: *3* pug.py: Properties dict
+# @+node:swot.20260501214636.1: *3* properties
 properties = {
     "commentEnd": "",
     "commentStart": "//-",
 }
-
-# @+node:ekr.20250501.21: *3* pug.py: Attributes dicts
+# @+node:swot.20260501214617.1: *3* attributesDictDict
 pug_main_attributes_dict = {
     "default": "null",
     "digit_re": "",
@@ -350,7 +305,7 @@ pug_main_attributes_dict = {
 attributesDictDict = {
     "pug_main": pug_main_attributes_dict,
 }
-# @+node:ekr.20250501.22: *3* pug.py: Keywords dicts
+# @+node:swot.20260501214553.1: *3* keywordsDictDict
 pug_main_keywords_dict = {
     # Pug directives - colored as keyword1
     "doctype": "keyword1",
@@ -420,7 +375,7 @@ pug_main_keywords_dict = {
 keywordsDictDict = {
     "pug_main": pug_main_keywords_dict,
 }
-# @+node:ekr.20250501.23: *3* pug.py: Rules dicts
+# @+node:swot.20260501214353.1: *3* rulesDict1
 rulesDict1 = {
     "/": [
         pug_rule_comment_buf,
@@ -445,6 +400,7 @@ rulesDict1 = {
     ":": [pug_rule_vue_bind],
     "@": [pug_rule_vue_event],
 }
+# @+node:swot.20260501214143.1: ** rulesDictDict
 # Add keyword / component / directive / attribute matchers for every word-start character.
 for _ch in string.ascii_letters + "_":
     if _ch == "v":
@@ -454,18 +410,13 @@ for _ch in string.ascii_letters + "_":
         rulesDict1.setdefault(_ch, []).insert(0, pug_rule_component)
     rulesDict1.setdefault(_ch, []).append(pug_rule_keyword)
     rulesDict1.setdefault(_ch, []).append(pug_rule_attribute)
-# @-others
 
 # Import dict for pug mode.
-importDict = {}
+# importDict = {}
 
 # x.rulesDictDict for pug mode.
 rulesDictDict = {
     "pug_main": rulesDict1,
 }
-
-# @-<< pug.py: dictionaries >>
-
-# @@language python
-# @@tabwidth -4
+# @-others
 # @-leo

--- a/leo/modes/pug.py
+++ b/leo/modes/pug.py
@@ -23,6 +23,7 @@ Design notes on cross-line strings:
 
 from __future__ import annotations
 import re
+import string
 from typing import Any
 from leo.core import leoGlobals as g
 
@@ -45,6 +46,12 @@ def pug_rule_comment(colorer: Any, s: str, i: int) -> int:
     return colorer.match_eol_span(s, i, kind="comment1", seq="//")
 
 
+# @+node:ekr.20250501.5: *3* pug_rule_handlebar {{..}}
+def pug_rule_handlebar(colorer: Any, s: str, i: int) -> int:
+    """Match Vue/Pug handlebar expression: {{...}}"""
+    return colorer.match_span(s, i, kind="literal3", begin="{{", end="}}")
+
+
 # @+node:ekr.20250501.6: *3* pug_rule_interpolation
 def pug_rule_interpolation(colorer: Any, s: str, i: int) -> int:
     """Match Pug interpolation: #{...} or !{...}"""
@@ -52,6 +59,12 @@ def pug_rule_interpolation(colorer: Any, s: str, i: int) -> int:
     if n:
         return n
     return colorer.match_span(s, i, kind="literal3", begin="!{", end="}")
+
+
+# @+node:ekr.20250501.25: *3* pug_rule_keyword
+def pug_rule_keyword(colorer: Any, s: str, i: int) -> int:
+    """Match keywords from keywordsDict (HTML tags, Pug directives, etc.)."""
+    return colorer.match_keywords(s, i)
 
 
 # @+node:ekr.20250501.7: *3* pug_rule_css_id
@@ -121,6 +134,7 @@ def pug_rule_dq_string(colorer: Any, s: str, i: int) -> int:
                 k += 2
             elif s[k] == '"':
                 colorer.colorRangeWithTag(s, 0, k + 1, tag="literal1")
+                colorer.clearState()  # End restart – restore normal colouring.
                 return k + 1
             else:
                 k += 1
@@ -135,8 +149,41 @@ def pug_rule_dq_string(colorer: Any, s: str, i: int) -> int:
 
 # @+node:ekr.20250501.16: *3* pug_rule_sq_string
 def pug_rule_sq_string(colorer: Any, s: str, i: int) -> int:
-    """Match single-quoted string."""
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
+    """Match single-quoted string with backslash line continuation."""
+    if i >= len(s) or s[i] != "'":
+        return 0
+
+    j = i + 1
+    while j < len(s):
+        if s[j] == '\\' and j + 1 < len(s):
+            j += 2
+        elif s[j] == "'":
+            colorer.colorRangeWithTag(s, i, j + 1, tag="literal1")
+            return j + 1 - i
+        else:
+            j += 1
+
+    # No closing quote on this line – string continues.
+    colorer.colorRangeWithTag(s, i, len(s), tag="literal1")
+
+    def restart_sq_string(s: str) -> int:
+        k = 0
+        while k < len(s):
+            if s[k] == '\\' and k + 1 < len(s):
+                k += 2
+            elif s[k] == "'":
+                colorer.colorRangeWithTag(s, 0, k + 1, tag="literal1")
+                colorer.clearState()  # End restart – restore normal colouring.
+                return k + 1
+            else:
+                k += 1
+        # Still continuing past this line – re-arm the restart.
+        colorer.colorRangeWithTag(s, 0, len(s), tag="literal1")
+        colorer.setRestart(restart_sq_string)
+        return len(s) + 1
+
+    colorer.setRestart(restart_sq_string)
+    return len(s) - i
 
 
 # @+node:ekr.20250501.17: *3* pug_rule_equals
@@ -387,7 +434,12 @@ rulesDict1 = {
     "!": [pug_rule_interpolation],
     # script: and style: delegation (only at start of line).
     "s": [pug_rule_script_block, pug_rule_style_block],
+    # Handlebar expressions.
+    "{": [pug_rule_handlebar],
 }
+# Add keyword matcher for every possible word-start character.
+for _ch in string.ascii_letters + "_":
+    rulesDict1.setdefault(_ch, []).append(pug_rule_keyword)
 # @-others
 
 # Import dict for pug mode.

--- a/leo/modes/pug.py
+++ b/leo/modes/pug.py
@@ -97,7 +97,7 @@ def pug_rule_vue_bind(colorer: Any, s: str, i: int) -> int:
     while j < len(s) and (s[j].isalnum() or s[j] in "-_."):
         j += 1
     if j > i + 1:
-        colorer.colorRangeWithTag(s, i, j, tag="keyword2")
+        colorer.colorRangeWithTag(s, i, j, tag="keyword1")
         return j - i
     return 0
 
@@ -111,7 +111,7 @@ def pug_rule_vue_event(colorer: Any, s: str, i: int) -> int:
     while j < len(s) and (s[j].isalnum() or s[j] in "-_."):
         j += 1
     if j > i + 1:
-        colorer.colorRangeWithTag(s, i, j, tag="keyword2")
+        colorer.colorRangeWithTag(s, i, j, tag="keyword1")
         return j - i
     return 0
 
@@ -136,7 +136,7 @@ def pug_rule_attribute(colorer: Any, s: str, i: int) -> int:
                 prev = s[p]
                 break
         if prev in "(,:":
-            colorer.colorRangeWithTag(s, i, j, tag="keyword2")
+            colorer.colorRangeWithTag(s, i, j, tag="keyword1")
             return j - i
     return 0
 
@@ -395,26 +395,26 @@ pug_main_keywords_dict = {
     "v-pre": "keyword1",
     "v-cloak": "keyword1",
     "v-once": "keyword1",
-    # HTML common attributes - colored as keyword2
-    "class": "keyword2",
-    "id": "keyword2",
-    "src": "keyword2",
-    "alt": "keyword2",
-    "href": "keyword2",
-    "title": "keyword2",
-    "type": "keyword2",
-    "name": "keyword2",
-    "value": "keyword2",
-    "placeholder": "keyword2",
-    "disabled": "keyword2",
-    "readonly": "keyword2",
-    "required": "keyword2",
-    "checked": "keyword2",
-    "selected": "keyword2",
-    "target": "keyword2",
-    "rel": "keyword2",
-    "role": "keyword2",
-    "tabindex": "keyword2",
+    # HTML common attributes - colored as keyword1 (orange)
+    "class": "keyword1",
+    "id": "keyword1",
+    "src": "keyword1",
+    "alt": "keyword1",
+    "href": "keyword1",
+    "title": "keyword1",
+    "type": "keyword1",
+    "name": "keyword1",
+    "value": "keyword1",
+    "placeholder": "keyword1",
+    "disabled": "keyword1",
+    "readonly": "keyword1",
+    "required": "keyword1",
+    "checked": "keyword1",
+    "selected": "keyword1",
+    "target": "keyword1",
+    "rel": "keyword1",
+    "role": "keyword1",
+    "tabindex": "keyword1",
 }
 
 keywordsDictDict = {

--- a/leo/modes/pug.py
+++ b/leo/modes/pug.py
@@ -1,0 +1,405 @@
+# @+leo-ver=5-thin
+# @+node:ekr.20250501.1: * @file ../modes/pug.py
+"""
+leo/modes/pug.py: Leo's mode file for @language pug.
+
+Supports:
+- Comments: //- (non-output), // (output)
+- Tag names (div, p, a, etc.)
+- CSS selectors (#id, .class)
+- HTML attributes with double/single quoted strings
+- Backslash line continuation in double-quoted strings: "foo \\n  bar \\n  baz"
+- Interpolation: #{}, !{}
+- Pug directives: doctype, if/else/each/mixin/include/block/extends/case/when/default/append/prepend
+- Embedded script: and style: blocks delegating to javascript/css
+- Keywords: true/false/and/or/not/null/undefined
+
+Design notes on cross-line strings:
+  leo's match_span uses a 'dots' hack for continued strings which
+  suppresses setRestart.  This means lines after a backslash-\n
+  lose all colouring until the closing quote.  We therefore use a
+  custom matcher for "..." that calls setRestart explicitly.
+"""
+
+from __future__ import annotations
+import re
+from typing import Any
+from leo.core import leoGlobals as g
+
+assert g
+
+
+# @+<< pug.py: rules >>
+# @+node:ekr.20250501.2: ** << pug.py: rules >>
+# @+others
+# @+node:ekr.20250501.3: *3* pug_rule_comment_buf //-
+def pug_rule_comment_buf(colorer: Any, s: str, i: int) -> int:
+    """Match buffer-only (non-output) Pug comment: //-"""
+    return colorer.match_eol_span(s, i, kind="comment1", seq="//-")
+
+
+# @+node:ekr.20250501.4: *3* pug_rule_comment // <!-- output comment -->
+def pug_rule_comment(colorer: Any, s: str, i: int) -> int:
+    """Match output Pug comment: //"""
+    # Must not match //- (handled by pug_rule_comment_buf first).
+    return colorer.match_eol_span(s, i, kind="comment1", seq="//")
+
+
+# @+node:ekr.20250501.6: *3* pug_rule_interpolation
+def pug_rule_interpolation(colorer: Any, s: str, i: int) -> int:
+    """Match Pug interpolation: #{...} or !{...}"""
+    n = colorer.match_span(s, i, kind="literal3", begin="#{", end="}")
+    if n:
+        return n
+    return colorer.match_span(s, i, kind="literal3", begin="!{", end="}")
+
+
+# @+node:ekr.20250501.7: *3* pug_rule_css_id
+def pug_rule_css_id(colorer: Any, s: str, i: int) -> int:
+    """Match CSS id selector: #id"""
+    if i > 0 and s[i - 1] not in (' ', '\t', '\n', '('):
+        return 0
+    m = re.match(r'#[a-zA-Z_][a-zA-Z0-9_-]*', s[i:])
+    if m:
+        colorer.colorRangeWithTag(s, i, i + m.end(), tag="keyword2")
+        return m.end()
+    return 0
+
+
+# @+node:ekr.20250501.8: *3* pug_rule_css_class
+def pug_rule_css_class(colorer: Any, s: str, i: int) -> int:
+    """Match CSS class selector: .class"""
+    if i > 0 and s[i - 1] not in (' ', '\t', '\n', '('):
+        return 0
+    m = re.match(r'\.[a-zA-Z_][a-zA-Z0-9_-]*', s[i:])
+    if m:
+        colorer.colorRangeWithTag(s, i, i + m.end(), tag="keyword3")
+        return m.end()
+    return 0
+
+
+# @+node:ekr.20250501.9: *3* pug_rule_paren_open
+def pug_rule_paren_open(colorer: Any, s: str, i: int) -> int:
+    """Match opening parenthesis: ( - colored as markup."""
+    return colorer.match_seq(s, i, kind="markup", seq="(")
+
+
+# @+node:ekr.20250501.10: *3* pug_rule_paren_close
+def pug_rule_paren_close(colorer: Any, s: str, i: int) -> int:
+    """Match closing parenthesis: ) - colored as markup."""
+    return colorer.match_seq(s, i, kind="markup", seq=")")
+
+
+# @+node:ekr.20250501.15: *3* pug_rule_dq_string
+def pug_rule_dq_string(colorer: Any, s: str, i: int) -> int:
+    """Match double-quoted string with backslash line continuation.
+
+    We do NOT use match_span because leo's 'dots' optimisation
+    suppresses setRestart for continued literal strings, causing
+    all subsequent lines to lose colouring until the closing quote.
+    """
+    if i >= len(s) or s[i] != '"':
+        return 0
+
+    j = i + 1
+    while j < len(s):
+        if s[j] == '\\' and j + 1 < len(s):
+            j += 2
+        elif s[j] == '"':
+            colorer.colorRangeWithTag(s, i, j + 1, tag="literal1")
+            return j + 1 - i
+        else:
+            j += 1
+
+    # No closing quote on this line – string continues.
+    colorer.colorRangeWithTag(s, i, len(s), tag="literal1")
+
+    def restart_dq_string(s: str) -> int:
+        k = 0
+        while k < len(s):
+            if s[k] == '\\' and k + 1 < len(s):
+                k += 2
+            elif s[k] == '"':
+                colorer.colorRangeWithTag(s, 0, k + 1, tag="literal1")
+                return k + 1
+            else:
+                k += 1
+        # Still continuing past this line – re-arm the restart.
+        colorer.colorRangeWithTag(s, 0, len(s), tag="literal1")
+        colorer.setRestart(restart_dq_string)
+        return len(s) + 1
+
+    colorer.setRestart(restart_dq_string)
+    return len(s) - i
+
+
+# @+node:ekr.20250501.16: *3* pug_rule_sq_string
+def pug_rule_sq_string(colorer: Any, s: str, i: int) -> int:
+    """Match single-quoted string."""
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
+
+
+# @+node:ekr.20250501.17: *3* pug_rule_equals
+def pug_rule_equals(colorer: Any, s: str, i: int) -> int:
+    """Match = operator in attribute."""
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
+
+
+# @+node:ekr.20250501.18: *3* pug_rule_comma
+def pug_rule_comma(colorer: Any, s: str, i: int) -> int:
+    """Match comma separator in attributes."""
+    return colorer.match_seq(s, i, kind="operator", seq=",")
+
+
+# @+node:ekr.20250501.10: *3* pug_rule_script_block
+def pug_rule_script_block(colorer: Any, s: str, i: int) -> int:
+    """
+    Match script: block at start of line.
+    Colorizes the 'script:' prefix, then delegates to javascript.
+    """
+    if i == 0 and s.startswith("script:"):
+        colorer.colorRangeWithTag(s, i, i + 7, kind="markup")
+        colorer.push_delegate('javascript')
+        return len(s)
+    return 0
+
+
+# @+node:ekr.20250501.11: *3* pug_rule_style_block
+def pug_rule_style_block(colorer: Any, s: str, i: int) -> int:
+    """
+    Match style: block at start of line.
+    Colorizes the 'style:' prefix, then delegates to css.
+    """
+    if i == 0 and s.startswith("style:"):
+        colorer.colorRangeWithTag(s, i, i + 6, kind="markup")
+        colorer.push_delegate('css')
+        return len(s)
+    return 0
+
+
+# @+node:ekr.20250501.12: *3* pug_rule_doctype
+def pug_rule_doctype(colorer: Any, s: str, i: int) -> int:
+    """Match doctype declaration."""
+    if i == 0 and s.startswith("doctype"):
+        colorer.match_seq(s, i, kind="keyword1", seq="doctype")
+        return len(s)
+    return 0
+
+
+# @+node:ekr.20250501.13: *3* pug_rule_pipe
+def pug_rule_pipe(colorer: Any, s: str, i: int) -> int:
+    """Match pipe character | for raw text."""
+    if i == 0 and s.startswith("|"):
+        colorer.match_seq(s, i, kind="operator", seq="|")
+        return len(s)
+    return 0
+
+
+# @-others
+# @-<< pug.py: rules >>
+
+
+# @+<< pug.py: dictionaries >>
+# @+node:ekr.20250501.19: ** << pug.py: dictionaries >>
+# @+others
+# @+node:ekr.20250501.20: *3* pug.py: Properties dict
+properties = {
+    "commentEnd": "",
+    "commentStart": "//-",
+}
+
+# @+node:ekr.20250501.21: *3* pug.py: Attributes dicts
+pug_main_attributes_dict = {
+    "default": "null",
+    "digit_re": "",
+    "escape": "\\",
+    "highlight_digits": "true",
+    "ignore_case": "true",
+    "no_word_sep": "",
+}
+
+attributesDictDict = {
+    "pug_main": pug_main_attributes_dict,
+}
+# @+node:ekr.20250501.22: *3* pug.py: Keywords dicts
+pug_main_keywords_dict = {
+    # HTML tag keywords - colored as markup
+    "a": "markup",
+    "abbr": "markup",
+    "address": "markup",
+    "area": "markup",
+    "article": "markup",
+    "aside": "markup",
+    "audio": "markup",
+    "b": "markup",
+    "base": "markup",
+    "bdi": "markup",
+    "bdo": "markup",
+    "blockquote": "markup",
+    "body": "markup",
+    "br": "markup",
+    "button": "markup",
+    "canvas": "markup",
+    "caption": "markup",
+    "cite": "markup",
+    "code": "markup",
+    "col": "markup",
+    "colgroup": "markup",
+    "data": "markup",
+    "datalist": "markup",
+    "dd": "markup",
+    "del": "markup",
+    "details": "markup",
+    "dfn": "markup",
+    "dialog": "markup",
+    "div": "markup",
+    "dl": "markup",
+    "dt": "markup",
+    "em": "markup",
+    "embed": "markup",
+    "fieldset": "markup",
+    "figcaption": "markup",
+    "figure": "markup",
+    "footer": "markup",
+    "form": "markup",
+    "h1": "markup",
+    "h2": "markup",
+    "h3": "markup",
+    "h4": "markup",
+    "h5": "markup",
+    "h6": "markup",
+    "head": "markup",
+    "header": "markup",
+    "hgroup": "markup",
+    "hr": "markup",
+    "html": "markup",
+    "i": "markup",
+    "iframe": "markup",
+    "img": "markup",
+    "input": "markup",
+    "ins": "markup",
+    "kbd": "markup",
+    "label": "markup",
+    "legend": "markup",
+    "li": "markup",
+    "link": "markup",
+    "main": "markup",
+    "map": "markup",
+    "mark": "markup",
+    "menu": "markup",
+    "meta": "markup",
+    "meter": "markup",
+    "nav": "markup",
+    "noscript": "markup",
+    "object": "markup",
+    "ol": "markup",
+    "optgroup": "markup",
+    "option": "markup",
+    "output": "markup",
+    "p": "markup",
+    "picture": "markup",
+    "pre": "markup",
+    "progress": "markup",
+    "q": "markup",
+    "rp": "markup",
+    "rt": "markup",
+    "ruby": "markup",
+    "s": "markup",
+    "samp": "markup",
+    "script": "markup",
+    "section": "markup",
+    "select": "markup",
+    "slot": "markup",
+    "small": "markup",
+    "source": "markup",
+    "span": "markup",
+    "strong": "markup",
+    "style": "markup",
+    "sub": "markup",
+    "summary": "markup",
+    "sup": "markup",
+    "table": "markup",
+    "tbody": "markup",
+    "td": "markup",
+    "template": "markup",
+    "textarea": "markup",
+    "tfoot": "markup",
+    "th": "markup",
+    "thead": "markup",
+    "time": "markup",
+    "title": "markup",
+    "tr": "markup",
+    "track": "markup",
+    "u": "markup",
+    "ul": "markup",
+    "var": "markup",
+    "video": "markup",
+    "wbr": "markup",
+    # Pug directives - colored as keyword1
+    "doctype": "keyword1",
+    "if": "keyword1",
+    "else": "keyword1",
+    "else if": "keyword1",
+    "unless": "keyword1",
+    "each": "keyword1",
+    "for": "keyword1",
+    "while": "keyword1",
+    "in": "keyword1",
+    "case": "keyword1",
+    "when": "keyword1",
+    "default": "keyword1",
+    "mixin": "keyword1",
+    "include": "keyword1",
+    "extends": "keyword1",
+    "block": "keyword1",
+    "append": "keyword1",
+    "prepend": "keyword1",
+    "yield": "keyword1",
+    # Pug keywords
+    "true": "keyword1",
+    "false": "keyword1",
+    "null": "keyword1",
+    "undefined": "keyword1",
+    "and": "keyword1",
+    "or": "keyword1",
+    "not": "keyword1",
+}
+
+keywordsDictDict = {
+    "pug_main": pug_main_keywords_dict,
+}
+# @+node:ekr.20250501.23: *3* pug.py: Rules dicts
+rulesDict1 = {
+    "/": [
+        pug_rule_comment_buf,
+        pug_rule_comment,
+    ],
+    "\"": [pug_rule_dq_string],
+    "'": [pug_rule_sq_string],
+    "#": [pug_rule_css_id, pug_rule_interpolation],
+    ".": [pug_rule_css_class],
+    "(": [pug_rule_paren_open],
+    ")": [pug_rule_paren_close],
+    "=": [pug_rule_equals],
+    ",": [pug_rule_comma],
+    # Pipe must come before | in interpolation.
+    "|": [pug_rule_pipe],
+    "!": [pug_rule_interpolation],
+    # script: and style: delegation (only at start of line).
+    "s": [pug_rule_script_block, pug_rule_style_block],
+}
+# @-others
+
+# Import dict for pug mode.
+importDict = {}
+
+# x.rulesDictDict for pug mode.
+rulesDictDict = {
+    "pug_main": rulesDict1,
+}
+
+# @-<< pug.py: dictionaries >>
+
+# @@language python
+# @@tabwidth -4
+# @-leo

--- a/leo/modes/pug.py
+++ b/leo/modes/pug.py
@@ -61,7 +61,21 @@ def pug_rule_interpolation(colorer: Any, s: str, i: int) -> int:
     return colorer.match_span(s, i, kind="literal3", begin="!{", end="}")
 
 
-# @+node:ekr.20250501.25: *3* pug_rule_keyword
+# @+node:ekr.20250501.25: *3* pug_rule_component
+def pug_rule_component(colorer: Any, s: str, i: int) -> int:
+    """Match Vue/Pug custom component names (PascalCase)."""
+    if i >= len(s) or not s[i].isupper():
+        return 0
+    j = i + 1
+    while j < len(s) and (s[j].isalnum() or s[j] in '_-'):
+        j += 1
+    if j > i:
+        colorer.colorRangeWithTag(s, i, j, tag="markup")
+        return j - i
+    return 0
+
+
+# @+node:ekr.20250501.26: *3* pug_rule_keyword
 def pug_rule_keyword(colorer: Any, s: str, i: int) -> int:
     """Match keywords from keywordsDict (HTML tags, Pug directives, etc.)."""
     return colorer.match_keywords(s, i)
@@ -439,6 +453,9 @@ rulesDict1 = {
 }
 # Add keyword matcher for every possible word-start character.
 for _ch in string.ascii_letters + "_":
+    if _ch.isupper():
+        # PascalCase component names take precedence over keywords.
+        rulesDict1.setdefault(_ch, []).insert(0, pug_rule_component)
     rulesDict1.setdefault(_ch, []).append(pug_rule_keyword)
 # @-others
 

--- a/leo/modes/pug.py
+++ b/leo/modes/pug.py
@@ -49,7 +49,7 @@ def pug_rule_comment(colorer: Any, s: str, i: int) -> int:
 # @+node:ekr.20250501.5: *3* pug_rule_handlebar {{..}}
 def pug_rule_handlebar(colorer: Any, s: str, i: int) -> int:
     """Match Vue/Pug handlebar expression: {{...}}"""
-    return colorer.match_span(s, i, kind="keyword2", begin="{{", end="}}")
+    return colorer.match_span(s, i, kind="keyword3", begin="{{", end="}}")
 
 
 # @+node:ekr.20250501.6: *3* pug_rule_interpolation
@@ -63,15 +63,81 @@ def pug_rule_interpolation(colorer: Any, s: str, i: int) -> int:
 
 # @+node:ekr.20250501.25: *3* pug_rule_component
 def pug_rule_component(colorer: Any, s: str, i: int) -> int:
-    """Match Vue/Pug custom component names (PascalCase)."""
+    """Match Vue/Pug custom component names (PascalCase, no colouring)."""
     if i >= len(s) or not s[i].isupper():
         return 0
     j = i + 1
     while j < len(s) and (s[j].isalnum() or s[j] in '_-'):
         j += 1
     if j > i:
-        colorer.colorRangeWithTag(s, i, j, tag="markup")
         return j - i
+    return 0
+
+
+# @+node:ekr.20250501.27: *3* pug_rule_vue_directive
+def pug_rule_vue_directive(colorer: Any, s: str, i: int) -> int:
+    """Match Vue directives: v-if, v-else, v-for, v-model, etc."""
+    if not s.startswith("v-", i):
+        return 0
+    j = i + 2
+    while j < len(s) and (s[j].isalnum() or s[j] == "-"):
+        j += 1
+    if j > i + 2:
+        colorer.colorRangeWithTag(s, i, j, tag="keyword1")
+        return j - i
+    return 0
+
+
+# @+node:ekr.20250501.28: *3* pug_rule_vue_bind
+def pug_rule_vue_bind(colorer: Any, s: str, i: int) -> int:
+    """Match Vue bind shorthand: :class, :src, etc."""
+    if s[i] != ":":
+        return 0
+    j = i + 1
+    while j < len(s) and (s[j].isalnum() or s[j] in "-_."):
+        j += 1
+    if j > i + 1:
+        colorer.colorRangeWithTag(s, i, j, tag="keyword2")
+        return j - i
+    return 0
+
+
+# @+node:ekr.20250501.29: *3* pug_rule_vue_event
+def pug_rule_vue_event(colorer: Any, s: str, i: int) -> int:
+    """Match Vue event shorthand: @click, @submit, etc."""
+    if s[i] != "@":
+        return 0
+    j = i + 1
+    while j < len(s) and (s[j].isalnum() or s[j] in "-_."):
+        j += 1
+    if j > i + 1:
+        colorer.colorRangeWithTag(s, i, j, tag="keyword2")
+        return j - i
+    return 0
+
+
+# @+node:ekr.20250501.30: *3* pug_rule_attribute
+def pug_rule_attribute(colorer: Any, s: str, i: int) -> int:
+    """Match HTML attribute names inside attribute lists."""
+    if not s[i].isalpha():
+        return 0
+    j = i + 1
+    while j < len(s) and (s[j].isalnum() or s[j] in "-_"):
+        j += 1
+    # Must be followed by optional whitespace then = or (
+    k = j
+    while k < len(s) and s[k] in " \t":
+        k += 1
+    if k < len(s) and s[k] in "=(:":
+        # Only match if preceded by ( or , (inside attribute list)
+        prev = ""
+        for p in range(i - 1, -1, -1):
+            if s[p] not in " \t":
+                prev = s[p]
+                break
+        if prev in "(,:":
+            colorer.colorRangeWithTag(s, i, j, tag="keyword2")
+            return j - i
     return 0
 
 
@@ -83,38 +149,40 @@ def pug_rule_keyword(colorer: Any, s: str, i: int) -> int:
 
 # @+node:ekr.20250501.7: *3* pug_rule_css_id
 def pug_rule_css_id(colorer: Any, s: str, i: int) -> int:
-    """Match CSS id selector: #id"""
+    """Match CSS id selector: #id (no colouring – default white)."""
     if i > 0 and s[i - 1] not in (' ', '\t', '\n', '('):
         return 0
     m = re.match(r'#[a-zA-Z_][a-zA-Z0-9_-]*', s[i:])
     if m:
-        colorer.colorRangeWithTag(s, i, i + m.end(), tag="keyword2")
         return m.end()
     return 0
 
 
 # @+node:ekr.20250501.8: *3* pug_rule_css_class
 def pug_rule_css_class(colorer: Any, s: str, i: int) -> int:
-    """Match CSS class selector: .class"""
+    """Match CSS class selector: .class (no colouring – default white)."""
     if i > 0 and s[i - 1] not in (' ', '\t', '\n', '('):
         return 0
     m = re.match(r'\.[a-zA-Z_][a-zA-Z0-9_-]*', s[i:])
     if m:
-        colorer.colorRangeWithTag(s, i, i + m.end(), tag="keyword3")
         return m.end()
     return 0
 
 
 # @+node:ekr.20250501.9: *3* pug_rule_paren_open
 def pug_rule_paren_open(colorer: Any, s: str, i: int) -> int:
-    """Match opening parenthesis: ( - colored as markup."""
-    return colorer.match_seq(s, i, kind="markup", seq="(")
+    """Match opening parenthesis: ( (no colouring)."""
+    if i < len(s) and s[i] == "(":
+        return 1
+    return 0
 
 
 # @+node:ekr.20250501.10: *3* pug_rule_paren_close
 def pug_rule_paren_close(colorer: Any, s: str, i: int) -> int:
-    """Match closing parenthesis: ) - colored as markup."""
-    return colorer.match_seq(s, i, kind="markup", seq=")")
+    """Match closing parenthesis: ) (no colouring)."""
+    if i < len(s) and s[i] == ")":
+        return 1
+    return 0
 
 
 # @+node:ekr.20250501.15: *3* pug_rule_dq_string
@@ -276,7 +344,7 @@ pug_main_attributes_dict = {
     "escape": "\\",
     "highlight_digits": "true",
     "ignore_case": "true",
-    "no_word_sep": "",
+    "no_word_sep": "-",
 }
 
 attributesDictDict = {
@@ -284,118 +352,6 @@ attributesDictDict = {
 }
 # @+node:ekr.20250501.22: *3* pug.py: Keywords dicts
 pug_main_keywords_dict = {
-    # HTML tag keywords - colored as markup
-    "a": "markup",
-    "abbr": "markup",
-    "address": "markup",
-    "area": "markup",
-    "article": "markup",
-    "aside": "markup",
-    "audio": "markup",
-    "b": "markup",
-    "base": "markup",
-    "bdi": "markup",
-    "bdo": "markup",
-    "blockquote": "markup",
-    "body": "markup",
-    "br": "markup",
-    "button": "markup",
-    "canvas": "markup",
-    "caption": "markup",
-    "cite": "markup",
-    "code": "markup",
-    "col": "markup",
-    "colgroup": "markup",
-    "data": "markup",
-    "datalist": "markup",
-    "dd": "markup",
-    "del": "markup",
-    "details": "markup",
-    "dfn": "markup",
-    "dialog": "markup",
-    "div": "markup",
-    "dl": "markup",
-    "dt": "markup",
-    "em": "markup",
-    "embed": "markup",
-    "fieldset": "markup",
-    "figcaption": "markup",
-    "figure": "markup",
-    "footer": "markup",
-    "form": "markup",
-    "h1": "markup",
-    "h2": "markup",
-    "h3": "markup",
-    "h4": "markup",
-    "h5": "markup",
-    "h6": "markup",
-    "head": "markup",
-    "header": "markup",
-    "hgroup": "markup",
-    "hr": "markup",
-    "html": "markup",
-    "i": "markup",
-    "iframe": "markup",
-    "img": "markup",
-    "input": "markup",
-    "ins": "markup",
-    "kbd": "markup",
-    "label": "markup",
-    "legend": "markup",
-    "li": "markup",
-    "link": "markup",
-    "main": "markup",
-    "map": "markup",
-    "mark": "markup",
-    "menu": "markup",
-    "meta": "markup",
-    "meter": "markup",
-    "nav": "markup",
-    "noscript": "markup",
-    "object": "markup",
-    "ol": "markup",
-    "optgroup": "markup",
-    "option": "markup",
-    "output": "markup",
-    "p": "markup",
-    "picture": "markup",
-    "pre": "markup",
-    "progress": "markup",
-    "q": "markup",
-    "rp": "markup",
-    "rt": "markup",
-    "ruby": "markup",
-    "s": "markup",
-    "samp": "markup",
-    "script": "markup",
-    "section": "markup",
-    "select": "markup",
-    "slot": "markup",
-    "small": "markup",
-    "source": "markup",
-    "span": "markup",
-    "strong": "markup",
-    "style": "markup",
-    "sub": "markup",
-    "summary": "markup",
-    "sup": "markup",
-    "table": "markup",
-    "tbody": "markup",
-    "td": "markup",
-    "template": "markup",
-    "textarea": "markup",
-    "tfoot": "markup",
-    "th": "markup",
-    "thead": "markup",
-    "time": "markup",
-    "title": "markup",
-    "tr": "markup",
-    "track": "markup",
-    "u": "markup",
-    "ul": "markup",
-    "var": "markup",
-    "video": "markup",
-    "wbr": "markup",
     # Pug directives - colored as keyword1
     "doctype": "keyword1",
     "if": "keyword1",
@@ -424,6 +380,41 @@ pug_main_keywords_dict = {
     "and": "keyword1",
     "or": "keyword1",
     "not": "keyword1",
+    # Vue directives - colored as keyword1 (logic control)
+    "v-if": "keyword1",
+    "v-else": "keyword1",
+    "v-else-if": "keyword1",
+    "v-for": "keyword1",
+    "v-show": "keyword1",
+    "v-model": "keyword1",
+    "v-bind": "keyword1",
+    "v-on": "keyword1",
+    "v-text": "keyword1",
+    "v-html": "keyword1",
+    "v-slot": "keyword1",
+    "v-pre": "keyword1",
+    "v-cloak": "keyword1",
+    "v-once": "keyword1",
+    # HTML common attributes - colored as keyword2
+    "class": "keyword2",
+    "id": "keyword2",
+    "src": "keyword2",
+    "alt": "keyword2",
+    "href": "keyword2",
+    "title": "keyword2",
+    "type": "keyword2",
+    "name": "keyword2",
+    "value": "keyword2",
+    "placeholder": "keyword2",
+    "disabled": "keyword2",
+    "readonly": "keyword2",
+    "required": "keyword2",
+    "checked": "keyword2",
+    "selected": "keyword2",
+    "target": "keyword2",
+    "rel": "keyword2",
+    "role": "keyword2",
+    "tabindex": "keyword2",
 }
 
 keywordsDictDict = {
@@ -450,13 +441,19 @@ rulesDict1 = {
     "s": [pug_rule_script_block, pug_rule_style_block],
     # Handlebar expressions.
     "{": [pug_rule_handlebar],
+    # Vue bind/event shorthands.
+    ":": [pug_rule_vue_bind],
+    "@": [pug_rule_vue_event],
 }
-# Add keyword matcher for every possible word-start character.
+# Add keyword / component / directive / attribute matchers for every word-start character.
 for _ch in string.ascii_letters + "_":
+    if _ch == "v":
+        rulesDict1.setdefault(_ch, []).insert(0, pug_rule_vue_directive)
     if _ch.isupper():
         # PascalCase component names take precedence over keywords.
         rulesDict1.setdefault(_ch, []).insert(0, pug_rule_component)
     rulesDict1.setdefault(_ch, []).append(pug_rule_keyword)
+    rulesDict1.setdefault(_ch, []).append(pug_rule_attribute)
 # @-others
 
 # Import dict for pug mode.

--- a/leo/modes/pug.py
+++ b/leo/modes/pug.py
@@ -49,7 +49,7 @@ def pug_rule_comment(colorer: Any, s: str, i: int) -> int:
 # @+node:ekr.20250501.5: *3* pug_rule_handlebar {{..}}
 def pug_rule_handlebar(colorer: Any, s: str, i: int) -> int:
     """Match Vue/Pug handlebar expression: {{...}}"""
-    return colorer.match_span(s, i, kind="literal3", begin="{{", end="}}")
+    return colorer.match_span(s, i, kind="keyword2", begin="{{", end="}}")
 
 
 # @+node:ekr.20250501.6: *3* pug_rule_interpolation

--- a/leo/plugins/importers/pug.py
+++ b/leo/plugins/importers/pug.py
@@ -1,0 +1,44 @@
+# @+leo-ver=5-thin
+# @+node:ekr.20250501.100: * @file ../plugins/importers/pug.py
+"""The @auto importer for Pug (HTML template language)."""
+
+from __future__ import annotations
+from typing import TYPE_CHECKING
+from leo.plugins.importers.base_importer import Importer
+
+if TYPE_CHECKING:
+    from leo.core.leoCommands import Commands as Cmdr
+    from leo.core.leoNodes import Position
+
+
+# @+others
+# @+node:ekr.20250501.101: ** class Pug_Importer(Importer)
+class Pug_Importer(Importer):
+    """A simple importer for Pug files."""
+
+    language = 'pug'
+    block_patterns: tuple = tuple()  # No block patterns: import as single node.
+
+    def __init__(self, c: Cmdr) -> None:
+        """Pug_Importer.__init__"""
+        super().__init__(c)
+
+
+# @-others
+
+
+def do_import(c: Cmdr, parent: Position, s: str) -> None:
+    """The importer callback for pug."""
+    Pug_Importer(c).import_from_string(parent, s)
+
+
+importer_dict = {
+    'extensions': [
+        '.pug',
+        '.jade',
+    ],
+    'func': do_import,
+}
+# @@language python
+# @@tabwidth -4
+# @-leo

--- a/leo/unittests/core/test_leoColorizer.py
+++ b/leo/unittests/core/test_leoColorizer.py
@@ -1582,6 +1582,47 @@ class TestColorizer(LeoUnitTest):
         )
         self.color('vbscript', text)
 
+    # @+node:ekr.20250501.40: *3* TestColorizer.test_colorizer_pug
+    def test_colorizer_pug(self):
+        text = self.prep(
+            """
+            //- This is a buffer-only comment.
+            // This is an HTML output comment.
+            doctype html
+            html
+                head
+                    title My Pug Page
+                body
+                    h1#title.main-header Hello Pug!
+                    p(class="description")
+                        | This is raw text.
+                    div(id="content")
+                        p Welcome to #{name}!
+                    mixin myMixin
+                        p Mixin content
+                    if condition
+                        p True!
+                    else
+                        p False!
+                    each item in items
+                        li= item
+
+                    // Multi-line backslash continuation in attribute value
+                    div(
+                      class="flex flex-col rounded-lg overflow-hidden \\
+                        border border-gray-200 bg-white \\
+                        transition-all duration-300 \\
+                        hover:-translate-y-1 hover:shadow-lg"
+                    )
+
+                    script:
+                        console.log("hello");
+                    style:
+                        body { color: red; }
+        """
+        )
+        self.color('pug', text)
+
     # @-others
 
 


### PR DESCRIPTION
### Add `@language pug` support for Leo Editor

As a frequent user of Vue 3's Pug syntax in my daily workflow, I found myself wishing Leo Editor could highlight Pug templates natively. So I decided to give it a try and implement it.

This PR adds basic Pug syntax highlighting support to Leo Editor:

- **New mode file**: `leo/modes/pug.py` — defines Pug syntax rules, including tags, attributes, comments, string interpolation, Vue directives (`v-if`, `v-for`, etc.), and Vue shorthand (`:bind`, `@event`)
- **Backslash line continuation**: supports multi-line strings with `\` (e.g., long `class` attributes spanning multiple lines)
- **Delegate highlighting**: `script:` and `style:` blocks inside Pug are delegated to JavaScript/CSS highlighters
- **Language registration**: `.pug` / `.jade` extensions and `@language pug` directive support via `leoApp.py`
- **Auto importer**: `leo/plugins/importers/pug.py` for `@auto` command support
- **Tests**: added `test_colorizer_pug` in `test_leoColorizer.py`

No changes to the core colorizer (`leoColorizer.py`) — colors can be customized with the standard `@color` syntax in `myLeoSettings.leo`:

```
@color pug.keyword1 = #FFA500 ; keywords (if, mixin, v-if, etc.) 
@color pug.comment1 = #6A9955 ; comments (//-) 
@color pug.literal1 = #CE9178 ; strings ("...") 
@color pug.literal3 = #9CDCFE ; interpolation (#{}) 
@color pug.keyword3 = #4EC9B0 ; handlebar expressions ({{}}) 
@color pug.operator = #D4D4D4 ; operators (=, |) 
@color pug.markup = #569CD6 ; script:/style: blocks
```

Any feedback or suggestions would be greatly appreciated!

<img width="848" height="333" alt="image" src="https://github.com/user-attachments/assets/bcc9377f-d5c3-49b1-9cb8-6165c1584d94" />
