### PR TITLE
PR fixes #4688: restore search args after failed abbrev search

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -274,7 +274,6 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
 
         # Search!
         c.endEditing()  # No need to re-edit the headline!
-        # g.es_print(f"Searching for {start_pat}...{end_pat}", color='blue')
         self.w.setInsertPoint(0)  # Start search at start.
         finder.interactive_search_helper(settings=settings)
 

--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -257,20 +257,24 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
 
         if node_only:
             # Tell the search command to restore settings on failure.
-            finder.previous_settings = g.Bunch(
-                find_text       = finder.find_text,
-                change_text     = finder.change_text,
-                file_only       = finder.file_only,
-                mark_changes    = finder.mark_changes,
-                mark_finds      = finder.mark_finds,
-                ignore_case     = finder.ignore_case,
-                node_only       = finder.node_only,
-                pattern_match   = finder.pattern_match,
-                search_body     = finder.search_body,
-                search_headline = finder.search_headline,
-                suboutline_only = finder.suboutline_only,
-                whole_word      = finder.whole_word,
-            )  # fmt: skip
+            ivars = (
+                'change_text',
+                'file_only',
+                'find_text',
+                'ignore_case',
+                'mark_changes',
+                'mark_finds',
+                'node_only',
+                'pattern_match',
+                'search_body',
+                'search_headline',
+                'suboutline_only',
+                'whole_word',
+            )
+            bunch = g.Bunch()
+            for ivar in ivars:
+                bunch[ivar] = getattr(finder, ivar)
+            finder.previous_settings = bunch
 
         # Search!
         c.endEditing()  # No need to re-edit the headline!

--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -255,6 +255,23 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
         else:
             return
 
+        if node_only:
+            # Tell the search command to restore settings on failure.
+            finder.previous_settings = g.Bunch(
+                find_text       = finder.find_text,
+                change_text     = finder.change_text,
+                file_only       = finder.file_only,
+                mark_changes    = finder.mark_changes,
+                mark_finds      = finder.mark_finds,
+                ignore_case     = finder.ignore_case,
+                node_only       = finder.node_only,
+                pattern_match   = finder.pattern_match,
+                search_body     = finder.search_body,
+                search_headline = finder.search_headline,
+                suboutline_only = finder.suboutline_only,
+                whole_word      = finder.whole_word,
+            )  # fmt: skip
+
         # Search!
         c.endEditing()  # No need to re-edit the headline!
         # g.es_print(f"Searching for {start_pat}...{end_pat}", color='blue')

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.plugins.qt_text import QTextMixin
 
     MatchGroups = tuple  # Best we can do so far.
-    Settings = g.Bunch
     UndoData = g.Bunch
 
 # @-<< leoFind imports & annotations >>
@@ -156,7 +155,7 @@ class LeoFind:
         self.reload_settings()
 
     # @+node:ekr.20210110073117.6: *4* find.default_settings
