### PR TITLE
PR fixes #4708: unused ivar

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -528,7 +528,6 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
             getBool('scripting-abbreviations')
         )  # fmt: skip
         self.globalDynamicAbbrevs = getBool('globalDynamicAbbrevs')
-        self.next_placeholder = getString("abbreviations-next-placeholder") or ',,'
 
         # Allow @data abbreviations-subst-env *only* in leoSettings.leo or myLeoSettings.leo!
         key = 'abbreviations-subst-env'

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -87,11 +87,6 @@
 <v t="ekr.20200226104131.1"><vh>Future settings</vh>
 <v t="ekr.20190926110217.1"><vh>@string adoc-base-directory = None</vh></v>
 </v>
-<v t="ekr.20260419074741.1"><vh>Unused settings</vh>
-<v t="ekr.20141024165714.1"><vh>@bool auto-scroll-find-tab = True</vh></v>
-<v t="jlunz.20151119171553.1"><vh>@bool cursor-stay-on-paste = True</vh></v>
-<v t="tbrown.20151114110207.1"><vh>@string abbreviations-next-placeholder = ,,</vh></v>
-</v>
 </v>
 <v t="ekr.20041119034357.1"><vh>@settings</vh>
 <v t="ekr.20201010141557.1"><vh>@string theme-name = None</vh></v>
@@ -9136,8 +9131,6 @@ c.k.simulateCommand('show-color-wheel')
 <t tx="ekr.20140922124047.19516"></t>
 <t tx="ekr.20140922124047.19517"></t>
 <t tx="ekr.20140922124047.20313"></t>
-<t tx="ekr.20141024165714.1">True:  Scroll the find tab ensure find input field visible. (fixes bug 1254861)
-False: Never scroll the find tab automatically.</t>
 <t tx="ekr.20141112072219.1"></t>
 <t tx="ekr.20141204160426.5">New.</t>
 <t tx="ekr.20150216135059.1">With @clean and @file, Leo can store persistent data in nodes. This
@@ -11908,7 +11901,6 @@ If not given, Leo's beautifier uses Leo's pyproject.toml file.
 
 True (Legacy):       Raise a dialog when any file changes externally.
 False (Recommended): Print a log message when any file changes externally.</t>
-<t tx="ekr.20260419074741.1"></t>
 <t tx="felix.20220506230435.1">True: (Legacy) The goto-first-visible-node and goto-first-visible-node commands collapse all nodes that are not ancestors of the target node that is selected.
 
 False: (Recommended) The commands act as simple navigation commands, and do not change the outline state.</t>
@@ -11953,7 +11945,6 @@ Leo accepts outline 'paste' data in both XML Leo format, or JSON format</t>
         
     QtCore.QTimer.singleShot(0, later)
 </t>
-<t tx="jlunz.20151119171553.1"></t>
 <t tx="jlunz.20151120072157.1">True: Wrap body text.
 
 </t>
@@ -12503,9 +12494,6 @@ This setting must be explicitly set to `False` to suppress
 the status line output, just deleting it to get a value of `None`
 won't work - this preserves the default `True` action in the
 absence of this setting.</t>
-<t tx="tbrown.20151114110207.1">"Abbreviation" to trigger the selection of the next placeholder,
-i.e. typing ,, will select the next &lt;|placeholder|&gt; text, after
-removing the &lt;| and |&gt;</t>
 <t tx="tbrown.20160130095933.1">legacy
 ::
 


### PR DESCRIPTION
See #4708.

Removing `self.globalDynamicAbbrevs = getBool('globalDynamicAbbrevs')` would be a mistake.

- [x] Remove the `next_placeholder` ivar.
- [x] Remove the `@string abbreviations-next-placeholder` setting.
- [x] Remove several other unused settings.
