### PR TITLE
PR fixes #4664: crash in leoclient.py

### DIFF
--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -198,7 +198,7 @@ async def client_main_loop(timeout):
                     "param": param,
                 }
                 if trace:
-                    print(f"{tag}: send: id: {n} package: {request_package}")
+                    print(f"{tag}: send: id: {n:4} {action:>40} {param}")
                 # Send the next request.
                 request = json.dumps(request_package, separators=(',', ':'))
                 await websocket.send(request)

--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -24,6 +24,7 @@ verbose = False
 timeout = 0.1
 times_d: dict[int, float] = {}  # Keys are n, values are time sent.
 tot_response_time = 0.0
+n_async_responses = 0
 n_known_response_times = 0
 n_unknown_response_times = 0
 
@@ -164,11 +165,6 @@ def _show_response(n, d):
 
 
 # @+node:ekr.20210205144500.1: ** function: client_main_loop
-n_async_responses = 0
-n_known_response_times = 0
-n_unknown_response_times = 0
-
-
 async def client_main_loop(timeout):
     global n_async_responses
     uri = f"ws://{wsHost}:{wsPort}"

--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -2,6 +2,12 @@
 # @+node:ekr.20210202110241.1: * @file leoclient.py
 """
 An example client for leoserver.py, based on work by Félix Malboeuf. Used by permission.
+
+First start the server in one console: `python -m leo.core.leoserver`.
+Then start the client in another console: `python -m leo.core.leoclient`.
+
+This client runs the commands given in the `_get_action_list` function.
+The last command ends both the client and the server.
 """
 
 import asyncio
@@ -49,7 +55,7 @@ def _get_action_list():
     import inspect
     import os
 
-    server = leoserver.LeoServer()
+    server = leoserver.LeoServer(silent=True)
     # file_name = "xyzzy.leo"
     file_name = g.finalize_join(g.app.loadDir, '..', 'test', 'test.leo')
     assert os.path.exists(file_name), repr(file_name)

--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -32,8 +32,7 @@ n_unknown_response_times = 0
 # @+node:ekr.20210219105145.1: ** function: _dump_outline
 def _dump_outline(c):  # pragma: no cover
     """Dump the outline."""
-    tag = '_dump_outline'
-    print(f"{tag}: {c.shortFileName()}...\n")
+    print(f"_dump_outline: {c.shortFileName()}...\n")
     for p in c.all_positions():
         level_s = ' ' * 2 * p.level()
         print(f"{level_s}{p.childIndex():2} {p.v.gnx} {p.h}")
@@ -255,6 +254,8 @@ def main():
         print(f"{tag}: Keyboard interrupt")
     except ConnectionRefusedError:
         print(f"{tag}: No server running")
+    except asyncio.CancelledError:
+        print(f"{tag}: Cancelled")
 
 
 # @-others

--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -136,10 +136,7 @@ def _get_action_list():
 def _show_response(n, d):
     global n_known_response_times
     global n_unknown_response_times
-    # global times_d
     global tot_response_time
-    # global trace
-    # global verbose
 
     # Calculate response time.
     t1 = times_d.get(n)
@@ -152,12 +149,12 @@ def _show_response(n, d):
         tot_response_time += response_time
         n_known_response_times += 1
         response_time_s = f"{response_time:3.2}"
-    if not trace and not verbose:
+    if not trace:
         return
     action = d.get('action')
     if not verbose:
-        print(f"id: {d.get('id', '---'):3} d: {sorted(d)}")
         return
+    print(f"id: {d.get('id', '---'):3} d: {sorted(d)}")
     if action == 'open_file':
         g.printObj(d, tag=f"{tag}: got: open-file response time: {response_time_s}")
     elif action == 'get_all_commands':
@@ -178,12 +175,12 @@ async def client_main_loop(timeout):
     uri = f"ws://{wsHost}:{wsPort}"
     action_list = _get_action_list()
     async with websockets.connect(uri) as websocket:
-        if trace and verbose:
+        if trace:
             print(f"{tag}: asyncInterval.timeout: {timeout}")
         # Await the startup package.
         json_s = g.toUnicode(await websocket.recv())
         d = json.loads(json_s)
-        if trace and verbose:
+        if trace:
             print(f"startup package: {d}")
         n = 0
         while True:
@@ -201,7 +198,7 @@ async def client_main_loop(timeout):
                     "action": action,
                     "param": param,
                 }
