### PR TITLE
PR fixes #4667: mypy complaints

### DIFF
--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -3680,6 +3680,7 @@ class QScintillaColorizer(BaseColorizer):
         # Define/configure various lexers.
         self.reloadSettings()
         self.nullLexer: NullScintillaLexer | g.NullObject
+        self.lexersDict: dict[str, Any]
         if Qsci:
             self.lexersDict = self.makeLexersDict()
             self.nullLexer = NullScintillaLexer(c)

--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -8,9 +8,10 @@
 # @+node:ekr.20260505180734.1: ** << leoQt.py: imports >>
 from typing import Any
 from PyQt6 import QtCore, QtGui, QtWidgets
-from PyQt6.QtCore import Qt
-from PyQt6.QtCore import QUrl  # noqa
-from PyQt6.QtGui import QAction, QCloseEvent  # noqa
+from PyQt6.QtCore import Qt, QUrl
+from PyQt6.QtGui import QAction, QCloseEvent
+
+assert QUrl and QAction and QCloseEvent  # To placate pyflakes.
 # @-<< leoQt.py: imports >>
 
 # A public list of missing Qt modules. Good for debugging.

--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -11,88 +11,72 @@ from PyQt6.QtGui import QAction, QActionGroup, QCloseEvent
 # A public list of missing Qt modules. Good for debugging.
 _missing_modules: list[str] = []
 
-if 0:
-    # @+<< testing: set all optional Qt modules to None >>
-    # @+node:ekr.20240528043206.1: ** << testing: set all optional Qt modules to None >>
-    Qsci: Any = None
+# @+<< import optional Qt modules >>
+# @+node:ekr.20240528041831.1: ** << import optional Qt modules >>
+# Leo 6.8.0: do *not* assume these exist.
+try:
+    from PyQt6 import Qsci
+
+    assert Qsci
+except Exception:
+    Qsci = None
+    _missing_modules.append('Qsci')
+
+try:
+    from PyQt6 import QtDesigner
+except Exception:
     QtDesigner = None
+    _missing_modules.append('PyQt6.QtDesigner')
+
+try:
+    from PyQt6 import QtMultimedia
+except Exception:
     QtMultimedia = None
+    _missing_modules.append('PyQt6.QtMultimedia')
+
+try:
+    from PyQt6 import QtNetwork
+except Exception:
     QtNetwork = None
+    _missing_modules.append('PyQt6.QtNetwork')
+
+try:
+    from PyQt6 import QtOpenGL
+except Exception:
     QtOpenGL = None
+    _missing_modules.append('PyQt6.QtOpenGL')
+
+try:
+    from PyQt6 import QtPrintSupport as printsupport
+except Exception:
     printsupport = None
+    _missing_modules.append('PyQt6.QtPrintSupport')
+
+try:
+    from PyQt6 import QtWebEngineCore  # included with PyQt6-WebEngine
+except Exception:
     QtWebEngineCore = None
+    _missing_modules.append('PyQt6.QtWebEngineCore')
+
+try:
+    from PyQt6 import QtWebEngineWidgets
+except Exception:
     QtWebEngineWidgets = None
+    _missing_modules.append('PyQt6.QtWebEngineWidgets')
+
+try:
+    import PyQt6.QtSvg as QtSvg
+except Exception:
     QtSvg = None
+    _missing_modules.append('PyQt6.QtSvg')
+
+try:
+    from PyQt6 import uic
+except Exception:
     uic = None
-    # @-<< testing: set all optional Qt modules to None >>
-else:
-    # @+<< import optional Qt modules >>
-    # @+node:ekr.20240528041831.1: ** << import optional Qt modules >>
-    # Leo 6.8.0: do *not* assume these exist.
-    try:
-        from PyQt6 import Qsci
-
-        assert Qsci
-    except Exception:
-        Qsci = None
-        _missing_modules.append('Qsci')
-
-    try:
-        from PyQt6 import QtDesigner
-    except Exception:
-        QtDesigner = None
-        _missing_modules.append('PyQt6.QtDesigner')
-
-    try:
-        from PyQt6 import QtMultimedia
-    except Exception:
-        QtMultimedia = None
-        _missing_modules.append('PyQt6.QtMultimedia')
-
-    try:
-        from PyQt6 import QtNetwork
-    except Exception:
-        QtNetwork = None
-        _missing_modules.append('PyQt6.QtNetwork')
-
-    try:
-        from PyQt6 import QtOpenGL
-    except Exception:
-        QtOpenGL = None
-        _missing_modules.append('PyQt6.QtOpenGL')
-
-    try:
-        from PyQt6 import QtPrintSupport as printsupport
-    except Exception:
-        printsupport = None
-        _missing_modules.append('PyQt6.QtPrintSupport')
-
-    try:
-        from PyQt6 import QtWebEngineCore  # included with PyQt6-WebEngine
-    except Exception:
-        QtWebEngineCore = None
-        _missing_modules.append('PyQt6.QtWebEngineCore')
-
-    try:
-        from PyQt6 import QtWebEngineWidgets
-    except Exception:
-        QtWebEngineWidgets = None
-        _missing_modules.append('PyQt6.QtWebEngineWidgets')
-
-    try:
-        import PyQt6.QtSvg as QtSvg
-    except Exception:
-        QtSvg = None
-        _missing_modules.append('PyQt6.QtSvg')
-
-    try:
-        from PyQt6 import uic
-    except Exception:
-        uic = None
-        # On Linux, uic may be a standalone program.
-        _missing_modules.append('uic')
-    # @-<< import optional Qt modules >>
-
+    # On Linux, uic may be a standalone program.
+    _missing_modules.append('uic')
+# @-<< import optional Qt modules >>
 # @+<< define PyQt6 enumerations >>
 # @+node:ekr.20240303142509.3: ** << define PyQt6 enumerations >>
 AlignmentFlag = Qt.AlignmentFlag

