### PR TITLE
PR: Fix crash in do_arrow

### DIFF
--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -3547,8 +3547,6 @@ class LeoFind:
         bunch = self.prev_searches[self.prev_searches_i]
         find_s, change_s = bunch.find_text, bunch.change_text
 
-        # g.trace(f"{char:4} {self.prev_searches_i} of {len(self.prev_searches)} : {bunch!r}")
-
         # Show the options in the status area. Like compute_find_options_in_status_area.
         options = []
         d = {

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -3538,10 +3538,11 @@ class LeoFind:
 
         # Compute the bunch to show.
         i = self.prev_searches_i
+        n = len(self.prev_searches)
         self.prev_searches_i = (
-            i - 1 if (char == 'Up' and i - 1 >= 0) else
-            i + 1 if (char == 'Down' and i + 1 < len(self.prev_searches)) else
-            i
+            i - 1 if (char == 'Up'   and i - 1 >= 0) else
+            i + 1 if (char == 'Down' and i + 1 < n) else
+            max(0, min(i, n - 1))
         )  # fmt: skip
         bunch = self.prev_searches[self.prev_searches_i]
         find_s, change_s = bunch.find_text, bunch.change_text


### PR DESCRIPTION
The call to `self.ftm.get_settings()` in `do_arrow` should ensure that the `prev_searches` list is not empty.