### PR TITLE
PR fixes #4662: Remove shell=True everywhere

### DIFF
--- a/leo/core/leoBackground.py
+++ b/leo/core/leoBackground.py
@@ -245,20 +245,12 @@ class BackgroundProcessManager:
         Start or queue a process described by command and fn.
         """
 
-        # Note: we can't set shell=True (at least on Windows) because the process
-        #       terminates immediately.
-        #
-        #       Anyway, setting shell=True is supposedly a security hazard.
-        #       https://docs.python.org/3/library/subprocess.html#security-considerations
-        #
-        #       However, we do not expect tools such as pylint, mypy, etc.
-        #       to create error messages that contain shell injection attacks!
         def open_process(data: ProcessData) -> Popen:
             g.es_print(f'{data.kind}: {g.shortFileName(data.fn)}')
             self.process_return_data = []
             proc = subprocess.Popen(
                 command,
-                shell=False,
+                shell=False,  # #4662.
                 stderr=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 universal_newlines=True,

--- a/leo/core/leoBackground.py
+++ b/leo/core/leoBackground.py
@@ -250,7 +250,6 @@ class BackgroundProcessManager:
             self.process_return_data = []
             proc = subprocess.Popen(
                 command,
-                shell=False,  # #4662.
                 stderr=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 universal_newlines=True,

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1081,7 +1081,7 @@ class Commands:
                 first_line = f.readline()
             return first_line.startswith('#!')
 
-        # @+node:tom.20241014154415.20: *4* runFile
+        # @+node:tom.20241014154415.20: *4* runFile @cmd c.execute-external-file
         def runfile(fullpath: str, processor: str, terminal: str) -> None:
             direc: str = os.path.expanduser(os.path.dirname(fullpath))
             if g.isWindows:
@@ -3392,7 +3392,7 @@ class Commands:
         try:
             proc = subprocess.Popen(
                 final_command,
-                shell=True,
+                shell=False,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
@@ -5233,12 +5233,12 @@ class Commands:
         args.append(f"--config {toml_s}")
 
         # Calculate the ruff command.
-        python = 'py' if g.isWindows else 'python'
+        python = sys.executable
         command = f"{python} -m ruff format {' '.join(args)} {filename}"
 
         # Run the command.
         try:
-            subprocess.Popen(command, shell=True).communicate()  # Wait for results.
+            subprocess.Popen(command).communicate()  # Wait for results.
             results = g.readFile(filename)
             if g.isWindows:
                 results = results.replace('\r', '')

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -942,8 +942,7 @@ class Commands:
             if not filetype:
                 return ''
             cmd = f'ftype {filetype}'
-            # pylint: disable=subprocess-run-check
-            proc = subprocess.run(cmd, shell=True, capture_output=True)
+            proc = subprocess.run(cmd, shell=True, capture_output=True, check=False)
             ftype_str = proc.stdout.decode('utf-8') or 'none'
             if not ftype_str:
                 return ''
@@ -973,10 +972,9 @@ class Commands:
                 'x-terminal-emulator',
             )
             TERM_STRINGS = ('*-terminal', '*term')
-            # pylint: disable=subprocess-run-check
             for ts in TERM_STRINGS:
                 cmd = f'find {dir} -type f -name {ts}'
-                proc = subprocess.run(cmd, shell=True, capture_output=True)
+                proc = subprocess.run(cmd, shell=True, capture_output=True, check=False)
                 terminals = proc.stdout.decode('utf-8')
                 for t in terminals.splitlines():
                     bare_term = t.split('/')[-1]
@@ -1031,11 +1029,10 @@ class Commands:
                 return EXECUTE_ARGS[terminal]
 
             # @+others
-            # @+node:tom.20241014154415.17: *5* get_help_message
+            # @+node:tom.20241014154415.17: *5* get_help_message (c.execute-external-file)
             def get_help_message(terminal: str, help_cmd: str) -> str:
                 cmd = f'{terminal} {help_cmd}'
-                # pylint: disable=subprocess-run-check
-                proc = subprocess.run(cmd, shell=True, capture_output=True)
+                proc = subprocess.run(cmd, shell=True, capture_output=True, check=False)
                 msg = proc.stdout.decode('utf-8')
                 if not msg:
                     # g.es('error:', proc.stderr.decode('utf-8'))

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -466,12 +466,10 @@ class ExternalFilesController:
             # could exist in @open-with nodes.
             command = '<no command>'
             if kind in ('os.system', 'os.startfile'):
-                # New in Leo 5.7:
-                # Use subProcess.Popen(..., shell=True)
                 c_arg = self.join(arg, fn)
                 if not testing:
                     try:
-                        subprocess.Popen(c_arg, shell=True)
+                        subprocess.Popen(c_arg)
                     except OSError:
                         g.es_print('c_arg', repr(c_arg))
                         g.es_exception()
@@ -497,7 +495,7 @@ class ExternalFilesController:
                 command = f"subprocess.Popen({c_arg})"
                 if not testing:
                     try:
-                        subprocess.Popen(c_arg, shell=True)
+                        subprocess.Popen(c_arg)
                     except OSError:
                         g.es_print('c_arg', repr(c_arg))
                         g.es_exception()

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7461,7 +7461,7 @@ def execute_shell_commands(commands: str | list[str], trace: bool = False) -> No
             g.trace(command)
         if command.startswith('&'):
             command = command[1:].strip()
-        proc = subprocess.Popen(command, shell=True)
+        proc = subprocess.Popen(command)
         if wait:
             proc.communicate()
 
@@ -7870,7 +7870,8 @@ def run_coverage_tests(module: str = '', filename: str = '') -> None:
     unittests_dir = g.finalize_join(g.app.loadDir, '..', 'unittests')
     assert os.path.exists(unittests_dir)
     os.chdir(unittests_dir)
-    prefix = r"python -m pytest --cov-report html --cov-report term-missing --cov "
+    python = sys.executable
+    prefix = rf"{python} -m pytest --cov-report html --cov-report term-missing --cov "
     command = f"{prefix} {module} {filename}"
     g.execute_shell_commands(command)
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5024,7 +5024,6 @@ def getGitVersion(directory: str = None) -> tuple[str, str, str]:
             'git log -n 1 --date=iso',
             cwd=directory or g.app.loadDir,
             stderr=subprocess.DEVNULL,
-            shell=True,
         )
     # #1209.
     except subprocess.CalledProcessError as e:

--- a/leo/plugins/at_produce.py
+++ b/leo/plugins/at_produce.py
@@ -140,8 +140,6 @@ def runList(c, aList):
                 f.write('produce: %s\n' % command)
                 p = subprocess.Popen(
                     command,
-                    # bufsize=bufsize,
-                    # close_fds=True, # Dubious to disable this.
                     stdin=PIPE,
                     stdout=PIPE,
                     stderr=PIPE,

--- a/leo/plugins/at_produce.py
+++ b/leo/plugins/at_produce.py
@@ -124,7 +124,7 @@ def getList(c, all):
     return aList
 
 
-# @+node:ekr.20040915085351.6: *3* runList
+# @+node:ekr.20040915085351.6: *3* runList (at_produce.py)
 def runList(c, aList):
     """
     Run all commands in aList (in a separate thread).
