### PR TITLE
PR: Remove unnecessary 'type: ignore' statements, etc.

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -152,7 +152,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
             )
             script = script.replace("\r\n", "\n")
             try:
-                exec(script, c.abbrev_subst_env, c.abbrev_subst_env)  # type:ignore
+                exec(script, c.abbrev_subst_env, c.abbrev_subst_env)
             except Exception:
                 g.es('Error executing @data abbreviations-subst-env')
                 g.es_exception()

--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -456,14 +456,14 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
         self.save_sel = None
         while c.abbrev_subst_start in val:
             prefix, rest = val.split(c.abbrev_subst_start, 1)
-            content = rest.split(c.abbrev_subst_end, 1)
-            if len(content) != 2:
+            content_list = rest.split(c.abbrev_subst_end, 1)
+            if len(content_list) != 2:
                 break
-            content, rest = content  # type:ignore
+            content, rest = content_list
             try:
                 self.expanding = True
                 c.abbrev_subst_env['x'] = ''
-                exec(content, c.abbrev_subst_env, c.abbrev_subst_env)  # type:ignore
+                exec(content, c.abbrev_subst_env, c.abbrev_subst_env)
             except Exception:
                 g.es_print('exception evaluating', content)
                 g.es_exception()

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -8,36 +8,34 @@ from __future__ import annotations
 import os
 import pathlib
 import re
-import shlex
 import sys
 import time
 from typing import Optional, TYPE_CHECKING
 
-#
 # Third-party imports.
 try:
+    import mypy
     from mypy import api as mypy_api
 except Exception:
+    mypy = None
     mypy_api = None
+
 try:
-    import flake8
-    # #2248: Import only flake8.
+    import flake8  # #2248: Import only flake8.
 except ImportError:
     flake8 = None  # type:ignore
-try:
-    import mypy
-except Exception:
-    mypy = None  # type:ignore
+
 try:
     import pyflakes
     from pyflakes import api, reporter
 except Exception:
     pyflakes = None  # type:ignore
+
 try:
     from pylint import lint
 except Exception:
-    lint = None  # type:ignore
-#
+    lint = None
+
 # Leo imports.
 from leo.core import leoGlobals as g
 
@@ -743,8 +741,6 @@ class PylintCommand:
         if g.isWindows:
             args = args.replace('\\', '\\\\')
         command = f'{sys.executable} -c "from pylint import lint; args=[{args}]; lint.Run(args)"'
-        if not g.isWindows:
-            command = shlex.split(command)  # type:ignore
 
         # Run the command using the BPM.
         bpm = g.app.backgroundProcessManager

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -374,7 +374,7 @@ def open_outline(self: Self, event: LeoKeyEvent = None) -> None:
     ]
     fileName = g.app.gui.runOpenFileDialog(c, title="Open", filetypes=filetypes)
     if fileName:
-        g.openWithFileName(fileName, old_c=c)  # type:ignore
+        g.openWithFileName(fileName, old_c=c)
 
 
 # @+node:ekr.20140717074441.17772: *3* c_file.refreshFromDisk

--- a/leo/commands/controlCommands.py
+++ b/leo/commands/controlCommands.py
@@ -46,8 +46,8 @@ class ControlCommandsClass(BaseEditCommandsClass):
                 shell=g.isWindows,
             )
             out, err = proc.communicate()
-            for line in g.splitLines(out):  # type:ignore
-                g.es_print(g.toUnicode(line.rstrip()))
+            for line in g.splitLines(g.toUnicode(out)):
+                g.es_print(line.rstrip())
         except Exception:
             g.es_exception()
         k.keyboardQuit()  # Inits vim mode too.

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -43,18 +43,16 @@ class BaseSpellWrapper:
     # @+node:ekr.20150514063305.513: *3* BaseSpellWrapper.clean_dict
     def clean_dict(self, fn: str) -> None:
         if g.os_path_exists(fn):
-            f = open(fn, mode='rb')
-            s = f.read()
-            f.close()
+            with open(fn, mode='rb') as f:
+                s = f.read()
             # Blanks lines cause troubles.
             s2 = s.replace(b'\r', b'').replace(b'\n\n', b'\n')
             if s2.startswith(b'\n'):
                 s2 = s2[1:]
             if s != s2:
                 g.es_print('cleaning', fn)
