### PR TITLE
PR fixes #4727: honor the --select=UNL command-line arg

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2431,6 +2431,11 @@ class LoadManager:
             factory.setTabForCommander(c)
         except Exception:
             pass
+
+        # #4747: honor the --select option.
+        if unl := self.options.get('select'):
+            g.findAnyUnl(unl, c)
+
         g.app.initing = False  # "idle" hooks may now call g.app.forceShutdown.
         g.app.logInited = True
         g.app.initComplete = True
@@ -2790,7 +2795,7 @@ class LoadManager:
           --save-session        always save session data when Leo closes
           --script=PATH         execute a script and then exit
           --script-window       execute script using default gui
-          --select=ID           headline or gnx of node to select
+          --select=GNX          gnx of node to select
           --silent              disable all log messages
           --theme=NAME          use the named theme file
           --trace=LIST          add one or more strings to g.app.debug

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2795,7 +2795,7 @@ class LoadManager:
           --save-session        always save session data when Leo closes
           --script=PATH         execute a script and then exit
           --script-window       execute script using default gui
-          --select=GNX          gnx of node to select
+          --select=UNL          unl of node to select
           --silent              disable all log messages
           --theme=NAME          use the named theme file
           --trace=LIST          add one or more strings to g.app.debug


### PR DESCRIPTION
See #4727.

- [x] Honor the `--select` option. It was not functional.
- [x] Fix the `--help` message: only UNLs are valid.