@@ -138,9 +138,6 @@ def runList(c, aList):
                 c.at_produce_command = command
                 command = command.lstrip(pr).lstrip()
                 f.write('produce: %s\n' % command)
-                # EKR: 2017/05/05
-                # Replace popen3 per https://docs.python.org/2.4/lib/node245.html
-                # fi, fo, fe  = os.popen3(command)
                 p = subprocess.Popen(
                     command,
                     # bufsize=bufsize,
@@ -148,7 +145,7 @@ def runList(c, aList):
                     stdin=PIPE,
                     stdout=PIPE,
                     stderr=PIPE,
-                    shell=True,
+                    # shell=True, # $4662.
                 )
                 fi, fo, fe = p.stdin, p.stdout, p.stderr
                 while 1:

--- a/leo/plugins/mime.py
+++ b/leo/plugins/mime.py
@@ -47,18 +47,18 @@ from leo.core import leoGlobals as g
 
 
 # @+others
-# @+node:dan.20090210183435.1: ** exec_full_cmd
+# @+node:dan.20090210183435.1: ** exec_full_cmd (mime.py)
 def exec_full_cmd(cmd):
     """Accept a command string including filename and return a function
     which executes the command."""
 
     def f(fpath):
-        return subprocess.Popen(cmd, shell=True)
+        return subprocess.Popen(cmd)
 
     return f
 
 
