### PR TITLE
PR fixes #4685: Add up/down arrows to search text widget

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -88,6 +88,7 @@
 <v t="ekr.20190926110217.1"><vh>@string adoc-base-directory = None</vh></v>
 </v>
 <v t="ekr.20260419074741.1"><vh>Unused settings</vh>
+<v t="ekr.20141024165714.1"><vh>@bool auto-scroll-find-tab = True</vh></v>
 <v t="jlunz.20151119171553.1"><vh>@bool cursor-stay-on-paste = True</vh></v>
 <v t="tbrown.20151114110207.1"><vh>@string abbreviations-next-placeholder = ,,</vh></v>
 </v>
@@ -669,7 +670,6 @@
 </v>
 </v>
 <v t="ekr.20041119034357.20"><vh>Find/replace options</vh>
-<v t="ekr.20141024165714.1"><vh>@bool auto-scroll-find-tab = True</vh></v>
 <v t="ekr.20131119143342.20107"><vh>@bool minibuffer-find-mode = False</vh></v>
 <v t="tbrown.20151010094807.1"><vh>@bool show-find-result-in-status = True</vh></v>
 <v t="ekr.20150710065036.1"><vh>@bool preload-find-pattern = False</vh></v>

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -3565,11 +3565,12 @@ class LeoFind:
                 setattr(self, key, val)
             if val and key in d:
                 options.append(d.get(key))
+        options.append(f"Change: {change_s}")
 
         # Update the gui.
         self.ftm.set_change_text(change_s)
         self.ftm.set_find_text(find_s)
-        c.k.setLabelBlue('Search: ')
+        c.k.setLabel('Search: ')
         c.k.extendLabel(find_s)
         c.frame.statusLine.put(f"Find: {' '.join(options)}")
 

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -135,7 +135,6 @@ class LeoFind:
         self.iSearchStrokes: list[Stroke] = []
         self.findTextList: list = []
         self.changeTextList: list = []
-        self.prevSearches: list[g.Bunch] = []  # #4685
 
         # For find/change...
         self.find_text = ""
@@ -156,6 +155,8 @@ class LeoFind:
         self.in_headline = False
         self.match_obj: re.Match = None
         self.previous_settings: g.Bunch = None
+        self.prev_searches: list[g.Bunch] = []  # #4685
+        self.prev_searches_i = 0  # #4685
         self.reverse = False
         self.root: Position = None  # The start of the search. For suboutline-only.
 
@@ -2178,15 +2179,15 @@ class LeoFind:
             return all(b1.get(z) == b2.get(z) for z in b1.keys())
 
         # Remove any previous match.
-        for bunch in self.prevSearches:
+        for bunch in self.prev_searches:
             if equal(settings, bunch):
-                self.prevSearches.remove(bunch)
+                self.prev_searches.remove(bunch)
                 break
 
         # Insert the new setting at the start of the list.
-        self.prevSearches.insert(0, settings)
+        self.prev_searches.insert(0, settings)
 
-        g.trace(len(self.prevSearches))  ###
+        g.trace(len(self.prev_searches))  ###
 
     # @+node:ekr.20210117143611.1: *5* find.start_search1
     def start_search1(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
@@ -3035,6 +3036,7 @@ class LeoFind:
     ) -> QTextMixin:
         """Display the result of a successful find operation."""
         c = self.c
+        g.trace('*****')
         # Set state vars.
         # Ensure progress in backwards searches.
         insert = min(pos, newpos) if self.reverse else max(pos, newpos)
@@ -3532,7 +3534,34 @@ class LeoFind:
 
     # @+node:ekr.20260521170130.1: *5* find.do_arrow
     def do_arrow(self, char: str) -> None:
-        g.trace(f"{char=}")
+        prev = self.prev_searches
+        if not prev:
+            return
+        i = self.prev_searches_i
+        self.prev_searches_i = (
+            i - 1 if char == 'Up' and i - 1 >= 0 else
+            i + 1 if char == 'Down' and i + 1 < len(prev) else
+            i
+        )  # fmt: skip
+
+        # Show compact status, like find.compute_result_status.
+        bunch = prev[self.prev_searches_i]
+        status = []
+        d = {
+            'find_text':        bunch.find_text,
+            'ignore_case':      'Ignore Case',
+            'node_only':        '[Node Only]',
+            'pattern_match':    'Regex',
+            'search_body':      'Body',
+            'search_headline':  'Head',
+            'suboutline_only':  '[Outline Only]',
+            'whole_word':       'Word',
+        }  # fmt: skip
+        for key in bunch.keys():
+            val = bunch.get(key)
+            if val and key in d:
+                status.append(d.get(key))
+        g.trace(status)
 
     # @+node:ekr.20131117164142.17008: *4* find.updateChange/FindList
     def update_change_list(self, s: str) -> None:  # pragma: no cover (cmd)

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoKeys import KeyHandlerClass as KeyHandler
     from leo.core.leoNodes import Position, VNode
-    from leo.plugins.leoQt import QtWidgets
     from leo.plugins.qt_frame import FindTabManager
     from leo.plugins.qt_text import QTextMixin
 # @-<< leoFind imports & annotations >>
@@ -3530,7 +3529,7 @@ class LeoFind:
             self.handler(event)
 
     # @+node:ekr.20260521170130.1: *5* find.do_arrow
-    def do_arrow(self, char: str, *, in_minibuffer: bool, w: QtWidgets.QLineEdit = None) -> None:
+    def do_arrow(self, char: str, *, in_minibuffer: bool) -> None:
         """Handle 'Up' and 'Down' arrows in the minibuffer and the 'Find' Tab/Dialog."""
         c = self.c
         settings = self.ftm.get_settings()

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2148,6 +2148,8 @@ class LeoFind:
         # #1840: headline-only one-shot
         #        Do this first, so the user can override.
         self.ftm.set_body_and_headline_checkbox()
+        settings = self.ftm.get_settings()
+        self._remember_settings(settings)
         if self.minibuffer_mode:
             # Set up the state machine.
             self.ftm.clear_focus()
@@ -2169,7 +2171,8 @@ class LeoFind:
     # @+node:ekr.20260521125623.1: *5* find._remember_settings
     def _remember_settings(self, settings: g.Bunch) -> None:
         """
-        Add the settings to the start of the previous searches list.
+        Add the settings to the start of the previous searches list,
+        but only if it does not already appear.
         """
 
         def equal(b1: g.Bunch, b2: g.Bunch) -> bool:
@@ -2183,9 +2186,8 @@ class LeoFind:
                 self.prev_searches.remove(bunch)
                 break
 
-        # Insert the new setting at the start of the list.
+        # Insert the setting at the start of the list.
         self.prev_searches.insert(0, settings)
