### PR TITLE
PR fixes #4616: remove dead code

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -75,12 +75,11 @@ if TYPE_CHECKING:  # pragma: no cover
 # @-<< leoGlobals: annotations >>
 # @+<< leoGlobals: global constants >>
 # @+node:ekr.20240515093718.1: ** << leoGlobals: global constants >>
-in_bridge = False  # True: leoApp object loads a null Gui.
+in_bridge = False  # True: leoApp object loads a null Gui by default.
 in_vs_code = False  # #2098.
-minimum_python_version = '3.9'
-minimum_python_version_tuple = (3, 9, 0)
-v1, v2, v3, junk2, junk3 = sys.version_info
-python_version_tuple = (v1, v2, v3)
+minimum_python_version = '3.10'
+minimum_python_version_tuple = (3, 10, 0)
+python_version_tuple = sys.version_info[:3]
 isPython3 = python_version_tuple >= (3, 0, 0)
 isValidPython = python_version_tuple >= minimum_python_version_tuple
 isMac = sys.platform.startswith('darwin')

--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -144,29 +144,6 @@ WindowState = Qt.WindowState
 WindowType = Qt.WindowType
 WrapMode = QtGui.QTextOption.WrapMode
 # @-<< define PyQt6 enumerations >>
-# @+<< asserts for pyflakes >>
-# @+node:ekr.20240528045757.1: ** << asserts for pyflakes >>
-
-# For pyflakes so it doesn't complain about unused imports.
-assert QAction
-assert QActionGroup
-assert QCloseEvent
-assert QUrl
-
-# assert QtCore
-# assert Qsci
-# assert QtDesigner
-# assert QtGui
-# assert QtMultimedia
-# assert QtNetwork
-# assert QtOpenGL
-# assert QtSvg
-# assert printsupport
-# assert QtWebEngineCore
-# assert QtWebEngineWidgets
-# assert QtWidgets
-# assert uic
-# @-<< asserts for pyflakes >>
 # @+<< define standard abbreviations >>
 # @+node:ekr.20240528050716.1: ** << define standard abbreviations >>
 qt_version = QtCore.QT_VERSION_STR
@@ -178,18 +155,4 @@ except Exception:
     WebEngineAttribute = None
     _missing_modules.append('QtWebEngineCore.QWebEngineSettings')
 # @-<< define standard abbreviations >>
-
-if 0:  # Quickly becomes annoying.
-    # @+<< print a hint if an optional module does not exist >>
-    # @+node:ekr.20240528050657.1: ** << print a hint if an optional module does not exist >>
-    if _missing_modules:
-        print('')
-        print('leoQt.py: the following optional Qt modules do not exist:')
-        for z in sorted(_missing_modules):
-            print(f"  {z}")
-        print('')
-        print('Please run `pip install -r requirements.txt`')
-        print('')
-    # @-<< print a hint if an optional module does not exist >>
-
 # @-leo


### PR DESCRIPTION
See #4616.

**Ground rules**

- This PR will assume nothing about existing plugins or scripts.
- This PR will retire no existing modules.

 Note: Removing the `<< testing: set all optional Qt modules to None >>` section in `leoQt.py` generates mypy complaints. Resolving those complaints deserves a separate PR. See #4667.

**Changes**

- [x] `leoGlobals.py`:
    - Simplify computations of constants.
    - Retain `g.isPython3` for compatibility with existing plugins and scripts.
    - Update the minimum version to 3.10.
- [x] `leoQt.py`:
    - Remove unnecessary asserts supposedly for pyflakes.
    - Remove commented out code, *retaining* the top-level `_missing_modules` var.
