### PR TITLE
PR fixes #4652: key-related quirps

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4715,7 +4715,10 @@ class Commands:
 
     def logWantsFocusNow(self) -> None:
         c, log = self, self.frame.log
-        c.widgetWantsFocusNow(log and log.logCtrl)
+        try:  # 4652
+            c.widgetWantsFocusNow(log.logCtrl.widget)
+        except AttributeError:
+            c.widgetWantsFocusNow(log.logCtrl)
 
     def minibufferWantsFocusNow(self) -> None:
         c = self

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -18,6 +18,7 @@ from leo.core import leoGlobals as g
 from leo.core import leoFrame
 from leo.core.leoAPI import StringTextWrapper
 from leo.core.leoQt import QtWidgets
+from leo.plugins.qt_frame import LeoQTreeWidget
 from leo.plugins.qt_text import QLineEditWrapper, QTextEditWrapper, QTextMixin
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -434,6 +435,9 @@ class LeoKeyEvent:
         if isinstance(w, QtWidgets.QLineEdit):
             self.w = w.leo_wrapper = QLineEditWrapper(widget=w, name=c.widget_name(w), c=c)
             trace_always('New wrapper', f"{self.w.__class__.__name__} for {obj_name(w)}")
+            return
+        if isinstance(w, LeoQTreeWidget):  # A very special case.
+            self.w = w
             return
         # Anything should be valid here: we don't expect the wrapper to do key handling.
         self.w = w

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -390,7 +390,7 @@ class LeoKeyEvent:
 
         def trace(prefix: str, message: str) -> None:
             if 'keys' in g.app.debug:
-                trace_always(prefix, message)
+                print(f"{tag} {prefix:>14}: {message}")
 
         def trace_always(prefix: str, message: str) -> None:
             print('')
@@ -399,16 +399,16 @@ class LeoKeyEvent:
         if w is None:
             # Special case for headlines.
             if headline_wrapper := c.headline_wrapper(c.p):
-                trace('no w', 'headline')
                 self.w = headline_wrapper
+                trace('no w: in headline', self.w.__class__.__name__)
                 return
             # Default to the widget with focus, if any.
             w = g.app.gui.get_focus()
-            trace('no w: focus', w.__class__.__name__)
+            trace('no w --> ', w.__class__.__name__)
             if w is None:
                 return
-        else:
-            trace(f" text? {isinstance(w, QTextMixin):1} w", w.__class__.__name__)
+        # else:
+        #     trace(f" text? {isinstance(w, QTextMixin):1} w", w.__class__.__name__)
 
         # Ensure that self.w is a wrapper for all key-related Qt widgets.
         if c.widget_name(w).startswith('log'):
@@ -439,6 +439,7 @@ class LeoKeyEvent:
         if isinstance(w, LeoQTreeWidget):  # A very special case.
             self.w = w
             return
+
         # Anything should be valid here: we don't expect the wrapper to do key handling.
         self.w = w
         trace('unknown w', w.__class__.__name__)

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2409,21 +2409,15 @@ class KeyHandlerClass:
     def makeMasterGuiBinding(self, stroke: Stroke, w: QTextMixin = None) -> None:
         """Make a master gui binding for stroke in pane w, or in all the standard widgets."""
         c, k = self.c, self
-        if not (c.frame and c.frame.body and c.frame.tree):
+        if not c.frame:  ### and c.frame.body and c.frame.tree):
             return
         if w:
             widgets = [w]
         else:
-            #### New in Leo 4.5: we *must* make the binding in the binding widget.
-            ### bindingWidget = getattr(c.frame.tree, 'bindingWidget', None)
-
-            ### What about log widgets???
-
             wrapper = getattr(c.frame.body, 'wrapper', None)
             canvas = getattr(c.frame.tree, 'canvas', None)
             widgets = [z for z in (wrapper, canvas) if z]
         for w in widgets:
-            ### g.print_unique_message(f"{g.my_name()}: {w.__class__.__name__:>20} {g.callers()}")  ###
             # Make the binding only if no binding for the stroke exists in the widget.
             aList = k.masterGuiBindingsDict.get(stroke, [])
             if w not in aList:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2409,21 +2409,21 @@ class KeyHandlerClass:
     def makeMasterGuiBinding(self, stroke: Stroke, w: QTextMixin = None) -> None:
         """Make a master gui binding for stroke in pane w, or in all the standard widgets."""
         c, k = self.c, self
