### PR TITLE
PR Use shell=True everywhere

### DIFF
--- a/leo/commands/controlCommands.py
+++ b/leo/commands/controlCommands.py
@@ -43,7 +43,7 @@ class ControlCommandsClass(BaseEditCommandsClass):
                 shlex.split(command),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL if trace else subprocess.PIPE,
-                shell=g.isWindows,
+                shell=True,
             )
             out, err = proc.communicate()
             for line in g.splitLines(g.toUnicode(out)):

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1568,9 +1568,7 @@ class LeoApp:
         g.es_print('Starting log_listener.py')
         path = g.finalize_join(app.loadDir, '..', 'external', 'log_listener.py')
         app.log_listener = subprocess.Popen(
-            [sys.executable, path],
-            shell=False,
-            universal_newlines=True,
+            [sys.executable, path], shell=True, universal_newlines=True
         )
 
     # @+node:ekr.20171118024827.1: *3* app.makeAllBindings

--- a/leo/core/leoBackground.py
+++ b/leo/core/leoBackground.py
@@ -253,6 +253,7 @@ class BackgroundProcessManager:
                 stderr=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 universal_newlines=True,
+                shell=True,
             )
             return proc
 

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1086,10 +1086,9 @@ class Commands:
                 if processor:
                     if processor == 'cmd.exe':
                         cmd = ['start', processor, '/k', fullpath]
-                        subprocess.Popen(cmd, shell=True)
                     else:
                         cmd = ['start', 'cmd.exe', '/k', processor, fullpath]
-                        subprocess.Popen(cmd, shell=True)
+                    subprocess.Popen(cmd, shell=True)
                 else:
                     g.es('Unknown processor', fullpath, color='red')
             elif g.isMac:
@@ -3388,10 +3387,7 @@ class Commands:
         # Execute the final command.
         try:
             proc = subprocess.Popen(
-                final_command,
-                shell=False,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                final_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
             )
             out, err = proc.communicate()
             for s in g.splitLines(g.toUnicode(out)):

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -5234,7 +5234,7 @@ class Commands:
 
         # Run the command.
         try:
-            subprocess.Popen(command).communicate()  # Wait for results.
+            subprocess.Popen(command, shell=True).communicate()  # Wait for results.
             results = g.readFile(filename)
             if g.isWindows:
                 results = results.replace('\r', '')

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -4804,11 +4804,7 @@ def execGitCommand(command: str, directory: str) -> list[str]:
         os.chdir(directory)
     try:
         proc = subprocess.Popen(
-            shlex.split(command),
-            stdout=subprocess.PIPE,
-            stderr=None,  # Shows error traces.
-            # stderr=subprocess.PIPE,
-            shell=False,
+            shlex.split(command), stdout=subprocess.PIPE, stderr=None, shell=True
         )
         out, err = proc.communicate()
         lines = [g.toUnicode(z) for z in g.splitLines(out or '')]
@@ -7311,7 +7307,7 @@ def os_startfile(fname: str) -> None:
                 ree.close()
             return
         try:
-            subPopen = subprocess.Popen(['xdg-open', fname], stderr=wre, shell=False)
+            subPopen = subprocess.Popen(['xdg-open', fname], stderr=wre, shell=True)
         except Exception:
             g.es_print(f"error opening {fname!r}")
             g.es_exception()

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -421,7 +421,7 @@ class MarkupCommands:
         if self.sphinx_default_command:
             if trace:
                 g.trace(f"\ncommand: {self.sphinx_default_command!r}\n")
-            g.execute_shell_commands(self.sphinx_default_command)
+            g.execute_shell_commands(self.sphinx_default_command, shell=True)
             return
         # Compute the input directory.
         input_dir = g.finalize(self.sphinx_input_dir or os.path.dirname(i_path))

--- a/leo/plugins/at_produce.py
+++ b/leo/plugins/at_produce.py
@@ -143,7 +143,7 @@ def runList(c, aList):
                     stdin=PIPE,
                     stdout=PIPE,
                     stderr=PIPE,
-                    # shell=True, # $4662.
+                    shell=True,
                 )
                 fi, fo, fe = p.stdin, p.stdout, p.stderr
                 while 1:

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -4443,7 +4443,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
 
         # We are not checking the return code here, so:
         # pylint: disable=subprocess-run-check
