### PR TITLE
P.R. (fix 4683) Handle leoserver security with password

### DIFF
--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -13,6 +13,8 @@ The last command ends both the client and the server.
 import asyncio
 import json
 import time
+import hashlib
+import hmac
 
 # Third party.
 import websockets
@@ -180,9 +182,21 @@ async def client_main_loop(timeout):
     async with websockets.connect(uri) as websocket:
         if trace:
             print(f"{tag}: asyncInterval.timeout: {timeout}")
-        await websocket.send(
-            json.dumps({"action": "!auth", "password": password})
-        )
+
+        # React to the server's challenge for authentication.
+        parsedData = json.loads(g.toUnicode(await websocket.recv()))
+        if trace:
+            print(f"{tag}: got: {parsedData}")
+        if parsedData.get("action") == "challenge":
+            challenge = parsedData.get("challenge")
+            expected_hash = hmac.new(password.encode(), challenge.encode(), hashlib.sha256).hexdigest()
+            await websocket.send(json.dumps({"action": "!auth", "response": expected_hash}))
+            if trace:
+                print(f"{tag}: sent authentication response")
+        else:
+            print(f"{tag}: expected challenge, got: {parsedData}")
+            return
+
         # Await the startup package.
         json_s = g.toUnicode(await websocket.recv())
         d = json.loads(json_s)

