### PR TITLE
one-line fix for issue #4738

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7307,7 +7307,7 @@ def os_startfile(fname: str) -> None:
                 ree.close()
             return
         try:
-            subPopen = subprocess.Popen(['xdg-open', fname], stderr=wre, shell=True)
+            subPopen = subprocess.Popen(['xdg-open', fname], stderr=wre, shell=False)
         except Exception:
             g.es_print(f"error opening {fname!r}")
             g.es_exception()


### PR DESCRIPTION
see https://github.com/leo-editor/leo-editor/issues/4738: **xdg-open fails due to recent-ish changes in subprocess.Popen() shell parameters #4738**

This fix works for me under Linux