-# @+node:dan.20090210180636.27: ** exec_string_cmd
+# @+node:dan.20090210180636.27: ** exec_string_cmd (mime.py)
 def exec_string_cmd(cmd):
     """Accept a command string and return a function which opens executes the command,
     replacing %s with the full file path."""
@@ -68,7 +68,7 @@ def exec_string_cmd(cmd):
 
     def f(fpath):
         s = cmd % fpath
-        return subprocess.Popen(s, shell=True)
+        return subprocess.Popen(s)
 
     return f
 

--- a/leo/plugins/run_nodes.py
+++ b/leo/plugins/run_nodes.py
@@ -322,7 +322,7 @@ def OpenProcess(p):
     OutThread = readingThread()
     ErrThread = readingThread()
 
-    proc = subprocess.Popen(command, shell=True)
+    proc = subprocess.Popen(command)
     In = proc.stdin
     OutThread.File = proc.stdout  # type:ignore
     ErrThread.File = proc.stderr  # type:ignore

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1363,12 +1363,12 @@ def find_dir(name, path):
     return None
 
 
-# @+node:tom.20221231143118.1: ** get_gems()
+# @+node:tom.20221231143118.1: ** get_gems() (VR3)
 def check_gems(gem: str, encoding: str = 'utf-8') -> bool:
     """Check if a particular ruby gem is installed."""
     cmd = f'gem list {gem}'
     # pylint: disable = subprocess-run-check
-    proc = subprocess.run(cmd, shell=True, capture_output=True)
+    proc = subprocess.run(cmd, capture_output=True)
     installed = gem in proc.stdout.decode(encoding)
     return installed
 

--- a/leo/plugins/vim.py
+++ b/leo/plugins/vim.py
@@ -316,9 +316,9 @@ class VimCommander:
             ext = 'txt'
             fn = efc.create_temp_file(c, ext, c.p)
         c_arg = '%s %s' % (' '.join(args), fn)
-        command = 'subprocess.Popen(%s,shell=True)' % c_arg
+        command = f"subprocess.Popen({c_arg})"
         try:
-            subprocess.Popen(c_arg, shell=True)
+            subprocess.Popen(c_arg)
         except OSError:
             g.es_print(command)
             g.es_exception()

--- a/leo/scripts/beautify_all_leo.py
+++ b/leo/scripts/beautify_all_leo.py
@@ -32,7 +32,6 @@ args = " ".join(
         # '--verbose',
     )
 )
-### isWindows = sys.platform.startswith('win')
 targets = (
     f"leo{os.sep}commands",
     f"leo{os.sep}core",

--- a/leo/scripts/beautify_all_leo.py
+++ b/leo/scripts/beautify_all_leo.py
@@ -32,8 +32,7 @@ args = " ".join(
         # '--verbose',
     )
 )