-                f = open(fn, mode='wb')  # type:ignore
-                f.write(s2)
-                f.close()
+                with open(fn, mode='wb') as f:
+                    f.write(s2)
 
     # @+node:ekr.20180207071114.5: *3* BaseSpellWrapper.create
     def create(self, fn: str) -> None:
@@ -97,6 +95,37 @@ class BaseSpellWrapper:
     # @+node:ekr.20150514063305.515: *3* BaseSpellWrapper.ignore
     def ignore(self, word: str) -> None:
         self.d.add_to_session(word)
+
+    # @+node:ekr.20150514063305.517: *3* BaseSpellWrapper.process_word
+    def process_word(self, word: str) -> list[str]:
+        """
+        Check the word. Return None if the word is properly spelled.
+        Otherwise, return a list of alternatives.
+        """
+        d = self.d
+        if not d:
+            return None
+        if d.check(word):
+            return None
+        # Speed doesn't matter here. The more we find, the more convenient.
+        # Remove all digits.
+        word = ''.join([i for i in word if not i.isdigit()])
+        if d.check(word) or d.check(word.lower()):
+            return None
+        if word.find('_') > -1:
+            # Snake case.
+            words = word.split('_')
+            for word2 in words:
+                if not d.check(word2) and not d.check(word2.lower()):
+                    return d.suggest(word)
+            return None
+        words = g.unCamel(word)
+        if words:
+            for word2 in words:
+                if not d.check(word2) and not d.check(word2.lower()):
+                    return d.suggest(word)
+            return None
+        return d.suggest(word)
 
     # @+node:ekr.20180209142310.1: *3* BaseSpellWrapper.show_info
     def show_info(self) -> None:
@@ -293,6 +322,7 @@ class DefaultWrapper(BaseSpellWrapper):
 
     # @+node:ekr.20180209141933.1: *3* DefaultWrapper.show_info
     def show_info(self) -> None:
+        table: tuple
         if self.main_fn:
             g.es_print('Default spell checker')
             table = (
@@ -303,9 +333,9 @@ class DefaultWrapper(BaseSpellWrapper):
             g.es_print('\nSpell checking has been disabled.')
             g.es_print('To enable, put a main dictionary at:')
             g.es_print('~/.leo/main_spelling_dict.txt')
-            table = (  # type:ignore
+            table = (
                 ('user', self.user_fn),
-            )
+            )  # fmt: skip
         for kind, fn in table:
             g.es_print(f"{kind} dictionary: {(g.os_path_normpath(fn) if fn else 'None')}")
 
@@ -409,37 +439,6 @@ class EnchantWrapper(BaseSpellWrapper):
             g.es_print('pip install pyenchant, NOT enchant')
         return d
 
-    # @+node:ekr.20150514063305.517: *3* enchant.process_word
-    def process_word(self, word: str) -> list[str]:
-        """
-        Check the word. Return None if the word is properly spelled.
-        Otherwise, return a list of alternatives.
-        """
-        d = self.d
-        if not d:
-            return None
-        if d.check(word):
-            return None
-        # Speed doesn't matter here. The more we find, the more convenient.
-        # Remove all digits.
-        word = ''.join([i for i in word if not i.isdigit()])
-        if d.check(word) or d.check(word.lower()):
-            return None
-        if word.find('_') > -1:
-            # Snake case.
-            words = word.split('_')
-            for word2 in words:
-                if not d.check(word2) and not d.check(word2.lower()):
-                    return d.suggest(word)
-            return None
-        words = g.unCamel(word)
-        if words:
-            for word2 in words:
-                if not d.check(word2) and not d.check(word2.lower()):
-                    return d.suggest(word)
-            return None
-        return d.suggest(word)
-
     # @-others
 
 
@@ -457,6 +456,7 @@ class SpellCommandsClass(BaseEditCommandsClass):
         # pylint: disable=super-init-not-called
         self.c = c
         self.handler: SpellTabHandler = None
+        self.suggestion_idx = 0
         self.reloadSettings()
 
     def reloadSettings(self) -> None:
@@ -526,8 +526,8 @@ class SpellCommandsClass(BaseEditCommandsClass):
         if not self.suggestions:
             g.es('[no suggestions]')
             return
-        word = self.suggestions[self.suggestion_idx]  # type:ignore
-        self.suggestion_idx = (self.suggestion_idx + 1) % len(self.suggestions)  # type:ignore
+        word = self.suggestions[self.suggestion_idx]
+        self.suggestion_idx = (self.suggestion_idx + 1) % len(self.suggestions)
         self.as_you_type_replace(word)
 
     # @+node:ekr.20150514063305.496: *4* as_you_type_undo
@@ -638,13 +638,14 @@ class SpellTabHandler:
         self.currentWord: str = None
         self.outerScrolledFrame = None
         self.seen: set[str] = set()  # Adding a word to seen will ignore it until restart.
+        self.spellController: EnchantWrapper | DefaultWrapper
         if enchant:
             self.spellController = EnchantWrapper(c)
             self.tab = g.app.gui.createSpellTab(c, self, tabName)
             self.loaded = True
             return
         # Create the spellController for the show-spell-info command.
-        self.spellController = DefaultWrapper(c)  # type:ignore
+        self.spellController = DefaultWrapper(c)
         self.loaded = bool(self.spellController.main_fn)
         if self.loaded:
             # Create the spell tab only if the main dict exists.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3113,7 +3113,7 @@ class LoadManager:
                     return
                 log = app.log
                 # Compute the effective args.
-                d = {
+                d: dict[str, Any] = {
                     'color': None,
                     'commas': False,
                     'newline': True,
@@ -3122,7 +3122,7 @@ class LoadManager:
                 }
                 # Handle keywords for g.pr and g.es_print.
                 d = g.doKeywordArgs(keys, d)
-                color: str = d.get('color')  # type:ignore
+                color: str = d.get('color')
                 if color == 'suppress':
                     return
                 if log and color is None:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1448,7 +1448,7 @@ class LeoApp:
         if 'shutdown' in g.app.debug:
             g.trace()
         # #2433 - use the same method as clicking on the close box.
-        g.app.gui.close_event(QCloseEvent())  # type:ignore
+        g.app.gui.close_event(QCloseEvent())
 
     # @+node:ekr.20230703100758.1: *4* app.saveSession
     def saveSession(self) -> None:

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -349,7 +349,7 @@ class AtFile:
             return
         path = c.fullPath(p)
         if g.os_path_exists(path):
-            g.openWithFileName(path, old_c=c)  # type:ignore
+            g.openWithFileName(path, old_c=c)
         else:
             g.red(f"file not found: {path}")
 
@@ -1449,7 +1449,7 @@ class AtFile:
         )
         for pred, func in table:
             if pred():
-                func(p)  # type:ignore
+                func(p)
                 break
         else:  # pragma: no cover
             g.trace(f"Can not happen: {p.h}")
@@ -1622,7 +1622,7 @@ class AtFile:
         )
         for pred, func in table:
             if pred():
-                func(p)  # type:ignore
+                func(p)
                 return
         g.trace(f"Can not happen unknown @<file> kind: {p.h}")
 
@@ -3343,7 +3343,7 @@ class AtFile:
     def getPathUa(self, p: Position) -> str:
         if hasattr(p.v, 'tempAttributes'):
             d = p.v.tempAttributes.get('read-path', {})
-            return d.get('path')  # type:ignore
+            return d.get('path')
         return ''
 
     def setPathUa(self, p: Position, path: str) -> None:

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -191,7 +191,7 @@ class BridgeController:
         if self.useCaches:
             g.app.setGlobalDb()  # #556.
         else:
-            g.app.db = g.NullObject()  # type:ignore
+            g.app.db = g.NullObject()
             g.app.global_cacher = g.NullObject()  # type:ignore
         if self.readSettings:
             # reads only standard settings files, using a null gui.

--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -98,7 +98,7 @@ class GlobalCacher:
             if trace:
                 g.es_exception()
             # Use a plain dict as a dummy.
-            self.db = {}  # type:ignore
+            self.db = {}
 
     # @+others
     # @+node:ekr.20180627045750.1: *3* g_cacher.clear

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -629,7 +629,7 @@ class Commands:
             try:
                 aList = [z.strip() for z in c.fixedWindowPositionData if z.strip()]
                 w, h, left, t = aList
-                c.fixedWindowPosition = [int(w), int(h), int(left), int(t)]  # ty--pe:ignore
+                c.fixedWindowPosition = [int(w), int(h), int(left), int(t)]
             except Exception:
                 g.error('bad @data fixedWindowPosition', repr(self.fixedWindowPosition))
         else:
