### PR TITLE
PR fixes #4681: open-with problems with asciidoc

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7447,12 +7447,15 @@ def exec_file(path: str, d: dict[str, Value], script: str = None) -> None:
 def execute_shell_commands(
     commands: str | list[str],
     *,
-    shell: bool = True,  # Shell=True is a minor security vulnerability.
+    shell: bool = True,  # Must be True in many places in Leo's code!
     trace: bool = False,
 ) -> None:
     """
     Execute each shell command in a separate process.
     Wait for each command to complete, except those starting with '&'
+
+    See https://docs.python.org/3/library/subprocess.html
+    for a discussion of the security considerations of using shell=True.
     """
     if isinstance(commands, str):
         commands = [commands]

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7444,7 +7444,12 @@ def exec_file(path: str, d: dict[str, Value], script: str = None) -> None:
 
 
 # @+node:ekr.20131016032805.16721: *3* g.execute_shell_commands
-def execute_shell_commands(commands: str | list[str], trace: bool = False) -> None:
+def execute_shell_commands(
+    commands: str | list[str],
+    *,
+    shell: bool = False,  # Shell=True is a security vulnerability.
+    trace: bool = False,
+) -> None:
     """
     Execute each shell command in a separate process.
     Wait for each command to complete, except those starting with '&'
@@ -7457,7 +7462,7 @@ def execute_shell_commands(commands: str | list[str], trace: bool = False) -> No
             g.trace(command)
         if command.startswith('&'):
             command = command[1:].strip()
-        proc = subprocess.Popen(command)
+        proc = subprocess.Popen(command, shell=shell)
         if wait:
             proc.communicate()
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7447,7 +7447,7 @@ def exec_file(path: str, d: dict[str, Value], script: str = None) -> None:
 def execute_shell_commands(
     commands: str | list[str],
     *,
-    shell: bool = False,  # Shell=True is a security vulnerability.
+    shell: bool = True,  # Shell=True is a minor security vulnerability.
     trace: bool = False,
 ) -> None:
     """

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -380,12 +380,15 @@ class MarkupCommands:
         """
         asciidoctor_exec = _asciidoctor_exec()
         asciidoc3_exec = _asciidoc3_exec()
-        assert asciidoctor_exec or asciidoc3_exec, g.callers()
+        prog = asciidoctor_exec if asciidoctor_exec else asciidoc3_exec
+        if not prog:
+            g.es_print('asciidoc not found', color='blue')
+            return
+
         # Call the external program to write the output file.
         # The -e option deletes css.
-        prog = asciidoctor_exec if asciidoctor_exec else asciidoc3_exec
         command = f"{prog} {i_path} -o {o_path} -b html5"
-        g.execute_shell_commands(command)
+        g.execute_shell_commands(command, shell=True)  # #4681: enable shell.
 
     # @+node:ekr.20191007043043.1: *4* markup.run_pandoc
     def run_pandoc(self, i_path: str, o_path: str) -> None:

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -399,12 +399,13 @@ class MarkupCommands:
         # Call pandoc to write the output file.
         # --quiet does no harm.
         command = f"pandoc {i_path} -t html5 -o {o_path}"
-        g.execute_shell_commands(command)
+        g.execute_shell_commands(command, shell=True)
 
     # @+node:ekr.20191017165427.1: *4* markup.run_sphinx
     def run_sphinx(self, i_path: str, o_path: str) -> None:
         """Process i_path and o_path with sphinx."""
         trace = True
+
         # cd to the command directory, or i_path's directory.
         command_dir = g.finalize(self.sphinx_command_dir or os.path.dirname(i_path))
         if os.path.exists(command_dir):
@@ -414,7 +415,7 @@ class MarkupCommands:
         else:
             g.error(f"command directory not found: {command_dir!r}")
             return
-        #
+
         # If a default command exists, just call it.
         # The user is responsible for making everything work.
         if self.sphinx_default_command:
@@ -438,7 +439,7 @@ class MarkupCommands:
         command = f"sphinx-build {input_dir} {output_dir} {i_path}"
         if trace:
             g.trace(f"\ncommand: {command!r}\n")
-        g.execute_shell_commands(command)
+        g.execute_shell_commands(command, shell=True)
 
     # @+node:ekr.20190515070742.24: *3* markup.write_root & helpers
     def write_root(self, root: Position) -> None:


### PR DESCRIPTION
See #4681.

- [x] Add the `shell` kwarg to `execute_shell_commands`.
    The default is `True`, for compatibility with many existing scripts.
- [x] Revise `run_asciidoctor`.