### PR TITLE
PR: Tweak colorizer traces

### DIFF
--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -95,6 +95,7 @@ def make_colorizer(c: Cmdr, widget: QWidget) -> JEditColorizer | PygmentsColoriz
 def dump_colorizer_last_colorizer_traces(event: LeoKeyEvent) -> None:
     c = event['c']
     colorizer = c.frame.body.colorizer
+    g.cls()
     print('\n'.join(colorizer.last_trace))
 
 
@@ -1415,16 +1416,16 @@ class JEditColorizer(BaseColorizer):
 
         # Do not delete these traces!
         if prev_state == -1 and s:
-            g.cls()
             message = (
                 f"New node: {self.language=} {len(s)=} {p.h=}\n"
-                f"        Callers:  {g.callers(3)}"
+                f"Callers:  {g.callers(3)}"
             )  # fmt: skip
             # Init the queued messages for the dump-last-colorizer-trace command.
             self.last_trace = [message]
             if trace:  # Print the trace immediately.
+                g.cls()
                 print('')
-                g.trace(message)
+                print(message)
 
         # mainLoop will do nothing if s is empty.
         if s:

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1423,7 +1423,11 @@ class JEditColorizer(BaseColorizer):
 
         # Do not delete these traces!
         if prev_state == -1 and s:
-            message = f"New node: p.h: {len(s)=} {p.h}"
+            g.cls()
+            message = (
+                f"New node: {self.language=} {len(s)=} {p.h=}\n"
+                f"        Callers:  {g.callers(3)}"
+            )  # fmt: skip
             # Init the queued messages for the dump-last-colorizer-trace command.
             self.last_trace = [message]
             if trace:  # Print the trace immediately.

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -90,15 +90,7 @@ def make_colorizer(c: Cmdr, widget: QWidget) -> JEditColorizer | PygmentsColoriz
     return JEditColorizer(c, widget)
 
 
-# @+node:ekr.20260215050008.1: ** command: clear/dump-last-colorizer-trace
-@g.command('clear-last-colorizer-trace')
-def clear_colorizer_last_colorizer_traces(event: LeoKeyEvent) -> None:
-    g.cls()
-    c = event['c']
-    colorizer = c.frame.body.colorizer
-    colorizer.last_trace = []
-
-
+# @+node:ekr.20260215050008.1: ** command: dump-last-colorizer-trace
 @g.command('dump-last-colorizer-trace')
 def dump_colorizer_last_colorizer_traces(event: LeoKeyEvent) -> None:
     c = event['c']
@@ -1496,10 +1488,6 @@ class JEditColorizer(BaseColorizer):
     # @+node:ekr.20110605121601.18641: *3* jedit.setTag
     def setTag(self, tag: str, s: str, i: int, j: int) -> None:
         """Set the tag in the highlighter."""
-        define_report = (
-            not g.unitTesting and
-            any(z in g.app.debug for z in ('coloring', 'verbose'))
-        )  # fmt: skip
         default_tag = f"{tag}_font"  # See default_font_dict.
         full_tag = f"{self.language}.{tag}"
         font: QtGui.QFont = None  # Set below. Define here for report().
@@ -1565,7 +1553,9 @@ class JEditColorizer(BaseColorizer):
             if g.unitTesting:
                 raise
         self.tagCount += 1
-        if define_report:
+        if True:
+            # PR #4752: *Always* define the report function, despite its cost.
+            #           Otherwise, the dump-last-colorizer-trace command is almost useless.
             # PR #4618: (Ville Vainio) https://github.com/leo-editor/leo-editor/pull/4618
             # Don't call report by default: It's setup is expensive!
             # @+<< setTag: define report >>


### PR DESCRIPTION
- [x] Clear the screen when showing recoloring traces.
- [x] Improve the 'New node' trace.
- [x] Remove the `clear-last-colorizer-trace` command. In effect, it is done automatically.
- [x] Always save the traces for the `dump-last-colorizer-trace` command.
- [x] Remove the `trace=verbose` hack: the performance gain is not worth the loss of functionality!