@@ -2119,7 +2119,7 @@ class Commands:
             # a VNode not in the tree
             return None
         v, n = stack.pop()
-        p = leoNodes.Position(v, n, stack)  # type:ignore
+        p = leoNodes.Position(v, n, stack)
         return p
 
     # @+node:ekr.20090130135126.1: *4* c.Properties

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -449,7 +449,7 @@ class Commands:
     def initOptionsIvars(self) -> None:
         """Init Commander ivars corresponding to user options."""
         self.fixed = False
-        self.fixedWindowPosition: list[tuple[int, int, int, int]] = []
+        self.fixedWindowPosition: list[int] = []
         self.forceExecuteEntireBody = False
         self.focus_border_color = 'white'
         self.focus_border_width = 1  # pixels
@@ -629,7 +629,7 @@ class Commands:
             try:
                 aList = [z.strip() for z in c.fixedWindowPositionData if z.strip()]
                 w, h, left, t = aList
-                c.fixedWindowPosition = int(w), int(h), int(left), int(t)  # type:ignore
+                c.fixedWindowPosition = [int(w), int(h), int(left), int(t)]  # ty--pe:ignore
             except Exception:
                 g.error('bad @data fixedWindowPosition', repr(self.fixedWindowPosition))
         else:

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1915,7 +1915,7 @@ class LocalConfigManager:
         family = self.get(family, "family")
         size = self.get(size, "size")
         if size in (None, 0):
-            size = str(defaultSize)  # type:ignore
+            size = str(defaultSize)
         slant = self.get(slant, "slant")
         if slant in (None, ""):
             slant = "roman"

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1533,7 +1533,7 @@ class GlobalConfigManager:
             family = None
         size = self.get(size, "size")
         if size in (None, 0):
-            size = str(defaultSize)  # type:ignore
+            size = str(defaultSize)
         slant = self.get(slant, "slant")
         if slant in (None, ""):
             slant = "roman"

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1178,8 +1178,8 @@ class FileCommands:
             g.trace('there should be at least one top level node!')
             return None
 
-        def findNode(x: VNode) -> VNode:
-            return fc.gnxDict.get(x, c.hiddenRootNode)  # type:ignore
+        def findNode(x: Any) -> VNode:
+            return fc.gnxDict.get(x, c.hiddenRootNode)
 
         # let us replace every gnx with the corresponding vnode
         for v in vnodes:
@@ -1226,7 +1226,7 @@ class FileCommands:
                 ).fetchall(),
             )
             # mypy complained that geom must be a tuple, not a generator.
-            geom = tuple(d.get(*x) for x in zip(keys, geom))  # type:ignore
+            geom = tuple(d.get(*x) for x in zip(keys, geom))
         except sqlite3.OperationalError:
             pass
         return geom

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2675,9 +2675,9 @@ tupleToString = objToString
 # @+node:ekr.20120912153732.10597: *4* g.wait
 def sleep(n: float) -> None:
     """Wait about n milliseconds."""
-    from time import sleep  # type:ignore
+    from time import sleep
 
-    sleep(n)  # type:ignore
+    sleep(n)
 
 
 # @+node:ekr.20171023140544.1: *4* g.printObj & aliases
@@ -3952,8 +3952,6 @@ def writeFile(contents: bytes | str, encoding: str, fileName: str) -> bool:
         return True
     except Exception as e:
         print(f"exception writing: {fileName}:\n{e}")
-        # g.trace(g.callers())
-        # g.es_exception()
         return False
 
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1956,8 +1956,8 @@ class Tracer:
             g.pr(f"{self.calledDict.get(key, 0):d}", key)  # noqa  # conflict between flake8 and black.
             # Print the called functions.
             d = self.callDict.get(key)
-            for key2 in sorted(d):  # type:ignore
-                g.pr(f"{d.get(key2):8d}", key2)  # type:ignore
+            for key2 in sorted(d):
+                g.pr(f"{d.get(key2):8d}", key2)
 
     # @+node:ekr.20080531075119.5: *4* stop
     def stop(self) -> None:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -207,7 +207,7 @@ def check_cmd_instance_dict(c: Cmdr, g: LeoGlobals) -> None:
     for key in d:
         ivars = d.get(key)
         # Produces warnings.
