### PR TITLE
PR fixes #4747: show-node-files command

### DIFF
--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -375,6 +375,17 @@ def show_clone_ancestors(event: LeoKeyEvent = None) -> None:
                 c.frame.log.put(message + '\n', nodeLink=f"{unl}::1")
 
 
+# @+node:ekr.20260622102739.1: *3* @g.command('show-clone-files')
+@g.command('show-clone-files')
+def show_clone_files(event: LeoKeyEvent = None) -> None:
+    """Display the names of all external files containing this clone."""
+    c = event.get('c')
+    if c and c.p:
+        p = c.p
+        for v in p.v.findAllAncestorAtFileNodes():
+            g.es(v.h, color='blue')
+
+
 # @+node:ekr.20191007034723.1: *3* @g.command('show-clone-parents')
 @g.command('show-clone-parents')
 def show_clones(event: LeoKeyEvent = None) -> None:

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -375,10 +375,10 @@ def show_clone_ancestors(event: LeoKeyEvent = None) -> None:
                 c.frame.log.put(message + '\n', nodeLink=f"{unl}::1")
 
 
-# @+node:ekr.20260622102739.1: *3* @g.command('show-clone-files')
-@g.command('show-clone-files')
-def show_clone_files(event: LeoKeyEvent = None) -> None:
-    """Display the names of all external files containing this clone."""
+# @+node:ekr.20260622102739.1: *3* @g.command('show-node-files')
+@g.command('show-node-files')
+def show_node_files(event: LeoKeyEvent = None) -> None:
+    """Display the headlines of all @<file> nodes containing this node."""
     c = event.get('c')
     if c and c.p:
         p = c.p

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2670,9 +2670,11 @@ class VNode:
 
         Original idea by Виталије Милошевић (Vitalije Milosevic).
 
-        #4565: Rewritten by EKR to use the to_do_set kwarg.
+        PR #4566: Rewritten by EKR to use the to_do_set kwarg.
+        https://github.com/leo-editor/leo-editor/pull/4566
 
         PR #4747: Create this helper function.
+        https://github.com/leo-editor/leo-editor/pull/4747
         """
         v = self
 

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2666,7 +2666,13 @@ class VNode:
     # @+node:ekr.20260622103203.1: *4* v.findAllAncetorAtFileNodes
     def findAllAncestorAtFileNodes(self, *, to_do_set: set[VNode] = None) -> list[VNode]:
         """