-    def default_settings(self) -> Settings:
+    def default_settings(self) -> g.Bunch:
         """Return a dict representing all default settings."""
         c = self.c
         return g.Bunch(
@@ -194,7 +193,7 @@ class LeoFind:
             dw.finishCreateLogPane()
 
     # @+node:ekr.20210110073117.4: *4* find.init_ivars_from_settings
-    def init_ivars_from_settings(self, settings: Settings) -> None:
+    def init_ivars_from_settings(self, settings: g.Bunch) -> None:
         """
         Initialize all ivars from settings, including required defaults.
 
@@ -240,7 +239,7 @@ class LeoFind:
         self,
         root: Position,
         replacements: list[tuple[str, str]],
-        settings: Settings = None,
+        settings: g.Bunch = None,
     ) -> int:
         # @+<< docstring: find.batch_change >>
         # @+node:ekr.20210925161347.1: *4* << docstring: find.batch_change >>
@@ -328,7 +327,7 @@ class LeoFind:
         return count
 
     # @+node:ekr.20210108083003.1: *4* find._init_from_dict
-    def _init_from_dict(self, settings: Settings) -> None:
+    def _init_from_dict(self, settings: g.Bunch) -> None:
         """Initialize ivars from settings (a dict or g.Bunch)."""
 
         # The valid ivars and reasonable defaults.
@@ -374,7 +373,7 @@ class LeoFind:
         *,
         dry_run: bool = False,
         root: Position = None,
-        settings: Settings = None,
+        settings: g.Bunch = None,
     ) -> None:  # pragma: no cover
         # @+<< docstring: find.interactive_search >>
         # @+node:ekr.20210925161451.1: *4* << docstring: find.interactive_search >>
@@ -445,7 +444,7 @@ class LeoFind:
 
     # @+node:ekr.20210114100105.1: *5* find.do_change_then_find
     # A stand-alone method for unit testing.
-    def do_change_then_find(self, settings: Settings) -> bool:
+    def do_change_then_find(self, settings: g.Bunch) -> bool:
         """
         Do the change-then-find command from settings.
 
@@ -882,12 +881,12 @@ class LeoFind:
         self.do_find_prev(settings)
 
     # @+node:ekr.20031218072017.3074: *5* find.do_find_next & do_find_prev
-    def do_find_prev(self, settings: Settings) -> tuple[Position, int, int]:
+    def do_find_prev(self, settings: g.Bunch) -> tuple[Position, int, int]:
         """Find the previous instance of self.find_text."""
         self.request_reverse = True
         return self.do_find_next(settings)
 
-    def do_find_next(self, settings: Settings) -> tuple[Position, int, int]:
+    def do_find_next(self, settings: g.Bunch) -> tuple[Position, int, int]:
         """
         Find the next instance of self.find_text.
 
@@ -1212,7 +1211,7 @@ class LeoFind:
         self.do_change_all(settings)
 
     # @+node:ekr.20131117164142.17016: *5* find.do_change_all & helpers
-    def do_change_all(self, settings: Settings) -> int:
+    def do_change_all(self, settings: g.Bunch) -> int:
         c = self.c
         # Settings...
         self.init_ivars_from_settings(settings)
@@ -1231,7 +1230,7 @@ class LeoFind:
         return n
 
     # @+node:ekr.20031218072017.3069: *6* find._change_all_helper & helper
-    def _change_all_helper(self, settings: Settings) -> int:
+    def _change_all_helper(self, settings: g.Bunch) -> int:
         """Do the change-all command. Return the number of changes, or 0 for error."""
         # Caller has checked settings.
         c, current, u = self.c, self.c.p, self.c.undoer
@@ -1490,7 +1489,7 @@ class LeoFind:
 
     # @+node:ekr.20210114094846.1: *5* find.do_clone_find_all
     # A stand-alone method for unit testing.
-    def do_clone_find_all(self, settings: Settings) -> int:
+    def do_clone_find_all(self, settings: g.Bunch) -> int:
         """
         Do the clone-all-find commands from settings.
 
@@ -1552,7 +1551,7 @@ class LeoFind:
 
     # @+node:ekr.20210114094944.1: *5* find.do_clone_find_all_flattened
     # A stand-alone method for unit testing.
-    def do_clone_find_all_flattened(self, settings: Settings) -> int:
+    def do_clone_find_all_flattened(self, settings: g.Bunch) -> int:
         """
         Do the clone-find-all-flattened command from the settings.
 
@@ -1720,7 +1719,7 @@ class LeoFind:
         self.do_change_all(settings)  # Correct: convert to change-all.
 
     # @+node:ekr.20031218072017.3073: *5* find.do_find_all & helpers
-    def do_find_all(self, settings: Settings) -> dict[str, Any]:
+    def do_find_all(self, settings: g.Bunch) -> dict[str, Any]:
         """
         Top-level helper for find-all command.
 
@@ -1750,7 +1749,7 @@ class LeoFind:
         return result_dict
 
     # @+node:ekr.20160422073500.1: *6* find._find_all_helper & helpers
-    def _find_all_helper(self, settings: Settings) -> dict[str, Any]:
+    def _find_all_helper(self, settings: g.Bunch) -> dict[str, Any]:
         """
         Handle the find-all command from p to after.
 
@@ -2393,11 +2392,11 @@ class LeoFind:
 
     # @+node:ekr.20210112192427.1: *3* LeoFind.Commands: helpers
     # @+node:ekr.20210110073117.9: *4* find._cf_helper & helpers
-    def _cf_helper(
-        self, settings: Settings, flatten: bool
-    ) -> int:  # Caller has  checked the settings.
+    def _cf_helper(self, settings: g.Bunch, flatten: bool) -> int:
         """
         The common part of the clone-find commands.
+
+        The caller must check the settings.
 
         Return the number of found nodes.
         """

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -173,7 +173,6 @@ class LeoFind:
             search_headline=True,
             suboutline_only=False,
             whole_word=False,
-            # wrapping=False,
         )
 
     # @+node:ekr.20131117164142.17022: *4* find.finishCreate

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -356,10 +356,8 @@ class LeoFind:
             if ivar in valid:
                 val = settings.get(ivar)
                 if val in (True, False):
-                    # g.trace(f"{ivar:10} = {val!r}")
                     setattr(self, ivar, val)
                 elif isinstance(val, str):
-                    # g.trace(f"{ivar:10} = {val!r}")
                     setattr(self, ivar, val)
                 else:  # pragma: no cover
                     g.trace(f"bad value: {ivar!r} = {val!r}")
@@ -2972,27 +2970,18 @@ class LeoFind:
         """
         c, p = self.c, data.p
 
-        ###
-        # if not g.unitTesting:
-        #     g.trace('data', data)
-        #     g.trace(repr(self.previous_settings))
-        #     g.trace(self.ftm)
-
-        # #4688: Restore previous settings, if they exist.
+        # #4688: Restore previous settings.
         if self.previous_settings:
             self.init_ivars_from_settings(self.previous_settings)
             self.ftm.set_widgets_from_dict(self.previous_settings)
             self.previous_settings = None
-            # self.request_reverse = False
-            # self.request_pattern_match = False
-            # self.request_whole_word = False
 
         c.frame.bringToFront()  # Needed on the Mac
         if not p or not c.positionExists(p):  # pragma: no cover
             # Better than selecting the root!
             return
+
         c.selectPosition(p)
-        # Fix bug 1258373: https://bugs.launchpad.net/leo-editor/+bug/1258373
         if self.in_headline:
             c.treeWantsFocus()
         else:

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -104,8 +104,8 @@ class LeoFind:
         # The work "widget".
         self.work_s = ''  # p.b or p.c.
         self.work_sel: tuple[int, int, int] = None  # pos, newpos, insert.
-        # Options ivars: set by FindTabManager.init.
-        # These *must* be initially None, not False.
+
+        # Options ivars: set by FindTabManager.init: must be None, not False.
         self.ignore_case: bool = None
         self.node_only: bool = None
         self.file_only: bool = None
@@ -116,7 +116,7 @@ class LeoFind:
         self.mark_changes: bool = None
         self.mark_finds: bool = None
         self.whole_word: bool = None
-        #
+
         # For isearch commands...
         self.stack: list[tuple[Position, int, int, bool]] = []
         self.inverseBindingDict: dict[str, list[tuple[str, Stroke]]] = {}
@@ -126,26 +126,29 @@ class LeoFind:
         self.iSearchStrokes: list[Stroke] = []
         self.findTextList: list = []
         self.changeTextList: list = []
-        #
+
         # For find/change...
         self.find_text = ""
         self.change_text = ""
-        #
+
         # State machine...
         self.escape_handler: Callable = None
         self.handler: Callable = None
+
         # "Delayed" requests for do_find_next.
         self.request_reverse = False
         self.request_pattern_match = False
         self.request_whole_word = False
+
         # Internal state...
         self.changeAllFlag = False
         self.find_def_data: g.Bunch = None
         self.in_headline = False
         self.match_obj: re.Match = None
+        self.previous_settings: g.Bunch = None
         self.reverse = False
-        self.root: Position = None  # The start of the search, especially for suboutline-only.
-        #
+        self.root: Position = None  # The start of the search. For suboutline-only.
+
         # User settings.
         self.minibuffer_mode: bool = None
         self.reverse_find_defs: bool = None
@@ -201,14 +204,14 @@ class LeoFind:
             if not self.check_args('find-next'):
                 return <appropriate error indication>
         """
-        #
+
         # Init required defaults.
         self.reverse = False
-        #
+
         # Init find/change strings.
         self.change_text = settings.change_text
         self.find_text = settings.find_text
-        #
+
         # Init find options.
         self.file_only = settings.file_only
         self.ignore_case = settings.ignore_case
@@ -220,7 +223,6 @@ class LeoFind:
         self.search_headline = settings.search_headline
         self.suboutline_only = settings.suboutline_only
         self.whole_word = settings.whole_word
-        # self.wrapping = settings.wrapping
 
     # @+node:ekr.20171113164709.1: *4* find.reload_settings
     def reload_settings(self) -> None:
@@ -328,8 +330,15 @@ class LeoFind:
     # @+node:ekr.20210108083003.1: *4* find._init_from_dict
     def _init_from_dict(self, settings: Settings) -> None:
         """Initialize ivars from settings (a dict or g.Bunch)."""
+
         # The valid ivars and reasonable defaults.
         valid = dict(
+            # New.
+            find_text='',
+            change_text='',
+            mark_changes=False,
+            mark_finds=False,
+            # Existing.
             ignore_case=False,
             node_only=False,
             pattern_match=False,
@@ -347,9 +356,13 @@ class LeoFind:
             if ivar in valid:
                 val = settings.get(ivar)
                 if val in (True, False):
+                    # g.trace(f"{ivar:10} = {val!r}")
+                    setattr(self, ivar, val)
+                elif isinstance(val, str):
+                    # g.trace(f"{ivar:10} = {val!r}")
                     setattr(self, ivar, val)
                 else:  # pragma: no cover
-                    g.trace("bad value: {ivar!r} = {val!r}")
+                    g.trace(f"bad value: {ivar!r} = {val!r}")
                     errors += 1
             else:  # pragma: no cover
                 g.trace(f"ignoring {ivar!r} setting")
@@ -884,19 +897,19 @@ class LeoFind:
 
         """
         c, p = self.c, self.c.p
-        #
+
         # The gui widget may not exist for headlines.
         w = c.headline_wrapper(p) if self.in_headline else c.frame.body.wrapper
-        #
+
         # Init the work widget, so we don't get stuck.
         s = p.h if self.in_headline else p.b
         ins = w.getInsertPoint() if w else 0
         self.work_s = s
         self.work_sel = (ins, ins, ins)
-        #
+
         # Set the settings *after* initing the search.
         self.init_ivars_from_settings(settings)
-        #
+
         # Honor delayed requests.
         for ivar in ('reverse', 'pattern_match', 'whole_word'):
             request = 'request_' + ivar
@@ -904,7 +917,7 @@ class LeoFind:
             if val:  # Only *set* the ivar!
                 setattr(self, ivar, val)  # Set the ivar.
                 setattr(self, request, False)  # Clear the request!
-        #
+
         # Leo 6.4: set/clear self.root
         if self.root:  # pragma: no cover
             if p != self.root and not self.root.isAncestorOf(p):
@@ -949,7 +962,7 @@ class LeoFind:
             self.root = node
             self.set_find_scope_file_only()  # Update find-tab & status area.
             p = node
-        #
+
         # Now check the args.
         tag = 'find-prev' if self.reverse else 'find-next'
         if not self.check_args(tag):  # Issues error message.
@@ -2958,6 +2971,22 @@ class LeoFind:
         Restore Leo's gui and settings from data, a g.Bunch.
         """
         c, p = self.c, data.p
+
+        ###
+        # if not g.unitTesting:
+        #     g.trace('data', data)
+        #     g.trace(repr(self.previous_settings))
+        #     g.trace(self.ftm)
+
+        # #4688: Restore previous settings, if they exist.
+        if self.previous_settings:
+            self.init_ivars_from_settings(self.previous_settings)
+            self.ftm.set_widgets_from_dict(self.previous_settings)
+            self.previous_settings = None
+            # self.request_reverse = False
+            # self.request_pattern_match = False
+            # self.request_whole_word = False
+
         c.frame.bringToFront()  # Needed on the Mac
         if not p or not c.positionExists(p):  # pragma: no cover
             # Better than selecting the root!

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -173,7 +173,7 @@ class LeoFind:
             search_headline=True,
             suboutline_only=False,
             whole_word=False,
-            wrapping=False,
+            # wrapping=False,
         )
 
     # @+node:ekr.20131117164142.17022: *4* find.finishCreate

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -20,10 +20,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoNodes import Position, VNode
     from leo.plugins.qt_frame import FindTabManager
     from leo.plugins.qt_text import QTextMixin
-
-    MatchGroups = tuple  # Best we can do so far.
-    UndoData = g.Bunch
-
 # @-<< leoFind imports & annotations >>
 # @+<< Theory of operation of find/change >>
 # @+node:ekr.20031218072017.2414: ** << Theory of operation of find/change >>
@@ -2864,14 +2860,12 @@ class LeoFind:
         return -1, -1
 
     # @+node:ekr.20210110073117.48: *4* find.make_regex_subs
-    def make_regex_subs(self, change_text: str, groups: MatchGroups) -> str:
+    def make_regex_subs(self, change_text: str, groups: tuple) -> str:
         """
         Substitute group[i-1] for \\i strings in change_text.
 
         Groups is a tuple of strings, one for every matched group.
         """
-
-        # g.printObj(list(groups), tag=f"groups in {change_text!r}")
 
         def repl(match_object: re.Match) -> str:
             """re.sub calls this function once per group."""
@@ -2891,8 +2885,7 @@ class LeoFind:
             # No replacement.
             return match_object.group(0)
 
-        result = re.sub(r'\\([0-9])', repl, change_text)
-        return result
+        return re.sub(r'\\([0-9])', repl, change_text)
 
     # @+node:ekr.20210110073117.49: *4* find.replace_back_slashes
     def replace_back_slashes(self, s: str) -> str:
@@ -2963,7 +2956,7 @@ class LeoFind:
         return val
 
     # @+node:ekr.20031218072017.3089: *4* find.restore
-    def restore(self, data: UndoData) -> None:
+    def restore(self, data: g.Bunch) -> None:
         """
         Restore Leo's gui and settings from data, a g.Bunch.
         """
@@ -2991,7 +2984,7 @@ class LeoFind:
             c.widgetWantsFocus(w)
 
     # @+node:ekr.20031218072017.3090: *4* find.save
-    def save(self) -> UndoData:
+    def save(self) -> g.Bunch:
         """Save everything needed to restore after a search fails."""
         c = self.c
         if self.in_headline:  # pragma: no cover

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1277,7 +1277,6 @@ class FindTabManager:
             search_headline=self.check_box_search_headline.isChecked(),
             suboutline_only=self.radio_button_suboutline_only.isChecked(),
             whole_word=self.check_box_whole_word.isChecked(),
-            # wrapping = self.check_box_wrap_around.isChecked(),
         )
 
     # @+node:ekr.20131117120458.16789: *3* FindTabManager.init_widgets (creates callbacks)


### PR DESCRIPTION
See #4688.

- [x] `abbrev.init_place_holder_search`: Set the new `LeoFind.previous_settings` ivar.
- [x] `LeoFind.restore`: honor the `previous_settings` ivar if it exists.

**Other changes**

- [x] Replace empty comment lines by blank lines&mdash;an ongoing project.
- [x] `LeoFind._init_from_dict`: Fix an f-string error and allow more ivars.
- [x] Replace two useless aliases with `g.Bunch`.
- [x] Replace another useless alias with `tuple`.
- [x] Remove all references to the dead `LeoFind.wrapping` ivar.