-isWindows = sys.platform.startswith('win')
-python = 'py' if isWindows else 'python'
+### isWindows = sys.platform.startswith('win')
 targets = (
     f"leo{os.sep}commands",
     f"leo{os.sep}core",
@@ -44,6 +43,7 @@ targets = (
     f"leo{os.sep}unittests",
 )
 # Use -m so that __name__ == '__main__'.
+python = sys.executable
 command = f"{python} -m ruff format {args} {' '.join(targets)}"
 subprocess.Popen(command).communicate()
 # @-leo

--- a/leo/scripts/beautify_all_leo.py
+++ b/leo/scripts/beautify_all_leo.py
@@ -45,5 +45,5 @@ targets = (
 )
 # Use -m so that __name__ == '__main__'.
 command = f"{python} -m ruff format {args} {' '.join(targets)}"
-subprocess.Popen(command, shell=True).communicate()
+subprocess.Popen(command).communicate()
 # @-leo

--- a/leo/scripts/build_leo.py
+++ b/leo/scripts/build_leo.py
@@ -15,6 +15,7 @@ https://github.com/leo-editor/leo-editor/issues/3837
 import glob
 import os
 import subprocess
+import sys
 
 print(os.path.basename(__file__))
 
@@ -32,7 +33,8 @@ for z in glob.glob(f"{dist_dir}{os.sep}*.*"):
     os.remove(z)
 
 # build *both* sdist and wheel.
-command = 'python -m build > build_log.txt'
+python = sys.executable
+command = f"{python} -m build > build_log.txt"
 print('')
 print(command)
 print('')

--- a/leo/scripts/build_leo.py
+++ b/leo/scripts/build_leo.py
@@ -36,7 +36,7 @@ command = 'python -m build > build_log.txt'
 print('')
 print(command)
 print('')
-subprocess.Popen(command, shell=True).communicate()
+subprocess.Popen(command).communicate()
 
 print('See build_log.txt')
 # @-leo

--- a/leo/scripts/flake8_leo.py
+++ b/leo/scripts/flake8_leo.py
@@ -24,9 +24,7 @@ leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
 os.chdir(leo_editor_dir)
 
 args = ' '.join(sys.argv[1:]) + leo_editor_dir
-isWindows = sys.platform.startswith('win')
-python = 'py' if isWindows else 'python'
-
+python = sys.executable
 command = rf'{python} -m flake8 {args} --show-source --config={leo_editor_dir}{os.sep}setup.cfg'
 subprocess.Popen(command).communicate()
 

--- a/leo/scripts/flake8_leo.py
+++ b/leo/scripts/flake8_leo.py
@@ -28,6 +28,6 @@ isWindows = sys.platform.startswith('win')
 python = 'py' if isWindows else 'python'
 
 command = rf'{python} -m flake8 {args} --show-source --config={leo_editor_dir}{os.sep}setup.cfg'
-subprocess.Popen(command, shell=True).communicate()
+subprocess.Popen(command).communicate()
 
 # @-leo

--- a/leo/scripts/full_test_leo.py
+++ b/leo/scripts/full_test_leo.py
@@ -36,9 +36,7 @@ leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
 os.chdir(leo_editor_dir)
 
 args = ' '.join(sys.argv[1:])
-isWindows = sys.platform.startswith('win')
-python = 'py' if isWindows else 'python'
-
+python = sys.executable
 for command in [
     rf'{python} -m leo.scripts.beautify_all_leo',
     rf'{python} -m leo.scripts.flake8_leo',

--- a/leo/scripts/full_test_leo.py
+++ b/leo/scripts/full_test_leo.py
@@ -49,5 +49,5 @@ for command in [
     rf'{python} -m leo.scripts.check_leo',
     rf'{python} -m leo.scripts.pylint_leo',
 ]:
-    subprocess.Popen(command, shell=True).communicate()
+    subprocess.Popen(command).communicate()
 # @-leo

--- a/leo/scripts/inspect_wheel.py
+++ b/leo/scripts/inspect_wheel.py
@@ -14,6 +14,7 @@ https://github.com/leo-editor/leo-editor/issues/3837
 
 import os
 import subprocess
+import sys
 
 print(os.path.basename(__file__))
 
@@ -24,7 +25,8 @@ assert os.path.exists(leo_editor_dir), repr(leo_editor_dir)
 assert os.path.isdir(leo_editor_dir), repr(leo_editor_dir)
 os.chdir(leo_editor_dir)
 
-command = r'python -m wheel_inspect dist\leo-6.8.8-py3-none-any.whl >inspect_wheel.txt'
+python = sys.executable
+command = rf"{python} -m wheel_inspect dist\leo-6.8.8-py3-none-any.whl >inspect_wheel.txt"
 print(command)
 subprocess.Popen(command).communicate()
 

--- a/leo/scripts/inspect_wheel.py
+++ b/leo/scripts/inspect_wheel.py
@@ -26,7 +26,7 @@ os.chdir(leo_editor_dir)
 
 command = r'python -m wheel_inspect dist\leo-6.8.8-py3-none-any.whl >inspect_wheel.txt'
 print(command)
-subprocess.Popen(command, shell=True).communicate()
+subprocess.Popen(command).communicate()
 
 print('See inspect_wheel.txt')
 # @-leo

--- a/leo/scripts/install_leo_from_pypi.py
+++ b/leo/scripts/install_leo_from_pypi.py
@@ -11,6 +11,7 @@ https://github.com/leo-editor/leo-editor/issues/3837
 
 import os
 import subprocess
+import sys
 
 print(os.path.basename(__file__))
 
@@ -19,7 +20,8 @@ home_dir = os.path.expanduser("~")
 os.chdir(home_dir)
 
 # Install.
-command = 'python -m pip install leo==6.8.8'
+python = sys.executable
+command = f"{python} -m pip install leo==6.8.8"
 print(command)
 subprocess.Popen(command).communicate()
 # @-leo

--- a/leo/scripts/install_leo_from_pypi.py
+++ b/leo/scripts/install_leo_from_pypi.py
@@ -21,5 +21,5 @@ os.chdir(home_dir)
 # Install.
 command = 'python -m pip install leo==6.8.8'
 print(command)
-subprocess.Popen(command, shell=True).communicate()
+subprocess.Popen(command).communicate()
 # @-leo

--- a/leo/scripts/install_leo_from_testpypi.py
+++ b/leo/scripts/install_leo_from_testpypi.py
@@ -11,6 +11,7 @@ https://github.com/leo-editor/leo-editor/issues/3837
 
 import os
 import subprocess
+import sys
 
 print(os.path.basename(__file__))
 
@@ -20,7 +21,8 @@ os.chdir(home_dir)
 
 # Install.
 # --no-build-isolation
-command = 'python -m pip install -i https://test.pypi.org/simple/ leo==6.8.8'
+python = sys.executable
+command = f"{python} -m pip install -i https://test.pypi.org/simple/ leo==6.8.8"
 print(command)
 subprocess.Popen(command).communicate()
 # @-leo

--- a/leo/scripts/install_leo_from_testpypi.py
+++ b/leo/scripts/install_leo_from_testpypi.py
@@ -22,5 +22,5 @@ os.chdir(home_dir)
 # --no-build-isolation
 command = 'python -m pip install -i https://test.pypi.org/simple/ leo==6.8.8'
 print(command)
-subprocess.Popen(command, shell=True).communicate()
+subprocess.Popen(command).communicate()
 # @-leo

--- a/leo/scripts/install_leo_locally.py
+++ b/leo/scripts/install_leo_locally.py
@@ -15,8 +15,8 @@ https://github.com/leo-editor/leo-editor/issues/3837
 
 import glob
 import os
-import sys
 import subprocess
+import sys
 
 version = '6.8.8'
 
@@ -43,7 +43,8 @@ else:
     wheel_file = f"leo-{version}-py3-none-any.whl"
     #  --no-cache-dir  # slow
     #  --force-reinstall
-    command = rf"python -m pip install {dist_dir}{os.sep}{wheel_file}"
+    python = sys.executable
+    command = rf"{python} -m pip install {dist_dir}{os.sep}{wheel_file}"
     print(command)
     subprocess.Popen(command).communicate()
 

--- a/leo/scripts/install_leo_locally.py
+++ b/leo/scripts/install_leo_locally.py
@@ -45,7 +45,7 @@ else:
     #  --force-reinstall
     command = rf"python -m pip install {dist_dir}{os.sep}{wheel_file}"
     print(command)
-    subprocess.Popen(command, shell=True).communicate()
+    subprocess.Popen(command).communicate()
 
     # List site-packages/leo*.
     python_dir = os.path.dirname(sys.executable)

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -31,5 +31,5 @@ if 1:  # Quick.
     command = rf'{python} -m mypy leo'
 else:  # Safe.
     command = rf'{python} -m mypy --no-incremental leo'
-subprocess.Popen(command, shell=True).communicate()
+subprocess.Popen(command).communicate()
 # @-leo

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -24,12 +24,10 @@ leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
 os.chdir(leo_editor_dir)
 
 args = ' '.join(sys.argv[1:])
-isWindows = sys.platform.startswith('win')
-python = 'py' if isWindows else 'python'
-
+python = sys.executable
 if 1:  # Quick.
-    command = rf'{python} -m mypy leo'
+    command = rf"{python} -m mypy leo"
 else:  # Safe.
-    command = rf'{python} -m mypy --no-incremental leo'
+    command = rf"{python} -m mypy --no-incremental leo"
 subprocess.Popen(command).communicate()
 # @-leo

--- a/leo/scripts/pip_install_r.py
+++ b/leo/scripts/pip_install_r.py
@@ -30,5 +30,5 @@ for command in [
     f"{python} -m pip list",
 ]:
     print(command)
-    subprocess.Popen(command, shell=True).communicate()
+    subprocess.Popen(command).communicate()
 # @-leo

--- a/leo/scripts/pip_install_r.py
+++ b/leo/scripts/pip_install_r.py
@@ -22,9 +22,7 @@ assert os.path.exists(leo_editor_dir), repr(leo_editor_dir)
 assert os.path.isdir(leo_editor_dir), repr(leo_editor_dir)
 os.chdir(leo_editor_dir)
 
-isWindows = sys.platform.startswith('win')
-python = 'py' if isWindows else 'python'
-
+python = sys.executable
 for command in [
     f"{python} -m pip install -r requirements.txt --no-warn-script-location",
     f"{python} -m pip list",

--- a/leo/scripts/pip_uninstall_all.py
+++ b/leo/scripts/pip_uninstall_all.py
@@ -22,9 +22,7 @@ assert os.path.exists(leo_editor_dir), repr(leo_editor_dir)
 assert os.path.isdir(leo_editor_dir), repr(leo_editor_dir)
 os.chdir(leo_editor_dir)
 
-isWindows = sys.platform.startswith('win')
-python = 'py' if isWindows else 'python'
-
+python = sys.executable
 for command in [
     f"{python} -m pip freeze > temp_requirements.txt",
     f"{python} -m pip uninstall -r temp_requirements.txt -y --verbose",

--- a/leo/scripts/pip_uninstall_all.py
+++ b/leo/scripts/pip_uninstall_all.py
@@ -33,7 +33,7 @@ for command in [
     print('')
     print(command)
     print('')
-    subprocess.Popen(command, shell=True).communicate()
+    subprocess.Popen(command).communicate()
 
 if os.path.exists('temp_requirements.txt'):
     print('')

--- a/leo/scripts/pylint_leo.py
+++ b/leo/scripts/pylint_leo.py
@@ -25,9 +25,7 @@ leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
 os.chdir(leo_editor_dir)
 
 args = ' '.join(sys.argv[1:])
-isWindows = sys.platform.startswith('win')
-python = 'py' if isWindows else 'python'
-
+python = sys.executable
 rc_file_name = PylintCommand(c=None).get_rc_file()  # #4191.
 rc_file = rf"--rcfile {rc_file_name}"
 # print(__file__, rc_file)

--- a/leo/scripts/pylint_leo.py
+++ b/leo/scripts/pylint_leo.py
@@ -35,5 +35,5 @@ extensions = 'PyQt6.QtCore,PyQt6.QtGui,PyQt6.QtWidgets,PyQt6.QtWebEngineWidgets'
 extension_pkg = f"--extension-pkg-allow-list={extensions}"
 command = rf"{python} -m pylint leo {rc_file} {extension_pkg}"
 
-subprocess.Popen(command, shell=True).communicate()
+subprocess.Popen(command).communicate()
 # @-leo

--- a/leo/scripts/ruff_leo.py
+++ b/leo/scripts/ruff_leo.py
@@ -26,9 +26,7 @@ leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
 os.chdir(leo_editor_dir)
 
 args = ' '.join(sys.argv[1:])
-isWindows = sys.platform.startswith('win')
-python = 'py' if isWindows else 'python'
-
+python = sys.executable
 command = rf'{python} -m ruff check leo'
 subprocess.Popen(command).communicate()
 # @-leo

--- a/leo/scripts/ruff_leo.py
+++ b/leo/scripts/ruff_leo.py
@@ -30,5 +30,5 @@ isWindows = sys.platform.startswith('win')
 python = 'py' if isWindows else 'python'
 
 command = rf'{python} -m ruff check leo'
-subprocess.Popen(command, shell=True).communicate()
+subprocess.Popen(command).communicate()
 # @-leo

--- a/leo/scripts/run_installed_leo.py
+++ b/leo/scripts/run_installed_leo.py
@@ -28,5 +28,5 @@ else:
     command = 'python -m leo.core.runLeo'
     print(command)
     print('')
-    subprocess.Popen(command, shell=True).communicate()
+    subprocess.Popen(command).communicate()
 # @-leo

--- a/leo/scripts/run_installed_leo.py
+++ b/leo/scripts/run_installed_leo.py
@@ -25,7 +25,8 @@ if any('leo-editor' in z for z in sys.path):
 else:
     # Run.
     print(file_name)
-    command = 'python -m leo.core.runLeo'
+    python = sys.executable
+    command = f"{python} -m leo.core.runLeo"
     print(command)
     print('')
     subprocess.Popen(command).communicate()

--- a/leo/scripts/run_test_leo.py
+++ b/leo/scripts/run_test_leo.py
@@ -29,5 +29,5 @@ isWindows = sys.platform.startswith('win')
 python = 'py' if isWindows else 'python'
 
 command = rf'{python} -m unittest {args}'
-subprocess.Popen(command, shell=True).communicate()
+subprocess.Popen(command).communicate()
 # @-leo

--- a/leo/scripts/run_test_leo.py
+++ b/leo/scripts/run_test_leo.py
@@ -25,9 +25,7 @@ leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
 os.chdir(leo_editor_dir)
 
 args = ' '.join(sys.argv[1:])
-isWindows = sys.platform.startswith('win')
-python = 'py' if isWindows else 'python'
-
+python = sys.executable
 command = rf'{python} -m unittest {args}'
 subprocess.Popen(command).communicate()
 # @-leo

--- a/leo/scripts/uninstall_leo.py
+++ b/leo/scripts/uninstall_leo.py
@@ -13,8 +13,8 @@ https://github.com/leo-editor/leo-editor/issues/3837
 
 import os
 import shutil
-import sys
 import subprocess
+import sys
 
 file_name = os.path.basename(__file__)
 
@@ -34,7 +34,8 @@ else:
 
     # Remove Leo from Python's site-packages directory.
     # --yes: Don’t ask for confirmation of uninstall deletions.
-    command = 'python -m pip uninstall leo'
+    python = sys.executable
+    command = f"{python} -m pip uninstall leo"
     print(command)
     subprocess.Popen(command).communicate()
 

--- a/leo/scripts/uninstall_leo.py
+++ b/leo/scripts/uninstall_leo.py
@@ -36,7 +36,7 @@ else:
     # --yes: Don’t ask for confirmation of uninstall deletions.
     command = 'python -m pip uninstall leo'
     print(command)
-    subprocess.Popen(command, shell=True).communicate()
+    subprocess.Popen(command).communicate()
 
     if 0:  # This hack should no longer be necessary.
         # Delete the leo/leo.egg-info directory.

--- a/leo/scripts/update_leo_tools.py
+++ b/leo/scripts/update_leo_tools.py
@@ -32,5 +32,5 @@ for command in [
 ]:
     print('')
     print(command)
-    subprocess.Popen(command, shell=True).communicate()
+    subprocess.Popen(command).communicate()
 # @-leo

--- a/leo/scripts/update_leo_tools.py
+++ b/leo/scripts/update_leo_tools.py
@@ -21,9 +21,7 @@ assert os.path.exists(leo_editor_dir), repr(leo_editor_dir)
 assert os.path.isdir(leo_editor_dir), repr(leo_editor_dir)
 os.chdir(leo_editor_dir)
 
-isWindows = sys.platform.startswith('win')
-python = 'py' if isWindows else 'python'
-
+python = sys.executable
 for command in [
     f"{python} -m pip install --upgrade flake8",
     f"{python} -m pip install --upgrade mypy",

--- a/leo/scripts/upload_leo_to_pypi.py
+++ b/leo/scripts/upload_leo_to_pypi.py
@@ -11,6 +11,7 @@ https://github.com/leo-editor/leo-editor/issues/3837
 
 import os
 import subprocess
+import sys
 
 print(os.path.basename(__file__))
 
@@ -21,7 +22,8 @@ assert os.path.exists(leo_editor_dir), repr(leo_editor_dir)
 assert os.path.isdir(leo_editor_dir), repr(leo_editor_dir)
 os.chdir(leo_editor_dir)
 
-command = 'python -m twine upload -r pypi dist/*.* --verbose'
+python = sys.executable
+command = f"{python} -m twine upload -r pypi dist/*.* --verbose"
 
 # Upload.
 if 1:  # Don't do this until we are ready to release.

--- a/leo/scripts/upload_leo_to_pypi.py
+++ b/leo/scripts/upload_leo_to_pypi.py
@@ -26,7 +26,7 @@ command = 'python -m twine upload -r pypi dist/*.* --verbose'
 # Upload.
 if 1:  # Don't do this until we are ready to release.
     print(command)
-    subprocess.Popen(command, shell=True).communicate()
+    subprocess.Popen(command).communicate()
 else:
     print(f"Skipped: {command}")
 # @-leo

--- a/leo/scripts/upload_leo_to_testpypi.py
+++ b/leo/scripts/upload_leo_to_testpypi.py
@@ -11,6 +11,7 @@ https://github.com/leo-editor/leo-editor/issues/3837
 
 import os
 import subprocess
+import sys
 
 print(os.path.basename(__file__))
 
@@ -21,7 +22,8 @@ assert os.path.exists(leo_editor_dir), repr(leo_editor_dir)
 assert os.path.isdir(leo_editor_dir), repr(leo_editor_dir)
 os.chdir(leo_editor_dir)
 
-command = 'python -m twine upload -r testpypi dist/*.* --verbose'
+python = sys.executable
+command = f"{python} -m twine upload -r testpypi dist/*.* --verbose"
 
 # Upload
 if 1:  # Don't do this until we are ready to release.

--- a/leo/scripts/upload_leo_to_testpypi.py
+++ b/leo/scripts/upload_leo_to_testpypi.py
@@ -26,7 +26,7 @@ command = 'python -m twine upload -r testpypi dist/*.* --verbose'
 # Upload
 if 1:  # Don't do this until we are ready to release.
     print(command)
-    subprocess.Popen(command, shell=True).communicate()
+    subprocess.Popen(command).communicate()
 else:
     print(f"Skipped: {command}")
 # @-leo


### PR DESCRIPTION
See #4662.

- [x] Remove `shell=True` everywhere except where executing knows Windows commands.

**Breaking changes**

-  `g.execute_shell_commands` no longer sets `shell=True`. 
- The `at_produce.py`, `mime.py`, and `run_nodes.py` plugins may be affected.

**Other changes**

- [x] Use the following pattern to execute Python code within Python scripts.
```python
python = sys.executable
command = f"{python} -m whatever {args}"
g.execute_shell_commands(command)
```

**Testing**

- [x] Check that removing `shell=True` does not affect the scripts in `leo/scripts`.
   Trivial check: all contains fixed arguments to `subprocess.Popen'.