-                if trace and verbose:
+                if trace:
                     print(f"{tag}: send: id: {n} package: {request_package}")
                 # Send the next request.
                 request = json.dumps(request_package, separators=(',', ':'))
@@ -249,14 +246,15 @@ async def client_main_loop(timeout):
         )  # About 0.1, regardless of tracing.
 
 
-# @+node:ekr.20210205141432.1: ** function: main
+# @+node:ekr.20210205141432.1: ** function: main (leoclient.py)
 def main():
-    loop = asyncio.get_event_loop()
     try:
-        loop.run_until_complete(client_main_loop(timeout))
+        asyncio.run(client_main_loop(timeout))  # #4664
     except KeyboardInterrupt:
         # This terminates the server abnormally.
         print(f"{tag}: Keyboard interrupt")
+    except ConnectionRefusedError:
+        print(f"{tag}: No server running")
 
 
 # @-others

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -5927,7 +5927,7 @@ def main() -> None:  # pragma: no cover (tested in client)
                         id_s = d.get('id', 'None')
                         action_s = d.get('action', 'None')
                         param_s = d.get('param', {})
-                        error = f"Error: {tag}: id: {id_s:4} {action_s:>40} {param_s} {e!s}"
+                        error = f"{tag}: Error: id: {id_s:4} {action_s:>40} {param_s} {e!s}"
                     else:
                         error = f"json syntax error: {json_message!r}"
                     data = f"{d}" if d else f"json syntax error: {json_message!r}"

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -944,7 +944,7 @@ class LeoServer:
 
     # @+others
     # @+node:felix.20210621233316.5: *3* server.__init__
-    def __init__(self, testing: bool = False) -> None:
+    def __init__(self, *, silent: bool = False, testing: bool = False) -> None:
         import leo.core.leoApp as leoApp
         import leo.core.leoBridge as leoBridge
 
@@ -1009,7 +1009,7 @@ class LeoServer:
         g.app.externalFilesController = ServerExternalFilesController()  # Replace
         g.app.idleTimeManager.start()
         t2 = time.process_time()
-        if not testing:
+        if not silent and not testing:
             print(f"LeoServer: init leoBridge in {t2 - t1:4.2} sec.", flush=True)
 
     # @+node:felix.20240110004711.1: *3* server.finishCreate

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -119,6 +119,7 @@ SERVER_STARTED_TOKEN = "LeoBridge started"  # Output when started successfully
 # Websocket connections (to be sent 'notify' messages)
 connectionsPool: set[Any] = set()
 connectionsTotal = 0  # Current connected client total
+gLoop = None  # Current server loop.
 # Customizable server options
 argFile = ""
 traces: list[str] = []  # list of traces names, to be used as flags to output traces
@@ -5505,7 +5506,7 @@ class LeoServer:
     # @-others
 
 
-# @+node:felix.20210621233316.105: ** main & helpers
+# @+node:felix.20210621233316.105: ** main & helpers (leoserver.py)
 def main() -> None:  # pragma: no cover (tested in client)
     """python script for leo integration via leoBridge"""
     if not websockets:
@@ -5554,8 +5555,8 @@ def main() -> None:  # pragma: no cover (tested in client)
         Close the server by stopping the loop
         """
         print('Closing Leo Server', flush=True)
-        if loop.is_running():
-            loop.stop()
+        if gLoop.is_running():
+            gLoop.stop()
         else:
             print('Loop was not running', flush=True)
 

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -1926,8 +1926,7 @@ class LeoServer:
 
     # @+node:felix.20220309205509.1: *5* server.goto_nav_entry
     def goto_nav_entry(self, param: Param) -> Response:
-        # activate entry in scon.its
-        tag = 'goto_nav_entry'
+        # activate entry in scon.its.
         c = self._check_c(param)
         scon: QuickSearchController = c.patched_quicksearch_controller
         try:
@@ -1935,8 +1934,7 @@ class LeoServer:
             scon.onSelectItem(it)
             focus = self._get_focus()
             result = {"focus": focus}
-        except Exception as e:
-            # raise ServerError(f"{tag}: exception selecting a nav entry: {e}")
+        except Exception:
             raise
         return self._make_response(result)
 

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -1934,8 +1934,8 @@ class LeoServer:
             scon.onSelectItem(it)
             focus = self._get_focus()
             result = {"focus": focus}
-        except Exception:
-            raise
+        except Exception as e:
+            raise ServerError(e)
         return self._make_response(result)
 
     # @+node:felix.20210621233316.19: *4* server.search commands

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -5554,11 +5554,11 @@ def main() -> None:  # pragma: no cover (tested in client)
         """
         Close the server by stopping the loop
         """
-        print('Closing Leo Server', flush=True)
-        if gLoop.is_running():
+        global gLoop
+        if gLoop and gLoop.is_running():
+            print('Closing Leo Server', flush=True)
             gLoop.stop()
-        else:
-            print('Loop was not running', flush=True)
+            gLoop = None
 
     # @+node:ekr.20210825172913.1: *3* function: general_yes_no_dialog & helpers
     def general_yes_no_dialog(
@@ -6019,7 +6019,9 @@ def main() -> None:  # pragma: no cover (tested in client)
                 await realtime_server.wait_closed()
 
             except KeyboardInterrupt:
-                print("Process interrupted", flush=True)
+                print("leoserver: keyboard interrupt", flush=True)
+            except asyncio.exceptions.CancelledError:
+                print("leoserver: cancelled", flush=True)
             finally:
                 if realtime_server:
                     realtime_server.close()
@@ -6031,7 +6033,12 @@ def main() -> None:  # pragma: no cover (tested in client)
         try:
             asyncio.run(start_server())
         except KeyboardInterrupt:
+            print('')
             print("Process interrupted", flush=True)
+        except Exception as e:
+            print('')
+            print(f"leoserver.py: exception starting the server:\n{e!r}")
+            return
     else:
         # For Python below 3.14
         loop = asyncio.get_event_loop()

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -905,7 +905,8 @@ class QuickSearchController:
         tgt = self.its.get(it)
         if not tgt:
             if not g.unitTesting:
-                print("onSelectItem: no target found for 'it' as key:" + str(it))
+                # print("onSelectItem: no target found for 'it' as key:" + str(it))
+                raise ServerError(f"onSelectItem: no target found for {it!s}")
             return
 
         # generic callable
@@ -1935,7 +1936,8 @@ class LeoServer:
             focus = self._get_focus()
             result = {"focus": focus}
         except Exception as e:
-            raise ServerError(f"{tag}: exception selecting a nav entry: {e}")
+            # raise ServerError(f"{tag}: exception selecting a nav entry: {e}")
+            raise
         return self._make_response(result)
 
     # @+node:felix.20210621233316.19: *4* server.search commands
@@ -5923,11 +5925,15 @@ def main() -> None:  # pragma: no cover (tested in client)
                     await websocket.close(code=1000, reason=str(e))
                     return
                 except ServerError as e:
+                    if d:
+                        id_s = d.get('id', 'None')
+                        action_s = d.get('action', 'None')
+                        param_s = d.get('param', {})
+                        error = f"Error: {tag}: id: {id_s:4} {action_s:>40} {param_s} {e!s}"
+                    else:
+                        error = f"json syntax error: {json_message!r}"
                     data = f"{d}" if d else f"json syntax error: {json_message!r}"
-                    error = f"{tag}:  ServerError: {e}...\n{tag}:  {data}"
-                    print("", flush=True)
                     print(error, flush=True)
-                    print("", flush=True)
                     package = {
                         "id": controller.current_id,
                         "action": controller.action,

--- a/leo/modes/python.py
+++ b/leo/modes/python.py
@@ -50,6 +50,7 @@ python_main_keywords_dict = {
     "ClassType": "keyword3",
     "CodeType": "keyword3",
     "ComplexType": "keyword3",
+    "ConnectionRefusedError": "keyword3",
     "DeprecationWarning": "keyword3",
     "DictProxyType": "keyword3",
     "DictType": "keyword3",


### PR DESCRIPTION
See #4664.

- [x] Fix various crashers.
- [x] Catch more exceptions and report them more clearly.
- [x] Improve traces and exception handling.
- [x] `leo/modes/python.py`: colorize `ConnectionRefusedError`.
- [x] Improve module-level docstrings from `leoserver.py` and `leoclient.py`.
- [x] Suppress confusing message when instantiating the `LeoServer` class from `leoclient.py`.

**Testing**

- [x] Test with Python 3.10.
- [x] Test with Python 3.14.