-        self.prev_searches_i = 0
 
     # @+node:ekr.20210117143611.1: *5* find.start_search1
     def start_search1(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
@@ -3531,18 +3533,22 @@ class LeoFind:
     def do_arrow(self, char: str, *, in_minibuffer: bool, w: QtWidgets.QLineEdit = None) -> None:
         """Handle 'Up' and 'Down' arrows in the minibuffer and the 'Find' Tab/Dialog."""
         c = self.c
-        i = self.prev_searches_i
         settings = self.ftm.get_settings()
+
+        # Change self.prev_searches_i only if the settings are new.
         self._remember_settings(settings)
 
         # Compute the bunch to show.
+        i = self.prev_searches_i
         self.prev_searches_i = (
-            i - 1 if char == 'Up' and i - 1 >= 0 else
-            i + 1 if char == 'Down' and i + 1 < len(self.prev_searches) else
+            i - 1 if (char == 'Up' and i - 1 >= 0) else
+            i + 1 if (char == 'Down' and i + 1 < len(self.prev_searches)) else
             i
         )  # fmt: skip
         bunch = self.prev_searches[self.prev_searches_i]
         find_s, change_s = bunch.find_text, bunch.change_text
+
+        # g.trace(f"{char:4} {self.prev_searches_i} of {len(self.prev_searches)} : {bunch!r}")
 
         # Show the options in the status area. Like compute_find_options_in_status_area.
         options = []

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2186,8 +2186,9 @@ class LeoFind:
             if equal(settings, bunch):
                 return
 
-        # Insert the setting at the *end* of the list.
-        self.prev_searches.append(settings)
+        # Insert the setting at the current place in the list. 
+        self.prev_searches_i += 1
+        self.prev_searches.insert(self.prev_searches_i, settings)
 
     # @+node:ekr.20210117143611.1: *5* find.start_search1
     def start_search1(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1054,11 +1054,12 @@ class LeoFind:
         Show the present find options in the status line.
         This is useful for commands like search-forward that do not show the Find Panel.
         """
-        frame = self.c.frame
-        frame.clearStatusLine()
-        part1, part2 = self.compute_find_options()
-        frame.putStatusLine(part1, bg='blue')
-        frame.putStatusLine(part2)
+        if g.unitTesting:
+            return
+
+        # #4685: Always open the Find Tab.
+        self.open_find_tab()
+        self.ftm.init_focus()
 
     # @+node:ekr.20171129205648.1: *5* LeoFind.compute_find_options
     def compute_find_options(self) -> tuple[str, str]:  # pragma: no cover (cmd)

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -135,6 +135,7 @@ class LeoFind:
         self.iSearchStrokes: list[Stroke] = []
         self.findTextList: list = []
         self.changeTextList: list = []
+        self.prevSearches: list[g.Bunch] = []  # #4685
 
         # For find/change...
         self.find_text = ""
@@ -2165,12 +2166,35 @@ class LeoFind:
 
     startSearch = start_search  # Compatibility. Do not delete.
 
+    # @+node:ekr.20260521125623.1: *5* find._remember_setting
+    def _remember_setting(self, settings: g.Bunch) -> None:
+        """
+        Add the settings to the start of the previous searches list.
+        """
+        # g.Bunch aren't directly comparable, so do so by hand.
+
+        def equal(b1: g.Bunch, b2: g.Bunch) -> bool:
+            assert sorted(list(b1.keys())) == sorted(list(b2.keys())), (repr(b1), repr(b2))
+            return all(b1.get(z) == b2.get(z) for z in b1.keys())
+
+        # Remove any previous match.
+        for bunch in self.prevSearches:
+            if equal(settings, bunch):
+                self.prevSearches.remove(bunch)
+                break
+
+        # Insert the new setting at the start of the list.
+        self.prevSearches.insert(0, settings)
+
+        g.trace(len(self.prevSearches))
+
     # @+node:ekr.20210117143611.1: *5* find.start_search1
     def start_search1(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
         """Common handler for use by vim commands and other find commands."""
         c, k, w = self.c, self.k, self.c.frame.body.wrapper
         # Settings...
         find_pattern = k.arg
+        ### g.trace(f"{find_pattern=}", g.callers())
         self.ftm.set_find_text(find_pattern)
         self.update_find_list(find_pattern)
         self.init_vim_search(find_pattern)
@@ -2182,6 +2206,7 @@ class LeoFind:
         k.showStateAndMode()
         c.widgetWantsFocusNow(w)
         # Do the command!
+        self._remember_setting(settings)
         self.do_find_next(settings)  # Handles reverse.
 
     # @+node:ekr.20210117143614.1: *5* find._start_search_escape1
@@ -2224,6 +2249,7 @@ class LeoFind:
         k.resetLabel()
         k.showStateAndMode()
         c.widgetWantsFocusNow(w)
+        self._remember_setting(settings)
         self.do_find_next(settings)
 
     # @+node:ekr.20231127044802.1: *4* find.summarize
@@ -3462,7 +3488,7 @@ class LeoFind:
                 break
         return f"Find: {' '.join(result)}"
 
-    # @+node:ekr.20131117164142.17007: *4* find.start_state_machine
+    # @+node:ekr.20131117164142.17007: *4* find.start_state_machine & helper
     def start_state_machine(
         self,
         event: LeoKeyEvent,
@@ -3494,6 +3520,7 @@ class LeoFind:
         # Start the state matching!
         k.get1Arg(event, handler=self.state0, tabList=self.findTextList, completion=True)
 
+    # @+node:ekr.20260521123442.1: *5* find.state0
     def state0(self, event: LeoKeyEvent) -> None:  # pragma: no cover (cmd)
         """Dispatch the next handler."""
         k = self.k

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2186,7 +2186,7 @@ class LeoFind:
         # Insert the new setting at the start of the list.
         self.prevSearches.insert(0, settings)
 
-        g.trace(len(self.prevSearches))
+        g.trace(len(self.prevSearches))  ###
 
     # @+node:ekr.20210117143611.1: *5* find.start_search1
     def start_search1(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2170,8 +2170,7 @@ class LeoFind:
     # @+node:ekr.20260521125623.1: *5* find._remember_settings
     def _remember_settings(self, settings: g.Bunch) -> None:
         """
-        Add the settings to the start of the previous searches list,
-        but only if it does not already appear.
+        Add the settings if necessary.
         """
 
         def equal(b1: g.Bunch, b2: g.Bunch) -> bool:
@@ -2182,11 +2181,10 @@ class LeoFind:
         # Remove any previous match.
         for bunch in self.prev_searches:
             if equal(settings, bunch):
-                self.prev_searches.remove(bunch)
-                break
+                return
 
-        # Insert the setting at the start of the list.
-        self.prev_searches.insert(0, settings)
+        # Insert the setting at the *end* of the list.
+        self.prev_searches.append(settings)
 
     # @+node:ekr.20210117143611.1: *5* find.start_search1
     def start_search1(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -436,7 +436,7 @@ class LeoFind:
         # Settings...
         self.init_in_headline()
         settings = self.ftm.get_settings()
-        self._remember_settings(settings)
+        self._remember_settings(settings)  # #4685
         self.do_change_then_find(settings)
 
     # @+node:ekr.20210114100105.1: *5* find.do_change_then_find

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2167,8 +2167,8 @@ class LeoFind:
 
     startSearch = start_search  # Compatibility. Do not delete.
 
-    # @+node:ekr.20260521125623.1: *5* find._remember_setting
-    def _remember_setting(self, settings: g.Bunch) -> None:
+    # @+node:ekr.20260521125623.1: *5* find._remember_settings
+    def _remember_settings(self, settings: g.Bunch) -> None:
         """
         Add the settings to the start of the previous searches list.
         """
@@ -2186,6 +2186,7 @@ class LeoFind:
 
         # Insert the new setting at the start of the list.
         self.prev_searches.insert(0, settings)
+        self.prev_searches_i = 0
 
     # @+node:ekr.20210117143611.1: *5* find.start_search1
     def start_search1(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
@@ -2204,7 +2205,7 @@ class LeoFind:
         k.showStateAndMode()
         c.widgetWantsFocusNow(w)
         # Do the command!
-        self._remember_setting(settings)
+        self._remember_settings(settings)
         self.do_find_next(settings)  # Handles reverse.
 
     # @+node:ekr.20210117143614.1: *5* find._start_search_escape1
@@ -2247,7 +2248,7 @@ class LeoFind:
         k.resetLabel()
         k.showStateAndMode()
         c.widgetWantsFocusNow(w)
-        self._remember_setting(settings)
+        self._remember_settings(settings)
         self.do_find_next(settings)
 
     # @+node:ekr.20231127044802.1: *4* find.summarize

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -262,7 +262,6 @@ class LeoFind:
         """
         # @-<< docstring: find.batch_change >>
         try:
-            # self._init_from_dict(settings or {})
             self._init_from_dict(settings or g.Bunch())
             count = 0
             for find, change in replacements:
@@ -437,6 +436,7 @@ class LeoFind:
         # Settings...
         self.init_in_headline()
         settings = self.ftm.get_settings()
+        self._remember_settings(settings)
         self.do_change_then_find(settings)
 
     # @+node:ekr.20210114100105.1: *5* find.do_change_then_find
@@ -891,6 +891,8 @@ class LeoFind:
 
         """
         c, p = self.c, self.c.p
+
+        self._remember_settings(settings)  # #4685
 
         # The gui widget may not exist for headlines.
         w = c.headline_wrapper(p) if self.in_headline else c.frame.body.wrapper
@@ -2148,8 +2150,6 @@ class LeoFind:
         # #1840: headline-only one-shot
         #        Do this first, so the user can override.
         self.ftm.set_body_and_headline_checkbox()
-        settings = self.ftm.get_settings()
-        self._remember_settings(settings)
         if self.minibuffer_mode:
             # Set up the state machine.
             self.ftm.clear_focus()
@@ -2204,7 +2204,6 @@ class LeoFind:
         k.showStateAndMode()
         c.widgetWantsFocusNow(w)
         # Do the command!
-        self._remember_settings(settings)
         self.do_find_next(settings)  # Handles reverse.
 
     # @+node:ekr.20210117143614.1: *5* find._start_search_escape1
@@ -2247,7 +2246,6 @@ class LeoFind:
         k.resetLabel()
         k.showStateAndMode()
         c.widgetWantsFocusNow(w)
-        self._remember_settings(settings)
         self.do_find_next(settings)
 
     # @+node:ekr.20231127044802.1: *4* find.summarize
@@ -2420,6 +2418,7 @@ class LeoFind:
         Return the number of found nodes.
         """
         c, u = self.c, self.c.undoer
+        self._remember_settings(settings)
         if self.pattern_match:
             ok = self.compile_pattern()
             if not ok:
@@ -3531,9 +3530,9 @@ class LeoFind:
     def do_arrow(self, char: str, *, in_minibuffer: bool) -> None:
         """Handle 'Up' and 'Down' arrows in the minibuffer and the 'Find' Tab/Dialog."""
         c = self.c
-        settings = self.ftm.get_settings()
 
-        # Change self.prev_searches_i only if the settings are new.
+        # Remember the existing settings.
+        settings = self.ftm.get_settings()
         self._remember_settings(settings)
 
         # Compute the bunch to show.

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -3035,7 +3035,6 @@ class LeoFind:
     ) -> QTextMixin:
         """Display the result of a successful find operation."""
         c = self.c
-        g.trace('*****')
         # Set state vars.
         # Ensure progress in backwards searches.
         insert = min(pos, newpos) if self.reverse else max(pos, newpos)
@@ -3547,9 +3546,8 @@ class LeoFind:
         bunch = prev[self.prev_searches_i]
 
         # Set the find/change text.
-        g.trace(f"{bunch.find_text=} {bunch.change_text=}")
-        self.ftm.set_change_text(bunch.change_text)
-        self.ftm.set_find_text(bunch.find_text)
+        ### g.trace(f"{bunch.find_text=} {bunch.change_text=}")
+        find_s, change_s = bunch.find_text, bunch.change_text
 
         # Show the options in the status area. Like compute_find_options_in_status_area.
         options = []
@@ -3569,9 +3567,15 @@ class LeoFind:
             val = bunch.get(key)
             if key in self.ivars:
                 setattr(self, key, val)
-                g.trace(f"Set {key}={val}")
+                ### g.trace(f"Set {key}={val}")
             if val and key in d:
                 options.append(d.get(key))
+
+        # Update the gui.
+        self.ftm.set_change_text(find_s)
+        self.ftm.set_find_text(change_s)
+        c.k.setLabelBlue('Search: ')
+        c.k.extendLabel(find_s)
         c.frame.statusLine.put(f"Find: {' '.join(options)}")
 
     # @+node:ekr.20131117164142.17008: *4* find.updateChange/FindList

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2195,7 +2195,6 @@ class LeoFind:
         c, k, w = self.c, self.k, self.c.frame.body.wrapper
         # Settings...
         find_pattern = k.arg
-        g.trace(f"{find_pattern=}")  ###
         self.ftm.set_find_text(find_pattern)
         self.update_find_list(find_pattern)
         self.init_vim_search(find_pattern)
@@ -3474,7 +3473,6 @@ class LeoFind:
             ('regeXp',  ftm.check_box_regexp),
             ('Body',    ftm.check_box_search_body),
             ('Head',    ftm.check_box_search_headline),
-            # ('wrap-Around', ftm.check_box_wrap_around),
             ('mark-Changes', ftm.check_box_mark_changes),
             ('mark-Finds', ftm.check_box_mark_finds),
         )  # fmt: skip
