### PR TITLE
Updated abbreviation documentation

### DIFF
--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -119,9 +119,9 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
             date;;={|{import time ; x=time.asctime()}|}
 
-        For example, typing ts;; gives::
+        For example, typing date;; gives::
 
-            20131009171117
+            Sun Jun 14 19:51:44 2026
 
         It's even possible to define a context in which abbreviation scripts execute.
 

--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -114,13 +114,12 @@ class HelpCommandsClass(BaseEditCommandsClass):
             \:name="<|name|>"
             \:value="" id="<|id|>">\n
 
-        Typing ",," after inserting a template selects the next field.
+        Typing "F3" after inserting a template selects the next field.
 
         Abbreviations can execute **abbreviation scripts**, delimited by {\|{ and
         }\|}::
 
             date;;={|{import time ; x=time.asctime()}|}
-            ts;;={|{import time ; x=time.strftime("%Y%m%d%H%M%S")}|}
 
         For example, typing ts;; gives::
 

--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -90,11 +90,9 @@ class HelpCommandsClass(BaseEditCommandsClass):
         Abbreviations typically end with something like ";;" so they won't trigger
         by accident.
 
-        You define abbreviations in @data abbreviations nodes or @data
-        global-abbreviations nodes. None come predefined, but leoSettings.leo
-        contains example abbreviations in the node::
-
-            @@data abbreviations examples
+        You define abbreviations in @data abbreviations nodes
+        or @data global-abbreviations nodes. Some come predefined
+        in @data global-abbreviations such as date;; and  html;;.
 
         Abbreviations can simply be shortcuts::
 

--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -14179,7 +14179,7 @@ Abbreviations can define templates in which ``&lt;|a-field-name|&gt;`` denotes a
     \:name="&lt;|name|&gt;"
     \:value="" id="&lt;|id|&gt;"&gt;\n
 
-Typing ``,,`` after inserting a template selects the next field.
+Typing ``F3`` after inserting a template selects the next field.
 
 Abbreviations can execute **abbreviation scripts**, delimited by ``{|{`` and ``}|}``::
 

--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -14157,11 +14157,11 @@ The rst3 command adds the body text of this node to the previous section:
 
 Leo optionally expands abbreviations as you type. Abbreviations typically end with something like ``;;`` so they won't trigger by accident.
 
-To use abbreviations, you must enable them in myLeoSettings.leo::
+Abbreviations are enabled by default through the following setting in myLeoSettings.leo::
 
     @bool enable-abbreviations = True
 
-You define abbreviations in ``@data abbreviations`` nodes or ``@data global-abbreviations`` nodes. None come predefined, but ``leo/config/exampleSettings.leo`` contains example abbreviations in the node ``@data abbreviations examples``
+You define abbreviations in ``@data abbreviations`` nodes or ``@data global-abbreviations`` nodes. Some come predefined in ``@data global-abbreviations`` such as ``date;;`` and  ``html;;``.
 
 Abbreviations can be shortcuts::
 
@@ -14184,15 +14184,14 @@ Typing ``,,`` after inserting a template selects the next field.
 Abbreviations can execute **abbreviation scripts**, delimited by ``{|{`` and ``}|}``::
 
     date;;={|{import time ; x=time.asctime()}|}
-    ts;;={|{import time ; x=time.strftime("%Y%m%d%H%M%S")}|}
 
 To use abbreviations scripts, enable them in myLeoSettings.leo as follows::
 
     @bool scripting-abbreviations = True
 
-With abbreviation scripts enabled, typing ``ts;;`` gives::
+With abbreviation scripts enabled, typing ``date;;`` gives::
 
-    20131009171117
+    Sun Jun 14 19:51:44 2026
 
 It's even possible to define a context in which abbreviation scripts execute. See leoSettings.leo for full details.
 </t>
@@ -29852,7 +29851,7 @@ any change to one clone inevitably affects all other clones.
 <t tx="ekr.20230121061309.1"></t>
 <t tx="ekr.20230121061335.1"></t>
 <t tx="ekr.20230121061433.1"></t>
-<t tx="ekr.20230121110340.1" _mod_time="4741d993336a2ad5e02e">@language batch
+<t tx="ekr.20230121110340.1" _mod_time="4741da464e3720be372e">@language batch
 echo off
 echo off
 cd C:\Repos\leo-editor\leo\doc\html
@@ -29860,7 +29859,7 @@ echo make clean
 call make clean
 </t>
 <t tx="ekr.20230121110345.1"></t>
-<t tx="ekr.20230121110533.1" _mod_time="4741d993336a2adb852e">@language batch
+<t tx="ekr.20230121110533.1" _mod_time="4741da464e3720ce992e">@language batch
 echo off
 echo off
 cd C:\Repos\leo-editor\leo\doc\html

--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -17969,7 +17969,7 @@ The following commands enable, disable or toggle various settings::
 2. Scripts may span multiple lines. Line starting with "\:" (2 characters) continue a script. This allows abbreviations to define multi-line templates.
 Helpers defined in ``@data abbreviations-subst-env`` can fill in templates with *calculated* (not predefined) data.
 
-3. Templates may contain placeholders that the user can fill in.  By default, the double comma binding selects the next placeholder.
+3. Templates may contain placeholders that the user can fill in.  By default, the F3 binding selects the next placeholder.
 
 4. Added a new setting: ``@bool scripting-abbreviations``, default False. Scripting abbreviations will be enabled if *either* of the following is True::
 

--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -13669,7 +13669,7 @@ Views allow multiple views of data to exist in a single outline.
 Leo expands abbreviations as you type.
 
 - Abbreviations range from simple shortcuts to multi-line templates containing fields.
-- Type ``,,`` to move to the next field.
+- Type ``F3`` to move to the next field.
 - Abbreviations can also insert the result of executing code.
 
 Ctrl-left-clicking any URL opens the URL.


### PR DESCRIPTION
Mentions that abbreviations are enabled by default, and give a working example with date;; instead of ts;; (which is not present anymore) for the scripting-abbreviations section.