--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -3,9 +3,11 @@
 """Leo's Qt import wrapper, specialized for Qt6."""
 
 # pylint: disable=no-name-in-module,unused-import
+from typing import Any
 from PyQt6 import QtCore, QtGui, QtWidgets
-from PyQt6.QtCore import Qt, QUrl  # noqa
-from PyQt6.QtGui import QAction, QActionGroup, QCloseEvent  # noqa
+from PyQt6.QtCore import Qt
+from PyQt6.QtCore import QUrl  # noqa
+from PyQt6.QtGui import QAction, QCloseEvent  # noqa
 
 # A public list of missing Qt modules. Good for debugging.
 _missing_modules: list[str] = []
@@ -130,6 +132,10 @@ WrapMode = QtGui.QTextOption.WrapMode
 # @+<< define standard abbreviations >>
 # @+node:ekr.20240528050716.1: ** << define standard abbreviations >>
 qt_version = QtCore.QT_VERSION_STR
+
+QWebEngineSettings: Any
+WebEngineAttribute: Any
+
 try:
     QWebEngineSettings = QtWebEngineCore.QWebEngineSettings
     WebEngineAttribute = QWebEngineSettings.WebAttribute

--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -3,10 +3,9 @@
 """Leo's Qt import wrapper, specialized for Qt6."""
 
 # pylint: disable=no-name-in-module,unused-import
-from typing import Any
 from PyQt6 import QtCore, QtGui, QtWidgets
-from PyQt6.QtCore import Qt, QUrl
-from PyQt6.QtGui import QAction, QActionGroup, QCloseEvent
+from PyQt6.QtCore import Qt, QUrl  # noqa
+from PyQt6.QtGui import QAction, QActionGroup, QCloseEvent  # noqa
 
 # A public list of missing Qt modules. Good for debugging.
 _missing_modules: list[str] = []

--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -3,17 +3,21 @@
 """Leo's Qt import wrapper, specialized for Qt6."""
 
 # pylint: disable=no-name-in-module,unused-import
+
+# @+<< leoQt.py: imports >>
+# @+node:ekr.20260505180734.1: ** << leoQt.py: imports >>
 from typing import Any
 from PyQt6 import QtCore, QtGui, QtWidgets
 from PyQt6.QtCore import Qt
 from PyQt6.QtCore import QUrl  # noqa
 from PyQt6.QtGui import QAction, QCloseEvent  # noqa
+# @-<< leoQt.py: imports >>
 
 # A public list of missing Qt modules. Good for debugging.
 _missing_modules: list[str] = []
 
-# @+<< import optional Qt modules >>
-# @+node:ekr.20240528041831.1: ** << import optional Qt modules >>
+# @+<< leoQt.py: import optional Qt modules >>
+# @+node:ekr.20240528041831.1: ** << leoQt.py: import optional Qt modules >>
 # Leo 6.8.0: do *not* assume these exist.
 try:
     from PyQt6 import Qsci
@@ -77,9 +81,9 @@ except Exception:
     uic = None
     # On Linux, uic may be a standalone program.
     _missing_modules.append('uic')
-# @-<< import optional Qt modules >>
-# @+<< define PyQt6 enumerations >>
-# @+node:ekr.20240303142509.3: ** << define PyQt6 enumerations >>
+# @-<< leoQt.py: import optional Qt modules >>
+# @+<< leoQt.py: define PyQt6 enumerations >>
+# @+node:ekr.20240303142509.3: ** << leoQt.py: define PyQt6 enumerations >>
 AlignmentFlag = Qt.AlignmentFlag
 AlignLeft = Qt.AlignmentFlag.AlignLeft
 AlignRight = Qt.AlignmentFlag.AlignRight