@@ -3534,34 +3532,47 @@ class LeoFind:
 
     # @+node:ekr.20260521170130.1: *5* find.do_arrow
     def do_arrow(self, char: str) -> None:
+        c = self.c
         prev = self.prev_searches
         if not prev:
             return
+
+        # Compute the bunch to show.
         i = self.prev_searches_i
         self.prev_searches_i = (
             i - 1 if char == 'Up' and i - 1 >= 0 else
             i + 1 if char == 'Down' and i + 1 < len(prev) else
             i
         )  # fmt: skip
-
-        # Show compact status, like find.compute_result_status.
         bunch = prev[self.prev_searches_i]
-        status = []
+
+        # Set the find/change text.
+        g.trace(f"{bunch.find_text=} {bunch.change_text=}")
+        self.ftm.set_change_text(bunch.change_text)
+        self.ftm.set_find_text(bunch.find_text)
+
+        # Show the options in the status area. Like compute_find_options_in_status_area.
+        options = []
         d = {
-            'find_text':        bunch.find_text,
-            'ignore_case':      'Ignore Case',
-            'node_only':        '[Node Only]',
-            'pattern_match':    'Regex',
+            'whole_word':       'Word',
+            'ignore_case':      'Ig-case',
+            'pattern_match':    'regeXp',
+            'node_only':        'Node',
             'search_body':      'Body',
             'search_headline':  'Head',
-            'suboutline_only':  '[Outline Only]',
-            'whole_word':       'Word',
+            'mark_changes':     'mark-Changes',
+            'mark_finds':       'mark-Finds',
+            'suboutline_only':  'Suboutline',
+            'file_only':        'File',
         }  # fmt: skip
         for key in bunch.keys():
             val = bunch.get(key)
+            if key in self.ivars:
+                setattr(self, key, val)
+                g.trace(f"Set {key}={val}")
             if val and key in d:
-                status.append(d.get(key))
-        g.trace(status)
+                options.append(d.get(key))
+        c.frame.statusLine.put(f"Find: {' '.join(options)}")
 
     # @+node:ekr.20131117164142.17008: *4* find.updateChange/FindList
     def update_change_list(self, s: str) -> None:  # pragma: no cover (cmd)

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -3488,7 +3488,7 @@ class LeoFind:
                 break
         return f"Find: {' '.join(result)}"
 
-    # @+node:ekr.20131117164142.17007: *4* find.start_state_machine & helper
+    # @+node:ekr.20131117164142.17007: *4* find.start_state_machine & helpers
     def start_state_machine(
         self,
         event: LeoKeyEvent,
@@ -3518,10 +3518,10 @@ class LeoFind:
         self.escape_handler = escape_handler
         self.total_links = 0  # Limit the total number of clickable links.
         # Start the state matching!
-        k.get1Arg(event, handler=self.state0, tabList=self.findTextList, completion=True)
+        k.get1Arg(event, handler=self.find_state0, tabList=self.findTextList, completion=True)
 
-    # @+node:ekr.20260521123442.1: *5* find.state0
-    def state0(self, event: LeoKeyEvent) -> None:  # pragma: no cover (cmd)
+    # @+node:ekr.20260521123442.1: *5* find.find_state0
+    def find_state0(self, event: LeoKeyEvent) -> None:  # pragma: no cover (cmd)
         """Dispatch the next handler."""
         k = self.k
         if k.getArgEscapeFlag:
@@ -3529,6 +3529,10 @@ class LeoFind:
             self.escape_handler(event)
         else:
             self.handler(event)
+
+    # @+node:ekr.20260521170130.1: *5* find.do_arrow
+    def do_arrow(self, char: str) -> None:
+        g.trace(f"{char=}")
 
     # @+node:ekr.20131117164142.17008: *4* find.updateChange/FindList
     def update_change_list(self, s: str) -> None:  # pragma: no cover (cmd)

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2171,9 +2171,9 @@ class LeoFind:
         """
         Add the settings to the start of the previous searches list.
         """
-        # g.Bunch aren't directly comparable, so do so by hand.
 
         def equal(b1: g.Bunch, b2: g.Bunch) -> bool:
+            """Return True if the two settings bunches are equivalent."""
             assert sorted(list(b1.keys())) == sorted(list(b2.keys())), (repr(b1), repr(b2))
             return all(b1.get(z) == b2.get(z) for z in b1.keys())
 

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -436,7 +436,6 @@ class LeoFind:
         # Settings...
         self.init_in_headline()
         settings = self.ftm.get_settings()
-        self._remember_settings(settings)  # #4685
         self.do_change_then_find(settings)
 
     # @+node:ekr.20210114100105.1: *5* find.do_change_then_find
@@ -892,8 +891,6 @@ class LeoFind:
         """
         c, p = self.c, self.c.p
 
-        self._remember_settings(settings)  # #4685
-
         # The gui widget may not exist for headlines.
         w = c.headline_wrapper(p) if self.in_headline else c.frame.body.wrapper
 
@@ -1005,7 +1002,7 @@ class LeoFind:
         else:
             c.frame.log.selectTab('Find')
 
-    # @+node:ekr.20031218072017.3068: *4* find.replace (replace)
+    # @+node:ekr.20031218072017.3068: *4* find.replace (change)
     @cmd('replace')
     @cmd('change')
     def change(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (cmd)
@@ -2170,14 +2167,19 @@ class LeoFind:
 
     # @+node:ekr.20260521125623.1: *5* find._remember_settings
     def _remember_settings(self, settings: g.Bunch) -> None:
-        """
-        Add the settings if necessary.
-        """
+        """Add the settings to the search history."""
 
         def equal(b1: g.Bunch, b2: g.Bunch) -> bool:
             """Return True if the two settings bunches are equivalent."""
-            assert sorted(list(b1.keys())) == sorted(list(b2.keys())), (repr(b1), repr(b2))
+            if sorted(list(b1.keys())) != sorted(list(b2.keys())):
+                return True  # Defensive.
             return all(b1.get(z) == b2.get(z) for z in b1.keys())
+
+        # Replace the placeholder text.
+        settings.find_text = settings.find_text.replace('<find pattern here>', '')
+
+        # Ignore the two state entries: they are usually False anyway.
+        settings.in_headline = settings.reverse = False
 
         # Remove any previous match.
         for bunch in self.prev_searches:
@@ -2418,7 +2420,6 @@ class LeoFind:
         Return the number of found nodes.
         """
         c, u = self.c, self.c.undoer
-        self._remember_settings(settings)
         if self.pattern_match:
             ok = self.compile_pattern()
             if not ok:
@@ -3531,9 +3532,8 @@ class LeoFind:
         """Handle 'Up' and 'Down' arrows in the minibuffer and the 'Find' Tab/Dialog."""
         c = self.c
 
-        # Remember the existing settings.
-        settings = self.ftm.get_settings()
-        self._remember_settings(settings)
+        # Remember the existing settings, as a side effect of calling get_settings.
+        self.ftm.get_settings()
 
         # Compute the bunch to show.
         i = self.prev_searches_i

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -3566,8 +3566,8 @@ class LeoFind:
                 options.append(d.get(key))
 
         # Update the gui.
-        self.ftm.set_change_text(find_s)
-        self.ftm.set_find_text(change_s)
+        self.ftm.set_change_text(change_s)
+        self.ftm.set_find_text(find_s)
         c.k.setLabelBlue('Search: ')
         c.k.extendLabel(find_s)
         c.frame.statusLine.put(f"Find: {' '.join(options)}")

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2187,8 +2187,6 @@ class LeoFind:
         # Insert the new setting at the start of the list.
         self.prev_searches.insert(0, settings)
 
-        g.trace(len(self.prev_searches))  ###
-
     # @+node:ekr.20210117143611.1: *5* find.start_search1
     def start_search1(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
         """Common handler for use by vim commands and other find commands."""
@@ -3544,9 +3542,6 @@ class LeoFind:
             i
         )  # fmt: skip
         bunch = prev[self.prev_searches_i]
-
-        # Set the find/change text.
-        ### g.trace(f"{bunch.find_text=} {bunch.change_text=}")
         find_s, change_s = bunch.find_text, bunch.change_text
 
         # Show the options in the status area. Like compute_find_options_in_status_area.
@@ -3567,7 +3562,6 @@ class LeoFind:
             val = bunch.get(key)
             if key in self.ivars:
                 setattr(self, key, val)
-                ### g.trace(f"Set {key}={val}")
             if val and key in d:
                 options.append(d.get(key))
 

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -3028,7 +3028,7 @@ class LeoFind:
         )
         return data
 