-        result = subprocess.run(cmd, shell=False, capture_output=True, text=True, encoding='utf-8')
+        result = subprocess.run(cmd, capture_output=True, text=True, encoding='utf-8', shell=True)
         return result.stdout, result.stderr
 
     # @-others

--- a/leo/scripts/beautify_all_leo.py
+++ b/leo/scripts/beautify_all_leo.py
@@ -44,5 +44,5 @@ targets = (
 # Use -m so that __name__ == '__main__'.
 python = sys.executable
 command = f"{python} -m ruff format {args} {' '.join(targets)}"
-subprocess.Popen(command).communicate()
+subprocess.Popen(command, shell=True).communicate()
 # @-leo

--- a/leo/scripts/build_leo.py
+++ b/leo/scripts/build_leo.py
@@ -38,7 +38,7 @@ command = f"{python} -m build > build_log.txt"
 print('')
 print(command)
 print('')
-subprocess.Popen(command).communicate()
+subprocess.Popen(command, shell=True).communicate()
 
 print('See build_log.txt')
 # @-leo

--- a/leo/scripts/flake8_leo.py
+++ b/leo/scripts/flake8_leo.py
@@ -26,6 +26,6 @@ os.chdir(leo_editor_dir)
 args = ' '.join(sys.argv[1:]) + leo_editor_dir
 python = sys.executable
 command = rf'{python} -m flake8 {args} --show-source --config={leo_editor_dir}{os.sep}setup.cfg'
-subprocess.Popen(command).communicate()
+subprocess.Popen(command, shell=True).communicate()
 
 # @-leo

--- a/leo/scripts/full_test_leo.py
+++ b/leo/scripts/full_test_leo.py
@@ -47,5 +47,5 @@ for command in [
     rf'{python} -m leo.scripts.check_leo',
     rf'{python} -m leo.scripts.pylint_leo',
 ]:
-    subprocess.Popen(command).communicate()
+    subprocess.Popen(command, shell=True).communicate()
 # @-leo

--- a/leo/scripts/inspect_wheel.py
+++ b/leo/scripts/inspect_wheel.py
@@ -28,7 +28,7 @@ os.chdir(leo_editor_dir)
 python = sys.executable
 command = rf"{python} -m wheel_inspect dist\leo-6.8.8-py3-none-any.whl >inspect_wheel.txt"
 print(command)
-subprocess.Popen(command).communicate()
+subprocess.Popen(command, shell=True).communicate()
 
 print('See inspect_wheel.txt')
 # @-leo

--- a/leo/scripts/install_leo_from_pypi.py
+++ b/leo/scripts/install_leo_from_pypi.py
@@ -23,5 +23,5 @@ os.chdir(home_dir)
 python = sys.executable
 command = f"{python} -m pip install leo==6.8.8"
 print(command)
-subprocess.Popen(command).communicate()
+subprocess.Popen(command, shell=True).communicate()
 # @-leo

--- a/leo/scripts/install_leo_from_testpypi.py
+++ b/leo/scripts/install_leo_from_testpypi.py
@@ -24,5 +24,5 @@ os.chdir(home_dir)
 python = sys.executable
 command = f"{python} -m pip install -i https://test.pypi.org/simple/ leo==6.8.8"
 print(command)
-subprocess.Popen(command).communicate()
+subprocess.Popen(command, shell=True).communicate()
 # @-leo

--- a/leo/scripts/install_leo_locally.py
+++ b/leo/scripts/install_leo_locally.py
@@ -46,7 +46,7 @@ else:
     python = sys.executable
     command = rf"{python} -m pip install {dist_dir}{os.sep}{wheel_file}"
     print(command)
-    subprocess.Popen(command).communicate()
+    subprocess.Popen(command, shell=True).communicate()
 
     # List site-packages/leo*.
     python_dir = os.path.dirname(sys.executable)

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -29,5 +29,5 @@ if 1:  # Quick.
     command = rf"{python} -m mypy leo"
 else:  # Safe.
     command = rf"{python} -m mypy --no-incremental leo"
-subprocess.Popen(command).communicate()
+subprocess.Popen(command, shell=True).communicate()
 # @-leo

--- a/leo/scripts/pip_install_r.py
+++ b/leo/scripts/pip_install_r.py
@@ -28,5 +28,5 @@ for command in [
     f"{python} -m pip list",
 ]:
     print(command)
-    subprocess.Popen(command).communicate()
+    subprocess.Popen(command, shell=True).communicate()
 # @-leo

--- a/leo/scripts/pip_uninstall_all.py
+++ b/leo/scripts/pip_uninstall_all.py
@@ -31,7 +31,7 @@ for command in [
     print('')
     print(command)
     print('')
-    subprocess.Popen(command).communicate()
+    subprocess.Popen(command, shell=True).communicate()
 
 if os.path.exists('temp_requirements.txt'):
     print('')

--- a/leo/scripts/pylint_leo.py
+++ b/leo/scripts/pylint_leo.py
@@ -33,5 +33,5 @@ extensions = 'PyQt6.QtCore,PyQt6.QtGui,PyQt6.QtWidgets,PyQt6.QtWebEngineWidgets'
 extension_pkg = f"--extension-pkg-allow-list={extensions}"
 command = rf"{python} -m pylint leo {rc_file} {extension_pkg}"
 
-subprocess.Popen(command).communicate()
+subprocess.Popen(command, shell=True).communicate()
 # @-leo

--- a/leo/scripts/ruff_leo.py
+++ b/leo/scripts/ruff_leo.py
@@ -28,5 +28,5 @@ os.chdir(leo_editor_dir)
 args = ' '.join(sys.argv[1:])
 python = sys.executable
 command = rf'{python} -m ruff check leo'
-subprocess.Popen(command).communicate()
+subprocess.Popen(command, shell=True).communicate()
 # @-leo

--- a/leo/scripts/run_installed_leo.py
+++ b/leo/scripts/run_installed_leo.py
@@ -29,5 +29,5 @@ else:
     command = f"{python} -m leo.core.runLeo"
     print(command)
     print('')
-    subprocess.Popen(command).communicate()
+    subprocess.Popen(command, shell=True).communicate()
 # @-leo

--- a/leo/scripts/run_test_leo.py
+++ b/leo/scripts/run_test_leo.py
@@ -27,5 +27,5 @@ os.chdir(leo_editor_dir)
 args = ' '.join(sys.argv[1:])
 python = sys.executable
 command = rf'{python} -m unittest {args}'
-subprocess.Popen(command).communicate()
+subprocess.Popen(command, shell=True).communicate()
 # @-leo

--- a/leo/scripts/uninstall_leo.py
+++ b/leo/scripts/uninstall_leo.py
@@ -37,7 +37,7 @@ else:
     python = sys.executable
     command = f"{python} -m pip uninstall leo"
     print(command)
-    subprocess.Popen(command).communicate()
+    subprocess.Popen(command, shell=True).communicate()
 
     if 0:  # This hack should no longer be necessary.
         # Delete the leo/leo.egg-info directory.

--- a/leo/scripts/update_leo_tools.py
+++ b/leo/scripts/update_leo_tools.py
@@ -30,5 +30,5 @@ for command in [
 ]:
     print('')
     print(command)
-    subprocess.Popen(command).communicate()
+    subprocess.Popen(command, shell=True).communicate()
 # @-leo

--- a/leo/scripts/upload_leo_to_pypi.py
+++ b/leo/scripts/upload_leo_to_pypi.py
@@ -28,7 +28,7 @@ command = f"{python} -m twine upload -r pypi dist/*.* --verbose"
 # Upload.
 if 1:  # Don't do this until we are ready to release.
     print(command)
-    subprocess.Popen(command).communicate()
+    subprocess.Popen(command, shell=True).communicate()
 else:
     print(f"Skipped: {command}")
 # @-leo

--- a/leo/scripts/upload_leo_to_testpypi.py
+++ b/leo/scripts/upload_leo_to_testpypi.py
@@ -28,7 +28,7 @@ command = f"{python} -m twine upload -r testpypi dist/*.* --verbose"
 # Upload
 if 1:  # Don't do this until we are ready to release.
     print(command)
-    subprocess.Popen(command).communicate()
+    subprocess.Popen(command, shell=True).communicate()
 else:
     print(f"Skipped: {command}")
 # @-leo


### PR DESCRIPTION
This PR fixes scripting issues on Linux. It backs out of previous security-oriented PRs.

- Explicitly setting `shell=True` is redundant in calls to `g.execute_shell_commands`.
- Setting `shell=True` is *required* in calls to `subprocess.Popen` and `subprocess.run`.

### About security

This PR is in no way a security risk. All scripts executed with `shell=True` contain static text, written by Leo's devs.

