### PR TITLE
Support myLeoSettings .leojs JSON format

### DIFF
--- a/leo/commands/commanderHelpCommands.py
+++ b/leo/commands/commanderHelpCommands.py
@@ -272,7 +272,7 @@ def createMyLeoSettings(c: Cmdr) -> Optional[Cmdr]:
         "myLeoSettings.leo personal settings file created {time}\n\n"
         "Only nodes that are descendants of the @settings node are read.\n\n"
         "Only settings you need to modify should be in this file, do\n"
-        "not copy large parts of leoSettings.py here.\n\n"
+        "not copy large parts of leoSettings.leo here.\n\n"
         "For more information see https://leo-editor.github.io/leo-editor/customizing.html"
         "".format(time=time.asctime())
     )

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1714,13 +1714,13 @@ class LoadManager:
     # @+node:ekr.20120209051836.10373: *4* LM.computeMyLeoSettingsPath
     def computeMyLeoSettingsPath(self) -> Optional[str]:
         """
-        Return the full path to myLeoSettings.leo.
+        Return the full path to either myLeoSettings.leo or myLeoSettings.leojs.
 
         The "footnote": Get the local directory from lm.files[0]
         """
         lm = self
         join = g.finalize_join
-        settings_fn = 'myLeoSettings.leo'
+        settings_fn = 'myLeoSettings'
         # This seems pointless: we need a machine *directory*.
         # For now, however, we'll keep the existing code as is.
         machine_fn = lm.computeMachineName() + settings_fn
@@ -1740,11 +1740,11 @@ class LoadManager:
             join(g.app.globalConfigDir, settings_fn),
         )
         for path in table:
-            if g.os_path_exists(path):
-                break
-        else:
-            path = None
-        return path
+            if g.os_path_exists(path+".leo"):
+                return path+".leo"
+            if g.os_path_exists(path+".leojs"):
+                return path+".leojs"
+        return None
 
     # @+node:ekr.20120209051836.10252: *4* LM.computeStandardDirectories & helpers
     def computeStandardDirectories(self) -> None:


### PR DESCRIPTION
This PR adds a small quality of life feature that I should have added a few years ago when support for JSON .leojs file format was added 😄 

A user may have saved his personnal preferences as JSON .leojs file: This PR adds support for both instead of only XML .leo files. 

So instead of just checking for the usual places for myLeoSettings.leo, it also checks for myLeoSettings.leojs at those same places, prioritizing .leo if present.