-    # @+node:ekr.20031218072017.3091: *4* LeoFind.find.show_success
+    # @+node:ekr.20031218072017.3091: *4* find.show_success
     def show_success(
         self, p: Position, pos: int, newpos: int, showState: bool = True
     ) -> QTextMixin:

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoKeys import KeyHandlerClass as KeyHandler
     from leo.core.leoNodes import Position, VNode
+    from leo.plugins.leoQt import QtWidgets
     from leo.plugins.qt_frame import FindTabManager
     from leo.plugins.qt_text import QTextMixin
 # @-<< leoFind imports & annotations >>
@@ -1099,7 +1100,7 @@ class LeoFind:
 
     # @+node:ekr.20131117164142.16919: *4* find.toggle-find-*
     @cmd('toggle-find-collapses-nodes')
-    def toggle_find_collapses_nodes(self, event: LeoKeyEvent) -> None:  # pragma: no cover (cmd)
+    def toggle_find_collapses_nodes(self, event: LeoKeyEvent) -> None:
         """Toggle the 'Collapse Nodes' checkbox in the find tab."""
         c = self.c
         c.sparse_find = not c.sparse_find
@@ -1107,51 +1108,49 @@ class LeoFind:
             g.es('sparse_find', c.sparse_find)
 
     @cmd('toggle-find-ignore-case-option')
-    def toggle_ignore_case_option(self, event: LeoKeyEvent) -> None:  # pragma: no cover (cmd)
+    def toggle_ignore_case_option(self, event: LeoKeyEvent) -> None:
         """Toggle the 'Ignore Case' checkbox in the Find tab."""
-        self.toggle_option('ignore_case')
+        self.toggle_option(event, 'ignore_case')
 
     @cmd('toggle-find-mark-changes-option')
-    def toggle_mark_changes_option(self, event: LeoKeyEvent) -> None:  # pragma: no cover (cmd)
+    def toggle_mark_changes_option(self, event: LeoKeyEvent) -> None:
         """Toggle the 'Mark Changes' checkbox in the Find tab."""
-        self.toggle_option('mark_changes')
+        self.toggle_option(event, 'mark_changes')
 
     @cmd('toggle-find-mark-finds-option')
-    def toggle_mark_finds_option(self, event: LeoKeyEvent) -> None:  # pragma: no cover (cmd)
+    def toggle_mark_finds_option(self, event: LeoKeyEvent) -> None:
         """Toggle the 'Mark Finds' checkbox in the Find tab."""
-        self.toggle_option('mark_finds')
+        self.toggle_option(event, 'mark_finds')
 
     @cmd('toggle-find-regex-option')
-    def toggle_regex_option(self, event: LeoKeyEvent) -> None:  # pragma: no cover (cmd)
+    def toggle_regex_option(self, event: LeoKeyEvent) -> None:
         """Toggle the 'Regexp' checkbox in the Find tab."""
-        self.toggle_option('pattern_match')
+        self.toggle_option(event, 'pattern_match')
 
     @cmd('toggle-find-in-body-option')
-    def toggle_search_body_option(self, event: LeoKeyEvent) -> None:  # pragma: no cover (cmd)
+    def toggle_search_body_option(self, event: LeoKeyEvent) -> None:
         """Set the 'Search Body' checkbox in the Find tab."""
-        self.toggle_option('search_body')
+        self.toggle_option(event, 'search_body')
 
     @cmd('toggle-find-in-headline-option')
-    def toggle_search_headline_option(self, event: LeoKeyEvent) -> None:  # pragma: no cover (cmd)
+    def toggle_search_headline_option(self, event: LeoKeyEvent) -> None:
         """Toggle the 'Search Headline' checkbox in the Find tab."""
-        self.toggle_option('search_headline')
+        self.toggle_option(event, 'search_headline')
 
     @cmd('toggle-find-word-option')
-    def toggle_whole_word_option(self, event: LeoKeyEvent) -> None:  # pragma: no cover (cmd)
+    def toggle_whole_word_option(self, event: LeoKeyEvent) -> None:
         """Toggle the 'Whole Word' checkbox in the Find tab."""
-        self.toggle_option('whole_word')
+        self.toggle_option(event, 'whole_word')
 
-    # @verbatim
-    # @cmd('toggle-find-wrap-around-option')
-    # def toggleWrapSearchOption(self, event):
-    # """Toggle the 'Wrap Around' checkbox in the Find tab."""
-    # return self.toggle_option('wrap')
-
-    def toggle_option(self, checkbox_name: str) -> None:  # pragma: no cover (cmd)
-        c, fc = self.c, self.c.findCommands
+    def toggle_option(self, event: LeoKeyEvent, checkbox_name: str) -> None:
+        c, finder = self.c, self.c.findCommands
         self.ftm.toggle_checkbox(checkbox_name)
-        options = fc.compute_find_options_in_status_area()
-        c.frame.statusLine.put(options)
+        if self.minibuffer_mode:
+            options = finder.compute_find_options_in_status_area()
+            c.frame.statusLine.put(options)
+        else:
+            # Put focus in the Find Tab/Dialog.
+            finder.start_search(event)
 
     # @+node:ekr.20131117164142.17013: *3* LeoFind.Commands (interactive)
     # @+node:ekr.20131117164142.16994: *4* find.change-all & helper
@@ -2161,7 +2160,7 @@ class LeoFind:
                 escape_handler=self.start_search_escape1,
             )
         else:
-            self.open_find_tab(event)
+            self.open_find_tab()
             self.ftm.init_focus()
             return
 
@@ -3529,20 +3528,20 @@ class LeoFind:
             self.handler(event)
 
     # @+node:ekr.20260521170130.1: *5* find.do_arrow
-    def do_arrow(self, char: str) -> None:
+    def do_arrow(self, char: str, *, in_minibuffer: bool, w: QtWidgets.QLineEdit = None) -> None:
+        """Handle 'Up' and 'Down' arrows in the minibuffer and the 'Find' Tab/Dialog."""
         c = self.c
-        prev = self.prev_searches
-        if not prev:
-            return
+        i = self.prev_searches_i
+        settings = self.ftm.get_settings()
+        self._remember_settings(settings)
 
         # Compute the bunch to show.
-        i = self.prev_searches_i
         self.prev_searches_i = (
             i - 1 if char == 'Up' and i - 1 >= 0 else
-            i + 1 if char == 'Down' and i + 1 < len(prev) else
+            i + 1 if char == 'Down' and i + 1 < len(self.prev_searches) else
             i
         )  # fmt: skip
-        bunch = prev[self.prev_searches_i]
+        bunch = self.prev_searches[self.prev_searches_i]
         find_s, change_s = bunch.find_text, bunch.change_text
 
         # Show the options in the status area. Like compute_find_options_in_status_area.
@@ -3565,14 +3564,20 @@ class LeoFind:
                 setattr(self, key, val)
             if val and key in d:
                 options.append(d.get(key))
-        options.append(f"Change: {change_s}")
 
         # Update the gui.
+        self.ftm.set_widgets_from_dict(bunch)
         self.ftm.set_change_text(change_s)
         self.ftm.set_find_text(find_s)
