### PR TITLE
PR: clean LeoFind class

### DIFF
--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -101,6 +101,20 @@ class LeoFind:
         self.work_sel: tuple[int, int, int] = None  # pos, newpos, insert.
 
         # Options ivars: set by FindTabManager.init: must be None, not False.
+        self.ivars = (
+            'change_text',
+            'file_only',
+            'find_text',
+            'ignore_case',
+            'mark_changes',
+            'mark_finds',
+            'node_only',
+            'pattern_match',
+            'search_body',
+            'search_headline',
+            'suboutline_only',
+            'whole_word',
+        )
         self.ignore_case: bool = None
         self.node_only: bool = None
         self.file_only: bool = None
@@ -200,21 +214,8 @@ class LeoFind:
         # Init required defaults.
         self.reverse = False
 
-        # Init find/change strings.
-        self.change_text = settings.change_text
-        self.find_text = settings.find_text
-
-        # Init find options.
-        self.file_only = settings.file_only
-        self.ignore_case = settings.ignore_case
-        self.mark_changes = settings.mark_changes
-        self.mark_finds = settings.mark_finds
-        self.node_only = settings.node_only
-        self.pattern_match = settings.pattern_match
-        self.search_body = settings.search_body
-        self.search_headline = settings.search_headline
-        self.suboutline_only = settings.suboutline_only
-        self.whole_word = settings.whole_word
+        for ivar in self.ivars:
+            setattr(self, ivar, settings.get(ivar))
 
     # @+node:ekr.20171113164709.1: *4* find.reload_settings
     def reload_settings(self) -> None:

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -153,11 +153,10 @@ class LeoFind:
     # @+node:ekr.20210110073117.6: *4* find.default_settings
     def default_settings(self) -> g.Bunch:
         """Return a dict representing all default settings."""