-        f = c.frame
+        if not (c.frame and c.frame.body and c.frame.tree):
+            return
         if w:
             widgets = [w]
         else:
-            # New in Leo 4.5: we *must* make the binding in the binding widget.
-            bindingWidget = (
-                f.tree and hasattr(f.tree, 'bindingWidget') and f.tree.bindingWidget or None
-            )
-            wrapper = f.body and hasattr(f.body, 'wrapper') and f.body.wrapper or None
-            canvas = f.tree and hasattr(f.tree, 'canvas') and f.tree.canvas or None
-            widgets = [c.miniBufferWidget, wrapper, canvas, bindingWidget]
-        aList: list[QTextMixin]
+            #### New in Leo 4.5: we *must* make the binding in the binding widget.
+            ### bindingWidget = getattr(c.frame.tree, 'bindingWidget', None)
+
+            ### What about log widgets???
+
+            wrapper = getattr(c.frame.body, 'wrapper', None)
+            canvas = getattr(c.frame.tree, 'canvas', None)
+            widgets = [z for z in (wrapper, canvas) if z]
         for w in widgets:
-            if not w:
-                continue
+            ### g.print_unique_message(f"{g.my_name()}: {w.__class__.__name__:>20} {g.callers()}")  ###
             # Make the binding only if no binding for the stroke exists in the widget.
             aList = k.masterGuiBindingsDict.get(stroke, [])
             if w not in aList:

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2561,8 +2561,10 @@ class LeoQtLog(leoFrame.LeoLog):
         c = self.c
         contents: Any
         if widget is None:
+            ### g.trace(f"{tabName:>4}: parent: {self.tabWidget.__class__.__name__} {g.callers(2)}")
             # widget is subclass of QTextBrowser.
-            widget = qt_text.LeoQTextBrowser(parent=None, c=c)
+            # #4652. Set the parent.
+            widget = qt_text.LeoQTextBrowser(parent=self.tabWidget, c=c)
             # contents is a wrapper.
             contents = qt_text.QTextEditWrapper(widget=widget, name='log', c=c)
             # Inject an ivar into the QTextBrowser that points to the wrapper.
@@ -2579,6 +2581,7 @@ class LeoQtLog(leoFrame.LeoLog):
             self.tabWidget.addTab(widget, tabName)
         else:
             # #1161: Don't set the wrapper unless it has the correct type.
+            ### g.trace(f"{tabName:>4}: widget: {widget.__class__.__name__} {g.callers(2)}")
             contents = widget  # Unlike text widgets, contents is the actual widget.
             if isinstance(contents, qt_text.QTextEditWrapper):
                 widget.leo_log_wrapper = widget  # The leo_log_wrapper is the widget itself.

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -1670,7 +1670,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
 
         text_name = 'body-text-renderer'
         w.setObjectName(text_name)
-        w.setReadOnly(True)
+        w.setReadOnly(False)  # #4652.
         # Create the standard Leo bindings in a wrapper widget.
         wrapper = qt_text.QTextEditWrapper(widget=w, name='rendering-pane-wrapper', c=c)
         c.k.completeAllBindingsForWidget(wrapper)


### PR DESCRIPTION
See #4652.


- [x] `LeoQtLog.createTab`: Set the `parent` kwarg when creating a `LeoQTextBrowser`.
- [x] `c.logWantsFocusNow`:  First, call `c.widgetWantsFocusNow(log.logCtrl.widget)`.
- [x] `viewrendered.py`: Clear the read-only bit.

**Other changes**

- [x] `k.makeMasterGuiBinding`: Simplify the code. Remove the reference to the dead `bindingWidget` ivar.
- [x] `LeoKeyEvent.__init__`: Improve traces.

**Testing**

- [x] Test that Alt-x nor Ctrl-s work in 'Log' and 'Completion' panes.
- [x] Test that bindings work in 'Log' pane after the `focus-to-log` command.
- [x] Test that there are no messages after pasting into VR pane (from menu or after Ctrl-c).
   Here is the message:
```console
p.b != w.getAllText() p: test
w:  <QTextEditWrapper: 1909264436752 body>
doCommand,new_cmd_wrapper,pasteText,afterChangeBody
```