-        c.k.setLabel('Search: ')
-        c.k.extendLabel(find_s)
-        c.frame.statusLine.put(f"Find: {' '.join(options)}")
+        if in_minibuffer:
+            options.append(f"Change: {change_s}")
+            c.k.setLabel('Search: ')
+            c.k.extendLabel(find_s)
+            c.frame.statusLine.put(f"Find: {' '.join(options)}")
+        else:
+            # Like start_search()
+            self.open_find_tab()
+            self.ftm.init_focus()
 
     # @+node:ekr.20131117164142.17008: *4* find.updateChange/FindList
     def update_change_list(self, s: str) -> None:  # pragma: no cover (cmd)

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2194,7 +2194,7 @@ class LeoFind:
         c, k, w = self.c, self.k, self.c.frame.body.wrapper
         # Settings...
         find_pattern = k.arg
-        ### g.trace(f"{find_pattern=}", g.callers())
+        g.trace(f"{find_pattern=}")  ###
         self.ftm.set_find_text(find_pattern)
         self.update_find_list(find_pattern)
         self.init_vim_search(find_pattern)

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -445,10 +445,12 @@ class LeoKeyEvent:
 
         # Anything should be valid here: we don't expect the wrapper to do key handling.
         self.w = w
-        if c.widget_name(w).startswith(('body', 'canvas', 'head', 'mini', 'find-wrapper')):
+        if c.widget_name(w).startswith(
+            ('body', 'canvas', 'head', 'mini', 'find-wrapper', 'MainWindow')
+        ):
             trace('known w', info(w))
         else:
-            trace_always('unusual w', info(w))
+            trace('unusual w', info(w))
 
     # @+node:ekr.20140907103315.18774: *3*  LeoKeyEvent.__repr__
     def __repr__(self) -> str:

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -415,7 +415,7 @@ class LeoKeyEvent:
             self.w = c.frame.log.logCtrl
             return
         if isinstance(w, QTextMixin):
-            trace('QTextMixin', 'w.__class__.__name__')
+            trace('QTextMixin', w.__class__.__name__)
             self.w = w
             return
         if wrapper := getattr(w, 'wrapper', None):

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -385,6 +385,9 @@ class LeoKeyEvent:
         )
         assert g.isStrokeOrNone(self.stroke), f"(LeoKeyEvent) {self.stroke!r} {g.callers()}"
 
+        def info(obj: Any) -> str:
+            return f"char: {self.char!r:>6} {id(obj)} {obj.__class__.__name__} {obj_name(obj)}"
+
         def obj_name(obj: Any) -> str:
             return g.app.gui.widget_name(obj)
 
@@ -415,15 +418,15 @@ class LeoKeyEvent:
             self.w = c.frame.log.logCtrl
             return
         if isinstance(w, QTextMixin):
-            trace('QTextMixin', f"{id(w)} {w.__class__.__name__}")
+            trace('QTextMixin', info(w))
             self.w = w
             return
         if wrapper := getattr(w, 'wrapper', None):
-            trace('w.wrapper', f"{id(w)} {w.__class__.__name__}")
+            trace('w.wrapper', info(wrapper))
             self.w = wrapper
             return
         if wrapper := getattr(w, 'leo_wrapper', None):
-            trace('w.leo_wrapper', f"{id(w)} {w.__class__.__name__}")
+            trace('w.leo_wrapper', info(wrapper))
             self.w = wrapper
             return
         if isinstance(w, QtWidgets.QTextEdit):
@@ -447,7 +450,7 @@ class LeoKeyEvent:
             # We expect that w is a wrapper, but we don't much care.
             name = obj_name(w)
             if not name.startswith(('body', 'canvas', 'head', 'mini')):
-                trace_always('unusual w', f"{w.__class__.__name__} name: {name}")
+                trace_always('unusual w', info(w))
 
     # @+node:ekr.20140907103315.18774: *3*  LeoKeyEvent.__repr__
     def __repr__(self) -> str:

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -415,15 +415,15 @@ class LeoKeyEvent:
             self.w = c.frame.log.logCtrl
             return
         if isinstance(w, QTextMixin):
-            trace('QTextMixin', w.__class__.__name__)
+            trace('QTextMixin', f"{id(w)} {w.__class__.__name__}")
             self.w = w
             return
         if wrapper := getattr(w, 'wrapper', None):
-            trace('w.wrapper', wrapper.__class__.__name__)
+            trace('w.wrapper', f"{id(w)} {w.__class__.__name__}")
             self.w = wrapper
             return
         if wrapper := getattr(w, 'leo_wrapper', None):
-            trace('w.leo_wrapper', wrapper.__class__.__name__)
+            trace('w.leo_wrapper', f"{id(w)} {w.__class__.__name__}")
             self.w = wrapper
             return
         if isinstance(w, QtWidgets.QTextEdit):

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -410,8 +410,8 @@ class LeoKeyEvent:
             trace('no w --> ', w.__class__.__name__)
             if w is None:
                 return
-        # else:
-        #     trace(f" text? {isinstance(w, QTextMixin):1} w", w.__class__.__name__)
+
+        # trace(f" text? {isinstance(w, QTextMixin):1} w", info(w))
 
         # Ensure that self.w is a wrapper for all key-related Qt widgets.
         if c.widget_name(w).startswith('log'):
@@ -445,12 +445,10 @@ class LeoKeyEvent:
 
         # Anything should be valid here: we don't expect the wrapper to do key handling.
         self.w = w
-        trace('unknown w', w.__class__.__name__)
-        if not isinstance(w, QtWidgets.QWidget):
-            # We expect that w is a wrapper, but we don't much care.
-            name = obj_name(w)
-            if not name.startswith(('body', 'canvas', 'head', 'mini')):
-                trace_always('unusual w', info(w))
+        if c.widget_name(w).startswith(('body', 'canvas', 'head', 'mini', 'find-wrapper')):
+            trace('known w', info(w))
+        else:
+            trace_always('unusual w', info(w))
 
     # @+node:ekr.20140907103315.18774: *3*  LeoKeyEvent.__repr__
     def __repr__(self) -> str:

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -492,6 +492,9 @@ class NullGui(LeoGui):
         self.script = None
 
     # @+node:ekr.20031218072017.3744: *3* NullGui.dialogs
+    def openFindDialog(self, c: Cmdr) -> None:
+        return None
+
     def runAboutLeoDialog(
         self, c: Cmdr, version: str, theCopyright: str, url: str, email: str
     ) -> str:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -3555,7 +3555,7 @@ class KeyHandlerClass:
                 if trace:
                     g.trace(state, 'k.isPlain: getArg', stroke)
                 return True
-            if stroke.s in ('Escape', 'Tab', 'BackSpace'):
+            if stroke.s in ('Escape', 'Tab', 'BackSpace', 'Up', 'Down'):
                 k.getArg(event, stroke=stroke)
                 if trace:
                     g.trace(state, f"{stroke.s!r}: getArg", stroke)
@@ -3611,14 +3611,14 @@ class KeyHandlerClass:
         """Call the state handler associated with this event."""
         k = self
         ch = event.char
-        #
+
         # Defensive programming
         if not k.state.kind:
             return None
         if not k.state.handler:
             g.error('callStateFunction: no state function for', k.state.kind)
             return None
-        #
+
         # Handle auto-completion before checking for unbound keys.
         if k.state.kind == 'auto-complete':
             # k.auto_completer_state_handler returns 'do-standard-keys' for control keys.
@@ -3634,7 +3634,7 @@ class KeyHandlerClass:
             and (ord(ch) < 32 or ord(ch) > 128)
         ):
             return None
-        #
+
         # Call the state handler.
         val = k.state.handler(event)
         return val

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1548,7 +1548,7 @@ class GetArg:
         c.check_event(event)
         c.minibufferWantsFocusNow()
         char = event.char if event else ''