-        c = self.c
         return g.Bunch(
             # State...
             in_headline=False,
-            p=c.rootPosition(),
+            reverse=False,
             # Find/change strings...
             find_text='',
             change_text='',
@@ -168,7 +167,6 @@ class LeoFind:
             mark_finds=False,
             node_only=False,
             pattern_match=False,
-            reverse=False,
             search_body=True,
             search_headline=True,
             suboutline_only=False,
@@ -418,6 +416,7 @@ class LeoFind:
         self.search_body = d.get('search_body', False)
         self.search_headline = d.get('search_headline', False)
         self.find_text = d.get('find_text', '')
+        self.reverse = d.get('reverse', False)  # Internal state.
         if not self.check_args('find-next'):
             return
         if dry_run:

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -169,23 +169,23 @@ class LeoFind:
         """Return a dict representing all default settings."""
         return g.Bunch(
             # State...
-            in_headline=False,
-            reverse=False,
+            in_headline = False,
+            reverse     = False,
             # Find/change strings...
-            find_text='',
-            change_text='',
+            find_text   = '',
+            change_text = '',
             # Find options...
-            file_only=False,
-            ignore_case=False,
-            mark_changes=False,
-            mark_finds=False,
-            node_only=False,
-            pattern_match=False,
-            search_body=True,
-            search_headline=True,
-            suboutline_only=False,
-            whole_word=False,
-        )
+            file_only       = False,
+            ignore_case     = False,
+            mark_changes    = False,
+            mark_finds      = False,
+            node_only       = False,
+            pattern_match   = False,
+            search_body     = True,
+            search_headline = True,
+            suboutline_only = False,
+            whole_word      = False,
+        )  # fmt: skip
 
     # @+node:ekr.20131117164142.17022: *4* find.finishCreate
     def finishCreate(self) -> None:  # pragma: no cover

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -772,6 +772,9 @@ class StringFindTabManager:
         Similar to LeoFind.default_settings, but only for find-tab values.
         """
         return g.Bunch(
+            # State...
+            in_headline     = False,
+            reverse         = False,
             # Find/change strings...
             find_text       = self.find_findbox.text(),
             change_text     = self.find_replacebox.text(),

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -773,8 +773,8 @@ class StringFindTabManager:
         """
         return g.Bunch(
             # Find/change strings...
-            find_text   = self.find_findbox.text(),
-            change_text = self.find_replacebox.text(),
+            find_text       = self.find_findbox.text(),
+            change_text     = self.find_replacebox.text(),
             # Find options...
             file_only       = self.radio_button_file_only.isChecked(),
             ignore_case     = self.check_box_ignore_case.isChecked(),

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1272,7 +1272,6 @@ class FindTabManager:
             mark_finds=self.check_box_mark_finds.isChecked(),
             node_only=self.radio_button_node_only.isChecked(),
             pattern_match=self.check_box_regexp.isChecked(),
-            # reverse = False,
             search_body=self.check_box_search_body.isChecked(),
             search_headline=self.check_box_search_headline.isChecked(),
             suboutline_only=self.radio_button_suboutline_only.isChecked(),

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1262,21 +1262,24 @@ class FindTabManager:
         Similar to LeoFind.default_settings, but only for find-tab values.
         """
         return g.Bunch(
+            # State...
+            in_headline = False,
+            reverse     = False,
             # Find/change strings...
-            find_text=self.find_findbox.text(),
-            change_text=self.find_replacebox.text(),
+            find_text       = self.find_findbox.text(),
+            change_text     = self.find_replacebox.text(),
             # Find options...
-            file_only=self.radio_button_file_only.isChecked(),
-            ignore_case=self.check_box_ignore_case.isChecked(),
-            mark_changes=self.check_box_mark_changes.isChecked(),
-            mark_finds=self.check_box_mark_finds.isChecked(),
-            node_only=self.radio_button_node_only.isChecked(),
-            pattern_match=self.check_box_regexp.isChecked(),
-            search_body=self.check_box_search_body.isChecked(),
-            search_headline=self.check_box_search_headline.isChecked(),
-            suboutline_only=self.radio_button_suboutline_only.isChecked(),
-            whole_word=self.check_box_whole_word.isChecked(),
-        )
+            file_only       = self.radio_button_file_only.isChecked(),
+            ignore_case     = self.check_box_ignore_case.isChecked(),
+            mark_changes    = self.check_box_mark_changes.isChecked(),
+            mark_finds      = self.check_box_mark_finds.isChecked(),
+            node_only       = self.radio_button_node_only.isChecked(),
+            pattern_match   = self.check_box_regexp.isChecked(),
+            search_body     = self.check_box_search_body.isChecked(),
+            search_headline = self.check_box_search_headline.isChecked(),
+            suboutline_only = self.radio_button_suboutline_only.isChecked(),
+            whole_word      = self.check_box_whole_word.isChecked(),
+        )  # fmt: skip
 
     # @+node:ekr.20131117120458.16789: *3* FindTabManager.init_widgets (creates callbacks)
     def init_widgets(self) -> None:

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -290,7 +290,6 @@ class TestFind(LeoUnitTest):
         # Test 3.
         init()
         settings.search_headline = False
-        settings.p.setVisited()
         x.do_find_all(settings)
         # Test 4.
         init()
@@ -440,8 +439,8 @@ class TestFind(LeoUnitTest):
         x.do_change_then_find(settings)
 
     def test_replace_then_find_in_headline(self):
-        settings, x = self.settings, self.x
-        p = settings.p
+        c, settings, x = self.c, self.settings, self.x
+        p = c.p
         settings.find_text = 'Node 1'
         settings.change_text = 'Node 1a'
         settings.in_headline = True
@@ -887,13 +886,13 @@ class TestFind(LeoUnitTest):
 
     # @+node:ekr.20210110073117.84: *4* TestFind.test_next_node_after_fail
     def test_fnm_next_after_fail(self):
-        settings, x = self.settings, self.x
+        c = self.c
+        settings = self.settings
+        x = self.x
         for reverse in (True, False):
             settings.reverse = reverse
-            for wrapping in (True, False):
-                settings.wrapping = wrapping
-                x.init_ivars_from_settings(settings)
-                x._fnm_next_after_fail(settings.p)
+            x.init_ivars_from_settings(settings)
+            x._fnm_next_after_fail(c.p)
 
     # @+node:ekr.20210829203927.2: *4* TestFind.test_replace_all_plain_search
     def test_replace_all_plain_search(self):


### PR DESCRIPTION
This PR removes some confusing code in the `LeoFind` class and related unit tests.

- [x] Add `LeoFind.ivars` ivar. Use it in `LeoFind.init_ivars_from_settings`.
- [x] Remove `p` key from result returned by `LeoFind.default_settings`.
- [x] Use common keys for all settings bunches: user settings plus `in_headline` and `reverse`.
- [x] `LeoFind.interactive_search_helper`: init `self.reverse`.

### Changes to unit tests

- [x] Remove tests on `settings.p`. These did nothing!
- [x] Remove references to `settings.wrapping`. `LeoFind.wrapping` no longer exists!

### What I *didn't* do

I wanted to make the annotations of settings more concrete, but that did not turn out well:

- I experimented with changing settings from `g.Bunch`'s to `dict`s, with the annotation `dict[str, str | bool]]`.
     Alas, mypy complains that ivars have the wrong type.
     Changing the annotation to `dict[str, Any]` is really no better than an annotation of `g.Bunch`.
- An alternative would be to define a new `FindSettings` *class*, but the benefits would be few.