@@ -128,9 +132,9 @@ WidgetAttribute = Qt.WidgetAttribute
 WindowState = Qt.WindowState
 WindowType = Qt.WindowType
 WrapMode = QtGui.QTextOption.WrapMode
-# @-<< define PyQt6 enumerations >>
-# @+<< define standard abbreviations >>
-# @+node:ekr.20240528050716.1: ** << define standard abbreviations >>
+# @-<< leoQt.py: define PyQt6 enumerations >>
+# @+<< leoQt.py: define standard abbreviations >>
+# @+node:ekr.20240528050716.1: ** << leoQt.py: define standard abbreviations >>
 qt_version = QtCore.QT_VERSION_STR
 
 QWebEngineSettings: Any
@@ -143,5 +147,5 @@ except Exception:
     QWebEngineSettings = None
     WebEngineAttribute = None
     _missing_modules.append('QtWebEngineCore.QWebEngineSettings')
-# @-<< define standard abbreviations >>
+# @-<< leoQt.py: define standard abbreviations >>
 # @-leo

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -751,7 +751,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
             w.setLineWidth(lineWidth)
             self.setName(w, name)
         if not hasattr(w, 'leo_wrapper'):
-            w.leo_wrapper = QTextEditWrapper(widget=w, name=name, c=c)
+            w.leo_wrapper = QTextEditWrapper(widget=w, name=name, c=c)  # type:ignore
         return w
 
     # @+node:ekr.20110605121601.18164: *4* dw.createTreeWidget

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -258,16 +258,15 @@ class QTextMixin:
         if 'focus' in g.app.debug:
             print('BaseQTextWrapper.setFocus', self.widget)
         # Call the base class
-        assert isinstance(
-            self.widget,
-            (
-                QtWidgets.QTextBrowser,
-                QtWidgets.QLineEdit,
-                QtWidgets.QTextEdit,
-                Qsci and Qsci.QsciScintilla,
-            ),
-        ), self.widget
-        QtWidgets.QTextBrowser.setFocus(self.widget)
+        classes = [
+            QtWidgets.QTextBrowser,
+            QtWidgets.QLineEdit,
+            QtWidgets.QTextEdit,
+        ]
+        if Qsci:
+            classes.append(Qsci.QsciScintilla)
+        assert isinstance(self.widget, tuple(classes)), self.widget
+        QtWidgets.QTextBrowser.setFocus(self.widget)  # type:ignore
 
     # @+node:ekr.20140901062324.18717: *4* QTextMixin.Generic text
     # @+node:ekr.20140901062324.18703: *5* QTextMixin.appendText

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -214,6 +214,7 @@ from leo.plugins import qt_text
 try:
     from leo.core.leoQt import WebEngineAttribute, QtWebEngineWidgets
 
+    qwv: Any
     qwv = QtWebEngineWidgets.QWebEngineView
     has_webengineview = True
 except Exception:

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -211,10 +211,10 @@ from leo.core.leoQt import QtMultimedia, QtSvg, QUrl
 from leo.core.leoQt import ContextMenuPolicy, WrapMode
 from leo.plugins import qt_text
 
+qwv: Any = None
 try:
     from leo.core.leoQt import WebEngineAttribute, QtWebEngineWidgets
 
-    qwv: Any
     qwv = QtWebEngineWidgets.QWebEngineView
     has_webengineview = True
 except Exception:

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1049,7 +1049,8 @@ except ImportError:
     if not g.unitTesting:
         g.trace("Can't import QtWebEngineWidgets")
 
-qwv = None
+QWebEngineSettings: Any = None
+qwv: Any = None
 if has_webengineview:
     qwv = QtWebEngineWidgets.QWebEngineView
     try:


### PR DESCRIPTION
See #4667.

**Discussion**

This PR completes #4616: (remove dead code). The assignments to Null in leoQt.py are evil. In effect, they are implicit, global suppressions. The required new suppressions are explicit, reasonable, and informative.

Removing over-general mypy annotations always seems to help mypy do a more thorough job.

**leoQt.py**

- [x] Delete the section `<< testing: set all optional Qt modules to None >>`.
- [x] Suppress flake8 warnings about unused imports.
- [x] Suppress mypy warnings.

**Other files**

- [x] `qt_text.py`: Improve an assert and suppress a mypy complaint about an injected ivar.
- [x] `leoColorizer.py`: Suppress a mypy warning in the QScintillaColorizer class.
- [x] `viewrendered.py` and `viewrendered3.py`: suppress two similar mypy warnings.

