### PR TITLE
PR fixes #4625: crash in console gui.

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -19,7 +19,7 @@ from leo.core import leoGlobals as g
 from leo.core import leoExternalFiles
 from leo.core.leoCache import GlobalCacher
 from leo.core.leoQt import QCloseEvent
-from leo.plugins.cursesGui2 import KeyEvent
+
 
 if TYPE_CHECKING:
     from leo.core.leoJupytext import JupytextManager
@@ -1448,7 +1448,14 @@ class LeoApp:
         """Exit Leo, prompting to save unsaved outlines first."""
         # #4625: Special case for console gui.
         name = g.app.gui.guiName()
-        gui_event: Any = QCloseEvent() if name == 'qt' else KeyEvent(g.app.log.c)
+        gui_event: Any
+        if name == 'qt':
+            gui_event = QCloseEvent()
+        else:
+            # Do *not* import KeyEvent at the top level!
+            from leo.plugins.cursesGui2 import KeyEvent
+
+            gui_event = KeyEvent(g.app.log.c)
         if 'shutdown' in g.app.debug:
             g.trace(gui_event)
         # #2433: Use the same method as clicking on the close box.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1446,20 +1446,11 @@ class LeoApp:
     @cmd('quit-leo')
     def onQuit(self, event: LeoKeyEvent = None) -> None:
         """Exit Leo, prompting to save unsaved outlines first."""
-        # #4625: Special case for console gui.
-        name = g.app.gui.guiName()
-        gui_event: Any
-        if name == 'qt':
-            gui_event = QCloseEvent()
-        else:
-            # Do *not* import KeyEvent at the top level!
-            from leo.plugins.cursesGui2 import KeyEvent
-
-            gui_event = KeyEvent(g.app.log.c)
         if 'shutdown' in g.app.debug:
-            g.trace(gui_event)
-        # #2433: Use the same method as clicking on the close box.
-        g.app.gui.close_event(gui_event)
+            g.trace()
+
+        # #2433 - use the same method as clicking on the close box.
+        g.app.gui.close_event(QCloseEvent())
 
     # @+node:ekr.20230703100758.1: *4* app.saveSession
     def saveSession(self) -> None:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -19,6 +19,7 @@ from leo.core import leoGlobals as g
 from leo.core import leoExternalFiles
 from leo.core.leoCache import GlobalCacher
 from leo.core.leoQt import QCloseEvent
+from leo.plugins.cursesGui2 import KeyEvent
 
 if TYPE_CHECKING:
     from leo.core.leoJupytext import JupytextManager
@@ -1445,10 +1446,13 @@ class LeoApp:
     @cmd('quit-leo')
     def onQuit(self, event: LeoKeyEvent = None) -> None:
         """Exit Leo, prompting to save unsaved outlines first."""
+        # #4625: Special case for console gui.
+        name = g.app.gui.guiName()
+        gui_event: Any = QCloseEvent() if name == 'qt' else KeyEvent(g.app.log.c)
         if 'shutdown' in g.app.debug:
-            g.trace()
-        # #2433 - use the same method as clicking on the close box.
-        g.app.gui.close_event(QCloseEvent())  # type:ignore
+            g.trace(gui_event)
+        # #2433: Use the same method as clicking on the close box.
+        g.app.gui.close_event(gui_event)
 
     # @+node:ekr.20230703100758.1: *4* app.saveSession
     def saveSession(self) -> None:

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -1726,8 +1726,8 @@ class LeoCursesGui(leoGui.LeoGui):
     # Do *not* define setClipboardSelection.
     # setClipboardSelection = replaceClipboardWith
     # @+node:ekr.20260508095719.1: *4* CGui.close_event
-    def close_event(self, event: KeyEvent) -> None:
-        c = event.c
+    def close_event(self, event: Any) -> None:
+        c = self.log.c
         g.app.closeLeoWindow(frame=c.frame)
 
     # @+node:ekr.20170502021145.1: *4* CGui.dialogs

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -1725,6 +1725,11 @@ class LeoCursesGui(leoGui.LeoGui):
 
     # Do *not* define setClipboardSelection.
     # setClipboardSelection = replaceClipboardWith
+    # @+node:ekr.20260508095719.1: *4* CGui.close_event
+    def close_event(self, event: KeyEvent) -> None:
+        c = event.c
+        g.app.closeLeoWindow(frame=c.frame)
+
     # @+node:ekr.20170502021145.1: *4* CGui.dialogs
     # @+node:ekr.20170712145632.2: *5* CGui.createFindDialog
     def createFindDialog(self, c: Cmdr) -> None:


### PR DESCRIPTION
See #4625.

Ground rule:  Make no significant change to Leo's core.

- [x] Add `CGui.close_event`.

**Testing**

- [x] Verify that Leo's `quit-leo` command works with `--gui=console`.
- [x] Ensure copy/paste work. A change to Leo's core ruined copy/paste!