-        obj = ivars2instance(c, g, ivars)  # type:ignore
+        obj = ivars2instance(c, g, ivars)
         if obj:
             name = obj.__class__.__name__
             if name != key:
@@ -310,7 +310,7 @@ commander_command = CommanderCommand
 
 
 # @+node:ekr.20150508164812.1: *3* g.ivars2instance
-def ivars2instance(c: Cmdr, g: LeoGlobals, ivars: list[str]) -> object:
+def ivars2instance(c: Cmdr, g: LeoGlobals, ivars: list[str]) -> Any:
     """
     Return the instance of c given by ivars.
     ivars is a list of strings.
@@ -5177,7 +5177,7 @@ def gitInfo(path: str = None) -> tuple[str, str]:
     except IOError:
         try:
             path = g.finalize_join(git_dir, 'packed-refs')
-            with open(path) as f:  # type:ignore
+            with open(path) as f:
                 for line in f:
                     if line.strip().endswith(' ' + pointer):
                         commit = line.split()[0][0:12]
@@ -7336,15 +7336,14 @@ def createTopologyList(c: Cmdr, root: Position = None, useHeadlines: bool = Fals
     if not root:
         root = c.rootPosition()
     v = root
+    aList: list
     if useHeadlines:
-        aList = [
-            (v.numberOfChildren(), v.headString()),
-        ]  # type: ignore
+        aList = [(v.numberOfChildren(), v.headString())]
     else:
-        aList = [v.numberOfChildren()]  # type: ignore
+        aList = [v.numberOfChildren()]
     child = v.firstChild()
     while child:
-        aList.append(g.createTopologyList(c, child, useHeadlines))  # type: ignore
+        aList.append(g.createTopologyList(c, child, useHeadlines))
         child = child.next()
     return aList
 

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2120,7 +2120,7 @@ class KeyHandlerClass:
     def bindKey(
         self,
         pane: str,
-        shortcut: str,
+        shortcut: Any,
         callback: Callable,
         commandName: str,
         modeFlag: bool = False,

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -76,8 +76,8 @@ class NodeIndices:
                 id_, t, n = self.scanGnx(gnx)
                 if t == ni.timeString and n is not None:
                     try:
-                        n = int(n)  # type:ignore
-                        self.lastIndex = max(self.lastIndex, n)  # type:ignore
+                        n_i = int(n)
+                        self.lastIndex = max(self.lastIndex, n_i)
                     except Exception:  # pragma: no cover
                         g.es_exception()
                         self.lastIndex += 1
@@ -1454,9 +1454,8 @@ class Position:
             p.v = p.v.children[n]
             p._childIndex = n
         else:
-            # mypy rightly doesn't like setting p.v to None.
             # Leo's code must use the test `if p:` as appropriate.
-            p.v = None  # type:ignore   # pragma: no cover
+            p.v = None
         return p
 
     # @+node:ekr.20080416161551.207: *4* p.moveToParent
@@ -1466,9 +1465,8 @@ class Position:
         if p.v and p.stack:
             p.v, p._childIndex = p.stack.pop()
         else:
-            # mypy rightly doesn't like setting p.v to None.
             # Leo's code must use the test `if p:` as appropriate.
-            p.v = None  # type:ignore
+            p.v = None
         return p
 
     # @+node:ekr.20080416161551.208: *4* p.moveToThreadBack

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -231,7 +231,7 @@ class BaseLeoPlugin:
         Ctor for the BaseLeoPlugin class.
         """
         # mypy can't infer the type of keywords['c'].
-        self.c: Cmdr = keywords['c']  # type:ignore
+        self.c: Any = keywords['c']
         self.commandNames: list[str] = []
 
     # @+node:ekr.20100908125007.6013: *3* BaseLeoPlugin.setCommand

--- a/leo/plugins/demo.py
+++ b/leo/plugins/demo.py
@@ -766,7 +766,7 @@ class Demo:
 
 # @+node:ekr.20170208045907.1: ** Graphics classes & helpers
 # @+node:ekr.20170206203005.1: *3*  class Label (QLabel)