--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -3,7 +3,7 @@
 """
 An example client for leoserver.py, based on work by Félix Malboeuf. Used by permission.
 
-First start the server in one console: `python -m leo.core.leoserver`.
+First start the server in one console: `python -m leo.core.leoserver --password test`.
 Then start the client in another console: `python -m leo.core.leoclient`.
 
 This client runs the commands given in the `_get_action_list` function.
@@ -21,6 +21,7 @@ from leo.core import leoserver
 
 wsHost = "localhost"
 wsPort = 32125
+password = 'test'  # Must match the server's password.
 
 tag = 'client'
 
@@ -175,9 +176,13 @@ async def client_main_loop(timeout):
     global n_async_responses
     uri = f"ws://{wsHost}:{wsPort}"
     action_list = _get_action_list()
+    print("leoserver must be started with argument --password test ", flush=True)
     async with websockets.connect(uri) as websocket:
         if trace:
             print(f"{tag}: asyncInterval.timeout: {timeout}")
+        await websocket.send(
+            json.dumps({"action": "!auth", "password": password})
+        )
         # Await the startup package.
         json_s = g.toUnicode(await websocket.recv())
         d = json.loads(json_s)

--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -189,7 +189,9 @@ async def client_main_loop(timeout):
             print(f"{tag}: got: {parsedData}")
         if parsedData.get("action") == "challenge":
             challenge = parsedData.get("challenge")
-            expected_hash = hmac.new(password.encode(), challenge.encode(), hashlib.sha256).hexdigest()
+            expected_hash = hmac.new(
+                password.encode(), challenge.encode(), hashlib.sha256
+            ).hexdigest()
             await websocket.send(json.dumps({"action": "!auth", "response": expected_hash}))
             if trace:
                 print(f"{tag}: sent authentication response")

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -5512,6 +5512,7 @@ class LeoServer:
 # @+node:felix.20210621233316.105: ** main & helpers (leoserver.py)
 def main() -> None:  # pragma: no cover (tested in client)
     """python script for leo integration via leoBridge"""
+    global gLoop
     if not websockets:
         print('websockets not found')
         print('pip install websockets')
@@ -5913,18 +5914,11 @@ def main() -> None:  # pragma: no cover (tested in client)
                 )
                 await websocket.close(code=1000, reason="Server full: too many connections")
                 return
-            connected = True  # local variable
-            connectionsTotal += 1  # global variable
-            print(
-                f"{tag}: Socket Connected {peer}, Total: {connectionsTotal}, Limit: {wsLimit}",
-                flush=True,
-            )
-
             try:
                 if wsPassword:
                     print(wsPassword)
                     print(f"{tag}: authenticating {peer}", flush=True)
-                    auth_message = await asyncio.wait_for(websocket.recv(), timeout=10)
+                    auth_message = await asyncio.wait_for(websocket.recv(), timeout=5)
                     if len(auth_message) > 4096:
                         raise ValueError("oversized auth packet")
 
@@ -5958,6 +5952,13 @@ def main() -> None:  # pragma: no cover (tested in client)
                 await websocket.close(code=1008, reason="Authentication failed")
                 return
 
+            connected = True  # local variable
+            connectionsTotal += 1  # global variable
+            print(
+                f"{tag}: Socket Connected {peer}, Total: {connectionsTotal}, Limit: {wsLimit}",
+                flush=True,
+            )
+            
             # If first connection, _init_connection will set it as the main client connection
             controller._init_connection(websocket)
             await register_client(websocket)
@@ -6022,13 +6023,16 @@ def main() -> None:  # pragma: no cover (tested in client)
                 if registered:
                     await unregister_client(websocket)
                 print(f"{tag} connection finished for {peer}  Total: {connectionsTotal}, Limit: {wsLimit}")
-            # Check for persistence flag if all connections are closed
-            if connectionsTotal == 0 and not wsPersist:
-                print("Shutting down leoserver")
-                # Preemptive closing of tasks
-                for task in asyncio.all_tasks():
-                    task.cancel()
-                close_Server()  # Stops the run_forever loop
+                # Check for persistence flag if all connections are closed
+                if connectionsTotal == 0 and not wsPersist:
+                    print("Shutting down leoserver")
+                    # Preemptive closing of tasks
+                    for task in asyncio.all_tasks():
+                        task.cancel()
+                    close_Server()  # Stops the run_forever loop
+            else:
+                # was just a non-registered, non-authenticated connection! Just log, don't kill the server.
+                print(f"{tag}: connection finished for {peer} (never registered)")
 
     # @-others
 
@@ -6106,6 +6110,7 @@ def main() -> None:  # pragma: no cover (tested in client)
     else:
         # For Python below 3.14
         loop = asyncio.get_event_loop()
+        gLoop = loop
 
         try:
             try:

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -92,7 +92,7 @@ Socket = Any
 # @-<< leoserver annotations >>
 # @+<< leoserver version >>
 # @+node:ekr.20220820160619.1: ** << leoserver version >>
-version_tuple = (1, 0, 15)
+version_tuple = (1, 0, 16)
 # Version History
 # 1.0.1 Initial commit.
 # 1.0.2 July 2022: Adding ui-scroll, undo/redo, chapters, ua's & node_tags info.
@@ -109,6 +109,7 @@ version_tuple = (1, 0, 15)
 # 1.0.13 July 2025: Added support for websockets version 14+.
 # 1.0.14 August 2025: Added support for Python 3.14+.
 # 1.0.15 September 2025: Added support for @leo <path> nodes.
+# 1.0.16 Mai 2026: Added support for password and !auth command for client authentication.
 v1, v2, v3 = version_tuple
 __version__ = f"leoserver.py version {v1}.{v2}.{v3}"
 # @-<< leoserver version >>
@@ -5836,8 +5837,9 @@ def main() -> None:  # pragma: no cover (tested in client)
             print(__version__)
             sys.exit(0)
         if not wsPassword:
-            print("Warning: Client connection password is required. Use --password to set one.", flush=True)
-            sys.exit(1)
+            print("No Client connection password given. Next version of leoserver will require a password for client connections. Use --password to set one.", flush=True)
+            # print("Warning: Client connection password is required. Use --password to set one.", flush=True)
+            # sys.exit(1)
 
         # Sanitize limit.
         if wsLimit < 1:
@@ -5919,20 +5921,24 @@ def main() -> None:  # pragma: no cover (tested in client)
             )
 
             try:
-                print(f"{tag}: authenticating {peer}", flush=True)
-                auth_message = await asyncio.wait_for(websocket.recv(), timeout=10)
-                if len(auth_message) > 4096:
-                    raise ValueError("oversized auth packet")
+                if wsPassword:
+                    print(wsPassword)
+                    print(f"{tag}: authenticating {peer}", flush=True)
+                    auth_message = await asyncio.wait_for(websocket.recv(), timeout=10)
+                    if len(auth_message) > 4096:
+                        raise ValueError("oversized auth packet")
 
-                auth_data = json.loads(auth_message)
+                    auth_data = json.loads(auth_message)
 
-                if not (
-                    auth_data.get("action") == "!auth"
-                    and hmac.compare_digest(auth_data.get("password", ""), wsPassword)
-                ):
-                    raise ValueError("invalid credentials")
+                    if not (
+                        auth_data.get("action") == "!auth"
+                        and hmac.compare_digest(auth_data.get("password", ""), wsPassword)
+                    ):
+                        raise ValueError("invalid credentials")
 
-                print(f"{tag}: authentication success {peer}", flush=True)
+                    print(f"{tag}: authentication success {peer}", flush=True)
+                else:
+                    print(f"{tag}: no authentication required for {peer}", flush=True)
 
             except asyncio.TimeoutError:
                 print(f"{tag}: authentication timeout {peer}", flush=True)

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -27,6 +27,7 @@ import sys
 import socket
 import textwrap
 import time
+import hmac
 from typing import Any, Generator, Iterable, Iterator, Optional
 import warnings
 
@@ -126,7 +127,8 @@ traces: list[str] = []  # list of traces names, to be used as flags to output tr
 wsLimit = 1
 wsPersist = False
 wsSkipDirty = False
-wsHost = "localhost"
+wsPassword = ""
+wsHost = "127.0.0.1"
 wsPort = 32125
 
 
@@ -5707,7 +5709,7 @@ def main() -> None:  # pragma: no cover (tested in client)
         """
         Get arguments from the command line and sets them globally.
         """
-        global wsHost, wsPort, wsLimit, wsPersist, wsSkipDirty, argFile  # traces
+        global wsHost, wsPort, wsLimit, wsPersist, wsSkipDirty, argFile, wsPassword
 
         def leo_file(s: str) -> str:
             if os.path.exists(s):
@@ -5767,11 +5769,10 @@ def main() -> None:  # pragma: no cover (tested in client)
             help='maximum number of clients. Defaults to ' + str(wsLimit),
         )
         add(
-            '',
             '--password',
             dest='wsPassword',
             type=str,
-            default='',
+            default=wsPassword,
             metavar='STR',
             help='password for client connections. Defaults to empty string',
         )
@@ -5818,6 +5819,7 @@ def main() -> None:  # pragma: no cover (tested in client)
         wsLimit = args.wsLimit
         wsPersist = bool(args.wsPersist)
         wsSkipDirty = bool(args.wsSkipDirty)
+        wsPassword = args.wsPassword
         argFile = args.argFile
         if args.traces:
             ok = True
@@ -5833,6 +5835,10 @@ def main() -> None:  # pragma: no cover (tested in client)
         if args.v:
             print(__version__)
             sys.exit(0)
+        if not wsPassword:
+            print("Warning: Client connection password is required. Use --password to set one.", flush=True)
+            sys.exit(1)
+
         # Sanitize limit.
         if wsLimit < 1:
             wsLimit = 1
@@ -5893,25 +5899,63 @@ def main() -> None:  # pragma: no cover (tested in client)
         trace = False
         verbose = False
         connected = False
+        registered = False
+        peer = websocket.remote_address if websocket.remote_address else 'unknown peer'
 
         try:
             # Websocket connection startup
             if connectionsTotal >= wsLimit:
                 print(
-                    f"{tag}: User Refused, Total: {connectionsTotal}, Limit: {wsLimit}",
+                    f"{tag}: Socket Refused {peer}, Total: {connectionsTotal}, Limit: {wsLimit}",
                     flush=True,
                 )
-                await websocket.close(1001)
+                await websocket.close(code=1000, reason="Server full: too many connections")
                 return
             connected = True  # local variable
             connectionsTotal += 1  # global variable
             print(
-                f"{tag}: User Connected, Total: {connectionsTotal}, Limit: {wsLimit}",
+                f"{tag}: Socket Connected {peer}, Total: {connectionsTotal}, Limit: {wsLimit}",
                 flush=True,
             )
+
+            try:
+                print(f"{tag}: authenticating {peer}", flush=True)
+                auth_message = await asyncio.wait_for(websocket.recv(), timeout=10)
+                if len(auth_message) > 4096:
+                    raise ValueError("oversized auth packet")
+
+                auth_data = json.loads(auth_message)
+
+                if not (
+                    auth_data.get("action") == "!auth"
+                    and hmac.compare_digest(auth_data.get("password", ""), wsPassword)
+                ):
+                    raise ValueError("invalid credentials")
+
+                print(f"{tag}: authentication success {peer}", flush=True)
+
+            except asyncio.TimeoutError:
+                print(f"{tag}: authentication timeout {peer}", flush=True)
+                await asyncio.sleep(1)
+                await websocket.close(code=1008, reason="Authentication timeout")
+                return
+
+            except json.JSONDecodeError:
+                print(f"{tag}: invalid auth json {peer}", flush=True)
+                await asyncio.sleep(1)
+                await websocket.close(code=1008, reason="Invalid auth JSON")
+                return
+
+            except Exception as e:
+                print(f"{tag}: authentication failed {peer}: {e}", flush=True)
+                await asyncio.sleep(1)
+                await websocket.close(code=1008, reason="Authentication failed")
+                return
+
             # If first connection, _init_connection will set it as the main client connection
             controller._init_connection(websocket)
             await register_client(websocket)
+            registered = True
             # Start by sending empty as 'ok'.
             n = 0
             await websocket.send(controller._make_response({"leoID": g.app.leoID}))
@@ -5969,8 +6013,9 @@ def main() -> None:  # pragma: no cover (tested in client)
         finally:
             if connected:
                 connectionsTotal -= 1
-                await unregister_client(websocket)
-                print(f"{tag} connection finished.  Total: {connectionsTotal}, Limit: {wsLimit}")
+                if registered:
+                    await unregister_client(websocket)
+                print(f"{tag} connection finished for {peer}  Total: {connectionsTotal}, Limit: {wsLimit}")
             # Check for persistence flag if all connections are closed
             if connectionsTotal == 0 and not wsPersist:
                 print("Shutting down leoserver")

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -18,6 +18,7 @@ import argparse
 import asyncio
 from collections.abc import Callable
 import fnmatch
+import hashlib
 import inspect
 import itertools
 import json
@@ -5916,15 +5917,21 @@ def main() -> None:  # pragma: no cover (tested in client)
             try:
                 if wsPassword:
                     print(f"{tag}: authenticating {peer}", flush=True)
+
+                    # First, send 'challenge' to the client to be used as salt with the returned password for authentication.
+                    challenge = os.urandom(16).hex()
+                    await websocket.send(json.dumps({"action": "challenge", "challenge": challenge}))
+
                     auth_message = await asyncio.wait_for(websocket.recv(), timeout=5)
                     if len(auth_message) > 4096:
                         raise ValueError("oversized auth packet")
 
                     auth_data = json.loads(auth_message)
+                    expected_hash = hmac.new(wsPassword.encode(), challenge.encode(), hashlib.sha256).hexdigest()
 
                     if not (
                         auth_data.get("action") == "!auth"
-                        and hmac.compare_digest(auth_data.get("password", ""), wsPassword)
+                        and hmac.compare_digest(auth_data.get("response", ""), expected_hash)
                     ):
                         raise ValueError("invalid credentials")
 

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -29,6 +29,7 @@ import socket
 import textwrap
 import time
 import hmac
+import ssl
 from typing import Any, Generator, Iterable, Iterator, Optional
 import warnings
 
@@ -132,7 +133,8 @@ wsSkipDirty = False
 wsPassword = ""
 wsHost = "127.0.0.1"
 wsPort = 32125
-
+wsCert = ""
+wsKey = ""
 
 # @-<< leoserver globals >>
 # @+others
@@ -5712,7 +5714,7 @@ def main() -> None:  # pragma: no cover (tested in client)
         """
         Get arguments from the command line and sets them globally.
         """
-        global wsHost, wsPort, wsLimit, wsPersist, wsSkipDirty, argFile, wsPassword
+        global wsHost, wsPort, wsLimit, wsPersist, wsSkipDirty, argFile, wsPassword, wsCert, wsKey
 
         def leo_file(s: str) -> str:
             if os.path.exists(s):
@@ -5761,6 +5763,24 @@ def main() -> None:  # pragma: no cover (tested in client)
             default=wsPort,
             metavar='N',
             help='port number. Defaults to ' + str(wsPort),
+        )
+        add(
+            '-c',
+            '--cert',
+            dest='wsCert',
+            type=str,
+            default=wsCert,
+            metavar='PATH',
+            help='path to the SSL certificate file. (.pem)',
+        )
+        add(
+            '-k',
+            '--key',
+            dest='wsKey',
+            type=str,
+            default=wsKey,
+            metavar='PATH',
+            help='Path to the SSL private key file (.key/.pem)',
         )
         add(
             '-l',
@@ -5846,6 +5866,24 @@ def main() -> None:  # pragma: no cover (tested in client)
         if wsLimit < 1:
             wsLimit = 1
 
+    # @+node:felix.20260523224253.1: *3* function: get_ssl_context
+    def get_ssl_context(cert_path: Optional[str], key_path: Optional[str]) -> Optional[ssl.SSLContext]:
+        """Returns an SSLContext if paths are valid, otherwise returns None."""
+        # Ensure both arguments were provided
+        if not cert_path or not key_path:
+            return None
+
+        # Verify files actually exist on disk
+        if not os.path.exists(cert_path) or not os.path.exists(key_path):
+            print(f"Error: Certificate files not found. Falling back to ws://")
+            return None
+
+        print(f"Running in secure mode (wss://) using {cert_path}")
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(certfile=cert_path, keyfile=key_path)
+        return context
+
+        
     # @+node:felix.20210803174312.1: *3* function: notify_clients
     async def notify_clients(action: str, excludedConn: Any = None) -> None:
         if connectionsPool:  # asyncio.wait doesn't accept an empty list
@@ -6051,6 +6089,8 @@ def main() -> None:  # pragma: no cover (tested in client)
         flush=True,
     )
 
+    ssl_context = get_ssl_context(wsCert, wsKey)
+
     # Open leoBridge.
     controller = LeoServer()  # Single instance of LeoServer, i.e., an instance of leoBridge
     if argFile:
@@ -6068,13 +6108,13 @@ def main() -> None:  # pragma: no cover (tested in client)
             realtime_server = None
             try:
                 try:
-                    server = await websockets.serve(ws_handler, wsHost, wsPort, max_size=None)
+                    server = await websockets.serve(ws_handler, wsHost, wsPort, max_size=None, ssl=ssl_context)
                     realtime_server = server
                 except OSError as e:
                     print(e)
                     print("Trying with IPv4 Family", flush=True)
                     server = await websockets.serve(
-                        ws_handler, wsHost, wsPort, family=socket.AF_INET, max_size=None
+                        ws_handler, wsHost, wsPort, family=socket.AF_INET, max_size=None, ssl=ssl_context
                     )
                     realtime_server = server
 
@@ -6119,13 +6159,13 @@ def main() -> None:  # pragma: no cover (tested in client)
 
         try:
             try:
-                server = websockets.serve(ws_handler, wsHost, wsPort, max_size=None)
+                server = websockets.serve(ws_handler, wsHost, wsPort, max_size=None, ssl=ssl_context)
                 realtime_server = loop.run_until_complete(server)
             except OSError as e:
                 print(e)
                 print("Trying with IPv4 Family", flush=True)
                 server = websockets.serve(
-                    ws_handler, wsHost, wsPort, family=socket.AF_INET, max_size=None
+                    ws_handler, wsHost, wsPort, family=socket.AF_INET, max_size=None, ssl=ssl_context
                 )
                 realtime_server = loop.run_until_complete(server)
 

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -136,6 +136,7 @@ wsPort = 32125
 wsCert = ""
 wsKey = ""
 
+
 # @-<< leoserver globals >>
 # @+others
 # @+node:felix.20210712224107.1: ** class SetEncoder
@@ -5859,7 +5860,10 @@ def main() -> None:  # pragma: no cover (tested in client)
             print(__version__)
             sys.exit(0)
         if not wsPassword:
-            print("Error: Connection password argument is required. Use --password to set one.", flush=True)
+            print(
+                "Error: Connection password argument is required. Use --password to set one.",
+                flush=True,
+            )
             sys.exit(1)
 
         # Sanitize limit.
@@ -5867,7 +5871,9 @@ def main() -> None:  # pragma: no cover (tested in client)
             wsLimit = 1
 
     # @+node:felix.20260523224253.1: *3* function: get_ssl_context
-    def get_ssl_context(cert_path: Optional[str], key_path: Optional[str]) -> Optional[ssl.SSLContext]:
+    def get_ssl_context(
+        cert_path: Optional[str], key_path: Optional[str]
+    ) -> Optional[ssl.SSLContext]:
         """Returns an SSLContext if paths are valid, otherwise returns None."""
         # Ensure both arguments were provided
         if not cert_path or not key_path:
@@ -5883,7 +5889,6 @@ def main() -> None:  # pragma: no cover (tested in client)
         context.load_cert_chain(certfile=cert_path, keyfile=key_path)
         return context
 
-        
     # @+node:felix.20210803174312.1: *3* function: notify_clients
     async def notify_clients(action: str, excludedConn: Any = None) -> None:
         if connectionsPool:  # asyncio.wait doesn't accept an empty list
@@ -5958,14 +5963,18 @@ def main() -> None:  # pragma: no cover (tested in client)
 
                     # First, send 'challenge' to the client to be used as salt with the returned password for authentication.
                     challenge = os.urandom(16).hex()
-                    await websocket.send(json.dumps({"action": "challenge", "challenge": challenge}))
+                    await websocket.send(
+                        json.dumps({"action": "challenge", "challenge": challenge})
+                    )
 
                     auth_message = await asyncio.wait_for(websocket.recv(), timeout=5)
                     if len(auth_message) > 4096:
                         raise ValueError("oversized auth packet")
 
                     auth_data = json.loads(auth_message)
-                    expected_hash = hmac.new(wsPassword.encode(), challenge.encode(), hashlib.sha256).hexdigest()
+                    expected_hash = hmac.new(
+                        wsPassword.encode(), challenge.encode(), hashlib.sha256
+                    ).hexdigest()
 
                     if not (
                         auth_data.get("action") == "!auth"
@@ -6001,7 +6010,7 @@ def main() -> None:  # pragma: no cover (tested in client)
                 f"{tag}: Socket Connected {peer}, Total: {connectionsTotal}, Limit: {wsLimit}",
                 flush=True,
             )
-            
+
             # If first connection, _init_connection will set it as the main client connection
             controller._init_connection(websocket)
             await register_client(websocket)
@@ -6065,7 +6074,9 @@ def main() -> None:  # pragma: no cover (tested in client)
                 connectionsTotal -= 1
                 if registered:
                     await unregister_client(websocket)
-                print(f"{tag} connection finished for {peer}  Total: {connectionsTotal}, Limit: {wsLimit}")
+                print(
+                    f"{tag} connection finished for {peer}  Total: {connectionsTotal}, Limit: {wsLimit}"
+                )
                 # Check for persistence flag if all connections are closed
                 if connectionsTotal == 0 and not wsPersist:
                     print("Shutting down leoserver")
@@ -6108,13 +6119,20 @@ def main() -> None:  # pragma: no cover (tested in client)
             realtime_server = None
             try:
                 try:
-                    server = await websockets.serve(ws_handler, wsHost, wsPort, max_size=None, ssl=ssl_context)
+                    server = await websockets.serve(
+                        ws_handler, wsHost, wsPort, max_size=None, ssl=ssl_context
+                    )
                     realtime_server = server
                 except OSError as e:
                     print(e)
                     print("Trying with IPv4 Family", flush=True)
                     server = await websockets.serve(
-                        ws_handler, wsHost, wsPort, family=socket.AF_INET, max_size=None, ssl=ssl_context
+                        ws_handler,
+                        wsHost,
+                        wsPort,
+                        family=socket.AF_INET,
+                        max_size=None,
+                        ssl=ssl_context,
                     )
                     realtime_server = server
 
@@ -6159,13 +6177,20 @@ def main() -> None:  # pragma: no cover (tested in client)
 
         try:
             try:
-                server = websockets.serve(ws_handler, wsHost, wsPort, max_size=None, ssl=ssl_context)
+                server = websockets.serve(
+                    ws_handler, wsHost, wsPort, max_size=None, ssl=ssl_context
+                )
                 realtime_server = loop.run_until_complete(server)
             except OSError as e:
                 print(e)
                 print("Trying with IPv4 Family", flush=True)
                 server = websockets.serve(
-                    ws_handler, wsHost, wsPort, family=socket.AF_INET, max_size=None, ssl=ssl_context
+                    ws_handler,
+                    wsHost,
+                    wsPort,
+                    family=socket.AF_INET,
+                    max_size=None,
+                    ssl=ssl_context,
                 )
                 realtime_server = loop.run_until_complete(server)
 

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -5838,9 +5838,8 @@ def main() -> None:  # pragma: no cover (tested in client)
             print(__version__)
             sys.exit(0)
         if not wsPassword:
-            print("No Client connection password given. Next version of leoserver will require a password for client connections. Use --password to set one.", flush=True)
-            # print("Warning: Client connection password is required. Use --password to set one.", flush=True)
-            # sys.exit(1)
+            print("Error: Connection password argument is required. Use --password to set one.", flush=True)
+            sys.exit(1)
 
         # Sanitize limit.
         if wsLimit < 1:
@@ -5916,7 +5915,6 @@ def main() -> None:  # pragma: no cover (tested in client)
                 return
             try:
                 if wsPassword:
-                    print(wsPassword)
                     print(f"{tag}: authenticating {peer}", flush=True)
                     auth_message = await asyncio.wait_for(websocket.recv(), timeout=5)
                     if len(auth_message) > 4096:

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -5767,6 +5767,15 @@ def main() -> None:  # pragma: no cover (tested in client)
             help='maximum number of clients. Defaults to ' + str(wsLimit),
         )
         add(
+            '',
+            '--password',
+            dest='wsPassword',
+            type=str,
+            default='',
+            metavar='STR',
+            help='password for client connections. Defaults to empty string',
+        )
+        add(
             '-f',
             '--file',
             dest='argFile',
@@ -5900,7 +5909,7 @@ def main() -> None:  # pragma: no cover (tested in client)
                 f"{tag}: User Connected, Total: {connectionsTotal}, Limit: {wsLimit}",
                 flush=True,
             )
-            # If first connection set it as the main client connection
+            # If first connection, _init_connection will set it as the main client connection
             controller._init_connection(websocket)
             await register_client(websocket)
             # Start by sending empty as 'ok'.

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -5844,6 +5844,8 @@ def main() -> None:  # pragma: no cover (tested in client)
         wsPersist = bool(args.wsPersist)
         wsSkipDirty = bool(args.wsSkipDirty)
         wsPassword = args.wsPassword
+        wsCert = args.wsCert
+        wsKey = args.wsKey
         argFile = args.argFile
         if args.traces:
             ok = True
@@ -5881,7 +5883,7 @@ def main() -> None:  # pragma: no cover (tested in client)
 
         # Verify files actually exist on disk
         if not os.path.exists(cert_path) or not os.path.exists(key_path):
-            print(f"Error: Certificate files not found. Falling back to ws://")
+            print("Error: Certificate files not found. Falling back to ws://")
             return None
 
         print(f"Running in secure mode (wss://) using {cert_path}")


### PR DESCRIPTION
See #4683.

Small list with general concepts for this issue. Mix of a todo and of things-to-not-forget-to-test!

- [X] Add --password CLI/server argument
- [X] Add authentication timeout (ex: 10 seconds)
- [X] Require first websocket message to be !auth
- [X] Reject invalid authentication with websocket close code 1008
- [X] Delay/register client and initial leoID/signon response only after successful authentication
- [X] Prevent unauthenticated clients from entering connectionsPool
- [X] Add auth success/failure logging
- [X] Add small delay before closing failed auth attempts
- [X] Modify leoclient.py to comply with the use of the new password argument