-        g.trace(f"{state=} {char=}")  ###
+        ### g.trace(f"{state=} {char=}")  ###
         if state == 0:
             self.do_state_zero(
                 completion,

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1548,7 +1548,6 @@ class GetArg:
         c.check_event(event)
         c.minibufferWantsFocusNow()
         char = event.char if event else ''
-        ### g.trace(f"{state=} {char=}")  ###
         if state == 0:
             self.do_state_zero(
                 completion,

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1548,6 +1548,7 @@ class GetArg:
         c.check_event(event)
         c.minibufferWantsFocusNow()
         char = event.char if event else ''
+        g.trace(f"{state=} {char=}")  ###
         if state == 0:
             self.do_state_zero(
                 completion,
@@ -1569,6 +1570,8 @@ class GetArg:
         elif char in ('\b', 'BackSpace'):
             self.do_back_space(self.tabList, self.arg_completion)
             c.minibufferWantsFocus()
+        elif char in ('Up', 'Down'):
+            g.trace(f"*** {char=}")
         elif k.isFKey(stroke):
             # Ignore only F-keys. Ignoring all except plain keys would kill unicode searches.
             pass
@@ -3528,6 +3531,7 @@ class KeyHandlerClass:
         k = self
         state = k.state.kind
         stroke = event.stroke
+        ### g.trace(f"{state=} {k.isPlainKey(stroke)=} {stroke.s=}")  ###
         if not k.inState():
             return False
         # First, honor minibuffer bindings for all except user modes.
@@ -3641,13 +3645,16 @@ class KeyHandlerClass:
 
     # @+node:ekr.20061031131434.152: *6* k.handleMiniBindings
     def handleMiniBindings(self, event: LeoKeyEvent, state: str, stroke: Stroke) -> bool:
-        """Find and execute commands bound to the event."""
+        """
+        Find and execute commands bound to the event.
+
+        Return True if a command was executed.
+        """
         k = self
-        #
+
         # Special case for bindings handled in k.getArg:
-        if state == 'full-command' and stroke in ('Up', 'Down'):
+        if state in ('getArg', 'full-command') and stroke in ('Up', 'Down'):
             return False
-        #
         # Ignore other special keys in the minibuffer.
         if state in ('getArg', 'full-command'):
             if stroke in (
@@ -3660,15 +3667,12 @@ class KeyHandlerClass:
                 return False
             if k.isFKey(stroke):
                 return False
-        #
         # Ignore autocompletion state.
         if state.startswith('auto-'):
             return False
-        #
         # Ignore plain key binding in the minibuffer.
         if not stroke or k.isPlainKey(stroke):
             return False
-        #
         # Get the command, based on the pane.
         for pane in ('mini', 'all', 'text'):
             result = k.handleMinibufferHelper(event, pane, state, stroke)
@@ -3678,7 +3682,6 @@ class KeyHandlerClass:
             if result == 'found':
                 # Do not call k.keyboardQuit here!
                 return True
-        #
         # No binding exists.
         return False
 

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -3531,7 +3531,6 @@ class KeyHandlerClass:
         k = self
         state = k.state.kind
         stroke = event.stroke
-        ### g.trace(f"{state=} {k.isPlainKey(stroke)=} {stroke.s=}")  ###
         if not k.inState():
             return False
         # First, honor minibuffer bindings for all except user modes.

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1573,7 +1573,7 @@ class GetArg:
             finder = c.findCommands
             handler = self.after_get_arg_state[2]
             if handler in (finder.find_state0, finder._start_search_escape2):
-                finder.do_arrow(char)
+                finder.do_arrow(char, in_minibuffer=True)
         elif k.isFKey(stroke):
             # Ignore only F-keys. Ignoring all except plain keys would kill unicode searches.
             pass

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1570,8 +1570,11 @@ class GetArg:
         elif char in ('\b', 'BackSpace'):
             self.do_back_space(self.tabList, self.arg_completion)
             c.minibufferWantsFocus()
-        elif char in ('Up', 'Down'):
-            g.trace(f"*** {char=}")
+        elif char in ('Up', 'Down'):  # 4685.
+            finder = c.findCommands
+            handler = self.after_get_arg_state[2]
+            if handler == finder.find_state0:
+                finder.do_arrow(char)
         elif k.isFKey(stroke):
             # Ignore only F-keys. Ignoring all except plain keys would kill unicode searches.
             pass

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1572,7 +1572,7 @@ class GetArg:
         elif char in ('Up', 'Down'):  # 4685.
             finder = c.findCommands
             handler = self.after_get_arg_state[2]
-            if handler == finder.find_state0:
+            if handler in (finder.find_state0, finder._start_search_escape2):
                 finder.do_arrow(char)
         elif k.isFKey(stroke):
             # Ignore only F-keys. Ignoring all except plain keys would kill unicode searches.

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1291,12 +1291,13 @@ class FindTabManager:
         """
         c = self.c
         find = c.findCommands
+
         # Find/change text boxes.
-        table1 = (
+        text_table = (
             ('find_findbox',    'find_text',   '<find pattern here>'),
             ('find_replacebox', 'change_text', ''),
         )  # fmt: skip
-        for ivar, setting_name, default in table1:
+        for ivar, setting_name, default in text_table:
             s = c.config.getString(setting_name) or default
             w = getattr(self, ivar)
             w.insert(s)
@@ -1304,8 +1305,9 @@ class FindTabManager:
                 w.clearFocus()
             else:
                 w.setSelection(0, len(s))
+
         # Check boxes.
-        table2 = (
+        check_box_table = (
             ('ignore_case',     self.check_box_ignore_case),
             ('mark_changes',    self.check_box_mark_changes),
             ('mark_finds',      self.check_box_mark_finds),
@@ -1313,9 +1315,8 @@ class FindTabManager:
             ('search_body',     self.check_box_search_body),
             ('search_headline', self.check_box_search_headline),
             ('whole_word',      self.check_box_whole_word),
-            # ('wrap',          self.check_box_wrap_around),
         )  # fmt: skip
-        for setting_name, w in table2:
+        for setting_name, w in check_box_table:
             val = c.config.getBool(setting_name, default=False)
             # The setting name is also the name of the LeoFind ivar.
             assert hasattr(find, setting_name), setting_name
@@ -1335,14 +1336,15 @@ class FindTabManager:
                 c.bodyWantsFocusNow()
 
             w.stateChanged.connect(check_box_callback)
+
         # Radio buttons
-        table3 = (
+        radio_buttons_table = (
             ('node_only',       'node_only',       self.radio_button_node_only),
             ('entire_outline',  None,              self.radio_button_entire_outline),
             ('suboutline_only', 'suboutline_only', self.radio_button_suboutline_only),
             ('file_only',       'file_only',       self.radio_button_file_only),
         )  # fmt: skip
-        for setting_name, ivar, w in table3:
+        for setting_name, ivar, w in radio_buttons_table:
             val = c.config.getBool(setting_name, default=False)
             # The setting name is also the name of the LeoFind ivar.
             if ivar is not None:

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -351,12 +351,15 @@ class DynamicWindow(QtWidgets.QMainWindow):
     # @+node:ekr.20131118152731.16848: *5* dw.create_find_findbox
     def create_find_findbox(self, grid: QGridLayout, parent: QWidget, row: int) -> int:
         """Create the Find: label and text area."""
+        g.trace(parent)
         c, dw = self.leo_c, self
         fc = c.findCommands
         ftm = fc.ftm
         assert ftm.find_findbox is None
         ftm.find_findbox = w = dw.createLineEdit(parent, 'findPattern')
         w.leo_wrapper = QLineEditWrapper(widget=w, name='find-wrapper', c=c)
+        ### c.k.completeAllBindingsForWidget(w.leo_wrapper)  ### Experimental.
+        g.app.gui.setFilter(c, w, w.leo_wrapper, tag='find-tab-find-textbox')  ### Experimental.
         lab2 = self.createLabel(parent, 'findLabel', 'Find:')
         grid.addWidget(lab2, row, 0)
         grid.addWidget(w, row, 1, 1, 2)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -551,6 +551,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
             # @+node:ekr.20131118172620.16894: *7* EventWrapper.keyPress
             def keyPress(self, event: LeoKeyEvent) -> bool:
                 s = event.text()
+                w = self.w
                 out = s and s in '\t\r\n'
                 if out:
                     # Move focus to next widget.
@@ -563,7 +564,15 @@ class DynamicWindow(QtWidgets.QMainWindow):
                     elif self.func:
                         self.func()
                     return True
+
                 binding, ch, lossage = self.eventFilter.toBinding(event)
+
+                # #4685: A hack for Up/Down arrows in the Find Tab/Dialog
+                if c.widget_name(w) == 'findPattern':  # A Qt Widget, not a Leo Wrapper.
+                    if ch in ('Up', 'Down'):
+                        c.findCommands.do_arrow(char=s, in_minibuffer=False, w=w)
+                        return True
+
                 # #2094: Use code similar to the end of LeoQtEventFilter.eventFilter.
                 #        The ctor converts <Alt-X> to <Alt-x> !!
                 #        That is, we must use the stroke, not the binding.

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1257,7 +1257,10 @@ class FindTabManager:
 
         Similar to LeoFind.default_settings, but only for find-tab values.
         """
-        return g.Bunch(
+        c = self.c
+        finder = c.findCommands
+
+        bunch = g.Bunch(
             # State...
             in_headline = False,
             reverse     = False,
@@ -1276,6 +1279,9 @@ class FindTabManager:
             suboutline_only = self.radio_button_suboutline_only.isChecked(),
             whole_word      = self.check_box_whole_word.isChecked(),
         )  # fmt: skip
+
+        finder._remember_settings(bunch)  # #4685
+        return bunch
 
     # @+node:ekr.20131117120458.16789: *3* FindTabManager.init_widgets (creates callbacks)
     def init_widgets(self) -> None:

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -900,46 +900,42 @@ class DynamicWindow(QtWidgets.QMainWindow):
     def createLogPane(self, parent: QWidget) -> None:
         """Create all parts of Leo's log pane."""
         c = self.leo_c
-        #
+
         # Create the log frame.
         logFrame = self.createFrame(parent, 'logFrame', vPolicy=Policy.Minimum)
         innerFrame = self.createFrame(
             logFrame, 'logInnerFrame', hPolicy=Policy.Preferred, vPolicy=Policy.Expanding
         )
         tabWidget = self.createTabWidget(innerFrame, 'logTabWidget')
-        #
+
         # Pack.
         innerGrid = self.createGrid(innerFrame, 'logInnerGrid')
         innerGrid.addWidget(tabWidget, 0, 0, 1, 1)
         outerGrid = self.createGrid(logFrame, 'logGrid')
         outerGrid.addWidget(innerFrame, 0, 0, 1, 1)
-        #
+
         # Create the Find tab, embedded in a QScrollArea.
         findScrollArea = QtWidgets.QScrollArea()
         findScrollArea.setObjectName('findScrollArea')
-        # Find tab.
         findTab = QtWidgets.QWidget()
         findTab.setObjectName('findTab')
-        #
+
         # #516 and #1507: Create a Find tab unless we are using a dialog.
-        #
-        # Careful: @bool minibuffer-ding-mode overrides @bool use-find-dialog.
         use_minibuffer = c.config.getBool('minibuffer-find-mode', default=False)
         use_dialog = c.config.getBool('use-find-dialog', default=False)
         if use_minibuffer or not use_dialog:
             tabWidget.addTab(findScrollArea, 'Find')
-        # Complete the Find tab in LeoFind.finishCreate.
-        self.findScrollArea = findScrollArea
-        self.findTab = findTab
-        #
+
         # Spell tab.
         spellTab = QtWidgets.QWidget()
         spellTab.setObjectName('spellTab')
         tabWidget.addTab(spellTab, 'Spell')
         self.createSpellTab(spellTab)
         tabWidget.setCurrentIndex(1)
-        #
+
         # Official ivars
+        self.findScrollArea = findScrollArea
+        self.findTab = findTab
         self.tabWidget = tabWidget  # Used by LeoQtLog.
 
     # @+node:ekr.20131118172620.16858: *5* dw.finishCreateLogPane

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2648,16 +2648,16 @@ class LeoQtLog(leoFrame.LeoLog):
     def numberOfVisibleTabs(self) -> int:
         return len([val for val in self.contentsDict.values() if val is not None])
 
-    # @+node:ekr.20110605121601.18331: *4* LeoQtLog.selectTab & helpers
+    # @+node:ekr.20110605121601.18331: *4* LeoQtLog.selectTab & helpers (**changed)
     def selectTab(self, tabName: str, wrap: str = 'none') -> None:
         """Create the tab if necessary and make it active."""
         i = self.findTabIndex(tabName)
         if i is None:
             self.createTab(tabName, wrap=wrap)
-            self.finishCreateTab(tabName)
+            ### self.finishCreateTab(tabName)
         self.finishSelectTab(tabName)
 
-    # @+node:ekr.20190603064815.1: *5* LeoQtLog.finishCreateTab
+    # @+node:ekr.20190603064815.1: *5* LeoQtLog.finishCreateTab (Necessary??)
     def finishCreateTab(self, tabName: str) -> None:
         """Finish creating the given tab. Do not set focus!"""
         c = self.c
@@ -2668,6 +2668,7 @@ class LeoQtLog(leoFrame.LeoLog):
             g.trace('Can not happen', tabName)
             self.tabName: str = None
             return
+        g.trace('=====', tabName, g.callers())  ###
         # #1161.
         if tabName == 'Log':
             widget = self.contentsDict.get('Log')
@@ -2680,6 +2681,7 @@ class LeoQtLog(leoFrame.LeoLog):
         if tabName == 'Find':
             # Do *not* set focus here!
             # #1254861: Ctrl-f doesn't ensure find input field visible.
+            g.trace(c.findCommands.ftm.find_findbox)  ###
             if c.config.getBool('auto-scroll-find-tab', default=True):
                 # This is the cause of unwanted scrolling.
                 findbox = c.findCommands.ftm.find_findbox

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -570,7 +570,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
                 # #4685: A hack for Up/Down arrows in the Find Tab/Dialog
                 if c.widget_name(w) == 'findPattern':  # A Qt Widget, not a Leo Wrapper.
                     if ch in ('Up', 'Down'):
-                        c.findCommands.do_arrow(char=s, in_minibuffer=False, w=w)
+                        c.findCommands.do_arrow(char=ch, in_minibuffer=False, w=w)
                         return True
 
                 # #2094: Use code similar to the end of LeoQtEventFilter.eventFilter.

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -357,8 +357,6 @@ class DynamicWindow(QtWidgets.QMainWindow):
         assert ftm.find_findbox is None
         ftm.find_findbox = w = dw.createLineEdit(parent, 'findPattern')
         w.leo_wrapper = QLineEditWrapper(widget=w, name='find-wrapper', c=c)
-        ### c.k.completeAllBindingsForWidget(w.leo_wrapper)  ### Experimental.
-        ### g.app.gui.setFilter(c, w, w.leo_wrapper, tag='find-tab-find-textbox')  ### Experimental.
         lab2 = self.createLabel(parent, 'findLabel', 'Find:')
         grid.addWidget(lab2, row, 0)
         grid.addWidget(w, row, 1, 1, 2)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -570,7 +570,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
                 # #4685: A hack for Up/Down arrows in the Find Tab/Dialog
                 if c.widget_name(w) == 'findPattern':  # A Qt Widget, not a Leo Wrapper.
                     if ch in ('Up', 'Down'):
-                        c.findCommands.do_arrow(char=ch, in_minibuffer=False, w=w)
+                        c.findCommands.do_arrow(char=ch, in_minibuffer=False)
                         return True
 
                 # #2094: Use code similar to the end of LeoQtEventFilter.eventFilter.

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2648,52 +2648,15 @@ class LeoQtLog(leoFrame.LeoLog):
     def numberOfVisibleTabs(self) -> int:
         return len([val for val in self.contentsDict.values() if val is not None])
 
-    # @+node:ekr.20110605121601.18331: *4* LeoQtLog.selectTab & helpers (**changed)
+    # @+node:ekr.20110605121601.18331: *4* LeoQtLog.selectTab & helpers
     def selectTab(self, tabName: str, wrap: str = 'none') -> None:
         """Create the tab if necessary and make it active."""
         i = self.findTabIndex(tabName)
         if i is None:
             self.createTab(tabName, wrap=wrap)
-            ### self.finishCreateTab(tabName)
         self.finishSelectTab(tabName)
 
-    # @+node:ekr.20190603064815.1: *5* LeoQtLog.finishCreateTab (Necessary??)
-    def finishCreateTab(self, tabName: str) -> None:
-        """Finish creating the given tab. Do not set focus!"""
-        c = self.c
-        i = self.findTabIndex(tabName)
-        widget: LeoQTextBrowser = None
-        wrapper: LeoQTextBrowser = None
-        if i is None:
-            g.trace('Can not happen', tabName)
-            self.tabName: str = None
-            return
-        g.trace('=====', tabName, g.callers())  ###
-        # #1161.
-        if tabName == 'Log':
-            widget = self.contentsDict.get('Log')
-            if widget:
-                wrapper = getattr(widget, 'leo_log_wrapper', None)
-                if wrapper and isinstance(wrapper, qt_text.QTextEditWrapper):
-                    self.logCtrl = wrapper
-            if not wrapper:
-                g.trace('NO LOG WRAPPER')
-        if tabName == 'Find':
-            # Do *not* set focus here!
-            # #1254861: Ctrl-f doesn't ensure find input field visible.
-            g.trace(c.findCommands.ftm.find_findbox)  ###
-            if c.config.getBool('auto-scroll-find-tab', default=True):
-                # This is the cause of unwanted scrolling.
-                findbox = c.findCommands.ftm.find_findbox
-                if hasattr(widget, 'ensureWidgetVisible'):
-                    widget.ensureWidgetVisible(findbox)
-                else:
-                    findbox.setFocus()
-        if tabName == 'Spell':
-            # Set a flag for the spell system.
-            self.qtFrameDict['Spell'] = self.tabWidget.widget(i)
-
-    # @+node:ekr.20190603064816.1: *5* LeoQtLog.finishSelectTab
+    # @+node:ekr.20190603064816.1: *4* LeoQtLog.finishSelectTab
     def finishSelectTab(self, tabName: str) -> None:
         """Select the proper tab."""
         w = self.tabWidget

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -4111,18 +4111,6 @@ class QtMenuWrapper(LeoQtMenu, QtWidgets.QMenu):  # type:ignore
     # @-others
 
 
-# @+node:ekr.20110605121601.18461: ** class QtSearchWidget
-class QtSearchWidget:
-    """A dummy widget class to pass to Leo's core find code."""
-
-    def __init__(self) -> None:
-        self.insertPoint = 0
-        self.selection = 0, 0
-        self.wrapper = self
-        self.body = self
-        self.text = None
-
-
 # @+node:ekr.20110605121601.18257: ** class QtStatusLineClass
 class QtStatusLineClass:
     """A class representing the status line."""

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -920,7 +920,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         findTab = QtWidgets.QWidget()
         findTab.setObjectName('findTab')
 
-        # #516 and #1507: Create a Find tab unless we are using a dialog.
+        # #516 and #1507: Create a Find tab unless we are *only* using the Find dialog.
         use_minibuffer = c.config.getBool('minibuffer-find-mode', default=False)
         use_dialog = c.config.getBool('use-find-dialog', default=False)
         if use_minibuffer or not use_dialog:
@@ -937,13 +937,6 @@ class DynamicWindow(QtWidgets.QMainWindow):
         self.findScrollArea = findScrollArea
         self.findTab = findTab
         self.tabWidget = tabWidget  # Used by LeoQtLog.
-
-    # @+node:ekr.20131118172620.16858: *5* dw.finishCreateLogPane
-    def finishCreateLogPane(self) -> None:
-        """It's useful to create this late, because c.config is now valid."""
-        assert self.findTab
-        self.createFindTab(self.findTab, self.findScrollArea)
-        self.findScrollArea.setWidget(self.findTab)
 
     # @+node:ekr.20110605121601.18146: *4* dw.createMainLayout
     def createMainLayout(self, parent: QWidget) -> tuple[QWidget, QWidget]:
@@ -1071,7 +1064,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         # Official ivars.
         self.leo_statusBar = w
 
-    # @+node:ekr.20240726174902.1: *4* dw.createVRPanes (new)
+    # @+node:ekr.20240726174902.1: *4* dw.createVRPanes
     def createVRPanes(self) -> list[QtWidgets.QFrame]:
         """
         Create the VR and/or the VR3 panes if either plugin is enabled.
@@ -1083,6 +1076,13 @@ class DynamicWindow(QtWidgets.QMainWindow):
         panes: list[QtWidgets.QFrame] = []
 
         return panes
+
+    # @+node:ekr.20131118172620.16858: *4* dw.finishCreateLogPane
+    def finishCreateLogPane(self) -> None:
+        """It's useful to create this late, because c.config is now valid."""
+        assert self.findTab
+        self.createFindTab(self.findTab, self.findScrollArea)
+        self.findScrollArea.setWidget(self.findTab)
 
     # @+node:ekr.20110605121601.18212: *4* dw.packLabel
     def packLabel(self, w: QWidget, n: int = None) -> None:
@@ -2303,8 +2303,7 @@ class LeoQtLog(leoFrame.LeoLog):
                 c.findCommands.startSearch(event=None)
 
         w.currentChanged.connect(tab_callback)
-        # #1286.
-        w.customContextMenuRequested.connect(self.onContextMenu)
+        w.customContextMenuRequested.connect(self.onContextMenu)  # #1286.
 
     # @+node:ekr.20110605121601.18316: *4* LeoQtLog.getName
     def getName(self) -> str:
@@ -2644,7 +2643,7 @@ class LeoQtLog(leoFrame.LeoLog):
     def numberOfVisibleTabs(self) -> int:
         return len([val for val in self.contentsDict.values() if val is not None])
 
-    # @+node:ekr.20110605121601.18331: *4* LeoQtLog.selectTab & helpers
+    # @+node:ekr.20110605121601.18331: *4* LeoQtLog.selectTab
     def selectTab(self, tabName: str, wrap: str = 'none') -> None:
         """Create the tab if necessary and make it active."""
         i = self.findTabIndex(tabName)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -351,7 +351,6 @@ class DynamicWindow(QtWidgets.QMainWindow):
     # @+node:ekr.20131118152731.16848: *5* dw.create_find_findbox
     def create_find_findbox(self, grid: QGridLayout, parent: QWidget, row: int) -> int:
         """Create the Find: label and text area."""
-        g.trace(parent)
         c, dw = self.leo_c, self
         fc = c.findCommands
         ftm = fc.ftm
@@ -359,7 +358,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         ftm.find_findbox = w = dw.createLineEdit(parent, 'findPattern')
         w.leo_wrapper = QLineEditWrapper(widget=w, name='find-wrapper', c=c)
         ### c.k.completeAllBindingsForWidget(w.leo_wrapper)  ### Experimental.
-        g.app.gui.setFilter(c, w, w.leo_wrapper, tag='find-tab-find-textbox')  ### Experimental.
+        ### g.app.gui.setFilter(c, w, w.leo_wrapper, tag='find-tab-find-textbox')  ### Experimental.
         lab2 = self.createLabel(parent, 'findLabel', 'Find:')
         grid.addWidget(lab2, row, 0)
         grid.addWidget(w, row, 1, 1, 2)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -316,8 +316,8 @@ class DynamicWindow(QtWidgets.QMainWindow):
         row = dw.create_find_replacebox(grid, parent, row)
         max_row2 = 1
         max_row2 = dw.create_find_checkboxes(grid, parent, max_row2, row)
-        row = dw.create_find_buttons(grid, parent, max_row2, row)
-        row = dw.create_help_row(grid, parent, row)
+        if 0:  # These buttons are non-functional reminders.
+            row = dw.create_find_buttons(grid, parent, max_row2, row)
         dw.override_events()
         # Last row: Widgets that take all additional vertical space.
         w = QtWidgets.QWidget()
@@ -445,17 +445,6 @@ class DynamicWindow(QtWidgets.QMainWindow):
             assert getattr(ftm, name) is None
             setattr(ftm, name, w)
         return max_row2
-
-    # @+node:ekr.20131118152731.16853: *5* dw.create_help_row
-    def create_help_row(self, grid: QGridLayout, parent: QWidget, row: int) -> int:
-        # Help row.
-        if False:
-            w = self.createLabel(
-                parent, 'findHelp', 'For help: <alt-x>help-for-find-commands<return>'
-            )
-            grid.addWidget(w, row, 0, 1, 3)
-            row += 1
-        return row
 
     # @+node:ekr.20131118152731.16852: *5* dw.create_find_buttons
     def create_find_buttons(

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1218,7 +1218,6 @@ class FindTabManager:
         self.check_box_search_body = None
         self.check_box_search_headline = None
         self.check_box_whole_word = None
-        # self.check_box_wrap_around = None
         # Radio buttons
         self.radio_button_file_only = None
         self.radio_button_entire_outline = None
@@ -1246,8 +1245,11 @@ class FindTabManager:
         w.setSelection(0, len(s))
 
     def set_entry_focus(self) -> None:
-        # Remember the widget that had focus, changing headline widgets
-        # to the tree pane widget.  Headline widgets can disappear!
+        """
+        Remember the widget that had focus, changing headline widgets to the tree pane widget.
+
+        Headline widgets can disappear!
+        """
         c = self.c
         w = g.app.gui.get_focus(raw=True)
         if w != c.frame.body.wrapper.widget:
@@ -1365,7 +1367,7 @@ class FindTabManager:
     # @+node:ekr.20210923060904.1: *3* FindTabManager.set_widgets_from_dict
     def set_widgets_from_dict(self, d: g.Bunch) -> None:
         """Set all settings from d."""
-        # Similar to FindTabManagerinit_widgets, which has already been called.
+        # Similar to FindTabManager.init_widgets, which has already been called.
         c = self.c
         find = c.findCommands
         # Set find text.


### PR DESCRIPTION
See #4685.

Here, **arrow keys** refer to the `Up` and `Down` keys only.

### Part 1: Support arrow keys when using the minibuffer for finds

That is, when `@bool minibuffer-find-mode` is `True`.

- [x] `k.doMode`: Call `k.getArg` for arrow keys.
- [x] `k.getArg`: Add special case for arrow keys.
- [x] Add `LeoFind.prevSearches` ivar.
- [x] Add `LeoFind. _remember_settings` method. Call it whenever calling `LeoFind.do_find_next`.
- [x] Add `LeoFind.do_arrow`: Handle arrow keys when getting search arguments.
- [x] Show all settings, *including* change text, after arrow keys.
- [x] Note: `tab` works properly (shows change text) after arrow keys
- [x] Make arrow work after tab shifts to replacement text.


### Part 2: Support arrow keys in the Find Tab/Dialog

That is, when `@bool minibuffer-find-mode` is `False`.

- [x] `EventWrapper.keyPress`: Add a hook to `LeoFind.do_arrow`.
- [x] Stay in Find Tab/Dialog after executing `toggle-find-x` commands.
- [x] Remove the "help" column. This reduces the necessary screen real estate!
- [x] The `show-find-options` *always* shows the Find Tab.  Hurray!
- [x] Remove the do-nothing `dw.create_help_row method`.

### Other changes

- [x] Improve traces in `LeoQtLog.__init__`. None of these traces are active unless `--trace=keys` is in effect.
- [x] Delete unused `QtSearchWidget` class.
- [x] Convert a comment to a docstring.
- [x] Remove several references to the dead `wrapping` option.
- [x] Delete the unused `LeoQtLog.finishCreateTab` and  `@bool auto-scroll-find-tab`.
- [x] Cleanups, including converting empty comment lines to blank lines.  An ongoing project.

### Testing

The following hand tests pass

- [x] Test legacy operation of Alt-Ctrl bindings to change search settings.
- [x] Test operation of up/down arrows after Ctrl-F.
- [x] Test that `tab` works properly (shows change text) after up/down arrows.
- [x] Test that arrow keys work when showing replacement text: they reset the entire search.