### PR TITLE
PR fixes #4728: quirp in test_find-prev

### DIFF
--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -377,8 +377,6 @@ class TestFind(LeoUnitTest):
         settings.find_text = 'def top1'
         # Start at end, so we stay in the node.
         grand_child = g.findNodeAnywhere(c, 'child 6')
-        settings.p = grand_child
-        assert settings.p
         settings.find_text = 'def child2'
         # Set c.p in the command.
         x.c.selectPosition(grand_child)


### PR DESCRIPTION
See #4728.

- [x] Remove do-nothing assignment to `settings.p` in `TestFind.test_find-prev`.