-        Return a list of all external files.
+        Return a list of all @<file> nodes containing this VNode.
+
+        Original idea by Виталије Милошевић (Vitalije Milosevic).
+
+        #4565: Rewritten by EKR to use the to_do_set kwarg.
+
+        #4747: Create this helper function.
         """
         v = self
 
@@ -2732,32 +2738,10 @@ class VNode:
 
     # @+node:ekr.20191213161023.1: *4* v.setAllAncestorAtFileNodesDirty
     def setAllAncestorAtFileNodesDirty(self, *, to_do_set: set[VNode] = None) -> None:
-        """
-        Original idea by Виталије Милошевић (Vitalije Milosevic).
-
-        #4565: Rewritten by EKR to use the to_do_set kwarg.
-        """
+        """Set all ancestor @<file> nodes dirty."""
         v = self
-
-        # Init seen and to_do_list.
-        seen: set[VNode] = set([v.context.hiddenRootNode])
-        to_do_list: list[VNode] = list(to_do_set) if to_do_set else [v]
-        if to_do_set:
-            for v2 in to_do_set:
-                to_do_list.extend(v2.parents)
-        to_do_list = list(set(to_do_list))
-
-        # The main loop.
-        while to_do_list:
-            v2 = to_do_list.pop()
-            seen.add(v2)
-            if v2.isAnyAtFileNode():
-                v2.setDirty()
-            else:
-                # Nested @<file> nodes are no longer valid.
-                for parent_v in v2.parents:
-                    if parent_v not in seen:
-                        to_do_list.append(parent_v)
+        for v2 in v.findAllAncestorAtFileNodes():
+            v2.setDirty()
 
     # @+node:ekr.20040315032144: *4* v.setBodyString & v.setHeadString
     def setBodyString(self, s: object) -> None:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2659,29 +2659,38 @@ class VNode:
     def setIcon(self) -> None:  # pragma: no cover
         pass  # Compatibility routine for old scripts
 
-    # @+node:ekr.20220905044353.1: *4* v.updateIcon
-    def updateIcon(self) -> None:
-        """Update any user icon."""
-        c, v = self.context, self
-        try:
-            tree = c.frame.tree  # May not exist at startup.
-            if not tree:
-                return
-            if not hasattr(tree, 'nodeIconsDict'):  # Only exists for Qt gui.
-                return
-        except AttributeError:
-            return
-
-        # #2870: Clear the icon cache (Remove v.gnx from the dict).
-        tree.nodeIconsDict.pop(v.gnx, None)
-        icon = tree.getIcon(v)
-        items = tree.vnode2items(v)
-        for item in items:
-            tree.setItemIcon(item, icon)
-
     # @+node:ville.20120502221057.7498: *4* v.contentModified
     def contentModified(self) -> None:
         g.contentModifiedSet.add(self)
+
+    # @+node:ekr.20260622103203.1: *4* v.findAllAncetorAtFileNodes
+    def findAllAncestorAtFileNodes(self, *, to_do_set: set[VNode] = None) -> list[VNode]:
+        """
+        Return a list of all external files.
+        """
+        v = self
+
+        # Init seen and to_do_list.
+        seen: set[VNode] = set([v.context.hiddenRootNode])
+        to_do_list: list[VNode] = list(to_do_set) if to_do_set else [v]
+        if to_do_set:
+            for v2 in to_do_set:
+                to_do_list.extend(v2.parents)
+        to_do_list = list(set(to_do_list))
+
+        # The main loop.
+        result: set[VNode] = set()
+        while to_do_list:
+            v2 = to_do_list.pop()
+            seen.add(v2)
+            if v2.isAnyAtFileNode():
+                result.add(v2)
+            else:
+                # Nested @<file> nodes are no longer valid.
+                for parent_v in v2.parents:
+                    if parent_v not in seen:
+                        to_do_list.append(parent_v)
+        return list(result)
 
     # @+node:ekr.20100303074003.5636: *4* v.restoreCursorAndScroll
     # Called only by LeoTree.selectHelper.
@@ -2785,6 +2794,26 @@ class VNode:
         v = self
         v.selectionStart = start
         v.selectionLength = length
+
+    # @+node:ekr.20220905044353.1: *4* v.updateIcon
+    def updateIcon(self) -> None:
+        """Update any user icon."""
+        c, v = self.context, self
+        try:
+            tree = c.frame.tree  # May not exist at startup.
+            if not tree:
+                return
+            if not hasattr(tree, 'nodeIconsDict'):  # Only exists for Qt gui.
+                return
+        except AttributeError:
+            return
+
+        # #2870: Clear the icon cache (Remove v.gnx from the dict).
+        tree.nodeIconsDict.pop(v.gnx, None)
+        icon = tree.getIcon(v)
+        items = tree.vnode2items(v)
+        for item in items:
+            tree.setItemIcon(item, icon)
 
     # @+node:ekr.20130524063409.10700: *3* v.Inserting & cloning
     def cloneAsNthChild(self, parent_v: VNode, n: int) -> VNode:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2672,7 +2672,7 @@ class VNode:
 
         #4565: Rewritten by EKR to use the to_do_set kwarg.
 
-        #4747: Create this helper function.
+        PR #4747: Create this helper function.
         """
         v = self
 


### PR DESCRIPTION
See #4747.

- [x] Add `v.findAllAncestorAtFileNodes`.
- [x] Simplify `v.setAllAncestorAtFileNodesDirty`.
- [x] Add `show-node-files` command.