### PR TITLE
PR: Cleanup redrawing and recoloring code

### DIFF
--- a/leo/commands/bufferCommands.py
+++ b/leo/commands/bufferCommands.py
@@ -195,8 +195,7 @@ class BufferCommandsClass(BaseEditCommandsClass):
         c = self.c
         p = self.findBuffer(name)
         if p:
-            c.selectPosition(p)
-            c.redraw_after_select(p)
+            c.redraw(p)
 
     # @+node:ekr.20150514045829.14: *3* buffer.Utils
     # @+node:ekr.20150514045829.15: *4* computeData

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -62,7 +62,6 @@ def cutOutline(self: Cmdr, event: LeoKeyEvent = None) -> None:
     if c.canDeleteHeadline():
         c.copyOutline()
         c.deleteOutline(op_name="Cut Node")
-        c.recolor()
 
 
 # @+node:ekr.20031218072017.1551: *3* c_oc.pasteOutline
@@ -113,7 +112,6 @@ def pasteOutline(
     if undoFlag:
         c.undoer.afterInsertNode(pasted, 'Paste Node', undoData)
     c.redraw(pasted)
-    c.recolor()
     return pasted
 
 
@@ -164,7 +162,6 @@ def pasteOutlineRetainingClones(
     # Finish the command.
     c.undoer.afterInsertNode(pasted, 'Paste As Clone', undoData)
     c.redraw(pasted)
-    c.recolor()
     return pasted
 
 
@@ -1763,7 +1760,6 @@ def moveOutlineLeft(self: Cmdr, event: LeoKeyEvent = None) -> None:
     if c.collapse_nodes_after_move and c.sparse_move:  # New in Leo 4.4.2
         parent.contract()
     c.redraw(p)
-    c.recolor()  # Moving can change syntax coloring.
 
 
 # @+node:ekr.20031218072017.1771: *3* c_oc.moveOutlineRight
@@ -1794,7 +1790,6 @@ def moveOutlineRight(self: Cmdr, event: LeoKeyEvent = None) -> None:
     c.setChanged()  # #2036.
     u.afterMoveNode(p, 'Move Right', undoData)
     c.redraw(p)
-    c.recolor()  # Moving can change syntax coloring.
 
 
 # @+node:ekr.20031218072017.1772: *3* c_oc.moveOutlineUp
@@ -1887,7 +1882,6 @@ def moveOutlineToFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
     c.setChanged()
     u.afterMoveNode(p, 'Move To First Child', undoData)
     c.redraw(p)
-    # c.recolor()  # Moving can *not* change syntax coloring.
 
 
 # @+node:ekr.20230902051833.1: *3* c_oc.moveOutlineToLastChild
@@ -1915,7 +1909,6 @@ def moveOutlineToLastChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
     c.setChanged()
     u.afterMoveNode(p, 'Move To Last Child', undoData)
     c.redraw(p)
-    # c.recolor()  # Moving can *not* change syntax coloring.
 
 
 # @+node:ekr.20031218072017.1774: *3* c_oc.promote

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -752,8 +752,7 @@ def findNextClone(self: Cmdr, event: LeoKeyEvent = None) -> None:
     if flag:
         if cc:
             cc.selectChapterByName('main')
-        c.selectPosition(p)
-        c.redraw_after_select(p)
+        c.redraw(p)
     else:
         g.blue('no more clones')
 

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -2176,12 +2176,11 @@ class EditCommandsClass(BaseEditCommandsClass):
         elif ch:
             # Null chars must not delete the selection.
             self.doPlainChar(action, ch, event, inBrackets, oldSel, stroke, w)
-        #
-        # Common processing.
+
         # Set the column for up and down keys.
         spot = w.getInsertPoint()
         c.editCommands.setMoveCol(w, spot)
-        #
+
         # Update the text and handle undo.
         newText = w.getAllText()
         if newText != oldText:
@@ -2189,7 +2188,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             newSel = w.getSelectionRange()
             newInsert = w.getInsertPoint()
             newSel = w.getSelectionRange()
-            newText = w.getAllText()  # Converts to unicode.
+            ### newText = w.getAllText()  # Converts to unicode.
             u.doTyping(
                 p,
                 'Typing',

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -2188,7 +2188,6 @@ class EditCommandsClass(BaseEditCommandsClass):
             newSel = w.getSelectionRange()
             newInsert = w.getInsertPoint()
             newSel = w.getSelectionRange()
-            ### newText = w.getAllText()  # Converts to unicode.
             u.doTyping(
                 p,
                 'Typing',

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -326,10 +326,10 @@ class TreeAPI:
     def headline_wrapper(self, p: Position) -> None:
         return None
 
-    def redraw(self, p: Position = None) -> None:
+    def redraw_tree(self, p: Position = None) -> None:
         pass
 
-    redraw_now = redraw
+    redraw_now = redraw_tree
 
     def scrollTo(self, p: Position) -> None:
         pass
@@ -347,7 +347,7 @@ class TreeAPI:
     def redraw_after_head_changed(self) -> None:
         pass
 
-    def redraw_after_select(self, p: Position = None) -> None:
+    def redraw_after_select(self, p: Position) -> None:
         pass
 
     # Must be defined in the LeoTree class...

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -347,9 +347,6 @@ class TreeAPI:
     def redraw_after_head_changed(self) -> None:
         pass
 
-    def redraw_after_select(self, p: Position) -> None:
-        pass
-
     # Must be defined in the LeoTree class...
     # def OnIconDoubleClick (self,p):
 

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -326,7 +326,7 @@ class TreeAPI:
     def headline_wrapper(self, p: Position) -> None:
         return None
 
-    def redraw_tree(self, p: Position = None) -> None:
+    def redraw_tree(self, p: Position = None) -> Position:
         pass
 
     redraw_now = redraw_tree

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2287,13 +2287,15 @@ class LoadManager:
     def load(self, fileName: str = None, pymacs: bool = None) -> None:
         """This is Leo's main startup method."""
         lm = self
-        #
+
         # Phase 1: before loading plugins.
         # Scan options, set directories and read settings.
         t1 = time.process_time()
         if not lm.isValidPython():
             return
+        g.app.disable_redraw = True
         lm.doPrePluginsInit(fileName, pymacs)  # sets lm.options and lm.files
+
         # Compute the signon after initing the gui.
         g.app.computeSignon()
         g.app.printSignon()
@@ -2301,9 +2303,7 @@ class LoadManager:
             return
         if not g.app.gui:
             return
-        # Disable redraw until all files are loaded.
-        g.app.disable_redraw = True
-        #
+
         # Phase 2: load plugins: the gui has already been set.
         t2 = time.process_time()
         g.doHook("start1")
@@ -2311,15 +2311,14 @@ class LoadManager:
         if g.app.killed:
             return
         g.app.idleTimeManager.start()
-        #
+
         # Phase 3: after loading plugins. Create one or more frames.
         t4 = time.process_time()
         if lm.options.get('script') and not self.files:
             ok = True
         else:
             ok = lm.doPostPluginsInit()
-            # Fix #579: Key bindings don't take for commands defined in plugins
-            g.app.makeAllBindings()
+            g.app.makeAllBindings()  # #579.
             if ok and g.app.diff:
                 lm.doDiff()
         if not ok:
@@ -2358,9 +2357,9 @@ class LoadManager:
                 g.app.log.c.abbrevCommands.listAbbrevs()
             except Exception:
                 pass
-        g.app.gui.runMainLoop()
         # For scripts, the gui is a nullGui.
         # and the gui.setScript has already been called.
+        g.app.gui.runMainLoop()
 
     # @+node:ekr.20150225133846.7: *4* LM.doDiff
     def doDiff(self) -> None:
@@ -2413,8 +2412,6 @@ class LoadManager:
                 g.es_print('Can not load session')
                 g.es_exception()
 
-        # Enable redraws.
-        g.app.disable_redraw = False
         if not c1:
             # Open or create a workbook.
             try:
@@ -2426,18 +2423,19 @@ class LoadManager:
         if not c:
             # Leo is out of options: Force an immediate exit.
             return False
-        # #199.
-        g.app.runAlreadyOpenDialog(c1)
-        #
+        g.app.runAlreadyOpenDialog(c1)  # #199.
+
         # Final inits...
-        # For qt gui, select the first-loaded tab.
-        if hasattr(g.app.gui, 'frameFactory'):
+        try:  # qt only: select the first-loaded tab.
             factory = g.app.gui.frameFactory
-            if factory and hasattr(factory, 'setTabForCommander'):
-                factory.setTabForCommander(c)
+            factory.setTabForCommander(c)
+        except Exception:
+            pass
+        g.app.initing = False  # "idle" hooks may now call g.app.forceShutdown.
         g.app.logInited = True
         g.app.initComplete = True
         c.setLog()
+        g.app.disable_redraw = False
         c.redraw()
         g.doHook("start2", c=c, p=c.p, fileName=c.fileName())
         c.initialFocusHelper()
@@ -3220,7 +3218,7 @@ class LoadManager:
         lm.createMenu(c, c.fileName())
 
         # Leo 6.7.6: New common finishing code.
-        g.app.disable_redraw = False
+        ### g.app.disable_redraw = False
         g.app.unlockLog()
         g.app.writeWaitingLog(c)
         c.setLog()

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3212,13 +3212,12 @@ class LoadManager:
         lm = self
         k = c.k
 
-        # New in Leo 4.6: provide an official way for very late initialization.
+        # Official very late initialization.
         c.frame.tree.initAfterLoad()
         c.initAfterLoad()
         lm.createMenu(c, c.fileName())
 
-        # Leo 6.7.6: New common finishing code.
-        ### g.app.disable_redraw = False
+        # Common finishing code.
         g.app.unlockLog()
         g.app.writeWaitingLog(c)
         c.setLog()

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1558,7 +1558,7 @@ class JEditColorizer(BaseColorizer):
             if g.unitTesting:
                 raise
         self.tagCount += 1
-        if True:  ### trace:
+        if trace:
             # PR #4618: (Ville Vainio) https://github.com/leo-editor/leo-editor/pull/4618
             # Don't call report by default: It's setup is expensive!
             # @+<< setTag: define report >>

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -54,27 +54,8 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 # @-<< leoColorizer annotations >>
-# @+others
-# @+node:ekr.20190323044524.1: ** function: make_colorizer
-def make_colorizer(c: Cmdr, widget: QWidget) -> JEditColorizer | PygmentsColorizer:
-    """Return an instance of JEditColorizer or PygmentsColorizer."""
-    use_pygments = c.config.getBool('use-pygments', default=False)
-    if use_pygments:
-        if pygments:
-            return PygmentsColorizer(c, widget)
-        if not g.unitTesting:
-            g.es_print('ignoring @bool use-pygments', color='red')
-            g.es_print('pip install pygments', color='red')
-    return JEditColorizer(c, widget)
-
-
-# @+node:ekr.20260215050008.1: ** command: dump-last-colorizer-trace
-@g.command('dump-last-colorizer-trace')
-def dump_colorizer_last_colorizer_traces(event: LeoKeyEvent) -> None:
-    c = event['c']
-    colorizer = c.frame.body.colorizer
-    print('\n'.join(colorizer.last_trace))
-
+# @+<< leoColorizer url sets >>
+# @+node:ekr.20260618100357.1: ** << leoColorizer url sets >>
 
 # PR #4619: Avoid str.lower in jedit.colorRangeWithTag.
 _url_leadins_set = frozenset(g.url_leadins + g.url_leadins.upper())
@@ -93,6 +74,36 @@ _url_bearing_tags = frozenset(
         'literal4',
     }
 )
+# @-<< leoColorizer url sets >>
+
+
+# @+others
+# @+node:ekr.20190323044524.1: ** function: make_colorizer
+def make_colorizer(c: Cmdr, widget: QWidget) -> JEditColorizer | PygmentsColorizer:
+    """Return an instance of JEditColorizer or PygmentsColorizer."""
+    use_pygments = c.config.getBool('use-pygments', default=False)
+    if use_pygments:
+        if pygments:
+            return PygmentsColorizer(c, widget)
+        if not g.unitTesting:
+            g.es_print('ignoring @bool use-pygments', color='red')
+            g.es_print('pip install pygments', color='red')
+    return JEditColorizer(c, widget)
+
+
+# @+node:ekr.20260215050008.1: ** command: clear/dump-last-colorizer-trace
+@g.command('clear-last-colorizer-trace')
+def clear_colorizer_last_colorizer_traces(event: LeoKeyEvent) -> None:
+    c = event['c']
+    colorizer = c.frame.body.colorizer
+    colorizer.last_trace = []
+
+
+@g.command('dump-last-colorizer-trace')
+def dump_colorizer_last_colorizer_traces(event: LeoKeyEvent) -> None:
+    c = event['c']
+    colorizer = c.frame.body.colorizer
+    print('\n'.join(colorizer.last_trace))
 
 
 # @+node:ekr.20170127141855.1: ** class BaseColorizer
@@ -1377,7 +1388,7 @@ class JEditColorizer(BaseColorizer):
         understand *every word* of the Theory of Operation:
         https://github.com/leo-editor/leo-editor/issues/4158
         """
-        trace = (False or 'coloring' in g.app.debug) and not g.unitTesting
+        trace = 'coloring' in g.app.debug and not g.unitTesting
         c = self.c
         p = self.c.p if c else None
         if not p:
@@ -1387,6 +1398,15 @@ class JEditColorizer(BaseColorizer):
         if g.callers(1) != 'highlightBlock':
             message = f"jedit.recolor: invalid caller: {g.callers()}"
             g.print_unique_message(message)
+
+        if g.app.disable_redraw:  ### Experimental.
+            return
+
+        if trace and self.prevState() == -1 and not s:  ###
+            print('')
+            g.trace(f"{self.prevState():2} {c.p.h}")  ###
+            #  print(g.callers(16).split(',')[:-8])
+            print(g.callers(12))
 
         self.recolorCount += 1
         prev_state = self.prevState()
@@ -1548,19 +1568,18 @@ class JEditColorizer(BaseColorizer):
             if g.unitTesting:
                 raise
         self.tagCount += 1
-        if trace:
+        if True:  ### trace:
             # PR #4618: (Ville Vainio) https://github.com/leo-editor/leo-editor/pull/4618
             # Don't call report by default: It's setup is expensive!
             # @+<< setTag: define report >>
             # @+node:ekr.20260528121410.1: *4* << setTag: define report >>
-
             def report(color: QtGui.QColor) -> None:
                 """A superb trace. Don't remove it."""
                 i_j_s = f"{i:>3}:{j:<3}"
                 matcher_name = g.caller(3)
                 rule_name = g.caller(4)
                 matcher_s = f"{self.rulesetName}::{rule_name}:{matcher_name}"
-                s2 = s[i:j]  # Show only the colored string.
+                s2 = g.truncate(s[i:j], 40)  # Show only the colored string.
                 state = self.currentState()
                 state_repr = self.stateNumberToStateString(state)
                 state_s = f"{self.currentState()}={state_repr}"

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -3729,10 +3729,10 @@ class QScintillaColorizer(BaseColorizer):
         # Alas, a QSciDocument is not a QTextDocument.
         self.updateSyntaxColorer(p)
         self.changeLexer(self.language)
-        # if self.NEW:
-        # # Works, but QScintillaWrapper.tag_configuration is presently a do-nothing.
-        # for s in g.splitLines(p.b):
-        # self.jeditColorizer.recolor(s)
+
+        # Works, but QScintillaWrapper.tag_configuration is presently a do-nothing.
+        #   for s in g.splitLines(p.b):
+        #       self.jeditColorizer.recolor(s)
 
     # @+node:ekr.20140906095826.18721: *3* qsc.configure_lexer
     def configure_lexer(self, lexer: Lexer) -> None:

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1399,15 +1399,6 @@ class JEditColorizer(BaseColorizer):
             message = f"jedit.recolor: invalid caller: {g.callers()}"
             g.print_unique_message(message)
 
-        if g.app.disable_redraw:  ### Experimental.
-            return
-
-        if trace and self.prevState() == -1 and not s:  ###
-            print('')
-            g.trace(f"{self.prevState():2} {c.p.h}")  ###
-            #  print(g.callers(16).split(',')[:-8])
-            print(g.callers(12))
-
         self.recolorCount += 1
         prev_state = self.prevState()
         if prev_state == -1:
@@ -1431,8 +1422,8 @@ class JEditColorizer(BaseColorizer):
         self.init_mode(self.language)
 
         # Do not delete these traces!
-        if prev_state == -1:
-            message = f"New node: p.h: {p.h}"
+        if prev_state == -1 and s:
+            message = f"New node: p.h: {len(s)=} {p.h}"
             # Init the queued messages for the dump-last-colorizer-trace command.
             self.last_trace = [message]
             if trace:  # Print the trace immediately.

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -56,7 +56,6 @@ if TYPE_CHECKING:  # pragma: no cover
 # @-<< leoColorizer annotations >>
 # @+<< leoColorizer url sets >>
 # @+node:ekr.20260618100357.1: ** << leoColorizer url sets >>
-
 # PR #4619: Avoid str.lower in jedit.colorRangeWithTag.
 _url_leadins_set = frozenset(g.url_leadins + g.url_leadins.upper())
 

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -635,14 +635,15 @@ class Commands:
         else:
             c.windowPosition = 500, 700, 50, 50  # width,height,left,top.
 
-    # @+node:ekr.20250508044308.1: *3* @cmd beautify-tree
+    # @+node:ekr.20260619060020.1: *3* @cmd commands
+    # @+node:ekr.20250508044308.1: *4* @cmd beautify-tree
     @cmd('beautify-tree')
     def beautify_tree_command(self, event: LeoKeyEvent = None) -> None:
         """Undoably beautify c.p and its subtree."""
         c = self
         c.beautify_script_tree(c.p)
 
-    # @+node:ekr.20210530065748.1: *3* @cmd c.execute-general-script
+    # @+node:ekr.20210530065748.1: *4* @cmd c.execute-general-script
     @cmd('execute-general-script')
     def execute_general_script_command(self, event: LeoKeyEvent = None) -> None:
         """
@@ -691,13 +692,13 @@ class Commands:
             directory = None
         c.general_script_helper(command, ext, language, directory=directory, regex=regex, root=p)
 
-    # @+node:tom.20241014154415.1: *3* @cmd c.execute-external-file
+    # @+node:tom.20241014154415.1: *4* @cmd c.execute-external-file
     # @@language python
     @cmd('execute-external-file')
     def execute_external_file(self, event: LeoKeyEvent = None) -> None:
         r"""
         # @+<< docstring >>
-        # @+node:tom.20241014154415.2: *4* << docstring >>
+        # @+node:tom.20241014154415.2: *5* << docstring >>
         Run external files.
 
         If there is an @language directive in the top node of the file,
@@ -748,7 +749,7 @@ class Commands:
         c = self
         MAP_SETTING_NODE = 'run-external-processor-map'
         # @+others
-        # @+node:tom.20241014154415.3: *4* Declarations
+        # @+node:tom.20241014154415.3: *5* Declarations
         EXECUTE_ARGS = {
             'konsole': '--noclose -e ',
             'gnome-terminal': '-- ',
@@ -764,7 +765,7 @@ class Commands:
         }
 
         PREFERRED_TERMINALS = EXECUTE_ARGS.keys()
-        # @+node:tom.20241014154415.4: *4* SETTINGS_HELP
+        # @+node:tom.20241014154415.4: *5* SETTINGS_HELP
         SETTINGS_HELP = r'''The data in the @data node body must have a
         PROCESSORS and an EXTENSIONS section, plus an optional TERMINAL
         section, looking like this example:
@@ -786,7 +787,7 @@ class Commands:
 
         Blank lines and lines starting with a "#" are ignored.
         '''
-        # @+node:tom.20241014154415.5: *4* extension map
+        # @+node:tom.20241014154415.5: *5* extension map
         LANGUAGE_EXTENSION_MAP = {
             '.cmd': 'batch',
             '.bat': 'batch',  # We'll get confused if a Linux program uses a .bat extension
@@ -797,7 +798,7 @@ class Commands:
             '.pyw': 'python',
             'rb': 'ruby',
         }
-        # @+node:tom.20241014154415.6: *4* processor map
+        # @+node:tom.20241014154415.6: *5* processor map
         PROCESSORS = {
             'batch': 'cmd.exe',
             'julia': 'julia',
@@ -806,12 +807,12 @@ class Commands:
             'ruby': 'ruby',
             'shellscript': 'bash',
         }
-        # @+node:tom.20241014154415.7: *4* get_external_maps
+        # @+node:tom.20241014154415.7: *5* get_external_maps
         MAP_SETTING_NODE = "run-external-processor-map"
 
         def get_external_maps() -> tuple[dict, dict, str]:
             # @+<< get_external_maps: docstring >>
-            # @+node:tom.20241014154415.8: *5* << get_external_maps: docstring >>
+            # @+node:tom.20241014154415.8: *6* << get_external_maps: docstring >>
             r"""Return processor, extension maps for @data node.
 
             The data in the @data node body must have a PROCESSORS and an
@@ -883,7 +884,7 @@ class Commands:
             extension_map = scan_map('EXTENSIONS')
             return processor_map, extension_map, terminal
 
-        # @+node:tom.20241014154415.9: *4* getExeKind
+        # @+node:tom.20241014154415.9: *5* getExeKind
         def getExeKind(ext: str) -> str:
             """
             Return the executable kind (a language) of the external file.
@@ -893,7 +894,7 @@ class Commands:
             """
             return c.getLanguage(c.p) or LANGUAGE_EXTENSION_MAP.get(ext, None)
 
-        # @+node:tom.20241014154415.10: *4* getProcessor
+        # @+node:tom.20241014154415.10: *5* getProcessor
         def getProcessor(language: str, path: str, extension: str) -> str:
             """Return the name or path of a program able to run our external program."""
             processor = ''
@@ -914,7 +915,7 @@ class Commands:
                     processor = ''
             return processor
 
-        # @+node:tom.20241014154415.11: *4* Get Windows File Associations
+        # @+node:tom.20241014154415.11: *5* Get Windows File Associations
         def get_win_assoc(extension: str) -> str:
             """Return Windows association for given file extension, or ''.
 
@@ -949,7 +950,7 @@ class Commands:
             prog_str = ftype_str.split('=')[1]
             return prog_str.split('"')[1]
 
-        # @+node:tom.20241014154415.12: *4* getShell
+        # @+node:tom.20241014154415.12: *5* getShell
         def getShell() -> str:
             # Prefer bash unless it is not present - we know its options' names
             shell = 'bash'
@@ -959,9 +960,9 @@ class Commands:
                 shell = os.environ['SHELL'].split('/')[-1]
             return shell
 
-        # @+node:tom.20241014154415.13: *4* getTerminal
+        # @+node:tom.20241014154415.13: *5* getTerminal
         # @+others
-        # @+node:tom.20241014154415.14: *5* getTerminalFromDirectory
+        # @+node:tom.20241014154415.14: *6* getTerminalFromDirectory
         def getTerminalFromDirectory(dir: str) -> str:
             BAD_NAMES = (
                 'xdg-terminal',
@@ -982,7 +983,7 @@ class Commands:
                         return t
             return ''
 
-        # @+node:tom.20241014154415.15: *5* getCommonTerminal
+        # @+node:tom.20241014154415.15: *6* getCommonTerminal
         def getCommonTerminal(names: str | Iterable[str]) -> str:
             """Return a terminal name given candidate names.
 
@@ -1014,7 +1015,7 @@ class Commands:
                 or getTerminalFromDirectory('/bin')
             )
 
-        # @+node:tom.20241014154415.16: *4* getTermExecuteCmd
+        # @+node:tom.20241014154415.16: *5* getTermExecuteCmd
         def getTermExecuteCmd(terminal: str) -> str:
             """Given a terminal's name, find the command line arg to launch a program.
 
@@ -1029,7 +1030,7 @@ class Commands:
                 return EXECUTE_ARGS[terminal]
 
             # @+others
-            # @+node:tom.20241014154415.17: *5* get_help_message (c.execute-external-file)
+            # @+node:tom.20241014154415.17: *6* get_help_message (c.execute-external-file)
             def get_help_message(terminal: str, help_cmd: str) -> str:
                 cmd = f'{terminal} {help_cmd}'
                 proc = subprocess.run(cmd, shell=True, capture_output=True, check=False)
@@ -1039,7 +1040,7 @@ class Commands:
                     return ''
                 return msg
 
-            # @+node:tom.20241014154415.18: *5* find_ex_arg
+            # @+node:tom.20241014154415.18: *6* find_ex_arg
             def find_ex_arg(help_msg: str) -> str:
                 for line in help_msg.splitlines():
                     if '--command' in line:
@@ -1070,7 +1071,7 @@ class Commands:
                 arg = '-x '  # We can only hope
             return arg
 
-        # @+node:tom.20241014154415.19: *4* checkShebang
+        # @+node:tom.20241014154415.19: *5* checkShebang
         def checkShebang(path: str) -> bool:
             """Return True if file begins with a shebang line, else False."""
             path = g.finalize(path)
@@ -1078,7 +1079,7 @@ class Commands:
                 first_line = f.readline()
             return first_line.startswith('#!')
 
-        # @+node:tom.20241014154415.20: *4* runFile @cmd c.execute-external-file
+        # @+node:tom.20241014154415.20: *5* runFile @cmd c.execute-external-file
         def runfile(fullpath: str, processor: str, terminal: str) -> None:
             direc: str = os.path.expanduser(os.path.dirname(fullpath))
             if g.isWindows:
@@ -1151,7 +1152,7 @@ class Commands:
         else:
             g.es('Cannot find an @- file', color='red')
 
-    # @+node:vitalije.20190924191405.1: *3* @cmd execute-pytest
+    # @+node:vitalije.20190924191405.1: *4* @cmd execute-pytest
     @cmd('execute-pytest')
     def execute_pytest(self, event: LeoKeyEvent = None) -> None:
         """Using pytest, execute all @test nodes for p, p's parents and p's subtree."""
@@ -1215,7 +1216,7 @@ class Commands:
         finally:
             del sys.path[:2]
 
-    # @+node:ekr.20171123135625.4: *3* @cmd execute-script & public helpers
+    # @+node:ekr.20171123135625.4: *4* @cmd execute-script & public helpers
     @cmd('execute-script')
     def executeScript(
         self,
@@ -1233,7 +1234,7 @@ class Commands:
         runPyflakes: bool = True,
     ) -> Value:
         # @+<< executeScript: docstring >>
-        # @+node:ekr.20250508025320.1: *4* << executeScript: docstring >>
+        # @+node:ekr.20250508025320.1: *5* << executeScript: docstring >>
         """
         Execute a *Leo* script, written in python.
         Keyword args:
@@ -1340,7 +1341,7 @@ class Commands:
             self.unredirectScriptOutput()
         return callResult
 
-    # @+node:ekr.20171123135625.5: *4* c.executeScriptHelper
+    # @+node:ekr.20171123135625.5: *5* c.executeScriptHelper
     def executeScriptHelper(
         self,
         args: list,
@@ -1378,14 +1379,14 @@ class Commands:
         finally:
             g.inScript = g.app.inScript = False
 
-    # @+node:ekr.20171123135625.6: *4* c.redirectScriptOutput
+    # @+node:ekr.20171123135625.6: *5* c.redirectScriptOutput
     def redirectScriptOutput(self) -> None:
         c = self
         if c.exists and c.config.getBool('redirect-execute-script-output-to-log-pane'):
             g.redirectStdout()  # Redirect stdout
             g.redirectStderr()  # Redirect stderr
 
-    # @+node:ekr.20171123135625.7: *4* c.setCurrentDirectoryFromContext
+    # @+node:ekr.20171123135625.7: *5* c.setCurrentDirectoryFromContext
     def setCurrentDirectoryFromContext(self, p: Position) -> None:
         c = self
         path = c.getPath(p)
@@ -1396,14 +1397,14 @@ class Commands:
             except Exception:
                 pass
 
-    # @+node:ekr.20171123135625.8: *4* c.unredirectScriptOutput
+    # @+node:ekr.20171123135625.8: *5* c.unredirectScriptOutput
     def unredirectScriptOutput(self) -> None:
         c = self
         if c.exists and c.config.getBool('redirect-execute-script-output-to-log-pane'):
             g.restoreStderr()
             g.restoreStdout()
 
-    # @+node:ekr.20080514131122.12: *3* @cmd recolor (c.recolorCommand)
+    # @+node:ekr.20080514131122.12: *4* @cmd recolor (c.recolorCommand)
     @cmd('recolor')
     def recolorCommand(self, event: LeoKeyEvent = None) -> None:
         """Force a full recolor."""
@@ -1419,7 +1420,7 @@ class Commands:
         wrapper.setAllText(c.p.b)
         wrapper.setSelectionRange(i, j, insert=ins)
 
-    # @+node:ekr.20260619021703.1: *3* @cmd redraw (c.redraw_command)
+    # @+node:ekr.20260619021703.1: *4* @cmd redraw (c.redraw_command)
     @cmd('redraw')
     def redraw_command(self, event: LeoKeyEvent) -> None:
         c = event.get('c')
@@ -2200,22 +2201,17 @@ class Commands:
     def setBodyString(self, p: Position, s: str) -> None:
         """
         This is equivalent to p.b = s.
-
-        Warning: This method may call c.recolor() or c.redraw().
         """
         c, v = self, p.v
         if not c or not v:
             return
         s = g.toUnicode(s)
-        current = c.p
-        # 1/22/05: Major change: the previous test was: 'if p == current:'
-        # This worked because commands work on the presently selected node.
-        # But setRecentFiles may change a _clone_ of the selected node!
-        if current and p.v == current.v:
+        if c.p and p.v == c.p.v:
             w = c.frame.body.wrapper
             w.setAllText(s)
             v.setSelection(0, 0)
-            c.recolor()
+            c.recolor()  ### To be removed ???
+
         # Keep the body text in the VNode up-to-date.
         if v.b != s:
             v.setBodyString(s)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4399,7 +4399,7 @@ class Commands:
         c.selectPosition(p2 or p)  # #503.
         # Clear the redraw request, again.
         c.requestLaterRedraw = False
-        c.redraw()  # Leo 6.8.10
+        c.recolor()  # Leo 6.8.10
 
     # Compatibility with old scripts.
     force_redraw = redraw

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4379,7 +4379,7 @@ class Commands:
         c = self
         trace = 'drawing' in g.app.debug and not g.unitTesting
         if not p:
-            p = c.p or c.rootPosition()
+            p = c.p
         if not p:
             return
         if not c.positionExists(p):

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1409,16 +1409,17 @@ class Commands:
     def recolorCommand(self, event: LeoKeyEvent = None) -> None:
         """Force a full recolor."""
         c = self
-        # Call colorer.force_recolor for pygments.
         colorer = c.frame.body.colorizer
         if hasattr(colorer, 'force_recolor'):
+            # For Qt (jEdit) and pygments.
             colorer.force_recolor()
-        # Setting all text appears to be the only way.
-        wrapper = c.frame.body.wrapper
-        i, j = wrapper.getSelectionRange()
-        ins = wrapper.getInsertPoint()
-        wrapper.setAllText(c.p.b)
-        wrapper.setSelectionRange(i, j, insert=ins)
+        else:
+            # Default: set all text, retaining the selection.
+            wrapper = c.frame.body.wrapper
+            i, j = wrapper.getSelectionRange()
+            ins = wrapper.getInsertPoint()
+            wrapper.setAllText(c.p.b)
+            wrapper.setSelectionRange(i, j, insert=ins)
 
     # @+node:ekr.20260619021703.1: *4* @cmd redraw (c.redraw_command)
     @cmd('redraw')
@@ -4348,6 +4349,13 @@ class Commands:
 
     # @+node:ekr.20080514131122.13: *5* c.recolor (Scintilla only!!)
     def recolor(self, p: Position = None) -> None:
+        """
+        Force a full recolor when using the Scintilla text widget.
+        This method has no effect when using the default Qt colorizer.
+
+        Leo 6.8.10: c.redraw calls this method, so could should call this
+                    method only if the code *doesn't* call c.redraw.
+        """
         c = self
         colorizer = c.frame.body.colorizer
         try:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1427,11 +1427,6 @@ class Commands:
         if c:
             p = c.p
             c.redraw()
-            # Use a trap door, not a kwarg.
-            colorizer = c.frame.body.colorizer
-            if colorizer and hasattr(colorizer, 'old_v'):
-                colorizer.old_v = None  # #4146
-            c.recolor(p)
 
     # @+node:ekr.20171124100654.1: *3* c.API
     # These methods are a fundamental, unchanging, part of Leo's API.
@@ -2210,7 +2205,7 @@ class Commands:
             w = c.frame.body.wrapper
             w.setAllText(s)
             v.setSelection(0, 0)
-            c.recolor()  ### To be removed ???
+            c.recolor()
 
         # Keep the body text in the VNode up-to-date.
         if v.b != s:
@@ -4356,10 +4351,13 @@ class Commands:
     def recolor(self, p: Position = None) -> None:
         c = self
         colorizer = c.frame.body.colorizer
-        if colorizer and hasattr(colorizer, 'colorize'):
+        try:
             # Only the QScintillaColorizer class has a colorize method.
             colorizer.colorize(p or c.p)
+        except Exception:
+            pass
 
+    # Compatibility.
     recolor_now = recolor
 
     # @+node:ekr.20080514131122.14: *5* c.redrawing...
@@ -4401,6 +4399,7 @@ class Commands:
         c.selectPosition(p2 or p)  # #503.
         # Clear the redraw request, again.
         c.requestLaterRedraw = False
+        c.redraw()  # Leo 6.8.10
 
     # Compatibility with old scripts.
     force_redraw = redraw

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1403,7 +1403,7 @@ class Commands:
             g.restoreStderr()
             g.restoreStdout()
 
-    # @+node:ekr.20080514131122.12: *3* @cmd recolor
+    # @+node:ekr.20080514131122.12: *3* @cmd recolor (c.recolorCommand)
     @cmd('recolor')
     def recolorCommand(self, event: LeoKeyEvent = None) -> None:
         """Force a full recolor."""
@@ -1418,6 +1418,19 @@ class Commands:
         ins = wrapper.getInsertPoint()
         wrapper.setAllText(c.p.b)
         wrapper.setSelectionRange(i, j, insert=ins)
+
+    # @+node:ekr.20260619021703.1: *3* @cmd redraw (c.redraw_command)
+    @cmd('redraw')
+    def redraw_command(self, event: LeoKeyEvent) -> None:
+        c = event.get('c')
+        if c:
+            p = c.p
+            c.redraw()
+            # Use a trap door, not a kwarg.
+            colorizer = c.frame.body.colorizer
+            if colorizer and hasattr(colorizer, 'old_v'):
+                colorizer.old_v = None  # #4146
+            c.recolor(p)
 
     # @+node:ekr.20171124100654.1: *3* c.API
     # These methods are a fundamental, unchanging, part of Leo's API.
@@ -4346,7 +4359,7 @@ class Commands:
                 g.doHook(kind, c=c, nodes=mods)
                 mods.clear()
 
-    # @+node:ekr.20080514131122.13: *5* c.recolor
+    # @+node:ekr.20080514131122.13: *5* c.recolor (Scintilla only!!)
     def recolor(self, p: Position = None) -> None:
         c = self
         colorizer = c.frame.body.colorizer
@@ -4367,19 +4380,7 @@ class Commands:
         c = self
         c.enableRedrawFlag = True
 
-    # @+node:ekr.20090110073010.1: *6* c.redraw ('redraw' command)
-    @cmd('redraw')
-    def redraw_command(self, event: LeoKeyEvent) -> None:
-        c = event.get('c')
-        if c:
-            p = c.p
-            c.redraw()
-            # Use a trap door, not a kwarg.
-            colorizer = c.frame.body.colorizer
-            if colorizer and hasattr(colorizer, 'old_v'):
-                colorizer.old_v = None  # #4146
-            c.recolor(p)
-
+    # @+node:ekr.20090110073010.1: *6* c.redraw
     def redraw(self, p: Position = None) -> None:
         """
         Redraw the screen immediately.

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4409,6 +4409,7 @@ class Commands:
     force_redraw = redraw
     redraw_after_contract = redraw
     redraw_after_expand = redraw
+    redraw_after_select = redraw
     redraw_now = redraw
 
     # @+node:ekr.20090110073010.2: *6* c.redraw_after_head_changed
@@ -4420,18 +4421,6 @@ class Commands:
         c = self
         if c.enableRedrawFlag:
             self.frame.tree.redraw_after_head_changed()
-        else:
-            c.requestLaterRedraw = True
-
-    # @+node:ekr.20090110073010.4: *6* c.redraw_after_select
-    def redraw_after_select(self, p: Position) -> None:
-        """Redraw the screen after node p has been selected."""
-        c = self
-        if c.enableRedrawFlag:
-            flag = c.expandAllAncestors(p)
-            if flag:
-                # This is the same as c.frame.tree.redraw_tree().
-                c.frame.tree.redraw_after_select(p)
         else:
             c.requestLaterRedraw = True
 
@@ -4490,8 +4479,7 @@ class Commands:
             if found:
                 break
         if found:
-            c.selectPosition(p)
-            c.redraw_after_select(p)
+            c.redraw(p)
             c.navTime = time.time()
             c.navPrefix = newPrefix
         else:
@@ -5129,9 +5117,7 @@ class Commands:
         if not p:
             p = c.p
         if p:
-            # Do not call expandAllAncestors here.
-            c.selectPosition(p)
-            c.redraw_after_select(p)
+            c.redraw(p)
         c.treeFocusHelper()  # This is essential.
 
     # @+node:ekr.20130823083943.12559: *3* c.recursiveImport

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4331,9 +4331,6 @@ class Commands:
         if c.requestLaterRedraw:
             if c.enableRedrawFlag:
                 c.requestLaterRedraw = False
-                if 'drawing' in g.app.debug and not g.unitTesting:
-                    g.trace('\nDELAYED REDRAW')
-                    time.sleep(1.0)
                 c.redraw()
         # Delayed focus requests will always be useful.
         if c.requestedFocusWidget:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4383,6 +4383,7 @@ class Commands:
         If p is given, set c.p to p.
         """
         c = self
+        trace = 'drawing' in g.app.debug and not g.unitTesting
         if not p:
             p = c.p or c.rootPosition()
         if not p:
@@ -4391,25 +4392,20 @@ class Commands:
             g.trace(f"Invalid position: {repr(p)}")
             g.trace(g.callers())
             return
+        if False and trace:
+            g.trace(p.h, g.callers())
         c.requestLaterRedraw = False
         c.expandAllAncestors(p)
-        if p:
-            # Fix bug https://bugs.launchpad.net/leo-editor/+bug/1183855
-            # This looks redundant, but it is probably the only safe fix.
-            c.frame.tree.select(p)
-        # tree.redraw will change the position if p is a hoisted @chapter node.
-        p2 = c.frame.tree.redraw(p)
-        # Be careful.  NullTree.redraw returns None.
-        # #503: NullTree.redraw(p) now returns p.
-        c.selectPosition(p2 or p)
-        # Do not call treeFocusHelper here.
-        # c.treeFocusHelper()
+        # Fix bug https://bugs.launchpad.net/leo-editor/+bug/1183855
+        # This looks redundant, but it is probably the only safe fix.
+        c.frame.tree.select(p)
+        # tree.redraw_tree will change the position if p is a hoisted @chapter node.
+        p2 = c.frame.tree.redraw_tree(p)
+        c.selectPosition(p2 or p)  # #503.
         # Clear the redraw request, again.
         c.requestLaterRedraw = False
 
     # Compatibility with old scripts.
-    # Do *not* delete redraw_after_select or redraw_after_head_changed.
-
     force_redraw = redraw
     redraw_after_contract = redraw
     redraw_after_expand = redraw

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4383,8 +4383,6 @@ class Commands:
         If p is given, set c.p to p.
         """
         c = self
-        # New in Leo 5.6: clear the redraw request.
-        c.requestLaterRedraw = False
         if not p:
             p = c.p or c.rootPosition()
         if not p:
@@ -4392,7 +4390,8 @@ class Commands:
         if not c.positionExists(p):
             g.trace(f"Invalid position: {repr(p)}")
             g.trace(g.callers())
-            p = c.rootPosition()
+            return
+        c.requestLaterRedraw = False
         c.expandAllAncestors(p)
         if p:
             # Fix bug https://bugs.launchpad.net/leo-editor/+bug/1183855

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4377,7 +4377,6 @@ class Commands:
         If p is given, set c.p to p.
         """
         c = self
-        trace = 'drawing' in g.app.debug and not g.unitTesting
         if not p:
             p = c.p
         if not p:
@@ -4423,7 +4422,7 @@ class Commands:
         if c.enableRedrawFlag:
             flag = c.expandAllAncestors(p)
             if flag:
-                # This is the same as c.frame.tree.full_redraw().
+                # This is the same as c.frame.tree.redraw_tree().
                 c.frame.tree.redraw_after_select(p)
         else:
             c.requestLaterRedraw = True

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4347,7 +4347,7 @@ class Commands:
                 g.doHook(kind, c=c, nodes=mods)
                 mods.clear()
 
-    # @+node:ekr.20080514131122.13: *5* c.recolor (Scintilla only!!)
+    # @+node:ekr.20080514131122.13: *5* c.recolor
     def recolor(self, p: Position = None) -> None:
         """
         Force a full recolor when using the Scintilla text widget.
@@ -4359,7 +4359,8 @@ class Commands:
         c = self
         colorizer = c.frame.body.colorizer
         try:
-            # Only the QScintillaColorizer class has a colorize method.
+            # Only the QScintillaColorizer class and NullColorizer classes
+            # have colorize methods.
             colorizer.colorize(p or c.p)
         except Exception:
             pass

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4386,8 +4386,6 @@ class Commands:
             g.trace(f"Invalid position: {repr(p)}")
             g.trace(g.callers())
             return
-        if False and trace:
-            g.trace(p.h, g.callers())
         c.requestLaterRedraw = False
         c.expandAllAncestors(p)
         # Fix bug https://bugs.launchpad.net/leo-editor/+bug/1183855

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1425,7 +1425,6 @@ class Commands:
     def redraw_command(self, event: LeoKeyEvent) -> None:
         c = event.get('c')
         if c:
-            p = c.p
             c.redraw()
 
     # @+node:ekr.20171124100654.1: *3* c.API

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1302,7 +1302,6 @@ class LeoFind:
         t2 = time.process_time()
         if not g.unitTesting:  # pragma: no cover
             g.es_print(f"changed {count} instances{g.plural(count)} in {t2 - t1:4.2f} sec.")
-        c.recolor()
         c.redraw(new_p)
         self.restore(saveData)
         return count

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -3176,8 +3176,7 @@ class LeoFind:
         k.resetLabel()
         p, i, j, in_headline = self.stack[0]
         self.in_headline = in_headline
-        c.selectPosition(p)
-        c.redraw_after_select(p)
+        c.redraw(p)
         c.bodyWantsFocus()
         w.setSelectionRange(i, j)
 

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1056,17 +1056,16 @@ class LeoTree:
         c = self.c
         w = c.frame.body.wrapper
         s = p.v.b  # Guaranteed to be unicode.
+
         # Part 1: get the old text.
         old_s = w.getAllText()
         if p and p == old_p and s == old_s:
             return
+
         # Part 2: set the new text. This forces a recolor.
-        # Important: do this *before* setting text,
-        # so that the colorizer will have the proper c.p.
+        # Important: set c.p *before* setting text.
         c.setCurrentPosition(p)
         w.setAllText(s)
-        # This is now done after c.p has been changed.
-        # p.restoreCursorAndScroll()
 
     # @+node:ekr.20140829053801.18458: *5* 3. LeoTree.change_current_position
     def change_current_position(self, old_p: Position, p: Position) -> None:

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1114,7 +1114,7 @@ class LeoTree:
     def redraw_after_head_changed(self) -> None:
         self.c.redraw()
 
-    def redraw_after_select(self, p: Position = None) -> None:
+    def redraw_after_select(self, p: Position) -> None:
         self.c.redraw()
 
     # @+node:ekr.20040803072955.91: *4* LeoTree.onHeadChanged
@@ -1236,10 +1236,10 @@ class LeoTree:
     # @+node:ekr.20031218072017.3706: *3* LeoTree: Must be defined in subclasses
     # Drawing & scrolling.
 
-    def redraw(self, p: Position = None) -> None:
+    def redraw_tree(self, p: Position = None) -> Position:
         raise NotImplementedError
 
-    redraw_now = redraw
+    redraw_now = redraw_tree
 
     def scrollTo(self, p: Position) -> None:
         raise NotImplementedError
@@ -1718,15 +1718,20 @@ class NullTree(LeoTree):
             w = d.get(key)
             g.pr('w', w, 'v.h:', key.headString, 's:', repr(w.s))
 
-    # @+node:ekr.20070228163350.1: *3* NullTree.redraw and scrollTo
-    def redraw(self, p: Position = None) -> None:
+    # @+node:ekr.20070228163350.1: *3* NullTree.redraw_tree and scrollTo
+    def redraw_tree(self, p: Position = None) -> Position:
         self.redrawCount += 1
+        return p
 
-    redraw_after_contract = redraw
-    redraw_after_expand = redraw
-    redraw_after_head_changed = redraw
-    redraw_after_select = redraw
-    redraw_now = redraw
+    redraw_after_contract = redraw_tree
+    redraw_after_expand = redraw_tree
+    redraw_now = redraw_tree
+
+    def redraw_after_head_changed(self) -> None:
+        pass
+
+    def redraw_after_select(self, p: Position) -> None:
+        pass
 
     def scrollTo(self, p: Position) -> None:
         pass

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1104,17 +1104,10 @@ class LeoTree:
             c.frame.putStatusLine(s)
 
     # @+node:ekr.20081005065934.8: *3* LeoTree: May be defined in subclasses
-    # These are new in Leo 4.6.
-
     def initAfterLoad(self) -> None:
         """Do late initialization. Called in g.openWithFileName after a successful load."""
 
-    # Hints for optimization. The proper default is c.redraw()
-
     def redraw_after_head_changed(self) -> None:
-        self.c.redraw()
-
-    def redraw_after_select(self, p: Position) -> None:
         self.c.redraw()
 
     # @+node:ekr.20040803072955.91: *4* LeoTree.onHeadChanged
@@ -1726,11 +1719,9 @@ class NullTree(LeoTree):
     redraw_after_contract = redraw_tree
     redraw_after_expand = redraw_tree
     redraw_now = redraw_tree
+    redraw_after_select = redraw_tree
 
     def redraw_after_head_changed(self) -> None:
-        pass
-
-    def redraw_after_select(self, p: Position) -> None:
         pass
 
     def scrollTo(self, p: Position) -> None:

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1169,11 +1169,6 @@ class LeoTree:
         """End editing of a headline and update p.h."""
         # Important: this will redraw if necessary.
         self.onHeadChanged(self.c.p)
-        # Do *not* call setDefaultUnboundKeyAction here: it might put us in ignore mode!
-        # k.setDefaultInputState()
-        # k.showStateAndMode()
-        # This interferes with the find command and interferes with focus generally!
-        # c.bodyWantsFocus()
 
     # @+node:ekr.20031218072017.3716: *4* LeoTree.getEditTextDict
     def getEditTextDict(self, v: VNode) -> Widget:

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -848,7 +848,6 @@ class LeoImportCommands:
         parent.expand()
         c.setChanged()
         u.afterChangeGroup(parent, command)
-        c.recolor(parent)
         c.redraw(parent)
         return parent
 

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2752,7 +2752,6 @@ class VNode:
 
     # @+node:ekr.20040315032144: *4* v.setBodyString & v.setHeadString
     def setBodyString(self, s: object) -> None:
-        # pylint: disable=no-else-return
         v = self
         if isinstance(s, str):
             v._bodyString = s
@@ -2763,9 +2762,6 @@ class VNode:
         v.updateIcon()
 
     def setHeadString(self, s: object) -> None:
-        # pylint: disable=no-else-return
-        # Fix bug: https://bugs.launchpad.net/leo-editor/+bug/1245535
-        # API allows headlines to contain newlines.
         v = self
         if isinstance(s, str):
             v._headString = s.replace('\n', '')

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -1880,6 +1880,7 @@ class Undoer:
         c, u = self.c, self
         # selectPosition causes recoloring, so don't do this unless needed.
         c.recolor(u.p)
+
         # Swap the ones from the 'bunch.headline' dict
         for gnx, oldNewTuple in u.headlines.items():
             v = c.fileCommands.gnxDict.get(gnx)
@@ -1888,7 +1889,6 @@ class Undoer:
                 u.p.setDirty()
                 # This is required.  Otherwise redraw will revert the change!
                 c.frame.tree.setHeadline(u.p, oldNewTuple[0])
-        #
         if c.p != u.p:
             c.selectPosition(u.p)
 

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -994,8 +994,6 @@ class Undoer:
         **Important**: Code should call this method *only* when the user has
         actually typed something. Commands should use u.beforeChangeBody and
         u.afterChangeBody.
-
-        Only qtm.onTextChanged and ec.selfInsertCommand now call this method.
         """
         c, u, w = self.c, self, self.c.frame.body.wrapper
         # Leo 6.4: undo_type must be 'Typing'.

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -3114,7 +3114,6 @@ class LeoQTreeWidget(QtWidgets.QTreeWidget):
         # c.setRootPosition(c.findRootPosition(pasted))
         u.afterInsertNode(pasted, undoType, undoData)
         c.redraw(pasted)
-        c.recolor()
 
     # @+node:ekr.20110605121601.18368: *6* LeoQTreeWidget.intraFileDrop
     def intraFileDrop(self, fn: str, p1: Position, p2: Position) -> None:

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -195,7 +195,7 @@ class QTextMixin:
         if hasattr(c.frame, 'statusLine'):
             c.frame.statusLine.update()
 
-    # @+node:ekr.20140901062324.18714: *4* QTextMixin.onTextChanged
+    # @+node:ekr.20140901062324.18714: *4* QTextMixin.onTextChanged (to be deleted??)
     def onTextChanged(self) -> None:
         """
         Update Leo after the body has been changed.
@@ -2007,6 +2007,7 @@ class QTextEditWrapper(QTextMixin):
         try:
             self.changingText = True  # Disable onTextChanged.
             w.setReadOnly(False)
+            # g.trace(f"{len(s):4} {g.callers(1)}")
             w.setPlainText(s)
         finally:
             self.changingText = False

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -157,7 +157,6 @@ class QTextMixin:
     def __init__(self, c: Cmdr = None) -> None:
         """Ctor for QTextMixin class"""
         self.c = c
-        self.changingText = False  # A lockout for onTextChanged.
         self.enabled = True
         self.tags: dict[str, str] = {}
         self.permanent = True  # False if selecting the minibuffer will make the widget go away.
@@ -194,47 +193,6 @@ class QTextMixin:
             return
         if hasattr(c.frame, 'statusLine'):
             c.frame.statusLine.update()
-
-    # @+node:ekr.20140901062324.18714: *4* QTextMixin.onTextChanged (to be deleted??)
-    def onTextChanged(self) -> None:
-        """
-        Update Leo after the body has been changed.
-
-        tree.tree_select_lockout is True during the entire selection process.
-        """
-        # Important: usually w.changingText is True.
-        # This method very seldom does anything.
-        w = self
-        c, p = self.c, self.c.p
-        tree = c.frame.tree
-        if w.changingText:
-            return
-        if tree.tree_select_lockout:
-            # g.trace('*** LOCKOUT', g.callers())
-            return
-        if not p:
-            return
-        newInsert = w.getInsertPoint()
-        newSel = w.getSelectionRange()
-        newText = w.getAllText()  # Converts to unicode.
-        # Get the previous values from the VNode.
-        oldText = p.b
-        if oldText == newText:
-            # This can happen as the result of undo.
-            # g.error('*** unexpected non-change')
-            return
-        i, j = p.v.selectionStart, p.v.selectionLength
-        oldSel = (i, i + j)
-        c.undoer.doTyping(
-            p,
-            'Typing',
-            oldText,
-            newText,
-            oldSel=oldSel,
-            oldYview=None,
-            newInsert=newInsert,
-            newSel=newSel,
-        )
 
     # @+node:ekr.20140901122110.18734: *3* QTextMixin.Generic high-level interface
     # These call only wrapper methods.
@@ -567,9 +525,6 @@ if QtWidgets:
             self.setCursorWidth(c.config.getInt('qt-cursor-width') or 1)
 
             # Connect event handlers...
-            if 0:  # Not a good idea: it will complicate delayed loading of body text.
-                # #1286
-                self.textChanged.connect(self.onTextChanged)
             self.cursorPositionChanged.connect(self.highlightCurrentLine)
             self.textChanged.connect(self.highlightCurrentLine)
             self.setContextMenuPolicy(ContextMenuPolicy.CustomContextMenu)
@@ -1422,11 +1377,7 @@ class QScintillaWrapper(QTextMixin):
         if j is None:
             j = i + 1
         self.setSelectionRange(i, j)
-        try:
-            self.changingText = True  # Disable onTextChanged
-            w.replaceSelectedText('')
-        finally:
-            self.changingText = False
+        w.replaceSelectedText('')
 
     # @+node:ekr.20140901062324.18594: *4* QScintillaWrapper.flashCharacter (disabled)
     def flashCharacter(
@@ -1659,7 +1610,7 @@ class QTextEditWrapper(QTextMixin):
         # tab stop in pixels - no config for this (yet)
         w.setTabStopDistance(24)
 
-    # @+node:ekr.20140901062324.18566: *4* QTextEditWrapper.set_signals (should be distributed?)
+    # @+node:ekr.20140901062324.18566: *4* QTextEditWrapper.set_signals
     def set_signals(self) -> None:
         """Set up signals."""
         c, name = self.c, self.name
@@ -1668,7 +1619,6 @@ class QTextEditWrapper(QTextMixin):
             g.app.gui.setFilter(c, self.widget, self, tag=name)
         if name == 'body':
             w = self.widget
-            w.textChanged.connect(self.onTextChanged)
             w.cursorPositionChanged.connect(self.onCursorPositionChanged)
         if name in ('body', 'log'):
             # Monkey patch the event handler.
@@ -1717,22 +1667,18 @@ class QTextEditWrapper(QTextMixin):
         sb = w.verticalScrollBar()
         pos = sb.sliderPosition()
         cursor = w.textCursor()
-        try:
-            self.changingText = True  # Disable onTextChanged
-            old_i, old_j = self.getSelectionRange()
-            if i == old_i and j == old_j:
-                # Work around an apparent bug in cursor.movePosition.
-                cursor.removeSelectedText()
-            elif i == j:
-                pass
-            else:
-                cursor.setPosition(i)
-                moveCount = abs(j - i)
-                cursor.movePosition(MoveOperation.Right, MoveMode.KeepAnchor, moveCount)
-                w.setTextCursor(cursor)  # Bug fix: 2010/01/27
-                cursor.removeSelectedText()
-        finally:
-            self.changingText = False
+        old_i, old_j = self.getSelectionRange()
+        if i == old_i and j == old_j:
+            # Work around an apparent bug in cursor.movePosition.
+            cursor.removeSelectedText()
+        elif i == j:
+            pass
+        else:
+            cursor.setPosition(i)
+            moveCount = abs(j - i)
+            cursor.movePosition(MoveOperation.Right, MoveMode.KeepAnchor, moveCount)
+            w.setTextCursor(cursor)  # Bug fix: 2010/01/27
+            cursor.removeSelectedText()
         sb.setSliderPosition(pos)
 
     # @+node:ekr.20110605121601.18080: *4* QTextEditWrapper.flashCharacter
@@ -1839,13 +1785,9 @@ class QTextEditWrapper(QTextMixin):
         """QTextEditWrapper."""
         w = self.widget
         cursor = w.textCursor()
-        try:
-            self.changingText = True  # Disable onTextChanged.
-            cursor.setPosition(i)
-            cursor.insertText(s)
-            w.setTextCursor(cursor)  # Bug fix: 2010/01/27
-        finally:
-            self.changingText = False
+        cursor.setPosition(i)
+        cursor.insertText(s)
+        w.setTextCursor(cursor)  # Bug fix: 2010/01/27
 
     # @+node:ekr.20110605121601.18077: *4* QTextEditWrapper.leoMoveCursorHelper & helper
     def leoMoveCursorHelper(self, kind: str, extend: bool = False, linesPerPage: int = 15) -> None:
@@ -2004,13 +1946,8 @@ class QTextEditWrapper(QTextMixin):
     def setAllText(self, s: str) -> None:
         """Set the text of body pane."""
         w = self.widget
-        try:
-            self.changingText = True  # Disable onTextChanged.
-            w.setReadOnly(False)
-            # g.trace(f"{len(s):4} {g.callers(1)}")
-            w.setPlainText(s)
-        finally:
-            self.changingText = False
+        w.setReadOnly(False)
+        w.setPlainText(s)
 
     # @+node:ekr.20110605121601.18095: *4* QTextEditWrapper.setInsertPoint
     def setInsertPoint(self, i: int) -> None:

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -168,6 +168,8 @@ class LeoQtTree(leoFrame.LeoTree):
         """
         Redraw all visible nodes of the tree.
         Preserve the vertical scrolling unless scroll is True.
+
+        Return a Position (which may change) unless drawing is disabled.
         """
         c = self.c
         if g.app.disable_redraw:

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -550,8 +550,6 @@ class LeoQtTree(leoFrame.LeoTree):
     def redraw_after_select(self, p: Position) -> None:
         """Redraw the entire tree after p has been selected.."""
         if self.busy:
-            if 'drawing' in g.app.debug:
-                g.trace('busy!', g.callers(1))
             return
         self.redraw_tree(p)
 

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -179,13 +179,10 @@ class LeoQtTree(leoFrame.LeoTree):
         if not p:
             p = c.currentPosition()
         elif c.hoistStack and p.h.startswith('@chapter') and p.hasChildren():
-            # Make sure the current position is visible.
-            # Part of fix of bug 875323: Hoist an @chapter node leaves a non-visible node selected.
+            # #875323: Make sure the current position is visible.
             p = p.firstChild()
             c.frame.tree.select(p)
-            c.setCurrentPosition(p)
-        else:
-            c.setCurrentPosition(p)
+        c.setCurrentPosition(p)
         assert not self.busy, g.callers()
         self.redrawCount += 1
         self.initData()

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -546,13 +546,6 @@ class LeoQtTree(leoFrame.LeoTree):
                         icon = self.declutter_node(c, p, item)
                         item.setIcon(0, icon)  # 0 is the column number.
 
-    # @+node:ekr.20110605121601.17884: *4* LeoQtTree.redraw_after_select
-    def redraw_after_select(self, p: Position) -> None:
-        """Redraw the entire tree after p has been selected.."""
-        if self.busy:
-            return
-        self.redraw_tree(p)
-
     # @+node:ekr.20140907201613.18986: *4* LeoQtTree.repaint (not used)
     def repaint(self) -> None:
         """Repaint the widget."""

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -163,8 +163,8 @@ class LeoQtTree(leoFrame.LeoTree):
         w = self.treeWidget
         w.clear()
 
-    # @+node:ekr.20110605121601.17873: *4* LeoQtTree.full_redraw & helpers
-    def full_redraw(self, p: Position = None) -> Position:
+    # @+node:ekr.20110605121601.17873: *4* LeoQtTree.redraw_tree & helpers
+    def redraw_tree(self, p: Position = None) -> Position:
         """
         Redraw all visible nodes of the tree.
         Preserve the vertical scrolling unless scroll is True.
@@ -198,10 +198,9 @@ class LeoQtTree(leoFrame.LeoTree):
         return p  # Return the position, which may have changed.
 
     # Compatibility
-
-    # mypy complains that there is a mismatch with the base redraw method.
-    redraw = full_redraw  # type:ignore
-    redraw_now = full_redraw  # type:ignore
+    full_redraw = redraw_tree
+    redraw = redraw_tree
+    redraw_now = redraw_tree
 
     # @+node:tbrown.20150807090639.1: *5* LeoQtTree.declutter_node & helpers
     def declutter_node(self, c: Cmdr, v: VNode, item: QTreeWidgetItem) -> QIcon:
@@ -483,7 +482,7 @@ class LeoQtTree(leoFrame.LeoTree):
                 p.moveToNext()
         if trace:
             t2 = time.process_time()
-            g.trace(f"{t2 - t1:5.2f} sec.", g.callers(3))
+            g.trace(f"{c.shortFileName()} {t2 - t1:5.2f} sec.")
 
     # @+node:ekr.20110605121601.17877: *5* LeoQtTree.drawTree
     def drawTree(self, p: Position, parent_item: QTreeWidgetItem = None) -> None:
@@ -551,7 +550,7 @@ class LeoQtTree(leoFrame.LeoTree):
                         item.setIcon(0, icon)  # 0 is the column number.
 
     # @+node:ekr.20110605121601.17884: *4* LeoQtTree.redraw_after_select
-    def redraw_after_select(self, p: Position = None) -> None:
+    def redraw_after_select(self, p: Position) -> None:
         """Redraw the entire tree when an invisible node is selected."""
         if self.busy:
             if 'drawing' in g.app.debug:

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -548,14 +548,12 @@ class LeoQtTree(leoFrame.LeoTree):
 
     # @+node:ekr.20110605121601.17884: *4* LeoQtTree.redraw_after_select
     def redraw_after_select(self, p: Position) -> None:
-        """Redraw the entire tree when an invisible node is selected."""
+        """Redraw the entire tree after p has been selected.."""
         if self.busy:
             if 'drawing' in g.app.debug:
                 g.trace('busy!', g.callers(1))
             return
-        self.full_redraw(p)
-        # c.redraw_after_select calls tree.select indirectly.
-        # Do not call it again here.
+        self.redraw_tree(p)
 
     # @+node:ekr.20140907201613.18986: *4* LeoQtTree.repaint (not used)
     def repaint(self) -> None:


### PR DESCRIPTION
See #4743.

PR #4748 fixes a critical blunder in this PR!

This PR does not change Leo's API: All existing plugins and scripts should work as before.

- [x] Add `clear-last-colorizer-trace` command.
- [x] Improve traces produced by `--trace=coloring`.
- [x] Remove redundant call to `w.getAllText` in `selfInsertCommand`.
- [x] Remove `QTextMixin.onTextChanged` and  `w.changingText` lockout.
- [x] Suppress redraws during startup.
- [x] Remove `# pylint: disable=no-else-return` from `v.setBodyString` and `v.setHeadString`.
- [x] Remove `# type:ignore` by unifying signatures of `redraw`, `redraw_now` and `full_redraw` methods.
- [x] `c.redraw` calls `c.recolor`. Remove all calls to `c.recolor` when calling `c.redraw`.
- [x] Rename `tree.redraw` to `redraw_tree`, retaining `redraw` as an alias for compatibility.
- [x] Remove confusing delay with `--trace=drawing`.
- [x] Replace `c.redraw_after_select` with `c.redraw`.