-class Label(QtWidgets.QLabel):  # type:ignore
+class Label(QtWidgets.QLabel):
     """A class for user-defined callouts in demo.py."""
 
     def __init__(self, text, font=None, pane=None, position=None, stylesheet=None):

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -313,19 +313,17 @@ class LeoQtGui(leoGui.LeoGui):
     ) -> None:
         """
         Create a script button for the script in node p.
-        The button's text defaults to p.headString."""
-        # pylint: disable=line-too-long
+        The button's text defaults to p.headString.
+        """
         k = c.k
         if p and not buttonText:
             buttonText = p.h.strip()
         if not buttonText:
             buttonText = 'Unnamed Script Button'
-        # @+<< create the button b >>
-        # @+node:ekr.20110605121601.18529: *4* << create the button b >>
+        # create the button.
         iconBar = c.frame.getIconBarObject()
         b = iconBar.add(text=buttonText)
 
-        # @-<< create the button b >>
         # @+<< define the callbacks for b >>
         # @+node:ekr.20110605121601.18530: *4* << define the callbacks for b >>
         def deleteButtonCallback(
@@ -362,27 +360,16 @@ class LeoQtGui(leoGui.LeoGui):
             # Do not assume the script will want to remain in this commander.
 
         # @-<< define the callbacks for b >>
-
         b.configure(command=executeScriptCallback)
         if shortcut:
-            # @+<< bind the shortcut to executeScriptCallback >>
-            # @+node:ekr.20110605121601.18531: *4* << bind the shortcut to executeScriptCallback >>
-            # In LeoQtGui.makeScriptButton.
-            func = executeScriptCallback
-            if shortcut:
-                shortcut = g.KeyStroke(shortcut)  # type:ignore
-            ok = k.bindKey('button', shortcut, func, buttonText)
+            ok = k.bindKey('button', shortcut, executeScriptCallback, buttonText)
             if ok:
-                g.blue('bound @button', buttonText, 'to', shortcut)
-            # @-<< bind the shortcut to executeScriptCallback >>
-        # @+<< create press-buttonText-button command >>
-        # @+node:ekr.20110605121601.18532: *4* << create press-buttonText-button command >> LeoQtGui.makeScriptButton
-        # #1121. Like sc.cleanButtonText
+                g.blue(f"bound @button {buttonText} to: {shortcut}")
+
+        # #1121: create press-buttonText-button command
         buttonCommandName = f"press-{buttonText.replace(' ', '-').strip('-')}-button"
-        #
         # This will use any shortcut defined in an @shortcuts node.
         k.registerCommand(buttonCommandName, executeScriptCallback, pane='button')
-        # @-<< create press-buttonText-button command >>
 
     # @+node:ekr.20200304125716.1: *3* LeoQtGui.onContextMenu
     def onContextMenu(self, c: Cmdr, w: QTextMixin, point: QPoint) -> None:

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -584,7 +584,7 @@ if QtWidgets:
 
             hl_color_setting = c.config.getString('line-highlight-color') or ''
             hl_color = QColor(hl_color_setting)
-            self.hiliter_params = {
+            self.hiliter_params: dict[str, Any] = {
                 'lastblock': -2,
                 'last_style_hash': 0,
                 'last_color_setting': hl_color_setting,
@@ -941,7 +941,7 @@ if QtWidgets:
             # https://doc.qt.io/qt-5/qtwidgets-widgets-codeeditor-example.html
 
             selection = editor.ExtraSelection()
-            selection.format.setBackground(hl_color)  # type:ignore
+            selection.format.setBackground(hl_color)
             selection.format.setProperty(FullWidthSelection, True)
             selection.cursor = curs
             selection.cursor.clearSelection()


### PR DESCRIPTION
Change only core files.

Many suppression could be remove due to more general annotations or improvements in mypy.

Many of the remaining `# type: ignore` comments apply to import statements.
I have found no way to workaround those suppressions.
Yes, they are a clear pattern, but I'm a bit surprised mypy seems to require them.

**Non-trivial changes**

- [x] `checkerCommands.py`: remove call to shlex in `run_pylint`.
- [x] `controlCommands.py: execute_subprocess`: Change where `g.toUnicode` is applied.
- [x] `spellCommands.py`:
    - Use `with` clauses to limit scope of `f` vars.
    - Fix a potential bug: move `process_word` method to the base class.
- [x] `qt_gui.py`: Remove small sections in `make_script_button` and `execute_script_callback` methods.
- [x] Create new variable names in the following core files:
   `abbrevCommands.py`, `leoNodes.py`.