### PR TITLE
PR fixes #4716: git version

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5010,7 +5010,7 @@ class GitIssueController:
 # @+node:ekr.20190428173354.1: *3* g.getGitVersion
 def getGitVersion(directory: str = None) -> tuple[str, str, str]:
     """Return a tuple (author, build, date) from the git log, or None."""
-    #
+
     # -n: Get only the last log.
     trace = 'git' in g.app.debug
     try:
@@ -5018,8 +5018,8 @@ def getGitVersion(directory: str = None) -> tuple[str, str, str]:
             'git log -n 1 --date=iso',
             cwd=directory or g.app.loadDir,
             stderr=subprocess.DEVNULL,
+            shell=True,
         )
-    # #1209.
     except subprocess.CalledProcessError as e:
         s = e.output
         if trace:


### PR DESCRIPTION
See #4716.

- [x] Add `shell=True` in call to `subprocess.check_output` in `g.getGitVersion`.