### PR TITLE
PR: remove mypy suppressions

### DIFF
--- a/leo/commands/bufferCommands.py
+++ b/leo/commands/bufferCommands.py
@@ -6,7 +6,7 @@
 # @+node:ekr.20150514045750.1: ** << bufferCommands imports & annotations >>
 from __future__ import annotations
 from collections.abc import Callable
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
 
@@ -220,7 +220,7 @@ class BufferCommandsClass(BaseEditCommandsClass):
             self.names[h] = nameList
 
     # @+node:ekr.20150514045829.16: *4* findBuffer
-    def findBuffer(self, name: str) -> Optional[Position]:
+    def findBuffer(self, name: str) -> Position | None:
         v = self.vnodes.get(name)
         for p in self.c.all_unique_positions():
             if p.v == v:

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -10,7 +10,7 @@ import pathlib
 import re
 import sys
 import time
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 # Third-party imports.
 try:
@@ -114,7 +114,7 @@ def find_long_lines(event: LeoKeyEvent) -> None:
 
     # @+others # helper functions
     # @+node:ekr.20190609135639.1: *4* function: get_root
-    def get_root(p: Position) -> Optional[Position]:
+    def get_root(p: Position) -> Position | None:
         """Return True if p is any @<file> node."""
         for parent in p.self_and_parents():
             if parent.anyAtFileNodeName():
@@ -640,7 +640,7 @@ class PylintCommand:
 
     # @+others
     # @+node:ekr.20150514125218.11: *3* 1. pylint.run
-    def run(self, root: Position, *, last_path: str = None) -> Optional[tuple[str, Position]]:
+    def run(self, root: Position, *, last_path: str = None) -> tuple[str, Position] | None:
         """Run Pylint on all Python @<file> nodes in root's tree."""
         c = self.c
         if not lint:
@@ -686,7 +686,7 @@ class PylintCommand:
         return data[-1] if data and is_at_file else None
 
     # @+node:ekr.20150514125218.10: *3* 3. pylint.get_rc_file
-    def get_rc_file(self) -> Optional[str]:
+    def get_rc_file(self) -> str | None:
         """Return the path to the pylint configuration file."""
         c = self.c
         base1 = '.pylintrc'  # Standard name.
@@ -719,7 +719,7 @@ class PylintCommand:
         return None
 
     # @+node:ekr.20150514125218.9: *3* 4. pylint.get_fn
-    def get_fn(self, p: Position) -> Optional[str]:
+    def get_fn(self, p: Position) -> str | None:
         """
         Finalize p's file name.
         Return if p is not an @file node for a python file.

--- a/leo/commands/commanderEditCommands.py
+++ b/leo/commands/commanderEditCommands.py
@@ -6,7 +6,7 @@
 # @+node:ekr.20220826084013.1: ** << commanderEditCommands imports & annotations >>
 from __future__ import annotations
 import re
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -518,7 +518,7 @@ def extractDef(c: Cmdr, s: str) -> str:
 
 
 # @+node:ekr.20171123135625.26: *3* function: extractDef_find
-def extractDef_find(c: Cmdr, lines: list[str]) -> Optional[str]:
+def extractDef_find(c: Cmdr, lines: list[str]) -> str | None:
     for line in lines:
         def_h = extractDef(c, line.strip())
         if def_h:
@@ -582,7 +582,7 @@ def extractSectionNames(self: Self, event: LeoKeyEvent = None) -> None:
 
 
 # @+node:ekr.20171123135625.28: *3* function: findSectionName
-def findSectionName(self: Self, s: str) -> Optional[str]:
+def findSectionName(self: Self, s: str) -> str | None:
     head1 = s.find("<<")
     if head1 > -1:
         head2 = s.find(">>", head1)

--- a/leo/commands/commanderHelpCommands.py
+++ b/leo/commands/commanderHelpCommands.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import os
 import sys
 import time
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -158,7 +158,7 @@ def openLeoDist(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20151225193723.1: *3* c_help.openLeoPy
 @g.commander_command('open-leo-py-leo')
 @g.commander_command('leo-py-leo')
-def openLeoPy(self: Self, event: LeoKeyEvent = None) -> Optional[Cmdr]:
+def openLeoPy(self: Self, event: LeoKeyEvent = None) -> Cmdr | None:
     """Open leoPy.leo or LeoPyRef.leo in a new Leo window."""
     c = self
     names = (
@@ -179,7 +179,7 @@ def openLeoPy(self: Self, event: LeoKeyEvent = None) -> Optional[Cmdr]:
 # @+node:ekr.20201013105418.1: *3* c_help.openLeoPyRef
 @g.commander_command('open-leo-py-ref-leo')
 @g.commander_command('leo-py-ref-leo')
-def openLeoPyRef(self: Self, event: LeoKeyEvent = None) -> Optional[Cmdr]:
+def openLeoPyRef(self: Self, event: LeoKeyEvent = None) -> Cmdr | None:
     """Open leoPyRef.leo in a new Leo window."""
     c = self
     path = g.finalize_join(g.app.loadDir, "..", "core", "LeoPyRef.leo")
@@ -209,7 +209,7 @@ def openLeoScripts(self: Self, event: LeoKeyEvent = None) -> None:
 @g.commander_command('open-leo-settings')
 @g.commander_command('open-leo-settings-leo')  # #1343.
 @g.commander_command('leo-settings')
-def openLeoSettings(self: Self, event: LeoKeyEvent = None) -> Optional[Cmdr]:
+def openLeoSettings(self: Self, event: LeoKeyEvent = None) -> Cmdr | None:
     """Open leoSettings.leo in a new Leo window."""
     c, lm = self, g.app.loadManager
     path = lm.computeLeoSettingsPath()
@@ -234,7 +234,7 @@ def openMyLeoSettings(self: Self, event: LeoKeyEvent = None) -> Cmdr:
 
 
 # @+node:ekr.20141119161908.2: *4* function: c_help.createMyLeoSettings
-def createMyLeoSettings(c: Cmdr) -> Optional[Cmdr]:
+def createMyLeoSettings(c: Cmdr) -> Cmdr | None:
     """createMyLeoSettings - Return true if myLeoSettings.leo created ok"""
     name = "myLeoSettings.leo"
     homeLeoDir = g.app.homeLeoDir

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -10,7 +10,7 @@ from collections.abc import Callable
 import xml.etree.ElementTree as ElementTree
 import json
 import time
-from typing import Any, Generator, Optional, TYPE_CHECKING
+from typing import Any, Generator, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoNodes
 from leo.core import leoFileCommands
@@ -41,7 +41,7 @@ def copyOutline(self: Cmdr, event: LeoKeyEvent = None) -> str:
 
 # @+node:ekr.20220314071523.1: *3* c_oc.copyOutlineAsJson & helpers
 @g.commander_command('copy-node-as-json')
-def copyOutlineAsJSON(self: Cmdr, event: LeoKeyEvent = None) -> Optional[str]:
+def copyOutlineAsJSON(self: Cmdr, event: LeoKeyEvent = None) -> str | None:
     """Copy the selected outline as JSON to the clipboard"""
     # Copying an outline has no undo consequences.
     c = self
@@ -71,7 +71,7 @@ def pasteOutline(
     event: LeoKeyEvent = None,
     s: str = None,
     undoFlag: bool = True,  # A hack for abbrev.paste_tree.
-) -> Optional[Position]:
+) -> Position | None:
     """
     Paste an outline into the present outline from the clipboard.
     Nodes do *not* retain their original identify.
@@ -121,7 +121,7 @@ def pasteOutlineRetainingClones(
     self: Cmdr,
     event: LeoKeyEvent = None,
     s: str = None,
-) -> Optional[Position]:
+) -> Position | None:
     """
     Paste an outline into the present outline from the clipboard.
     Nodes *retain* their original identify.
@@ -1102,7 +1102,7 @@ def hoist(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.1759: ** c_oc.Insert, Delete & Clone commands
 # @+node:ekr.20031218072017.1762: *3* c_oc.clone
 @g.commander_command('clone-node')
-def clone(self: Cmdr, event: LeoKeyEvent = None) -> Optional[Position]:
+def clone(self: Cmdr, event: LeoKeyEvent = None) -> Position | None:
     """Create a clone of the selected outline."""
     c, p, u = self, self.p, self.undoer
     if not p:
@@ -1248,7 +1248,7 @@ def insertHeadline(
     event: LeoKeyEvent = None,
     op_name: str = "Insert Node",
     as_child: bool = False,
-) -> Optional[Position]:
+) -> Position | None:
     """
     If c.p is expanded, insert a new node as the first or last child of c.p,
     depending on @bool insert-new-nodes-at-end.
@@ -1261,14 +1261,14 @@ def insertHeadline(
 
 
 @g.commander_command('insert-as-first-child')
-def insertNodeAsFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> Optional[Position]:
+def insertNodeAsFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> Position | None:
     """Insert a node as the first child of the previous node."""
     c = self
     return insertHeadlineHelper(c, event=event, as_first_child=True)
 
 
 @g.commander_command('insert-as-last-child')
-def insertNodeAsLastChild(self: Cmdr, event: LeoKeyEvent = None) -> Optional[Position]:
+def insertNodeAsLastChild(self: Cmdr, event: LeoKeyEvent = None) -> Position | None:
     """Insert a node as the last child of the previous node."""
     c = self
     return insertHeadlineHelper(c, event=event, as_last_child=True)
@@ -1282,7 +1282,7 @@ def insertHeadlineHelper(
     as_child: bool = False,
     as_first_child: bool = False,
     as_last_child: bool = False,
-) -> Optional[Position]:
+) -> Position | None:
     """Insert a node after the presently selected node."""
     u = c.undoer
     current = c.p
@@ -1316,7 +1316,7 @@ def insertHeadlineHelper(
 
 # @+node:ekr.20130922133218.11540: *3* c_oc.insertHeadlineBefore
 @g.commander_command('insert-node-before')
-def insertHeadlineBefore(self: Cmdr, event: LeoKeyEvent = None) -> Optional[Position]:
+def insertHeadlineBefore(self: Cmdr, event: LeoKeyEvent = None) -> Position | None:
     """Insert a node before the presently selected node."""
     c, current, u = self, self.p, self.undoer
     op_name = 'Insert Node Before'

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -1993,12 +1993,10 @@ def sortSiblings(
     newChildren = parent_v.children[:]
     if key is None:
 
-        def lowerKey(self: Cmdr) -> str:
-            return self.h.lower()
+        def key(v: VNode) -> str:
+            return v.h.lower()
 
-        key = lowerKey
-
-    newChildren.sort(key=key, reverse=reverse)  # type:ignore
+    newChildren.sort(key=key, reverse=reverse)
     if oldChildren == newChildren:
         return
     # 2010/01/20. Fix bug 510148.

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -1222,7 +1222,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                     if word in ivars:
                         # replace word by self.word
                         word = "self." + word
-                        body[i:j] = list(word)
+                        body[i:j] = list(word)  # #4753
                         delta = len(word) - (j - i)
                         i = j + delta
                     else:

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -1405,17 +1405,17 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 return aList
 
             # @+node:ekr.20160213070235.4: *6* msf.scan_d
-            def scan_d(self, kind: str) -> dict[str, list[str]]:
+            def scan_d(self, kind: str) -> dict[str, str]:
                 """Return a dict created from an @data node of the given kind."""
                 c = self.c
                 aList = c.config.getData(kind, strip_comments=True, strip_data=True)
-                d: dict[str, list[str]] = {}
+                d: dict[str, str] = {}
                 if aList is None:
                     g.trace(f"warning: no @data {kind} node")
                 for s in aList or []:
                     # Split s into two strings.
                     name, value = s.split(':', 1)
-                    d[name.strip()] = value.strip()  # type:ignore
+                    d[name.strip()] = value.strip()
                 return d
 
             # @+node:ekr.20160213070235.5: *6* msf.scan_patterns

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -1222,8 +1222,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                     if word in ivars:
                         # replace word by self.word
                         word = "self." + word
-                        word = list(word)  # type:ignore
-                        body[i:j] = word
+                        body[i:j] = list(word)
                         delta = len(word) - (j - i)
                         i = j + delta
                     else:

--- a/leo/commands/debugCommands.py
+++ b/leo/commands/debugCommands.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from collections.abc import Callable
 import os
 import sys
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
 
@@ -63,7 +63,7 @@ class DebugCommandsClass(BaseEditCommandsClass):
         os.spawnv(os.P_NOWAIT, python, args)
 
     # @+node:ekr.20150514063305.105: *3* debug.findDebugger
-    def findDebugger(self) -> Optional[str]:
+    def findDebugger(self) -> str | None:
         """Find the winpdb debugger."""
         c = self.c
         pythonDir = g.os_path_dirname(sys.executable)

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 import difflib
 import os
 import re
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoCommands
 from leo.commands.baseCommands import BaseEditCommandsClass
@@ -110,7 +110,7 @@ class ConvertAtRoot:
                 self.units.append(p.copy())
 
     # @+node:ekr.20210307082125.1: *3* atRoot.find_section
-    def find_section(self, root: Position, section_name: str) -> Optional[Position]:
+    def find_section(self, root: Position, section_name: str) -> Position | None:
         """Find the section definition node in root's subtree for the given section."""
 
         def munge(s: str) -> str:
@@ -133,7 +133,7 @@ class ConvertAtRoot:
                     self.errors += 1
 
     # @+node:ekr.20210307080500.1: *3* atRoot.make_clone
-    def make_clone(self, p: Position, section_name: str) -> Optional[Position]:
+    def make_clone(self, p: Position, section_name: str) -> Position | None:
         """Make c clone for section, if necessary."""
 
         def clone_and_move(parent: Position, section_p: Position) -> None:
@@ -930,7 +930,7 @@ class GitDiffController:
         # Patterns matching @+node sentinels for each gnx.
         node_patterns: list[tuple[str, re.Pattern]],
         revs_list: list[str],
-    ) -> Optional[g.Bunch]:
+    ) -> g.Bunch | None:
         """
         Return a g.Bunch describing the action to be taken at rev i.
         """
@@ -1017,7 +1017,7 @@ class GitDiffController:
         # For debugging only.
         gnx: str,  # gnx being matched.
         rev: str,  # Full hash.
-    ) -> Optional[tuple[int, int]]:
+    ) -> tuple[int, int] | None:
         """
         Return (i1, i2) the range of lines of the node, or None.
         i1: The index of the line matching pattern.
@@ -1077,7 +1077,7 @@ class GitDiffController:
         self,
         path: str,
         rev_list: list[str],
-        limit: Optional[int] = None,
+        limit: int | None = None,
     ) -> list[list[str]]:
         """
         Return the contents of the file as a list of lines.
@@ -1399,7 +1399,7 @@ class GitDiffController:
         return p
 
     # @+node:ekr.20170806094320.7: *4* gdc.find_file
-    def find_file(self, fn: str) -> Optional[Position]:
+    def find_file(self, fn: str) -> Position | None:
         """Return the @<file> node matching fn."""
         c = self.c
         fn = g.os_path_basename(fn)
@@ -1411,7 +1411,7 @@ class GitDiffController:
         return None
 
     # @+node:ekr.20170806094321.3: *4* gdc.find_git_working_directory
-    def find_git_working_directory(self, directory: str) -> Optional[str]:
+    def find_git_working_directory(self, directory: str) -> str | None:
         """Return the git working directory, starting at directory."""
         while directory:
             if g.os_path_exists(g.finalize_join(directory, '.git')):
@@ -1423,7 +1423,7 @@ class GitDiffController:
         return None
 
     # @+node:ekr.20170819132219.1: *4* gdc.find_gnx
-    def find_gnx(self, c: Cmdr, gnx: str) -> Optional[Position]:
+    def find_gnx(self, c: Cmdr, gnx: str) -> Position | None:
         """Return a position in c having the given gnx."""
         for p in c.all_unique_positions():
             if p.v.fileIndex == gnx:
@@ -1453,7 +1453,7 @@ class GitDiffController:
         c.treeWantsFocusNow()
 
     # @+node:ekr.20210819080657.1: *4* gdc.get_parent_of_git_directory
-    def get_parent_of_git_directory(self) -> Optional[str]:
+    def get_parent_of_git_directory(self) -> str | None:
         """
         #2143.
         Resolve filename to the nearest directory containing a .git directory.

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -6,7 +6,7 @@
 # @+node:ekr.20220827065126.1: ** << gotoCommands imports & annotations >>
 from __future__ import annotations
 import re
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -97,7 +97,7 @@ class GoToCommands:
         return None, -1
 
     # @+node:ekr.20160921210529.1: *3* goto.find_node_start & helper
-    def find_node_start(self, p: Position, s: str = None) -> Optional[int]:
+    def find_node_start(self, p: Position, s: str = None) -> int | None:
         """
         Helper for show-file-line command.
 
@@ -147,7 +147,7 @@ class GoToCommands:
         delims: tuple[str, str, str],  # The comment delims.
         contents: list[str],  # The contents of the file *including* sentinels.
         target_i: int,  # The line number of the target line.
-    ) -> Optional[int]:
+    ) -> int | None:
         """
         Return the number of hidden sentinels preceding contents[target_i].
         """
@@ -357,7 +357,7 @@ class GoToCommands:
         p = self.find_gnx2(gnx)
         return p, bool(p)
 
-    def find_gnx2(self, gnx: str) -> Optional[Position]:
+    def find_gnx2(self, gnx: str) -> Position | None:
         """
         Scan the outline for a node with the given gnx and vnodeName.
 

--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -6,7 +6,7 @@
 # @+node:ekr.20150514050411.1: ** << killBufferCommands imports & annotations >>
 from __future__ import annotations
 from collections.abc import Callable
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
 
@@ -122,7 +122,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         g.app.globalKillBuffer = []
 
     # @+node:ekr.20150514063305.415: *3* getClipboard
-    def getClipboard(self) -> Optional[str]:
+    def getClipboard(self) -> str | None:
         """Return the contents of the clipboard."""
         try:
             ctxt = g.app.gui.getTextFromClipboard()

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 from collections.abc import Callable
 import re
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 # Third-party annotations
 try:
@@ -255,7 +255,7 @@ class DefaultWrapper(BaseSpellWrapper):
         self.save_user_dict()
 
     # @+node:ekr.20180207100238.1: *3* DefaultWrapper.find_main_dict
-    def find_main_dict(self) -> Optional[str]:
+    def find_main_dict(self) -> str | None:
         """Return the full path to the global dictionary."""
         c = self.c
         fn = c.config.getString('main-spelling-dictionary')
@@ -266,7 +266,7 @@ class DefaultWrapper(BaseSpellWrapper):
         return fn if g.os_path_exists(fn) else None
 
     # @+node:ekr.20230926171905.1: *3* DefaultWrapper.find_user_dict
-    def find_user_dict(self) -> Optional[str]:
+    def find_user_dict(self) -> str | None:
         """Return the full path to the global dictionary."""
         c = self.c
         fn = c.config.getString('enchant-local-dictionary')
@@ -707,7 +707,7 @@ class SpellTabHandler:
     re_part = re.compile(r'[a-zA-z]+')
     re_http = re.compile(r'.*?(http|https)://(.*?)$')
 
-    def find(self, event: LeoKeyEvent = None) -> Optional[str]:
+    def find(self, event: LeoKeyEvent = None) -> str | None:
         """
         Find the next unknown word.
 

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -148,8 +148,8 @@ class LeoApp:
         self.start_fullscreen = False  # For qt_frame plugin.
         self.start_maximized = False  # For qt_frame plugin.
         self.start_minimized = False  # For qt_frame plugin.
-        self.trace_binding: str = None  # The name of a binding to trace, or None.
-        self.trace_setting: str = None  # The name of a setting to trace, or None.
+        self.trace_binding: str | None = None  # The name of a binding to trace, or None.
+        self.trace_setting: str | None = None  # The name of a setting to trace, or None.
         self.translateToUpperCase = False  # Never set to True.
         self.use_splash_screen = True  # True: put up a splash screen.
 
@@ -161,7 +161,7 @@ class LeoApp:
         self.disableSave = False  # May be set by plugins.
         self.idle_timers: list[IdleTime] = []  # A list of IdleTime instances, so they persist.
         # The external process created by the 'listen-for-log' command.
-        self.log_listener: Popen = None
+        self.log_listener: Popen | None = None
         self.positions = 0  # The number of positions generated.
         self.scanErrors = 0  # The number of errors seen by g.scanError.
         self.statsDict: dict[str, Value] = {}  # dict used by g.stat, g.clear_stats, g.print_stats.
@@ -210,17 +210,17 @@ class LeoApp:
         self.config: GlobalConfigManager = None  # g.app.config.
         # A global db, managed by g.app.global_cacher.
         self.db: dict | SqlitePickleShare | g.NullObject = None
-        self.externalFilesController: ExternalFilesController = None
-        self.global_cacher: dict | GlobalCacher | g.NullObject = None
-        self.idleTimeManager: IdleTimeManager = None
+        self.externalFilesController: ExternalFilesController | None = None
+        self.global_cacher: dict | GlobalCacher | g.NullObject | None = None
+        self.idleTimeManager: IdleTimeManager | None = None
         self.jupytextManager: JupytextManager = None
-        self.loadManager: LoadManager = None
-        self.nodeIndices: NodeIndices = None
-        self.pluginsController: LeoPluginsController = None
-        self.sessionManager: SessionManager = None
+        self.loadManager: LoadManager | None = None
+        self.nodeIndices: NodeIndices | None = None
+        self.pluginsController: LeoPluginsController | None = None
+        self.sessionManager: SessionManager | None = None
 
         # Global status vars for the Commands class...
-        self.commandName: str = None  # The name of the command being executed.
+        self.commandName: str | None = None  # The name of the command being executed.
         self.commandInterruptFlag = False  # True: command within a command.
         # @-<< LeoApp: global controller/manager objects >>
         # @+<< LeoApp: global importer/reader/writer data >>

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -12,7 +12,7 @@ import string
 import sys
 import textwrap
 import time
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 import zipfile
 import platform
 from leo.core import leoGlobals as g
@@ -148,8 +148,8 @@ class LeoApp:
         self.start_fullscreen = False  # For qt_frame plugin.
         self.start_maximized = False  # For qt_frame plugin.
         self.start_minimized = False  # For qt_frame plugin.
-        self.trace_binding: Optional[str] = None  # The name of a binding to trace, or None.
-        self.trace_setting: Optional[str] = None  # The name of a setting to trace, or None.
+        self.trace_binding: str = None  # The name of a binding to trace, or None.
+        self.trace_setting: str = None  # The name of a setting to trace, or None.
         self.translateToUpperCase = False  # Never set to True.
         self.use_splash_screen = True  # True: put up a splash screen.
 
@@ -161,7 +161,7 @@ class LeoApp:
         self.disableSave = False  # May be set by plugins.
         self.idle_timers: list[IdleTime] = []  # A list of IdleTime instances, so they persist.
         # The external process created by the 'listen-for-log' command.
-        self.log_listener: Optional[Popen] = None
+        self.log_listener: Popen = None
         self.positions = 0  # The number of positions generated.
         self.scanErrors = 0  # The number of errors seen by g.scanError.
         self.statsDict: dict[str, Value] = {}  # dict used by g.stat, g.clear_stats, g.print_stats.
@@ -1278,7 +1278,7 @@ class LeoApp:
 
     # @+node:ekr.20180924093227.1: *3* app.c property
     @property
-    def c(self) -> Optional[Cmdr]:
+    def c(self) -> Cmdr | None:
         return self.log and self.log.c
 
     # @+node:ekr.20171127111053.1: *3* app.Closing
@@ -1493,7 +1493,7 @@ class LeoApp:
 
     # @+node:ekr.20171127111141.1: *3* app.Import utils
     # @+node:ekr.20140727180847.17985: *4* app.scanner_for_at_auto
-    def scanner_for_at_auto(self, p: Position) -> Optional[Callable]:
+    def scanner_for_at_auto(self, p: Position) -> Callable | None:
         """A factory returning a scanner function for p, an @auto node."""
         d = g.app.atAutoDict
         for key in d:
@@ -1503,7 +1503,7 @@ class LeoApp:
         return None
 
     # @+node:ekr.20140130172810.15471: *4* app.scanner_for_ext
-    def scanner_for_ext(self, ext: str) -> Optional[Callable]:
+    def scanner_for_ext(self, ext: str) -> Callable | None:
         """A factory returning a scanner function for the given file extension."""
         return g.app.classDispatchDict.get(ext)
 
@@ -1652,7 +1652,7 @@ class LoadManager:
         return fileName
 
     # @+node:ekr.20120209051836.10372: *4* LM.computeLeoSettingsPath
-    def computeLeoSettingsPath(self) -> Optional[str]:
+    def computeLeoSettingsPath(self) -> str | None:
         """Return the full path to leoSettings.leo."""
         # lm = self
         join = g.finalize_join
@@ -1672,7 +1672,7 @@ class LoadManager:
         return path
 
     # @+node:ekr.20120209051836.10373: *4* LM.computeMyLeoSettingsPath
-    def computeMyLeoSettingsPath(self) -> Optional[str]:
+    def computeMyLeoSettingsPath(self) -> str | None:
         """
         Return the full path to either myLeoSettings.leo or myLeoSettings.leojs.
 
@@ -1725,7 +1725,7 @@ class LoadManager:
         g.app.testDir = join(g.app.loadDir, '..', 'test')
 
     # @+node:ekr.20120209051836.10253: *5* LM.computeGlobalConfigDir
-    def computeGlobalConfigDir(self) -> Optional[str]:
+    def computeGlobalConfigDir(self) -> str | None:
         leo_config_dir = getattr(sys, 'leo_config_directory', None)
         if leo_config_dir:
             theDir = leo_config_dir
@@ -1738,7 +1738,7 @@ class LoadManager:
         return theDir
 
     # @+node:ekr.20120209051836.10254: *5* LM.computeHomeDir
-    def computeHomeDir(self) -> Optional[str]:
+    def computeHomeDir(self) -> str | None:
         """Returns the user's home directory."""
         # Windows searches the HOME, HOMEPATH and HOMEDRIVE
         # environment vars, then gives up.
@@ -1902,7 +1902,7 @@ class LoadManager:
         return path
 
     # @+node:ekr.20180321124503.1: *5* LM.resolve_theme_path
-    def resolve_theme_path(self, fn: str, tag: str) -> Optional[str]:
+    def resolve_theme_path(self, fn: str, tag: str) -> str | None:
         """Search theme directories for the given .leo file."""
         if not fn:
             return None
@@ -1919,7 +1919,7 @@ class LoadManager:
         return None
 
     # @+node:ekr.20120211121736.10772: *4* LM.computeWorkbookFileName
-    def computeWorkbookFileName(self) -> Optional[str]:
+    def computeWorkbookFileName(self) -> str | None:
         """
         Return full path to the workbook.
 
@@ -2013,7 +2013,7 @@ class LoadManager:
     # @+node:ekr.20120214165710.10726: *4* LM.createSettingsDicts
     def createSettingsDicts(
         self, c: Cmdr, localFlag: bool
-    ) -> Optional[tuple[g.SettingsDict, g.SettingsDict]]:
+    ) -> tuple[g.SettingsDict, g.SettingsDict] | None:
         from leo.core import leoConfig
 
         if c:
@@ -2177,7 +2177,7 @@ class LoadManager:
         return result
 
     # @+node:ekr.20120222103014.10312: *4* LM.openSettingsFile
-    def openSettingsFile(self, fn: str) -> Optional[Cmdr]:
+    def openSettingsFile(self, fn: str) -> Cmdr | None:
         """
         Open a settings file with a null gui.  Return the commander.
 
@@ -2698,7 +2698,7 @@ class LoadManager:
             g.app.createDefaultGui()
 
     # @+node:ekr.20120219154958.10482: *5* LM.getDefaultFile
-    def getDefaultFile(self) -> Optional[str]:
+    def getDefaultFile(self) -> str | None:
         # Get the name of the workbook.
         fn = g.app.config.getString('default-leo-file')
         fn = g.finalize(fn)
@@ -2832,7 +2832,7 @@ class LoadManager:
             return gui
 
         # @+node:ekr.20210927034148.7: *6* function: doScriptOption
-        def doScriptOption() -> Optional[str]:
+        def doScriptOption() -> str | None:
             """Handle --script=path"""
             m = utils.find_complex_option(r'--script=(.+)')
             if not m:
@@ -2847,7 +2847,7 @@ class LoadManager:
             return script
 
         # @+node:ekr.20230615055158.1: *6* function: doSelectOption
-        def doSelectOption() -> Optional[str]:
+        def doSelectOption() -> str | None:
             """Handle --select=headline"""
             m = utils.find_complex_option(r'--select=(.+)')
             return m.group(1) if m else None
@@ -2912,7 +2912,7 @@ class LoadManager:
                     helper()
 
         # @+node:ekr.20230615060055.1: *6* function: doThemeOption
-        def doThemeOption() -> Optional[str]:
+        def doThemeOption() -> str | None:
             """Handle --theme=path"""
             m = utils.find_complex_option(r'--theme=(.+)')
             return m.group(1).replace('"', '') if m else None
@@ -2976,7 +2976,7 @@ class LoadManager:
             print(f"\nEnabling --trace={', '.join(g.app.debug)}\n")
 
         # @+node:ekr.20210927034148.10: *6* function: doWindowSizeOption
-        def doWindowSizeOption() -> Optional[tuple[int, int]]:
+        def doWindowSizeOption() -> tuple[int, int] | None:
             """Handle --window-size"""
             m = utils.find_complex_option(r'--window-size=(\d+)x(\d+)')
             if not m:
@@ -2989,7 +2989,7 @@ class LoadManager:
             return h, w
 
         # @+node:ekr.20210927034148.9: *6* function: doWindowSpotOption
-        def doWindowSpotOption() -> Optional[tuple[int, int]]:
+        def doWindowSpotOption() -> tuple[int, int] | None:
             """Handle --window-spot"""
             m = utils.find_complex_option(r'--window-spot=(\d+)x(\d+)')
             if not m:
@@ -3137,7 +3137,7 @@ class LoadManager:
             return False
 
     # @+node:ekr.20120223062418.10393: *4* LM.openWithFileName & helpers
-    def openWithFileName(self, fn: str, gui: LeoGui, old_c: Cmdr) -> Optional[Cmdr]:
+    def openWithFileName(self, fn: str, gui: LeoGui, old_c: Cmdr) -> Cmdr | None:
         """
         Completely read a file, creating the corresponding outline.
 
@@ -3192,7 +3192,7 @@ class LoadManager:
             # c.enableMenuBar()
 
     # @+node:ekr.20120223062418.10406: *5* LM.findOpenFile
-    def findOpenFile(self, fn: str) -> Optional[Cmdr]:
+    def findOpenFile(self, fn: str) -> Cmdr | None:
         def munge(name: str) -> str:
             return g.os_path_normpath(name or '').lower()
 
@@ -3241,7 +3241,7 @@ class LoadManager:
         c.initialFocusHelper()
 
     # @+node:ekr.20120223062418.10408: *5* LM.openExternalFile
-    def openExternalFile(self, fn: str, gui: Optional[LeoGui], old_c: Optional[Cmdr]) -> Cmdr:
+    def openExternalFile(self, fn: str, gui: LeoGui | None, old_c: Cmdr | None) -> Cmdr:
         """
         Create a wrapper commander (in a new tab) for the given external file.
 
@@ -3321,7 +3321,7 @@ class LoadManager:
         return bool(fn and zipfile.is_zipfile(fn))
 
     # @+node:ekr.20220318033804.1: *5* LM.openEmptyLeoFile
-    def openEmptyLeoFile(self, fn: str, gui: Optional[LeoGui], old_c: Optional[Cmdr]) -> Cmdr:
+    def openEmptyLeoFile(self, fn: str, gui: LeoGui | None, old_c: Cmdr | None) -> Cmdr:
         """Open an empty Leo file with the given file name."""
         lm = self
 
@@ -3354,7 +3354,7 @@ class LoadManager:
         return c
 
     # @+node:ekr.20231124134846.1: *5* LM.openExistingLeoFile & helper
-    def openExistingLeoFile(self, fn: str, gui: Optional[LeoGui], old_c: Optional[Cmdr]) -> Cmdr:
+    def openExistingLeoFile(self, fn: str, gui: LeoGui | None, old_c: Cmdr | None) -> Cmdr:
         """
         Create a commander for an existing .leo, .db, or .leojs file.
         """
@@ -3428,7 +3428,7 @@ class LoadManager:
         c.clearChanged()
 
     # @+node:ekr.20120223062418.10410: *5* LM.openZipFile
-    def openZipFile(self, fn: str) -> Optional[StringIO]:
+    def openZipFile(self, fn: str) -> StringIO | None:
         """
         Open a zipped file for reading.
         Return a StringIO file if successful.
@@ -3621,7 +3621,7 @@ class RecentFilesManager:
         rf_always = c.config.getBool("recent-files-group-always")
         groupedEntries = rf_group or rf_always
         if groupedEntries:  # if so, make dict of groups
-            dirCount: dict[str, dict[str, Optional[list[str]]]] = {}
+            dirCount: dict[str, dict[str, list[str]]] | None = {}
             for fileName in rf.getRecentFiles()[:n]:
                 dirName, baseName = g.os_path_split(fileName)
                 if baseName not in dirCount:
@@ -3763,7 +3763,7 @@ class RecentFilesManager:
         return True
 
     # @+node:ekr.20120225072226.10285: *3* rf.sanitize
-    def sanitize(self, name: str) -> Optional[str]:
+    def sanitize(self, name: str) -> str | None:
         """Return a sanitized file name."""
         if name is None:
             return None
@@ -3983,7 +3983,7 @@ def openUrl(event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20150514125218.6: *3* open-url-under-cursor
 @g.command('open-url-under-cursor')
-def openUrlUnderCursor(event: LeoKeyEvent = None) -> Optional[str]:
+def openUrlUnderCursor(event: LeoKeyEvent = None) -> str | None:
     """Open the url under the cursor."""
     return g.openUrlOnClick(event)
 

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -209,7 +209,7 @@ class LeoApp:
         self.backgroundProcessManager: BackgroundProcessManager = None
         self.config: GlobalConfigManager = None  # g.app.config.
         # A global db, managed by g.app.global_cacher.
-        self.db: dict | SqlitePickleShare = None
+        self.db: dict | SqlitePickleShare | g.NullObject = None
         self.externalFilesController: ExternalFilesController = None
         self.global_cacher: dict | GlobalCacher | g.NullObject = None
         self.idleTimeManager: IdleTimeManager = None

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -211,7 +211,7 @@ class LeoApp:
         # A global db, managed by g.app.global_cacher.
         self.db: dict | SqlitePickleShare = None
         self.externalFilesController: ExternalFilesController = None
-        self.global_cacher: dict | GlobalCacher = None
+        self.global_cacher: dict | GlobalCacher | g.NullObject = None
         self.idleTimeManager: IdleTimeManager = None
         self.jupytextManager: JupytextManager = None
         self.loadManager: LoadManager = None

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1846,7 +1846,7 @@ class LoadManager:
         return [g.os_path_normslashes(z) for z in table if g.os_path_exists(z)]
 
     # @+node:ekr.20180318133620.1: *4* LM.computeThemeFilePath & helper
-    def computeThemeFilePath(self) -> str:
+    def computeThemeFilePath(self) -> str | None:
         """
         Return the absolute path to the theme .leo file, resolved using the search order for themes.
 
@@ -1861,7 +1861,7 @@ class LoadManager:
         trace = 'themes' in g.app.db
         lm = self
         resolve = self.resolve_theme_path
-        #
+
         # Step 1: Use the --theme command-line options if it exists
         path = resolve(lm.options.get('theme_path'), tag='--theme')
         if path:
@@ -1869,7 +1869,7 @@ class LoadManager:
             if trace:
                 g.trace('--theme:', path)
             return path
-        #
+
         # Step 2: look for the @string theme-name setting in the first loaded file.
         path = lm.files[0] if lm.files else ''
         if path and g.os_path_exists(path):
@@ -1891,7 +1891,7 @@ class LoadManager:
                         if trace:
                             g.trace("First loaded file", theme_c.shortFileName(), path)
                         return path
-        #
+
         # Step 3: use the @string theme-name setting in myLeoSettings.leo.
         # Note: the setting should *never* appear in leoSettings.leo!
         setting = lm.globalSettingsDict.get_string_setting('theme-name')
@@ -2013,7 +2013,7 @@ class LoadManager:
     # @+node:ekr.20120214165710.10726: *4* LM.createSettingsDicts
     def createSettingsDicts(
         self, c: Cmdr, localFlag: bool
-    ) -> tuple[g.SettingsDict, g.SettingsDict] | None:
+    ) -> tuple[g.SettingsDict, g.SettingsDict] | tuple[None, None]:
         from leo.core import leoConfig
 
         if c:
@@ -2447,7 +2447,7 @@ class LoadManager:
         return True
 
     # @+node:ekr.20131028155339.17098: *5* LM.openWorkBook
-    def openWorkBook(self) -> Cmdr:
+    def openWorkBook(self) -> Cmdr | None:
         """
         Open or create a new workbook.
 
@@ -3241,7 +3241,7 @@ class LoadManager:
         c.initialFocusHelper()
 
     # @+node:ekr.20120223062418.10408: *5* LM.openExternalFile
-    def openExternalFile(self, fn: str, gui: LeoGui | None, old_c: Cmdr | None) -> Cmdr:
+    def openExternalFile(self, fn: str, gui: LeoGui | None, old_c: Cmdr | None) -> Cmdr | None:
         """
         Create a wrapper commander (in a new tab) for the given external file.
 
@@ -3354,7 +3354,7 @@ class LoadManager:
         return c
 
     # @+node:ekr.20231124134846.1: *5* LM.openExistingLeoFile & helper
-    def openExistingLeoFile(self, fn: str, gui: LeoGui | None, old_c: Cmdr | None) -> Cmdr:
+    def openExistingLeoFile(self, fn: str, gui: LeoGui | None, old_c: Cmdr | None) -> Cmdr | None:
         """
         Create a commander for an existing .leo, .db, or .leojs file.
         """

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -14,7 +14,7 @@ import sys
 import tabnanny
 import time
 import tokenize
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoNodes
 
@@ -215,7 +215,7 @@ class AtFile:
         self.initAllIvars(root)
 
     # @+node:ekr.20041005105605.15: *4* at.initWriteIvars
-    def initWriteIvars(self, root: Position) -> Optional[str]:
+    def initWriteIvars(self, root: Position) -> str | None:
         """
         Compute default values of all write-related ivars.
         Return the finalized name of the output file.
@@ -354,7 +354,7 @@ class AtFile:
             g.red(f"file not found: {path}")
 
     # @+node:ekr.20041005105605.19: *5* at.openFileForReading & helper
-    def openFileForReading(self, fromString: str = None) -> tuple[Optional[str], Optional[str]]:
+    def openFileForReading(self, fromString: str = None) -> tuple[str | None, str | None]:
         """
         Open the file given by at.root.
         This will be the private file for @shadow nodes.
@@ -392,7 +392,7 @@ class AtFile:
         return fn, s
 
     # @+node:ekr.20150204165040.4: *6* at.openAtShadowFileForReading
-    def openAtShadowFileForReading(self, fn: str) -> Optional[str]:  # pragma: no cover
+    def openAtShadowFileForReading(self, fn: str) -> str | None:  # pragma: no cover
         """Open an @shadow for reading and return shadow_fn."""
         at = self
         x = at.c.shadowController
@@ -1044,7 +1044,7 @@ class AtFile:
         return valid, new_df, start, end, isThin
 
     # @+node:ekr.20130911110233.11284: *5* at.readFileToUnicode & helpers
-    def readFileToUnicode(self, fileName: str) -> Optional[str]:  # pragma: no cover
+    def readFileToUnicode(self, fileName: str) -> str | None:  # pragma: no cover
         """
         Carefully sets at.encoding, then uses at.encoding to convert the file
         to a unicode string.
@@ -1672,14 +1672,14 @@ class AtFile:
             return False
 
     # @+node:ekr.20140728040812.17993: *7* at.dispatch & helpers
-    def dispatch(self, ext: str, p: Position) -> Optional[Callable]:  # pragma: no cover
+    def dispatch(self, ext: str, p: Position) -> Callable | None:  # pragma: no cover
         """Return the correct writer function for p, an @auto node."""
         at = self
         # Match @auto type before matching extension.
         return at.writer_for_at_auto(p) or at.writer_for_ext(ext)
 
     # @+node:ekr.20140728040812.17995: *8* at.writer_for_at_auto
-    def writer_for_at_auto(self, root: Position) -> Optional[Callable]:  # pragma: no cover
+    def writer_for_at_auto(self, root: Position) -> Callable | None:  # pragma: no cover
         """A factory returning a writer function for the given kind of @auto directive."""
         at = self
         d = g.app.atAutoWritersDict
@@ -1687,7 +1687,7 @@ class AtFile:
             aClass = d.get(key)
             if aClass and g.match_word(root.h, 0, key):
 
-                def writer_for_at_auto_cb(root: Position) -> Optional[str]:
+                def writer_for_at_auto_cb(root: Position) -> str | None:
                     try:
                         writer = aClass(at.c)  # noqa
                         s = writer.write(root)
@@ -1700,14 +1700,14 @@ class AtFile:
         return None
 
     # @+node:ekr.20140728040812.17997: *8* at.writer_for_ext
-    def writer_for_ext(self, ext: str) -> Optional[Callable]:  # pragma: no cover
+    def writer_for_ext(self, ext: str) -> Callable | None:  # pragma: no cover
         """A factory returning a writer function for the given file extension."""
         at = self
         d = g.app.writersDispatchDict
         aClass = d.get(ext)
         if aClass:
 
-            def writer_for_ext_cb(root: Position) -> Optional[str]:
+            def writer_for_ext_cb(root: Position) -> str | None:
                 try:
                     return aClass(at.c).write(root)
                 except Exception:
@@ -3567,7 +3567,7 @@ class FastAtRead:
         re.VERBOSE,
     )
 
-    def scan_header(self, lines: list[str]) -> Optional[tuple[tuple, list[str], int]]:
+    def scan_header(self, lines: list[str]) -> tuple[tuple, list[str], int] | None:
         """
         Scan for the header line, which follows any @first lines.
         Return (delims, first_lines, i+1) or None

--- a/leo/core/leoBeautify.py
+++ b/leo/core/leoBeautify.py
@@ -286,11 +286,11 @@ class CPrettyPrinter:
         tokens = self.tokenize(p.b)
         s = ''.join(tokens)
         assert s == p.b
-        new_tokens = self.add_statement_braces(s, tokens, giveWarnings=giveWarnings)
+        new_tokens = self.add_statement_braces(s, tokens, giveWarnings=giveWarnings)  # #4753
         self.bracketLevel = 0
         self.parens = 0
         self.result = []
-        for s in new_tokens:
+        for s in new_tokens:  # #4753
             self.put_token(s)
         return self.result if toList else ''.join(self.result)
 
@@ -308,7 +308,7 @@ class CPrettyPrinter:
 
         i = 0
         result: list[str] = []
-        for token in tokens:
+        for token in tokens:  # #4753
             progress = i
             if token in ('if', 'for', 'while'):
                 j = self.skip_ws_and_comments(s, i + 1)

--- a/leo/core/leoBeautify.py
+++ b/leo/core/leoBeautify.py
@@ -283,19 +283,21 @@ class CPrettyPrinter:
         if not p.b:
             return [] if toList else ''  # #2271
         self.p = p.copy()
-        aList = self.tokenize(p.b)
-        assert ''.join(aList) == p.b
-        ### This type mismatch looks serious. Tests needed!
-        aList = self.add_statement_braces(aList, giveWarnings=giveWarnings)  # type:ignore
+        tokens = self.tokenize(p.b)
+        s = ''.join(tokens)
+        assert s == p.b
+        new_tokens = self.add_statement_braces(s, tokens, giveWarnings=giveWarnings)
         self.bracketLevel = 0
         self.parens = 0
         self.result = []
-        for s in aList:
+        for s in new_tokens:
             self.put_token(s)
         return self.result if toList else ''.join(self.result)
 
     # @+node:ekr.20110918225821.6815: *4* cpp.add_statement_braces
-    def add_statement_braces(self, s: str, giveWarnings: bool = False) -> list[str]:
+    def add_statement_braces(
+        self, s: str, tokens: list[str], giveWarnings: bool = False
+    ) -> list[str]:
         p = self.p
 
         def oops(message: str, i: int, j: int) -> None:
@@ -304,10 +306,9 @@ class CPrettyPrinter:
                 g.error('** changed ', p.h)
                 g.es_print(f'{message} after\n{repr("".join(s[i:j]))}')
 
-        i, n = 0, len(s)
+        i = 0
         result: list[str] = []
-        while i < n:
-            token = s[i]
+        for token in tokens:
             progress = i
             if token in ('if', 'for', 'while'):
                 j = self.skip_ws_and_comments(s, i + 1)

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -192,7 +192,7 @@ class BridgeController:
             g.app.setGlobalDb()  # #556.
         else:
             g.app.db = g.NullObject()
-            g.app.global_cacher = g.NullObject()  # type:ignore
+            g.app.global_cacher = g.NullObject()
         if self.readSettings:
             # reads only standard settings files, using a null gui.
             # uses lm.files[0] to compute the local directory

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -54,7 +54,7 @@ import os
 import sys
 import time
 import traceback
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from types import ModuleType
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -310,7 +310,7 @@ class BridgeController:
         return bool(g and g.app and g.app.gui)
 
     # @+node:ekr.20070227092442.5: *3* bridge.openLeoFile & helpers
-    def openLeoFile(self, fileName: str) -> Optional[Cmdr]:
+    def openLeoFile(self, fileName: str) -> Cmdr | None:
         """Open a .leo file, or create a new Leo frame if no fileName is given."""
         g = self.g
         g.app.silentMode = self.silentMode

--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -9,7 +9,7 @@ import fnmatch
 import os
 import pickle
 import sqlite3
-from typing import Any, Generator, Optional, TYPE_CHECKING
+from typing import Any, Generator, TYPE_CHECKING
 import zlib
 from leo.core import leoGlobals as g
 
@@ -167,7 +167,7 @@ class SqlitePickleShare:
         self.conn = sqlite3.connect(dbfile, isolation_level=None)
         self.init_dbtables(self.conn)
 
-        def loadz(data: Value) -> Optional[Value]:
+        def loadz(data: Value) -> Value | None:
             if data:
                 # Retain this code for maximum compatibility.
                 try:

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 from collections.abc import Callable
 import re
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -40,7 +40,7 @@ class ChapterController:
         self.chaptersDict: dict[str, Chapter] = {}  # Keys are chapter names, values are chapters.
         self.initing = True  # #31: True: suppress undo when creating chapters.
         self.re_chapter: re.Pattern = None  # Set where used.
-        self.selectedChapter: Optional[Chapter] = None
+        self.selectedChapter: Chapter = None
         self.selectChapterLockout = False  # True: cc.selectChapterForPosition does nothing.
         self.tt: LeoQtTreeTab = None  # May be set in createChaptersIcon.
         self.reloadSettings()
@@ -247,7 +247,7 @@ class ChapterController:
         return 'main'
 
     # @+node:ekr.20070325093617: *4* cc.findChapterNode
-    def findChapterNode(self, name: str) -> Optional[Position]:
+    def findChapterNode(self, name: str) -> Position | None:
         """
         Return the position of the first @chapter node with the given name
         anywhere in the entire outline.
@@ -387,8 +387,8 @@ class Chapter:
         self.name: str = g.checkUnicode(name)
         self.selectLockout = False  # True: in chapter.select logic.
         # State variables: saved/restored when the chapter is unselected/selected.
-        self.p: Optional[Position] = c.p
-        self.root: Optional[Position] = self.findRootNode()
+        self.p: Position | None = c.p
+        self.root: Position | None = self.findRootNode()
         if cc.tt:
             cc.tt.createTab(name)
 
@@ -400,7 +400,7 @@ class Chapter:
     __repr__ = __str__
 
     # @+node:ekr.20110607182447.16464: *3* chapter.findRootNode
-    def findRootNode(self) -> Optional[Position]:
+    def findRootNode(self) -> Position | None:
         """Return the @chapter node for this chapter."""
         if self.name == 'main':
             return None
@@ -454,7 +454,7 @@ class Chapter:
         g.doHook('hoist-changed', c=c)
 
     # @+node:ekr.20070317131708: *4* chapter.findPositionInChapter
-    def findPositionInChapter(self, p1: Position, strict: bool = False) -> Optional[Position]:
+    def findPositionInChapter(self, p1: Position, strict: bool = False) -> Position | None:
         """Return a valid position p such that p.v == v."""
         c, name = self.c, self.name
         # Bug fix: 2012/05/24: Search without root arg in the main chapter.

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -39,10 +39,10 @@ class ChapterController:
         # Note: chapter names never change, even if their @chapter node changes.
         self.chaptersDict: dict[str, Chapter] = {}  # Keys are chapter names, values are chapters.
         self.initing = True  # #31: True: suppress undo when creating chapters.
-        self.re_chapter: re.Pattern = None  # Set where used.
-        self.selectedChapter: Chapter = None
+        self.re_chapter: re.Pattern | None = None  # Set where used.
+        self.selectedChapter: Chapter | None = None
         self.selectChapterLockout = False  # True: cc.selectChapterForPosition does nothing.
-        self.tt: LeoQtTreeTab = None  # May be set in createChaptersIcon.
+        self.tt: LeoQtTreeTab | None = None  # May be set in createChaptersIcon.
         self.reloadSettings()
 
     def reloadSettings(self) -> None:

--- a/leo/core/leoColor.py
+++ b/leo/core/leoColor.py
@@ -734,7 +734,7 @@ for key in leo_color_database:
 # @+others
 # @+node:bob.20080115070511.3: ** color database functions
 # @+node:bob.20071231111744.2: *3* function: leoColor.get / getColor
-def getColor(name: str, default: str = None) -> str:
+def getColor(name: str, default: str = None) -> str | None:
     """Translate a named color into #rrggbb' format.
 
     if 'name' is not a string it is returned unchanged.
@@ -775,7 +775,7 @@ getRGB = getColorRGB
 
 
 # @+node:bob.20080115072302: *3* function: leoColor.getCairo / getColorCairo
-def getColorCairo(name: str, default: str = None) -> tuple[float, float, float]:
+def getColorCairo(name: str, default: str = None) -> tuple[float, float, float] | None:
     """Convert a named color into a cairo color tuple."""
     color = getColorRGB(name, default)
     if color is None:

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -12,7 +12,7 @@ from collections.abc import Callable
 import re
 import string
 import time
-from typing import Any, Generator, Sequence, Optional, TYPE_CHECKING
+from typing import Any, Generator, Sequence, TYPE_CHECKING
 from types import ModuleType
 import warnings
 
@@ -559,7 +559,7 @@ class JEditColorizer(BaseColorizer):
     def init_section_delims(self) -> None:
         p = self.c.p
 
-        def find_delims(v: VNode) -> Optional[re.Match]:
+        def find_delims(v: VNode) -> re.Match | None:
             for s in g.splitLines(v.b):
                 if m := g.g_section_delims_pat.match(s):
                     return m
@@ -3239,7 +3239,7 @@ if QtGui:
         # Distributed under the terms of the Modified BSD License.
         # @+others
         # @+node:ekr.20190320153605.1: *4* leo_h._get_format & helpers
-        def _get_format(self, token: object) -> Optional[object]:
+        def _get_format(self, token: object) -> object | None:
             """Returns a QTextCharFormat for token or None."""
             if token in self._formats:
                 return self._formats[token]

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1005,7 +1005,7 @@ class JEditColorizer(BaseColorizer):
 
         # @+<< function: resolve_color_key >>
         # @+node:ekr.20230314052558.1: *6* << function: resolve_color_key >>
-        def resolve_color_key(key: str) -> str:
+        def resolve_color_key(key: str) -> str | None:
             """
             Resolve the given color name to a *valid* color.
             """

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -3747,13 +3747,10 @@ class QScintillaColorizer(BaseColorizer):
         color: str
         style: str
         if aList:
-            aList = [s.split(',') for s in aList]  # type:ignore
-            for z in aList:
+            for z in [s.split(',') for s in aList]:
                 if len(z) == 2:
                     color, style = z  # type:ignore
-                    table.append(
-                        (color.strip(), style.strip()),
-                    )
+                    table.append((color.strip(), style.strip()))
                 else:
                     g.trace(f"entry: {z}")
         if not table:

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -3747,7 +3747,7 @@ class QScintillaColorizer(BaseColorizer):
         color: str
         style: str
         if aList:
-            for z in [s.split(',') for s in aList]:
+            for z in [s.split(',') for s in aList]:  # #4753
                 if len(z) == 2:
                     color, style = z  # type:ignore
                     table.append((color.strip(), style.strip()))

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -276,13 +276,13 @@ class Commands:
     def initFileIvars(self, fileName: str, relativeFileName: str) -> None:
         """Init file-related ivars of the commander."""
         self.changed = False  # True: the outline has changed since the last save.
-        self.ignored_at_file_nodes: list[Position] = []  # List of nodes for c.raise_error_dialogs.
+        self.ignored_at_file_nodes: list[str] = []  # List of headlines for c.raise_error_dialogs.
         self.last_dir: str = None  # The last used directory.
         # Do _not_ use os_path_norm: it converts an empty path to '.' (!!)
         self.mFileName: str = fileName or ''
         self.mRelativeFileName = relativeFileName or ''
         # List of orphaned nodes for c.raise_error_dialogs.
-        self.orphan_at_file_nodes: list[Position] = []
+        self.orphan_at_file_nodes: list[str] = []
 
     # @+node:ekr.20120217070122.10470: *5* c.initObjects
     def initObjects(self, gui: LeoGui) -> None:
@@ -4143,7 +4143,7 @@ class Commands:
             c.init_error_dialogs()
             return
         if c.ignored_at_file_nodes:
-            files = '\n'.join(sorted(set(c.ignored_at_file_nodes)))  # type:ignore
+            files = '\n'.join(sorted(set(c.ignored_at_file_nodes)))
             if files not in self.warnings_dict:
                 self.warnings_dict[files] = True
                 kind_s = 'read' if kind == 'read' else 'written'
@@ -4163,9 +4163,10 @@ class Commands:
             message = '\n'.join(
                 [
                     'The following were not written because of errors:\n',
-                    '\n'.join(sorted(set(c.orphan_at_file_nodes))),  # type:ignore
+                    '\n'.join(sorted(set(c.orphan_at_file_nodes))),
                     '',
-                    'Warning: changes to these files will be lost\nunless you can save the files successfully.',
+                    'Warning: changes to these files will be lost',
+                    'unless you can save the files successfully.',
                 ]
             )
             g.app.gui.runAskOkDialog(c, message=message, title='Not Written')

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -277,7 +277,6 @@ class Commands:
         """Init file-related ivars of the commander."""
         self.changed = False  # True: the outline has changed since the last save.
         self.ignored_at_file_nodes: list[Position] = []  # List of nodes for c.raise_error_dialogs.
-        self.import_error_nodes: list[Position] = []  # List of nodes for c.raise_error_dialogs.
         self.last_dir: str = None  # The last used directory.
         # Do _not_ use os_path_norm: it converts an empty path to '.' (!!)
         self.mFileName: str = fileName or ''
@@ -4112,7 +4111,6 @@ class Commands:
     def init_error_dialogs(self) -> None:
         c = self
         g.app.syntax_error_files = []
-        c.import_error_nodes = []
         c.ignored_at_file_nodes = []
         c.orphan_at_file_nodes = []
 
@@ -4138,25 +4136,12 @@ class Commands:
             return
         # Issue one or two dialogs or messages.
         saved_body = c.rootPosition().b  # Save the root's body. The dialog destroys it!
-        if c.import_error_nodes or c.ignored_at_file_nodes or c.orphan_at_file_nodes:
+        if c.ignored_at_file_nodes or c.orphan_at_file_nodes:
             g.app.gui.dismiss_splash_screen()
         else:
             # #1007: Exit now, so we don't have to restore c.rootPosition().b.
             c.init_error_dialogs()
             return
-        if c.import_error_nodes:
-            files = '\n'.join(sorted(set(c.import_error_nodes)))  # type:ignore
-            if files not in self.warnings_dict:
-                self.warnings_dict[files] = True
-                import_message1 = 'The following were not imported properly.'
-                import_message2 = f"Inserted @ignore in...\n{files}"
-                g.es_print(import_message1, color='red')
-                g.es_print(import_message2)
-                if use_dialogs:
-                    import_dialog_message = f"{import_message1}\n{import_message2}"
-                    g.app.gui.runAskOkDialog(
-                        c, message=import_dialog_message, title='Import errors'
-                    )
         if c.ignored_at_file_nodes:
             files = '\n'.join(sorted(set(c.ignored_at_file_nodes)))  # type:ignore
             if files not in self.warnings_dict:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -15,7 +15,7 @@ import tabnanny
 import tempfile
 import time
 import tokenize
-from typing import Any, Generator, Iterable, Optional, Sequence, TYPE_CHECKING
+from typing import Any, Generator, Iterable, Sequence, TYPE_CHECKING
 import xml.etree.ElementTree as ElementTree
 
 from leo.core import leoGlobals as g
@@ -119,8 +119,8 @@ class Commands:
         t1 = time.process_time()
         c = self
         # Official ivars.
-        self._currentPosition: Optional[Position] = None
-        self._topPosition: Optional[Position] = None
+        self._currentPosition: Position | None = None
+        self._topPosition: Position | None = None
         self.command_count = 0
         self.frame: Widget = None
         self.parentFrame: Widget = parentFrame  # New in Leo 6.0.
@@ -227,7 +227,7 @@ class Commands:
         self.commandsDict: dict[str, Any] = {}  # Keys: command names, values: various.
         self.disableCommandsMessage = ''  # The presence of this message disables all commands.
         # One of three places that g.doHook looks for hook functions.
-        self.hookFunction: Optional[Callable] = None
+        self.hookFunction: Callable | None = None
         self.ignoreChangedPaths = False  # True: disable path changed message in at.WriteAllHelper.
         self.inCommand = False  # Interlocks to prevent premature closing of a window.
         self.outlineToNowebDefaultFileName: str = "noweb.nw"  # For Outline To Noweb dialog.
@@ -236,7 +236,7 @@ class Commands:
         self.hoistStack: list[g.Bunch] = []  # Stack of g.Bunches to be root of drawn tree.
         # For outline navigation.
         self.navPrefix: str = ''  # Must always be a string.
-        self.navTime: Optional[float] = None
+        self.navTime: float | None = None
         self.recent_commands_list: list[str] = []  # List of command names.
 
     # @+node:ekr.20120217070122.10466: *5* c.initDebugIvars
@@ -252,7 +252,7 @@ class Commands:
         self.expansionLevel = 0  # The expansion level of this outline.
         self.expansionNode = None  # The last node we expanded or contracted.
         self.nodeConflictList: list[Position] = []  # List of nodes with conflicting read-time data.
-        self.nodeConflictFileName: Optional[str] = None  # The fileName for c.nodeConflictList.
+        self.nodeConflictFileName: str = None  # The fileName for c.nodeConflictList.
         # Non-persistent dictionary for free use by scripts and plugins.
         self.user_dict: dict[str, Value] = {}
 
@@ -659,7 +659,7 @@ class Commands:
         """
         c, p, tag = self, self.p, 'execute-general-script'
 
-        def get_setting_for_language(setting: str) -> Optional[str]:
+        def get_setting_for_language(setting: str) -> str | None:
             """
             Return the setting from the given @data setting.
             The first colon ends each key.
@@ -1650,7 +1650,7 @@ class Commands:
     # @+node:ekr.20171123135625.29: *5* c.getBodyLines
     def getBodyLines(
         self,
-    ) -> tuple[str, list[str], str, Optional[tuple], Optional[tuple]]:
+    ) -> tuple[str, list[str], str, tuple | None, tuple | None]:
         """
         Return (head, lines, tail, oldSel, oldYview).
 
@@ -1756,7 +1756,7 @@ class Commands:
 
         # Passes 3 & 4: Use the file extension in @<file> nodes.
 
-        def get_language_from_headline(v: VNode) -> Optional[str]:
+        def get_language_from_headline(v: VNode) -> str | None:
             """Return the extension for @<file> nodes."""
             if v.isAnyAtFileNode():
                 name = v.anyAtFileNodeName()
@@ -1852,14 +1852,14 @@ class Commands:
     # https://en.wikipedia.org/wiki/Filename
     at_path_pattern = re.compile(r'^@path\s+(.+)$', re.MULTILINE)
 
-    def getPathFromNode(self, p: Position) -> Optional[str]:
+    def getPathFromNode(self, p: Position) -> str | None:
         """
         Scan p.h then p.b for @path directives.
         """
         c = self
         c.scanAtPathDirectivesCount += 1  # An important statistic.
 
-        def get_path(m: re.Match) -> Optional[str]:
+        def get_path(m: re.Match) -> str | None:
             return g.stripPathCruft(m.group(1)) if m else None
 
         # The headline has higher precedence because it is more visible.
@@ -2027,7 +2027,7 @@ class Commands:
     # @+node:ekr.20040803140033.2: *5* c.rootPosition
     _rootCount = 0
 
-    def rootPosition(self) -> Optional[Position]:
+    def rootPosition(self) -> Position | None:
         """Return a new *copy* of the root position or None."""
         c = self
         if c.hiddenRootNode.children:
@@ -2309,7 +2309,7 @@ class Commands:
         # c.setRootPosition()
 
     # @+node:ekr.20040311173238: *5* c.topPosition & c.setTopPosition
-    def topPosition(self) -> Optional[Position]:
+    def topPosition(self) -> Position | None:
         """Return the root position."""
         c = self
         if c._topPosition:
@@ -3619,7 +3619,7 @@ class Commands:
         prefix: str = None,
         silent: bool = False,
         useTimeStamp: bool = True,
-    ) -> Optional[str]:
+    ) -> str | None:
         """
         Back up given fileName or c.fileName().
         If useTimeStamp is True, append a timestamp to the filename.
@@ -4215,7 +4215,7 @@ class Commands:
         c.updateSyntaxColorer(p)  # Dragging can change syntax coloring.
 
     # @+node:ekr.20031218072017.2353: *5* c.dragAfter
-    def dragAfter(self, p: Position, after: Optional[Position]) -> None:
+    def dragAfter(self, p: Position, after: Position | None) -> None:
         c, p, u = self, self.p, self.undoer
         if not c.checkDrag(p, after):
             return

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -809,7 +809,7 @@ class Commands:
         # @+node:tom.20241014154415.7: *5* get_external_maps
         MAP_SETTING_NODE = "run-external-processor-map"
 
-        def get_external_maps() -> tuple[dict, dict, str]:
+        def get_external_maps() -> tuple[dict, dict, str] | tuple[None, None, str]:
             # @+<< get_external_maps: docstring >>
             # @+node:tom.20241014154415.8: *6* << get_external_maps: docstring >>
             r"""Return processor, extension maps for @data node.

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4165,7 +4165,7 @@ class Commands:
                     'The following were not written because of errors:\n',
                     '\n'.join(sorted(set(c.orphan_at_file_nodes))),
                     '',
-                    'Warning: changes to these files will be lost',
+                    'Warning: changes to these files will be lost\n',
                     'unless you can save the files successfully.',
                 ]
             )

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2192,7 +2192,7 @@ class Commands:
         g.doHook("clear-mark", c=c, p=p)
 
     # @+node:ekr.20040305223522: *5* c.setBodyString
-    def setBodyString(self, p: Position, s: str) -> None:
+    def setBodyString(self, p: Position, s: bytes | str) -> None:
         """
         This is equivalent to p.b = s.
         """

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3081,7 +3081,7 @@ class Commands:
         default_language = c.getLanguage(p) or c.target_language or 'python'
         default_delims = g.set_delims_from_language(default_language)
         wrap = c.config.getBool("body-pane-wraps")
-        table = (  # type:ignore
+        table: tuple = (
             ('encoding',    None,           g.scanAtEncodingDirectives),
             ('lang-dict',   {},             g.scanAtCommentAndAtLanguageDirectives),
             ('lineending',  None,           g.scanAtLineendingDirectives),

--- a/leo/core/leoCompare.py
+++ b/leo/core/leoCompare.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position, VNode
-    from io import FileIO, TextIO
+    from io import BufferedWriter, TextIO
 # @-<< leoCompare imports & annotations >>
 
 
@@ -68,7 +68,7 @@ class BaseLeoCompare:
         self.fileName1 = None
         self.fileName2 = None
         # Open files...
-        self.outputFile: FileIO = None
+        self.outputFile: BufferedWriter = None
 
     # @+node:ekr.20031218072017.3635: *3* compare_directories (entry)
     # We ignore the filename portion of path1 and path2 if it exists.
@@ -428,10 +428,10 @@ class BaseLeoCompare:
         try:
             if self.appendOutput:
                 self.show("appending to " + self.outputFileName)
-                self.outputFile = open(self.outputFileName, "ab")  # type:ignore
+                self.outputFile = open(self.outputFileName, "ab")
             else:
                 self.show("writing to " + self.outputFileName)
-                self.outputFile = open(self.outputFileName, "wb")  # type:ignore
+                self.outputFile = open(self.outputFileName, "wb")
             return True
         except Exception:
             self.outputFile = None

--- a/leo/core/leoCompare.py
+++ b/leo/core/leoCompare.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import difflib
 import filecmp
 import os
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -346,7 +346,7 @@ class BaseLeoCompare:
 
     # @+node:ekr.20031218072017.3645: *3* compare.utils...
     # @+node:ekr.20031218072017.3646: *4* compare.doOpen
-    def doOpen(self, name: str) -> Optional[TextIO]:
+    def doOpen(self, name: str) -> TextIO | None:
         try:
             f = open(name, 'r')
             return f
@@ -398,7 +398,7 @@ class BaseLeoCompare:
     # sentinel line.
     # @@c
 
-    def isLeoHeader(self, s: str) -> Optional[str]:
+    def isLeoHeader(self, s: str) -> str | None:
         tag = "@+leo"
         j = s.find(tag)
         if j > 0:

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -389,7 +389,7 @@ class ParserBaseClass:
             items = items_s.split(',')
             name = name[:i] + name[j + 1 :].strip()
             try:
-                int_items = [int(item.strip()) for item in items]
+                int_items = [int(item.strip()) for item in items]  # #4753
             except ValueError:
                 self.valueError(p, 'ints[]', name, val)
                 return

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -9,7 +9,7 @@ import os
 import sys
 import re
 import textwrap
-from typing import Any, Callable, Generator, Optional, TYPE_CHECKING
+from typing import Any, Callable, Generator, TYPE_CHECKING
 from leo.plugins.mod_scripting import build_rclick_tree
 from leo.core import leoGlobals as g
 
@@ -1287,8 +1287,8 @@ class GlobalConfigManager:
         self.buttonsFileName = ''
         self.configsExist = False  # True when we successfully open a setting file.
         self.default_derived_file_encoding = 'utf-8'
-        self.enabledPluginsFileName: Optional[str] = None
-        self.enabledPluginsString: Optional[str] = ''
+        self.enabledPluginsFileName: str = None
+        self.enabledPluginsString: str = ''
         self.menusList: list[Any] = []
         self.menusFileName = ''
         self.modeCommandsDict: dict[str, g.SettingsDict] = g.SettingsDict('modeCommandsDict')
@@ -1482,7 +1482,7 @@ class GlobalConfigManager:
             data = [z.strip() for z in data if z.strip()]
         return data
 
-    def getOutlineData(self, setting: str) -> Optional[list[str]]:
+    def getOutlineData(self, setting: str) -> list[str] | None:
         """Return the pastable (xml text) of the entire @outline-data tree."""
         return self.get(setting, "outlinedata")
 
@@ -1570,7 +1570,7 @@ class GlobalConfigManager:
         return val
 
     # @+node:ekr.20041122070752: *4* gcm.getRatio
-    def getRatio(self, setting: str) -> Optional[float]:
+    def getRatio(self, setting: str) -> float | None:
         """
         Return the value of @float setting, or None if there is an error.
         """
@@ -1966,7 +1966,7 @@ class LocalConfigManager:
         return val
 
     # @+node:ekr.20120215072959.12536: *5* c.config.getRatio
-    def getRatio(self, setting: str) -> Optional[float]:
+    def getRatio(self, setting: str) -> float | None:
         """
         Return the value of @float setting, or None if there is an error.
         """

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -389,12 +389,11 @@ class ParserBaseClass:
             items = items_s.split(',')
             name = name[:i] + name[j + 1 :].strip()
             try:
-                items = [int(item.strip()) for item in items]  # type:ignore
+                int_items = [int(item.strip()) for item in items]
             except ValueError:
-                items = []
                 self.valueError(p, 'ints[]', name, val)
                 return
-            kind = f"ints[{','.join([str(item) for item in items])}]"
+            kind = f"ints[{','.join([str(z) for z in int_items])}]"
             try:
                 val = int(val)
             except ValueError:

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -253,7 +253,7 @@ class ParserBaseClass:
         return 'skip'
 
     # @+node:ekr.20131114051702.16546: *5* pbc.getOutlineDataHelper
-    def getOutlineDataHelper(self, p: Position) -> str:
+    def getOutlineDataHelper(self, p: Position) -> str | None:
         c = self.c
         if not p:
             return None
@@ -314,7 +314,7 @@ class ParserBaseClass:
                 self.set(p, setKind, name, val)
 
     # @+node:ekr.20150426034813.1: *4* pbc.doIfEnv
-    def doIfEnv(self, p: Position, kind: str, name: str, val: Any) -> str:
+    def doIfEnv(self, p: Position, kind: str, name: str, val: Any) -> str | None:
         """
         Support @ifenv in @settings trees.
 
@@ -332,7 +332,7 @@ class ParserBaseClass:
         return 'skip'
 
     # @+node:dan.20080410121257.2: *4* pbc.doIfHostname
-    def doIfHostname(self, p: Position, kind: str, name: str, val: Any) -> str:
+    def doIfHostname(self, p: Position, kind: str, name: str, val: Any) -> str | None:
         """
         Support @ifhostname in @settings trees.
 
@@ -354,7 +354,7 @@ class ParserBaseClass:
         return None
 
     # @+node:ekr.20041120104215: *4* pbc.doIfPlatform
-    def doIfPlatform(self, p: Position, kind: str, name: str, val: Any) -> str:
+    def doIfPlatform(self, p: Position, kind: str, name: str, val: Any) -> str | None:
         """Support @ifplatform in @settings trees."""
         platform = sys.platform.lower()
         for s in name.split(','):
@@ -485,7 +485,7 @@ class ParserBaseClass:
                 self.dumpMenuTree(val, level + 1, path=path + '/' + name)
 
     # @+node:tbrown.20080514180046.8: *5* pbc.patchMenuTree
-    def patchMenuTree(self, orig: list[Any], targetPath: str, path: str = '') -> Any:
+    def patchMenuTree(self, orig: list[Any], targetPath: str, path: str = '') -> Any | None:
         kind: str
         val: Any
         val2: Any
@@ -849,7 +849,7 @@ class ParserBaseClass:
             d[tag] = val
 
     # @+node:ekr.20041120112043: *4* pbc.parseShortcutLine
-    def parseShortcutLine(self, kind: str, s: str) -> tuple[str, Any]:
+    def parseShortcutLine(self, kind: str, s: str) -> tuple[str | None, Any]:
         """Parse a shortcut line.  Valid forms:
 
         --> entry-command
@@ -1337,7 +1337,7 @@ class GlobalConfigManager:
                 yield key2, val, c, letter
 
     # @+node:ekr.20041123070429: *3* gcm.canonicalizeSettingName (munge)
-    def canonicalizeSettingName(self, name: str) -> str:
+    def canonicalizeSettingName(self, name: str) -> str | None:
         if name is None:
             return None
         name = name.lower()
@@ -1359,7 +1359,7 @@ class GlobalConfigManager:
         return False
 
     # @+node:ekr.20041117083141: *4* gcm.get & allies
-    def get(self, setting: str, kind: str) -> Any:
+    def get(self, setting: str, kind: str) -> Any | None:
         """Get the setting and make sure its type matches the expected type."""
         # It *is* valid to call this method: it returns the global settings.
         lm = g.app.loadManager
@@ -1377,7 +1377,7 @@ class GlobalConfigManager:
         setting: str,
         requestedType: str,
         warn: bool = True,
-    ) -> tuple[Any, bool]:
+    ) -> tuple[Any | None, bool]:
         """
         Look up the setting in d. If warn is True, warn if the requested type
         does not (loosely) match the actual type.
@@ -1487,7 +1487,7 @@ class GlobalConfigManager:
         return self.get(setting, "outlinedata")
 
     # @+node:ekr.20041117093009.1: *4* gcm.getDirectory
-    def getDirectory(self, setting: str) -> str:
+    def getDirectory(self, setting: str) -> str | None:
         """Return the value of @directory setting, or None if the directory does not exist."""
         # Fix https://bugs.launchpad.net/leo-editor/+bug/1173763
         theDir = self.get(setting, 'directory')
@@ -1501,7 +1501,7 @@ class GlobalConfigManager:
         return g.app.config.enabledPluginsString
 
     # @+node:ekr.20041117082135: *4* gcm.getFloat
-    def getFloat(self, setting: str) -> float:
+    def getFloat(self, setting: str) -> float | None:
         """Return the value of @float setting."""
         val = self.get(setting, "float")
         try:
@@ -1541,7 +1541,7 @@ class GlobalConfigManager:
         return g.app.gui.getFontFromParams(family, size, slant, weight)
 
     # @+node:ekr.20041117081513: *4* gcm.getInt
-    def getInt(self, setting: str) -> int:
+    def getInt(self, setting: str) -> int | None:
         """Return the value of @int setting."""
         val = self.get(setting, "int")
         try:
@@ -1594,7 +1594,7 @@ class GlobalConfigManager:
         return self.get(setting, "string")
 
     # @+node:ekr.20171115062202.1: *3* gcm.valueInMyLeoSettings
-    def valueInMyLeoSettings(self, settingName: str) -> Any:
+    def valueInMyLeoSettings(self, settingName: str) -> Any | None:
         """Return the value of the setting, if any, in myLeoSettings.leo."""
         lm = g.app.loadManager
         d = lm.globalSettingsDict
@@ -2271,7 +2271,7 @@ class SettingsTreeParser(ParserBaseClass):
     # @+others
     # @+node:ekr.20041119204103: *3* ctor (SettingsTreeParser)
     # @+node:ekr.20041119204714: *3* visitNode (SettingsTreeParser)
-    def visitNode(self, p: Position) -> str:
+    def visitNode(self, p: Position) -> str | None:
         """Init any settings found in node p."""
         p = p.copy()
         munge = g.app.config.munge

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -8,7 +8,7 @@ import getpass
 import os
 import subprocess
 import tempfile
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -122,7 +122,7 @@ class ExternalFilesController:
         self.files = [z for z in self.files if z.path not in paths]
 
     # @+node:ekr.20150407141838.1: *4* efc.find_path_for_node (called from vim.py)
-    def find_path_for_node(self, p: Position) -> Optional[str]:
+    def find_path_for_node(self, p: Position) -> str | None:
         """
         Find the path corresponding to node p.
         called from vim.py.

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1135,7 +1135,7 @@ class FileCommands:
         return root
 
     # @+node:vitalije.20170630152841.1: *5* fc.retrieveVnodesFromDb & helpers
-    def retrieveVnodesFromDb(self, conn: Conn) -> VNode:
+    def retrieveVnodesFromDb(self, conn: Conn) -> VNode | None:
         """
         Recreates tree from the data contained in table vnodes.
 

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -20,7 +20,7 @@ import shutil
 import sqlite3
 import tempfile
 import time
-from typing import Any, IO, Iterable, Optional, TYPE_CHECKING
+from typing import Any, IO, Iterable, TYPE_CHECKING
 import zipfile
 import xml.etree.ElementTree as ElementTree
 import xml.sax
@@ -135,7 +135,7 @@ class FastRead:
         return v
 
     # @+node:felix.20220618164929.1: *3* fast.readJsonFile
-    def readJsonFile(self, theFile: IO, path: str) -> Optional[VNode]:
+    def readJsonFile(self, theFile: IO, path: str) -> VNode | None:
         """Read the leojs JSON file, change splitter ratios, and return its hidden vnode."""
         s = theFile.read()
         v, g_dict = self.readWithJsonTree(path, s)
@@ -152,7 +152,7 @@ class FastRead:
         return v
 
     # @+node:ekr.20210316035646.1: *3* fast.readFileFromClipboard
-    def readFileFromClipboard(self, s_or_b: bytes | str) -> Optional[VNode]:
+    def readFileFromClipboard(self, s_or_b: bytes | str) -> VNode | None:
         """
         Recreate a file from a string s_or_b, and return its hidden vnode.
 
@@ -336,7 +336,7 @@ class FastRead:
             # Next, scan for uA's for this gnx.
             for key, val in e.attrib.items():
                 if key != 'tx':
-                    s: Optional[str] = self.resolveUa(key, val)
+                    s: str = self.resolveUa(key, val)
                     if s:
                         gnx2ua[gnx][key] = s
         return gnx2body, gnx2ua
@@ -546,7 +546,7 @@ class FastRead:
         gnx2vnode: dict[str, VNode],
         gnx2ua: dict[str, Value],
         v_elements: Element,
-    ) -> Optional[VNode]:
+    ) -> VNode | None:
         c, fc = self.c, self.c.fileCommands
 
         def v_element_visitor(parent_e: Element, parent_v: VNode) -> None:
@@ -839,7 +839,7 @@ class FileCommands:
         return True
 
     # @+node:ekr.20180709205603.1: *5* fc.getLeoOutlineFromClipBoard
-    def getLeoOutlineFromClipboard(self, s: str) -> Optional[Position]:
+    def getLeoOutlineFromClipboard(self, s: str) -> Position | None:
         """Read a Leo outline from string s in clipboard format."""
         c = self.c
         current = c.p
@@ -882,7 +882,7 @@ class FileCommands:
     getLeoOutline = getLeoOutlineFromClipboard  # for compatibility
 
     # @+node:ekr.20180709205640.1: *5* fc.getLeoOutlineFromClipBoardRetainingClones
-    def getLeoOutlineFromClipboardRetainingClones(self, s: str) -> Optional[Position]:
+    def getLeoOutlineFromClipboardRetainingClones(self, s: str) -> Position | None:
         """Read a Leo outline from string s in clipboard format."""
         c = self.c
         current = c.p
@@ -949,7 +949,7 @@ class FileCommands:
         *,
         checkOpenFiles: bool = True,
         readAtFileNodesFlag: bool = True,
-    ) -> Optional[VNode]:
+    ) -> VNode | None:
         """Open any kind of Leo file."""
         c = self.c
         fc = c.fileCommands
@@ -965,7 +965,7 @@ class FileCommands:
         return v
 
     # @+node:ekr.20230910154358.1: *6* fc._getLeoDBFileByName
-    def _getLeoDBFileByName(self, path: str, readAtFileNodesFlag: bool) -> Optional[VNode]:
+    def _getLeoDBFileByName(self, path: str, readAtFileNodesFlag: bool) -> VNode | None:
         """
         Open, read, and close a .db file.
 
@@ -1012,7 +1012,7 @@ class FileCommands:
             c.loading = False  # reenable c.changed
 
     # @+node:ekr.20230910160254.1: *6* fc._getLeoFileByName
-    def _getLeoFileByName(self, path: str, readAtFileNodesFlag: bool) -> Optional[VNode]:
+    def _getLeoFileByName(self, path: str, readAtFileNodesFlag: bool) -> VNode | None:
         """
         Open, read, and close a .leo or .leojs file.
 
@@ -1068,7 +1068,7 @@ class FileCommands:
             c.loading = False  # reenable c.changed
 
     # @+node:ekr.20120212220616.10537: *5* fc.readExternalFiles & helper
-    def readExternalFiles(self) -> Optional[Position]:
+    def readExternalFiles(self) -> Position | None:
         """Read all external files in the outline."""
         c, fc = self.c, self
         c.atFileCommands.readAll(c.rootPosition())
@@ -1082,7 +1082,7 @@ class FileCommands:
         return recoveryNode
 
     # @+node:ekr.20100205060712.8314: *6* fc.handleNodeConflicts
-    def handleNodeConflicts(self) -> Optional[Position]:
+    def handleNodeConflicts(self) -> Position | None:
         """Create a 'Recovered Nodes' node for each entry in c.nodeConflictList."""
         c = self.c
         if not c.nodeConflictList:
@@ -1273,7 +1273,7 @@ class FileCommands:
         v = self.getVnodeFromClipboard(s)
         return leoNodes.Position(v)
 
-    def getVnodeFromClipboard(self, s: str) -> Optional[VNode]:
+    def getVnodeFromClipboard(self, s: str) -> VNode | None:
         """Called only from getPosFromClipboard."""
         c = self.c
         self.initReadIvars()
@@ -1317,7 +1317,7 @@ class FileCommands:
         self,
         archivedPosition: list[str],
         root_v: VNode,
-    ) -> Optional[VNode]:
+    ) -> VNode | None:
         """
         Return a VNode corresponding to the archived position relative to root
         node root_v.

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -592,7 +592,7 @@ class FastRead:
                     if uaDict:
                         v.unknownAttributes = uaDict
                     # Recursively create the children.
-                    v_element_visitor(v_dict.get('children', []), v)  # type:ignore
+                    v_element_visitor(v_dict.get('children', []), v)  # type:ignore # required.
 
         gnx = 'hidden-root-vnode-gnx'
         hidden_v = leoNodes.VNode(context=c, gnx=gnx)

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1913,17 +1913,9 @@ class FileCommands:
     # @+node:ekr.20070412095520: *5* fc.writeZipFile
     def writeZipFile(self, s: str) -> None:
         """Write string s as a .zip file."""
-        # The name of the file in the archive.
-        contentsName = g.toEncodedString(
-            g.shortFileName(self.mFileName), self.leo_file_encoding, reportErrors=True
-        )
-        # The name of the archive itself.
-        fileName = g.toEncodedString(self.mFileName, self.leo_file_encoding, reportErrors=True)
-        # Write the archive.
-        # These mypy complaints look valid.
-        theFile = zipfile.ZipFile(fileName, 'w', zipfile.ZIP_DEFLATED)  # type:ignore
-        theFile.writestr(contentsName, s)  # type:ignore
-        theFile.close()
+        fileName = g.toUnicode(self.mFileName)
+        with zipfile.ZipFile(fileName, 'w', zipfile.ZIP_DEFLATED) as f:
+            f.writestr(fileName, s)
 
     # @+node:ekr.20210316034532.1: *4* fc.Writing Utils
     # @+node:ekr.20080805085257.2: *5* fc.pickle

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 import keyword
 import re
 import time
-from typing import Any, Generator, Optional, TYPE_CHECKING
+from typing import Any, Generator, TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -669,7 +669,7 @@ class LeoFind:
         w.returnPressed()
 
     # @+node:ekr.20150629084611.1: *6* find._compute_find_def_word
-    def _compute_find_def_word(self, event: LeoKeyEvent) -> Optional[str]:  # pragma: no cover (cmd)
+    def _compute_find_def_word(self, event: LeoKeyEvent) -> str | None:  # pragma: no cover (cmd)
         """Init the find-def command. Return the word to find or None."""
         c = self.c
         w = c.frame.body.wrapper
@@ -828,7 +828,7 @@ class LeoFind:
         return results
 
     # @+node:ekr.20180511045458.1: *6* find._switch_style
-    def _switch_style(self, word: str) -> Optional[str]:
+    def _switch_style(self, word: str) -> str | None:
         """
         Switch between camelCase and underscore_style function definitions.
         Return None if there would be no change.
@@ -1994,7 +1994,7 @@ class LeoFind:
 
         # @+others  # Define helper functions
         # @+node:ekr.20250316070519.1: *6* function: _find_position
-        def _find_position(c: Cmdr, target: str) -> Optional[Position]:
+        def _find_position(c: Cmdr, target: str) -> Position | None:
             """Search c for a pattern matching the target."""
             for p in c.all_positions():
                 # Search headline:
@@ -2658,7 +2658,7 @@ class LeoFind:
         return None, None, None
 
     # @+node:ekr.20131123132043.16476: *5* find._fnm_next_after_fail & helper
-    def _fnm_next_after_fail(self, p: Position) -> Optional[Position]:
+    def _fnm_next_after_fail(self, p: Position) -> Position | None:
         """Return the next node after a failed search or None."""
         # Move to the next position.
         p = p.threadBack() if self.reverse else p.threadNext()

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1459,7 +1459,7 @@ class NullLog(LeoLog):
         nodeLink: str = None,
     ) -> None:
         if self.enabled and not g.unitTesting:
-            g.pr(g.toUnicode(s), newline=False)
+            g.pr(g.toUnicode(s), newline=False)  # #4753
 
     def putnl(self, tabName: str = 'Log') -> None:
         if self.enabled and not g.unitTesting:

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1459,11 +1459,7 @@ class NullLog(LeoLog):
         nodeLink: str = None,
     ) -> None:
         if self.enabled and not g.unitTesting:
-            try:
-                g.pr(s, newline=False)
-            except UnicodeError:
-                s = s.encode('ascii', 'replace')  # type:ignore
-                g.pr(s, newline=False)
+            g.pr(g.toUnicode(s), newline=False)
 
     def putnl(self, tabName: str = 'Log') -> None:
         if self.enabled and not g.unitTesting:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3366,8 +3366,7 @@ def set_delims_from_string(s: str) -> tuple[str, str, str]:
                     g.warning(f"'{delims[i]}' delimiter is invalid")
                     return None, None, None
                 try:
-                    delims[i] = binascii.unhexlify(delims[i][3:])  # type:ignore
-                    delims[i] = g.toUnicode(delims[i])
+                    delims[i] = g.toUnicode(binascii.unhexlify(delims[i][3:]))
                 except Exception as e:
                     g.warning(f"'{delims[i]}' delimiter is invalid: {e}")
                     return None, None, None

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -739,24 +739,15 @@ class KeyStroke:
             self.s = None
 
     # @+node:ekr.20120203053243.10117: *4* ks.__eq__, etc
-    # @+at All these must be defined in order to say, for example:
-    #     for key in sorted(d)
+    # All these must be defined in order to say, for example:
+    #   for key in sorted(d)
     # where the keys of d are KeyStroke objects.
-    # @@c
 
     def __eq__(self, other: object) -> bool:
-        if not other:
-            return False
-        if hasattr(other, 's'):
-            return self.s == other.s
-        return self.s == other
+        return hasattr(other, 's') and self.s == other.s
 
     def __lt__(self, other: KeyStroke) -> bool:
-        if not other:
-            return False
-        if hasattr(other, 's'):
-            return self.s < other.s
-        return self.s < other  # type:ignore
+        return hasattr(other, 's') and self.s < other.s
 
     def __le__(self, other: KeyStroke) -> bool:
         return self.__lt__(other) or self.__eq__(other)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -743,11 +743,19 @@ class KeyStroke:
     #   for key in sorted(d)
     # where the keys of d are KeyStroke objects.
 
-    def __eq__(self, other: object) -> bool:
-        return hasattr(other, 's') and self.s == other.s
+    def __eq__(self, other: object) -> bool:  # other must be annotated as object.
+        if not other:
+            return False
+        if hasattr(other, 's'):
+            return self.s == other.s
+        return self.s == other
 
     def __lt__(self, other: KeyStroke) -> bool:
-        return hasattr(other, 's') and self.s < other.s
+        if not other:
+            return False
+        if hasattr(other, 's'):
+            return self.s < other.s
+        return self.s < other  # type:ignore  # Required.
 
     def __le__(self, other: KeyStroke) -> bool:
         return self.__lt__(other) or self.__eq__(other)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -310,7 +310,7 @@ commander_command = CommanderCommand
 
 
 # @+node:ekr.20150508164812.1: *3* g.ivars2instance
-def ivars2instance(c: Cmdr, g: LeoGlobals, ivars: list[str]) -> Any:
+def ivars2instance(c: Cmdr, g: LeoGlobals, ivars: list[str]) -> Any | None:
     """
     Return the instance of c given by ivars.
     ivars is a list of strings.
@@ -1240,7 +1240,7 @@ class MatchBrackets:
         right: int,
         max_right: int,
         expand: bool = False,
-    ) -> tuple[int | None, int | None, str | None, int | None]:
+    ) -> tuple[int, int, str, int] | tuple[None, None, None, None]:
         """
         Find the bracket nearest the cursor searching outwards left and right.
 
@@ -3327,7 +3327,7 @@ def set_delims_from_language(language: str) -> tuple[str, str, str]:
 
 
 # @+node:ekr.20031218072017.1383: *3* g.set_delims_from_string
-def set_delims_from_string(s: str) -> tuple[str, str, str]:
+def set_delims_from_string(s: str) -> tuple[str, str, str] | tuple[None, None, None]:
     """
     Return (delim1, delim2, delim2), the delims following the @comment
     directive.
@@ -3377,7 +3377,9 @@ def set_delims_from_string(s: str) -> tuple[str, str, str]:
 
 
 # @+node:ekr.20031218072017.1384: *3* g.set_language
-def set_language(s: str, i: int, issue_errors_flag: bool = False) -> tuple:
+def set_language(
+    s: str, i: int, issue_errors_flag: bool = False
+) -> tuple[str, str, str, str] | tuple[None, None, None, None]:
     """Scan the @language directive that appears at s[i:].
 
     The @language may have been stripped away.
@@ -3493,7 +3495,7 @@ def create_temp_file(textMode: bool = False) -> tuple[IO, str]:
 
 
 # @+node:ekr.20210307060731.1: *3* g.createHiddenCommander
-def createHiddenCommander(fn: str) -> Cmdr:
+def createHiddenCommander(fn: str) -> Cmdr | None:
     """Read the given outline into a hidden commander."""
     lm = g.app.loadManager
     if lm.isLeoFile(fn):
@@ -3748,7 +3750,7 @@ def readFileIntoString(
     encoding: str = 'utf-8',  # BOM may override this.
     kind: str = None,  # @file, @edit, ...
     verbose: bool = True,
-) -> tuple[str, str]:
+) -> tuple[str, str] | tuple[None, None]:
     """
     Return the contents of the file whose full path is fileName.
 
@@ -5214,7 +5216,7 @@ contentModifiedSet: set[VNode] = set()
 
 
 # @+node:ekr.20031218072017.1596: *3* g.doHook
-def doHook(tag: str, *args: Args, **kwargs: KWargs) -> Value:
+def doHook(tag: str, *args: Args, **kwargs: KWargs) -> Value | None:
     """
     This global function calls a hook routine. Hooks are identified by the
     tag param.
@@ -5324,7 +5326,7 @@ def enableIdleTimeHook(*args: Args, **kwargs: KWargs) -> None:
 
 
 # @+node:ekr.20140825042850.18410: *3* g.IdleTime
-def IdleTime(handler: Callable, delay: int = 500, tag: str = None) -> QtIdleTime:
+def IdleTime(handler: Callable, delay: int = 500, tag: str = None) -> QtIdleTime | None:
     """
     A thin wrapper for the LeoQtGui.IdleTime class.
 
@@ -5754,7 +5756,7 @@ def isWordChar1(ch: str) -> bool:
 
 
 # @+node:ekr.20130910044521.11304: *4* g.stripBOM
-def stripBOM(s_bytes: bytes) -> tuple[str, bytes]:
+def stripBOM(s_bytes: bytes) -> tuple[str | None, bytes]:
     """
     If there is a BOM, return (e,s2) where e is the encoding
     implied by the BOM and s2 is the s stripped of the BOM.
@@ -6870,7 +6872,7 @@ init_zodb_failed: dict[str, bool] = {}  # Keys are paths, values are True.
 init_zodb_db: dict[str, Value] = {}  # Keys are paths, values are ZODB.DB instances.
 
 
-def init_zodb(pathToZodbStorage: str, verbose: bool = True) -> Value:
+def init_zodb(pathToZodbStorage: str, verbose: bool = True) -> Value | None:
     """
     Return an ZODB.DB instance from the given path.
     return None on any error.
@@ -8627,7 +8629,7 @@ def getUNLFilePart(s: str) -> str:
 
 
 # @+node:ekr.20230630132340.1: *4* g.openUNLFile
-def openUNLFile(c: Cmdr, s: str) -> Cmdr:
+def openUNLFile(c: Cmdr, s: str) -> Cmdr | None:
     """
     Open the commander for filename s, the file part of an unl.
     Return None if the file can not be found.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -38,7 +38,7 @@ import time
 import traceback
 import types
 from types import ModuleType
-from typing import Any, IO, Iterable, Optional, Sequence, TYPE_CHECKING
+from typing import Any, IO, Iterable, Sequence, TYPE_CHECKING
 import unittest
 import urllib
 import urllib.parse as urlparse
@@ -417,7 +417,7 @@ def standard_timestamp() -> str:
 
 
 # @+node:ekr.20201211183100.1: *3* g.get_backup_directory
-def get_backup_path(sub_directory: str) -> Optional[str]:
+def get_backup_path(sub_directory: str) -> str | None:
     """
     Return the full path to the subdirectory of the main backup directory.
 
@@ -1240,7 +1240,7 @@ class MatchBrackets:
         right: int,
         max_right: int,
         expand: bool = False,
-    ) -> tuple[Optional[int], Optional[int], Optional[str], Optional[int]]:
+    ) -> tuple[int | None, int | None, str | None, int | None]:
         """
         Find the bracket nearest the cursor searching outwards left and right.
 
@@ -1287,7 +1287,7 @@ class MatchBrackets:
         return None, None, None, None
 
     # @+node:ekr.20061113221414: *4* mb.find_matching_bracket
-    def find_matching_bracket(self, ch1: str, s: str, i: int) -> Optional[int]:
+    def find_matching_bracket(self, ch1: str, s: str, i: int) -> int | None:
         """Find the bracket matching s[i] for self.language."""
         self.forward = ch1 in self.open_brackets
         # Find the character matching the initial bracket.
@@ -1301,7 +1301,7 @@ class MatchBrackets:
         return f(ch1, target, s, i)
 
     # @+node:ekr.20160121164556.1: *4* mb.scan & helpers
-    def scan(self, ch1: str, target: str, s: str, i: int) -> Optional[int]:
+    def scan(self, ch1: str, target: str, s: str, i: int) -> int | None:
         """Scan forward for target."""
         level = 0
         while 0 <= i < len(s):
@@ -1329,7 +1329,7 @@ class MatchBrackets:
         return None
 
     # @+node:ekr.20160119090634.1: *5* mb.scan_comment
-    def scan_comment(self, s: str, i: int) -> Optional[int]:
+    def scan_comment(self, s: str, i: int) -> int | None:
         """Return the index of the character after a comment."""
         i1 = i
         start = self.start_comment if self.forward else self.end_comment
@@ -1388,7 +1388,7 @@ class MatchBrackets:
         return self.start_comment and self.end_comment and g.match(s, i, self.end_comment)
 
     # @+node:ekr.20160119230141.1: *4* mb.scan_back & helpers
-    def scan_back(self, ch1: str, target: str, s: str, i: int) -> Optional[int]:
+    def scan_back(self, ch1: str, target: str, s: str, i: int) -> int | None:
         """Scan backwards for delim."""
         level = 0
         while i >= 0:
@@ -1621,7 +1621,7 @@ class OptionsUtils:
         return sorted(list(set(valid)))
 
     # @+node:ekr.20230615084117.1: *4* OptionsUtils.find_complex_option
-    def find_complex_option(self, regex: str) -> Optional[re.Match]:
+    def find_complex_option(self, regex: str) -> re.Match | None:
         """
         Check arguments that take an argument.
 
@@ -1820,14 +1820,14 @@ class SettingsDict(dict):
             self[key] = aList
 
     # @+node:ekr.20190903181030.1: *4* SettingsDict.get_setting & get_string_setting
-    def get_setting(self, key: str) -> Optional[str]:
+    def get_setting(self, key: str) -> str | None:
         """Return the canonical setting name."""
         key = key.replace('-', '').replace('_', '')
         gs = self.get(key)
         val = gs and gs.val
         return val
 
-    def get_string_setting(self, key: str) -> Optional[str]:
+    def get_string_setting(self, key: str) -> str | None:
         val = self.get_setting(key)
         return val if val and isinstance(val, str) else None
 
@@ -1964,7 +1964,7 @@ class Tracer:
         self.report()
 
     # @+node:ekr.20080531075119.6: *4* tracer
-    def tracer(self, frame: LeoFrame, event: QEvent, arg: object) -> Optional[Callable]:
+    def tracer(self, frame: LeoFrame, event: QEvent, arg: object) -> Callable | None:
         """A function to be passed to sys.settrace."""
         n = len(self.stack)
         if event == 'return':
@@ -2912,7 +2912,7 @@ def findAllValidLanguageDirectives(s: str) -> list:
 
 
 # @+node:ekr.20090214075058.8: *3* g.findAtTabWidthDirectives (must be fast)
-def findTabWidthDirectives(c: Cmdr, p: Position) -> Optional[str]:
+def findTabWidthDirectives(c: Cmdr, p: Position) -> str | None:
     """Return the tab width in effect at position p."""
     if c is None:
         return None  # c may be None for testing.
@@ -2936,7 +2936,7 @@ def findTabWidthDirectives(c: Cmdr, p: Position) -> Optional[str]:
 
 
 # @+node:ekr.20170127142001.5: *3* g.findFirstAtLanguageDirective
-def findFirstValidAtLanguageDirective(s: str) -> Optional[str]:
+def findFirstValidAtLanguageDirective(s: str) -> str | None:
     """
     Return the first language for which there is a valid @language
     directive in s.
@@ -2951,14 +2951,14 @@ def findFirstValidAtLanguageDirective(s: str) -> Optional[str]:
 
 
 # @+node:ekr.20090214075058.6: *3* g.findLanguageDirectives (must be fast)
-def findLanguageDirectives(c: Cmdr, p: Position) -> Optional[str]:
+def findLanguageDirectives(c: Cmdr, p: Position) -> str | None:
     """Return the language in effect at position p."""
     if c is None or p is None:
         return None  # c may be None for testing.
 
     v0 = p.v
 
-    def find_language(p_or_v: Position | VNode) -> Optional[str]:
+    def find_language(p_or_v: Position | VNode) -> str | None:
         for s in p_or_v.h, p_or_v.b:
             for m in g_language_pat.finditer(s):
                 language = m.group(1)
@@ -2994,7 +2994,7 @@ def findLanguageDirectives(c: Cmdr, p: Position) -> Optional[str]:
 # Also called from write at.putRefAt.
 
 
-def findReference(name: str, root: Position) -> Optional[Position]:
+def findReference(name: str, root: Position) -> Position | None:
     """Return the position containing the section definition for name."""
     for p in root.subtree(copy=False):
         assert p != root
@@ -3053,7 +3053,7 @@ def get_directives_dict_list(p: Position) -> list[dict]:
 
 
 # @+node:ekr.20111010082822.15545: *3* g.getLanguageFromAncestorAtFileNode (deprecated)
-def getLanguageFromAncestorAtFileNode(p: Position) -> Optional[str]:
+def getLanguageFromAncestorAtFileNode(p: Position) -> str | None:
     """Return the language in effect at node p."""
     g.deprecated()
     c = p.v.context
@@ -3135,7 +3135,7 @@ def isValidLanguage(language: str) -> bool:
 
 # @+node:ekr.20250403040834.1: *3* --- to be deprecated! Using directives list
 # @+node:ekr.20080827175609.52: *4* g.scanAtCommentAndLanguageDirectives (deprecated)
-def scanAtCommentAndAtLanguageDirectives(aList: list) -> Optional[dict[str, str]]:
+def scanAtCommentAndAtLanguageDirectives(aList: list) -> dict[str, str] | None:
     """
     Scan aList for @comment and @language directives.
 
@@ -3159,7 +3159,7 @@ def scanAtCommentAndAtLanguageDirectives(aList: list) -> Optional[dict[str, str]
 
 
 # @+node:ekr.20080827175609.32: *4* g.scanAtEncodingDirectives (deprecated)
-def scanAtEncodingDirectives(aList: list) -> Optional[str]:
+def scanAtEncodingDirectives(aList: list) -> str | None:
     """Scan aList for @encoding directives."""
     g.deprecated()
     for d in aList:
@@ -3181,7 +3181,7 @@ def scanAtHeaderDirectives(aList: list) -> None:
 
 
 # @+node:ekr.20080827175609.33: *4* g.scanAtLineendingDirectives (deprecated)
-def scanAtLineendingDirectives(aList: list) -> Optional[str]:
+def scanAtLineendingDirectives(aList: list) -> str | None:
     """Scan aList for @lineending directives."""
     g.deprecated()
     for d in aList:
@@ -3195,7 +3195,7 @@ def scanAtLineendingDirectives(aList: list) -> Optional[str]:
 
 
 # @+node:ekr.20080827175609.34: *4* g.scanAtPagewidthDirectives (deprecated)
-def scanAtPagewidthDirectives(aList: list, issue_error_flag: bool = False) -> Optional[int]:
+def scanAtPagewidthDirectives(aList: list, issue_error_flag: bool = False) -> int | None:
     """Scan aList for @pagewidth directives. Return the page width or None"""
     g.deprecated()
     for d in aList:
@@ -3224,7 +3224,7 @@ def scanAllAtPathDirectives(c: Cmdr, p: Position) -> str:
 
 
 # @+node:ekr.20080827175609.37: *4* g.scanAtTabwidthDirectives & scanAllAtTabWidthDirectives (deprecated)
-def scanAtTabwidthDirectives(aList: list, issue_error_flag: bool = False) -> Optional[int]:
+def scanAtTabwidthDirectives(aList: list, issue_error_flag: bool = False) -> int | None:
     """Scan aList for @tabwidth directives."""
     g.deprecated()
     for d in aList:
@@ -3238,7 +3238,7 @@ def scanAtTabwidthDirectives(aList: list, issue_error_flag: bool = False) -> Opt
     return None
 
 
-def scanAllAtTabWidthDirectives(c: Cmdr, p: Position) -> Optional[int]:
+def scanAllAtTabWidthDirectives(c: Cmdr, p: Position) -> int | None:
     """Scan p and all ancestors looking for @tabwidth directives."""
     g.deprecated()
     if c and p:
@@ -3251,7 +3251,7 @@ def scanAllAtTabWidthDirectives(c: Cmdr, p: Position) -> Optional[int]:
 
 
 # @+node:ekr.20080831084419.4: *4* g.scanAtWrapDirectives & scanAllAtWrapDirectives (deprecated)
-def scanAtWrapDirectives(aList: list, issue_error_flag: bool = False) -> Optional[bool]:
+def scanAtWrapDirectives(aList: list, issue_error_flag: bool = False) -> bool | None:
     """Scan aList for @wrap and @nowrap directives."""
     g.deprecated()
     for d in aList:
@@ -3262,7 +3262,7 @@ def scanAtWrapDirectives(aList: list, issue_error_flag: bool = False) -> Optiona
     return None
 
 
-def scanAllAtWrapDirectives(c: Cmdr, p: Position) -> Optional[bool]:
+def scanAllAtWrapDirectives(c: Cmdr, p: Position) -> bool | None:
     """Scan p and all ancestors looking for @wrap/@nowrap directives."""
     g.deprecated()
     if c and p:
@@ -3596,7 +3596,7 @@ def getEncodingAt(p: Position, b: bytes = None) -> str:
 
 
 # @+node:ville.20090701144325.14942: *3* g.guessExternalEditor
-def guessExternalEditor(c: Cmdr = None) -> Optional[str]:
+def guessExternalEditor(c: Cmdr = None) -> str | None:
     """Return a 'sensible' external editor"""
     editor = (
         c
@@ -3667,7 +3667,7 @@ def is_binary_string(s: str) -> bool:
 
 
 # @+node:ekr.20031218072017.3119: *3* g.makeAllNonExistentDirectories
-def makeAllNonExistentDirectories(theDir: str) -> Optional[str]:
+def makeAllNonExistentDirectories(theDir: str) -> str | None:
     """
     A wrapper from os.makedirs.
     Attempt to make all non-existent directories.
@@ -3698,7 +3698,7 @@ def makePathRelativeTo(fullPath: str, basePath: str) -> str:
 
 
 # @+node:ekr.20090520055433.5945: *3* g.openWithFileName
-def openWithFileName(fileName: str, old_c: Cmdr = None, gui: LeoGui = None) -> Optional[Cmdr]:
+def openWithFileName(fileName: str, old_c: Cmdr = None, gui: LeoGui = None) -> Cmdr | None:
     """
     Load any kind of file in the appropriate way:
 
@@ -3801,9 +3801,9 @@ def readFileIntoString(
 # @+node:ekr.20160504062833.1: *3* g.readFileIntoUnicodeString
 def readFileIntoUnicodeString(
     fn: str,
-    encoding: Optional[str] = None,
+    encoding: str | None = None,
     silent: bool = False,
-) -> Optional[str]:
+) -> str | None:
     """Return the raw contents of the file whose full path is fn."""
     try:
         with open(fn, 'rb') as f:
@@ -3828,7 +3828,7 @@ def readFileIntoUnicodeString(
 # @@c
 
 
-def readlineForceUnixNewline(f: IO, fileName: Optional[str] = None) -> str:
+def readlineForceUnixNewline(f: IO, fileName: str | None = None) -> str:
     try:
         s = f.readline()
     except UnicodeDecodeError:
@@ -4007,7 +4007,7 @@ def find_word(s: str, word: str, i: int = 0) -> int:
 
 
 # @+node:ekr.20211029090118.1: *3* g.findAncestorVnodeByPredicate
-def findAncestorVnodeByPredicate(p: Position, v_predicate: Optional[Callable]) -> Optional[VNode]:
+def findAncestorVnodeByPredicate(p: Position, v_predicate: Callable | None) -> VNode | None:
     """
     Return first ancestor vnode matching the predicate.
 
@@ -4658,7 +4658,7 @@ def skip_to_start_of_line(s: str, i: int) -> int:
 
 
 # @+node:ekr.20031218072017.3188: *4* g.skip_long
-def skip_long(s: str, i: int) -> tuple[int, Optional[int]]:
+def skip_long(s: str, i: int) -> tuple[int, int | None]:
     """
     Scan s[i:] for a valid int.
     Return (i, val) or (i, None) if s[i] does not point at a number.
@@ -4819,7 +4819,7 @@ def getGitIssues(
     base_url: str = None,
     label_list: list = None,
     milestone: str = None,
-    state: Optional[str] = None,  # in (None, 'closed', 'open')
+    state: str = None,  # in (None, 'closed', 'open')
 ) -> None:
     """Get a list of issues from Leo's GitHub site."""
     if base_url is None:
@@ -5113,7 +5113,7 @@ def gitDescribe(path: str = None) -> tuple[str, str, str]:
 
 
 # @+node:ekr.20170414034616.6: *3* g.gitHeadPath
-def gitHeadPath(path_s: str) -> Optional[str]:
+def gitHeadPath(path_s: str) -> str | None:
     """
     Compute the path to .git/HEAD given the path.
     """
@@ -5300,7 +5300,7 @@ def getLoadedPlugins() -> list:
     return pc.getLoadedPlugins()
 
 
-def getPluginModule(moduleName: str) -> Optional[ModuleType]:
+def getPluginModule(moduleName: str) -> ModuleType | None:
     pc = g.app.pluginsController
     return pc.getPluginModule(moduleName)
 
@@ -5394,7 +5394,7 @@ def cantImport(moduleName: str, pluginName: str = None, verbose: bool = True) ->
 
 
 # @+node:ekr.20191220044128.1: *3* g.import_module
-def import_module(name: str, package: str = None) -> Optional[ModuleType]:
+def import_module(name: str, package: str = None) -> ModuleType | None:
     """
     A thin wrapper over importlib.import_module.
     """
@@ -6991,7 +6991,7 @@ def truncate(s: str, n: int) -> str:
 
 
 # @+node:ekr.20031218072017.3150: *3* g.windows
-def windows() -> Optional[list]:
+def windows() -> list | None:
     return app.windowList if app else None
 
 
@@ -7496,7 +7496,7 @@ def execute_shell_commands_with_options(
 
 
 # @+node:ekr.20180217152624.1: *4* g.computeBaseDir
-def computeBaseDir(c: Cmdr, base_dir: str, path_setting: str) -> Optional[str]:
+def computeBaseDir(c: Cmdr, base_dir: str, path_setting: str) -> str | None:
     """
     Compute a base_directory.
     If given, @string path_setting takes precedence.
@@ -7573,7 +7573,7 @@ def executeFile(filename: str, options: str = '') -> None:
 # @+node:ekr.20040321065415: *3* g.find*Node*
 # @+others
 # @+node:ekr.20210303123423.3: *4* g.findNodeAnywhere
-def findNodeAnywhere(c: Cmdr, headline: str, exact: bool = True) -> Optional[Position]:
+def findNodeAnywhere(c: Cmdr, headline: str, exact: bool = True) -> Position | None:
     h = headline.strip()
     for p in c.all_unique_positions(copy=False):
         if p.h.strip() == h:
@@ -7586,7 +7586,7 @@ def findNodeAnywhere(c: Cmdr, headline: str, exact: bool = True) -> Optional[Pos
 
 
 # @+node:ekr.20210303123525.1: *4* g.findNodeByPath
-def findNodeByPath(c: Cmdr, path: str) -> Optional[Position]:
+def findNodeByPath(c: Cmdr, path: str) -> Position | None:
     """Return the first @<file> node in Cmdr c whose path is given."""
     if not os.path.isabs(path):  # #2049. Only absolute paths could possibly work.
         g.trace(f"path not absolute: {repr(path)}")
@@ -7601,9 +7601,7 @@ def findNodeByPath(c: Cmdr, path: str) -> Optional[Position]:
 
 
 # @+node:ekr.20210303123423.1: *4* g.findNodeInChildren
-def findNodeInChildren(
-    c: Cmdr, p: Position, headline: str, exact: bool = True
-) -> Optional[Position]:
+def findNodeInChildren(c: Cmdr, p: Position, headline: str, exact: bool = True) -> Position | None:
     """Search for a node in v's tree matching the given headline."""
     p1 = p.copy()
     h = headline.strip()
@@ -7618,7 +7616,7 @@ def findNodeInChildren(
 
 
 # @+node:ekr.20210303123423.2: *4* g.findNodeInTree
-def findNodeInTree(c: Cmdr, p: Position, headline: str, exact: bool = True) -> Optional[Position]:
+def findNodeInTree(c: Cmdr, p: Position, headline: str, exact: bool = True) -> Position | None:
     """Search for a node in v's tree matching the given headline."""
     h = headline.strip()
     p1 = p.copy()
@@ -7633,7 +7631,7 @@ def findNodeInTree(c: Cmdr, p: Position, headline: str, exact: bool = True) -> O
 
 
 # @+node:ekr.20210303123423.4: *4* g.findTopLevelNode
-def findTopLevelNode(c: Cmdr, headline: str, exact: bool = True) -> Optional[Position]:
+def findTopLevelNode(c: Cmdr, headline: str, exact: bool = True) -> Position | None:
     h = headline.strip()
     for p in c.rootPosition().self_and_siblings(copy=False):
         if p.h.strip() == h:
@@ -8010,7 +8008,7 @@ def es_clickable_link(
 
 
 # @+node:ekr.20230628072620.1: *3* g.findAnyUnl
-def findAnyUnl(unl_s: str, c: Cmdr) -> Optional[Position]:
+def findAnyUnl(unl_s: str, c: Cmdr) -> Position | None:
     """
     Find the Position corresponding to an UNL.
 
@@ -8089,7 +8087,7 @@ def findAnyUnl(unl_s: str, c: Cmdr) -> Optional[Position]:
 find_gnx_pat = re.compile(r'^(.*)::([-\d]+)?$')
 
 
-def findGnx(gnx: str, c: Cmdr) -> Optional[Position]:
+def findGnx(gnx: str, c: Cmdr) -> Position | None:
     """
     gnx: the gnx part of a gnx-based unl.
 
@@ -8117,7 +8115,7 @@ def findGnx(gnx: str, c: Cmdr) -> Optional[Position]:
 
 
 # @+node:tbrown.20140311095634.15188: *3* g.findUnl & helpers (legacy unls)
-def findUnl(unlList1: list[str], c: Cmdr) -> Optional[Position]:
+def findUnl(unlList1: list[str], c: Cmdr) -> Position | None:
     """
     g.findUnl: support for legacy UNLs.
     unlList is a list of headlines.
@@ -8219,7 +8217,7 @@ findUNL = findUnl  # Compatibility.
 
 
 # @+node:ekr.20120311151914.9917: *3* g.getUrlFromNode
-def getUrlFromNode(p: Position) -> Optional[str]:
+def getUrlFromNode(p: Position) -> str | None:
     """
     Get an url from node p:
     1. Use the headline if it contains a valid url.
@@ -8255,7 +8253,7 @@ def getUrlFromNode(p: Position) -> Optional[str]:
 
 
 # @+node:ekr.20170221063527.1: *3* g.handleUnl
-def handleUnl(unl_s: str, c: Cmdr) -> Optional[Cmdr]:
+def handleUnl(unl_s: str, c: Cmdr) -> Cmdr | None:
     """
     Select the node given by any kind of unl.
     This must *never* open a browser.
@@ -8301,7 +8299,7 @@ def handleUnl(unl_s: str, c: Cmdr) -> Optional[Cmdr]:
 
 
 # @+node:tbrown.20090219095555.63: *3* g.handleUrl & helpers
-def handleUrl(url: str, c: Cmdr = None, p: Position = None) -> Optional[str]:
+def handleUrl(url: str, c: Cmdr = None, p: Position = None) -> str | None:
     """Open a url or a unl."""
     if c and not p:
         p = c.p
@@ -8450,7 +8448,7 @@ def openUrl(p: Position) -> None:  # pragma: no cover
 
 
 # @+node:ekr.20110605121601.18135: *3* g.openUrlOnClick (open-url-under-cursor)
-def openUrlOnClick(event: QMouseEvent, url: str = None) -> Optional[str]:  # pragma: no cover
+def openUrlOnClick(event: QMouseEvent, url: str = None) -> str | None:  # pragma: no cover
     """Open the URL under the cursor.  Return it for unit testing."""
     from leo.core.leoGui import LeoKeyEvent
     from leo.plugins.qt_text import QTextEditWrapper
@@ -8469,7 +8467,7 @@ def openUrlOnClick(event: QMouseEvent, url: str = None) -> Optional[str]:  # pra
 
 
 # @+node:ekr.20170216091704.1: *4* g.openUrlHelper
-def openUrlHelper(event: LeoKeyEvent, url: str = None) -> Optional[str]:
+def openUrlHelper(event: LeoKeyEvent, url: str = None) -> str | None:
     """Open the unl, url or gnx under the cursor.  Return it for unit testing."""
     if not event:
         return None

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2748,9 +2748,9 @@ def printGcObjects() -> int:
     print(f"{count:7} objects...")
     # Invert the dict.
     d2: dict[int, str] = {v: k for k, v in d.items()}
-    for key in reversed(sorted(d2.keys())):  # type:ignore
-        val = d2.get(key)  # type:ignore
-        print(f"{key:7} {val}")
+    for key2 in reversed(sorted(d2.keys())):
+        val2 = d2.get(key2)
+        print(f"{key2:7} {val2}")
     lastObjectCount = count
     return delta
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3944,11 +3944,12 @@ def splitLongFileName(fn: str, limit: int = 40) -> str:
 def writeFile(contents: bytes | str, encoding: str, fileName: str) -> bool:
     """Create a file with the given contents."""
     try:
-        if isinstance(contents, str):
-            contents = g.toEncodedString(contents, encoding=encoding)
-        # 'wb' preserves line endings.
+        bytes_contents = (
+            contents if isinstance(contents, bytes)
+            else g.toEncodedString(contents, encoding=encoding)
+        )  # fmt: skip
         with open(fileName, 'wb') as f:
-            f.write(contents)  # type:ignore
+            f.write(bytes_contents)
         return True
     except Exception as e:
         print(f"exception writing: {fileName}:\n{e}")

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3664,6 +3664,7 @@ def is_binary_string(s: str) -> bool:
     # http://stackoverflow.com/questions/898669
     # aList is a list of all non-binary characters.
     aList = [7, 8, 9, 10, 12, 13, 27] + list(range(0x20, 0x100))
+    # mypy bug?
     return bool(s.translate(None, bytes(aList)))  # type:ignore
 
 
@@ -6489,7 +6490,7 @@ def prettyPrintType(obj: object) -> str:
     if t in [types.MethodType, types.BuiltinMethodType]:
         return 'method'
     # Fall back to a hack.
-    t = str(type(obj))  # type:ignore
+    t = str(type(obj))
     if t.startswith("<type '"):
         t = t[7:]
     if t.endswith("'>"):

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2747,7 +2747,7 @@ def printGcObjects() -> int:
     print(f"{count:7} objects...")
     # Invert the dict.
     d2: dict[int, str] = {v: k for k, v in d.items()}
-    for key2 in reversed(sorted(d2.keys())):
+    for key2 in reversed(sorted(d2.keys())):  # #4753
         val2 = d2.get(key2)
         print(f"{key2:7} {val2}")
     lastObjectCount = count
@@ -3365,7 +3365,7 @@ def set_delims_from_string(s: str) -> tuple[str, str, str] | tuple[None, None, N
                     g.warning(f"'{delims[i]}' delimiter is invalid")
                     return None, None, None
                 try:
-                    delims[i] = g.toUnicode(binascii.unhexlify(delims[i][3:]))
+                    delims[i] = g.toUnicode(binascii.unhexlify(delims[i][3:]))  # #4753
                 except Exception as e:
                     g.warning(f"'{delims[i]}' delimiter is invalid: {e}")
                     return None, None, None
@@ -3945,7 +3945,7 @@ def splitLongFileName(fn: str, limit: int = 40) -> str:
 def writeFile(contents: bytes | str, encoding: str, fileName: str) -> bool:
     """Create a file with the given contents."""
     try:
-        bytes_contents = (
+        bytes_contents = (  # #4753
             contents if isinstance(contents, bytes)
             else g.toEncodedString(contents, encoding=encoding)
         )  # fmt: skip
@@ -5808,10 +5808,9 @@ def toEncodedString(s: bytes | str, encoding: str = 'utf-8', reportErrors: bool 
     try:
         return s.encode(encoding, "strict")
     except UnicodeError:
-        s2 = s.encode(encoding, "replace")
-        if reportErrors:
-            g.error(f"Error converting {s2!r} from unicode to {encoding} encoding")
-        return s2
+        if reportErrors:  # #4753.
+            g.error(f"Error converting {s!r} from unicode to {encoding} encoding")
+        return s.encode(encoding, "replace")
 
 
 # @+node:ekr.20050208093800.1: *4* g.toUnicode

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5399,19 +5399,16 @@ def import_module(name: str, package: str = None) -> Optional[ModuleType]:
     A thin wrapper over importlib.import_module.
     """
     trace = 'plugins' in g.app.debug and not g.unitTesting
-    exceptions = []
+    exceptions: list[str] = []
     try:
         m = importlib.import_module(name, package=package)
     except Exception as e:
         m = None
         if trace:
-            t, v, tb = sys.exc_info()
-            del tb  # don't need the traceback
-            # In case v is empty, we'll at least have the exception type
-            v = v or str(t)  # type:ignore
-            if v not in exceptions:
-                exceptions.append(v)
-                g.trace(f"Can not import {name}: {e}")
+            message = f"Can not import {name}: {e}"
+            if message not in exceptions:
+                exceptions.append(message)
+                g.trace(message)
     return m
 
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5804,16 +5804,16 @@ def toEncodedString(s: bytes | str, encoding: str = 'utf-8', reportErrors: bool 
     # These are the only significant calls to s.encode in Leo.
     # Tracing these calls directly yields thousands of calls.
     try:
-        return s.encode(encoding, "strict")  # ty--pe:ignore
+        return s.encode(encoding, "strict")
     except UnicodeError:
-        s2 = s.encode(encoding, "replace")  # ty--pe:ignore
+        s2 = s.encode(encoding, "replace")
         if reportErrors:
             g.error(f"Error converting {s2!r} from unicode to {encoding} encoding")
         return s2
 
 
 # @+node:ekr.20050208093800.1: *4* g.toUnicode
-def toUnicode(s: object, encoding: str = None, reportErrors: bool = False) -> str:
+def toUnicode(s: bytes | str, encoding: str = None, reportErrors: bool = False) -> str:
     """Convert bytes to unicode if necessary."""
     if isinstance(s, str):
         return s
@@ -5830,7 +5830,7 @@ def toUnicode(s: object, encoding: str = None, reportErrors: bool = False) -> st
         encoding = 'utf-8'
     try:
         return s.decode(encoding, 'strict')
-    except (UnicodeDecodeError, UnicodeError):  # noqa
+    except (UnicodeDecodeError, UnicodeError):
         # https://wiki.python.org/moin/UnicodeDecodeError
         s = s.decode(encoding, 'replace')
         if g.unitTesting:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5795,21 +5795,21 @@ def strToBytes(s: str, reportErrors: bool = False) -> bytes:
 
 
 # @+node:ekr.20050208093800: *4* g.toEncodedString
-def toEncodedString(s: str, encoding: str = 'utf-8', reportErrors: bool = False) -> bytes:
+def toEncodedString(s: bytes | str, encoding: str = 'utf-8', reportErrors: bool = False) -> bytes:
     """Convert unicode string to an encoded string."""
     if not isinstance(s, str):
         return s
     if not encoding:
         encoding = 'utf-8'
     # These are the only significant calls to s.encode in Leo.
-    try:
-        s = s.encode(encoding, "strict")  # type:ignore
-    except UnicodeError:
-        s = s.encode(encoding, "replace")  # type:ignore
-        if reportErrors:
-            g.error(f"Error converting {s} from unicode to {encoding} encoding")
     # Tracing these calls directly yields thousands of calls.
-    return s  # type:ignore
+    try:
+        return s.encode(encoding, "strict")  # ty--pe:ignore
+    except UnicodeError:
+        s2 = s.encode(encoding, "replace")  # ty--pe:ignore
+        if reportErrors:
+            g.error(f"Error converting {s2!r} from unicode to {encoding} encoding")
+        return s2
 
 
 # @+node:ekr.20050208093800.1: *4* g.toUnicode

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -13,7 +13,7 @@ Plugins may define their own gui classes by setting g.app.gui.
 # @+node:ekr.20220414080546.1: ** << leoGui imports & annotations >>
 from __future__ import annotations
 from collections.abc import Callable
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoFrame
 from leo.core.leoAPI import StringTextWrapper
@@ -53,7 +53,7 @@ class LeoGui:
         self.mGuiName = guiName
         self.mainLoop = None
         self.root: Position = None
-        self.script: Optional[str] = None
+        self.script: str = None
         self.splashScreen: Widget = None
         self.utils = None
         # To keep pylint happy.

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -588,7 +588,7 @@ class LeoImportCommands:
         ext: str = None,
         s: str = None,
         treeType: str = '@file',
-    ) -> Position:
+    ) -> Position | None:
         """
         Create an outline by importing a file, reading the file with the
         given encoding if string s is None.
@@ -656,7 +656,7 @@ class LeoImportCommands:
         return p
 
     # @+node:ekr.20140724175458.18052: *5* ic.init_import
-    def init_import(self, ext: str, fileName: str, s: str) -> tuple[str, str]:
+    def init_import(self, ext: str, fileName: str, s: str) -> tuple[str, str] | tuple[None, None]:
         """
         Init ivars imports and read the file into s.
         Return ext, s.
@@ -1506,7 +1506,7 @@ class MindMapImporter:
         return -1
 
     # @+node:ekr.20160503130810.5: *4* mindmap.csv_string
-    def csv_string(self, row: list[str]) -> str:
+    def csv_string(self, row: list[str]) -> str | None:
         """Return the string for the given csv row."""
         count = 0
         while count <= len(row):
@@ -1592,7 +1592,7 @@ class MORE_Importer:
         return None
 
     # @+node:ekr.20031218072017.3215: *3* MORE.import_lines
-    def import_lines(self, strings: list[str], first_p: Position) -> Position:
+    def import_lines(self, strings: list[str], first_p: Position) -> Position | None:
         c = self.c
         if not strings:
             return None
@@ -2450,7 +2450,7 @@ class ZimImportController:
         self.zimNodeName = c.config.getString('zim-node-name') or 'Imported Zim Tree'
 
     # @+node:ekr.20141210051628.28: *3* zic.parseZimIndex
-    def parseZimIndex(self) -> list[tuple[int, str, list[str]]]:
+    def parseZimIndex(self) -> list[tuple[int, str, list[str]]] | None:
         """
         Parse Zim wiki index.rst and return a list of tuples (level, name, path) or None.
         """
@@ -2588,7 +2588,7 @@ class LegacyExternalFileImporter:
             print('orphan line: ', repr(line))
 
     # @+node:ekr.20200424160847.1: *3* legacy.compute_delim1
-    def compute_delim1(self, path: str) -> str:
+    def compute_delim1(self, path: str) -> str | None:
         """Return the opening comment delim for the given file."""
         junk, ext = os.path.splitext(path)
         if not ext:

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -10,7 +10,7 @@ import os
 import re
 import textwrap
 import time
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 import urllib
 
 #
@@ -460,7 +460,7 @@ class LeoImportCommands:
         theFile.close()
 
     # @+node:ekr.20031218072017.3300: *4* ic.removeSentinelsCommand
-    def removeSentinelsCommand(self, paths: list[str], toString: bool = False) -> Optional[str]:
+    def removeSentinelsCommand(self, paths: list[str], toString: bool = False) -> str | None:
         c = self.c
         self.encoding = c.getEncoding(c.p)
         for fileName in paths:
@@ -638,7 +638,7 @@ class LeoImportCommands:
         return p
 
     # @+node:ekr.20140724064952.18038: *5* ic.dispatch & helpers
-    def dispatch(self, ext: str, p: Position) -> Optional[Callable]:
+    def dispatch(self, ext: str, p: Position) -> Callable | None:
         """Return the correct scanner function for p, an @auto node."""
         # Match the @auto type first, then the file extension.
         return g.app.scanner_for_at_auto(p) or g.app.scanner_for_ext(ext)
@@ -738,7 +738,7 @@ class LeoImportCommands:
         parent: Position = None,
         paths: list[str] = None,
         command: str = 'Import',
-    ) -> Optional[Position]:
+    ) -> Position | None:
         """
         Import one or more external files.
         This is not a command.  It must *not* have an event arg.
@@ -824,7 +824,7 @@ class LeoImportCommands:
         FreeMindImporter(self.c).import_files(files)
 
     # @+node:ekr.20241027003435.1: *4* ic.importJupytextFiles
-    def importJupytextFiles(self, paths: list[str] = None) -> Optional[Position]:
+    def importJupytextFiles(self, paths: list[str] = None) -> Position | None:
         """
         Import one or more .ipynb files.
         This is not a command.  It must *not* have an event arg.
@@ -892,7 +892,7 @@ class LeoImportCommands:
         return p
 
     # @+node:ekr.20031218072017.3227: *5* ic.findFunctionDef
-    def findFunctionDef(self, s: str, i: int) -> Optional[str]:
+    def findFunctionDef(self, s: str, i: int) -> str | None:
         # Look at the next non-blank line for a function name.
         i = g.skip_ws_and_nl(s, i)
         k = g.skip_line(s, i)
@@ -1558,7 +1558,7 @@ class MORE_Importer:
                 c.redraw(p)
 
     # @+node:ekr.20161006101347.1: *3* MORE.import_file
-    def import_file(self, fileName: str) -> Optional[Position]:  # Not a command, so no event arg.
+    def import_file(self, fileName: str) -> Position | None:  # Not a command, so no event arg.
         c = self.c
         u = c.undoer
         ic = c.importCommands
@@ -1732,7 +1732,7 @@ class RecursiveImportController:
         self,
         c: Cmdr,
         *,  # All other args are kwargs.
-        dir_: Optional[str],
+        dir_: str | None,
         ignore_pattern: re.Pattern = None,
         kind: str,
         recursive: bool = True,
@@ -1748,7 +1748,7 @@ class RecursiveImportController:
         self.recursive = recursive
         self.root: Position = None
         file_name = c.fileName()
-        self.outline_directory: Optional[str] = os.path.dirname(file_name) if file_name else None
+        self.outline_directory: str | None = os.path.dirname(file_name) if file_name else None
         self.safe_at_file = safe_at_file
         self.theTypes = theTypes
         self.verbose = verbose
@@ -1947,7 +1947,7 @@ class RecursiveImportController:
             c.deletePositionsInList(aList)  # Don't redraw.
 
     # @+node:ekr.20230829043849.1: *3* ric_resolve_dir_arg
-    def resolve_dir_arg(self, arg: str) -> Optional[str]:
+    def resolve_dir_arg(self, arg: str) -> str | None:
         """
         arg can be None or a path (relative or absolute) to a file or
         directory.
@@ -1984,7 +1984,7 @@ class RecursiveImportController:
         return arg
 
     # @+node:ekr.20130823083943.12613: *3* ric.run
-    def run(self, dir_: Optional[str]) -> None:
+    def run(self, dir_: str | None) -> None:
         """
         dir_ can be None, a directory contained in the outline's directory, or a single file.
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1265,7 +1265,7 @@ class LeoImportCommands:
         if s:
             p.b = p.b + g.toUnicode(s, self.encoding)
 
-    def setBodyString(self, p: Position, s: str) -> None:
+    def setBodyString(self, p: Position, s: bytes | str) -> None:
         """
         Similar to c.setBodyString, but does not recolor the text or
         redraw the screen.

--- a/leo/core/leoJupytext.py
+++ b/leo/core/leoJupytext.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import io
 import os
 import textwrap
-from typing import Any, Tuple, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 # Defer importing jupytext until first use: jupytext imports pandoc at module
@@ -228,7 +228,7 @@ class JupytextManager:
         return config_file
 
     # @+node:ekr.20241023155136.1: *3* jtm.read
-    def read(self, c: Cmdr, p: Position) -> Tuple[str, str]:  # pragma: no cover
+    def read(self, c: Cmdr, p: Position) -> tuple[str, str]:  # pragma: no cover
         """
         Called from at.readOneAtJupytextNode.
         p must be an @jupytext node describing an .ipynb file.

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -14,7 +14,7 @@ import string
 import sys
 import textwrap
 import time
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from types import ModuleType
 from leo.core import leoGlobals as g
 from leo.external import codewise
@@ -388,7 +388,7 @@ class AutoCompleterClass:
             log.clearTab(self.tabName)
 
     # @+node:ekr.20110509064011.14556: *4* ac.attr_matches
-    def attr_matches(self, s: str, namespace: dict) -> Optional[list[str]]:
+    def attr_matches(self, s: str, namespace: dict) -> list[str] | None:
         """Compute matches when string s is of the form name.name....name.
 
         Evaluates s using eval(s,namespace)
@@ -420,7 +420,7 @@ class AutoCompleterClass:
         return result
 
     # @+node:ekr.20061031131434.11: *4* ac.auto_completer_state_handler
-    def auto_completer_state_handler(self, event: LeoKeyEvent) -> Optional[str]:
+    def auto_completer_state_handler(self, event: LeoKeyEvent) -> str | None:
         """Handle all keys while autocompleting."""
         c, k, tag = self.c, self.k, 'auto-complete'
         state = k.getState(tag)
@@ -1806,7 +1806,7 @@ class KeyHandlerClass:
         self.qcompleter = None  # Set by AutoCompleter.start.
         self.setDefaultUnboundKeyAction()
         self.setDefaultEditingAction()
-        self.modeWidget: Optional[Widget]
+        self.modeWidget: Widget | None
 
     # @+node:ekr.20061031131434.78: *5* k.defineExternallyVisibleIvars
     def defineExternallyVisibleIvars(self) -> None:
@@ -2795,7 +2795,7 @@ class KeyHandlerClass:
                 return g.toUnicode(s.replace('-', '').replace('_', '').lower())
 
             # @+node:ekr.20241210055239.1: *5* ShowCommands.open_hidden_commander
-            def open_hidden_commander(self, path: str) -> Optional[Cmdr]:
+            def open_hidden_commander(self, path: str) -> Cmdr | None:
                 """Open a hidden commander with the given filename."""
                 c = g.openWithFileName(path, old_c=self.c, gui=g.app.nullGui)
                 if not c:
@@ -4373,7 +4373,7 @@ class KeyHandlerClass:
         return result_d
 
     # @+node:ekr.20061031131434.179: *4* k.getShortcutForCommandName
-    def getStrokeForCommandName(self, commandName: str) -> Optional[Stroke]:
+    def getStrokeForCommandName(self, commandName: str) -> Stroke | None:
         c, k = self.c, self
         command = c.commandsDict.get(commandName)
         if command:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2408,7 +2408,7 @@ class KeyHandlerClass:
                 tag = bi.kind
                 pane = bi.pane
                 if stroke and pane and not pane.endswith('-mode'):
-                    k.bindKey(pane, stroke, command, commandName, tag=tag)  # type:ignore
+                    k.bindKey(pane, stroke, command, commandName, tag=tag)
 
     # @+node:ekr.20061031131434.103: *4* k.makeMasterGuiBinding
     def makeMasterGuiBinding(self, stroke: Stroke, w: QTextMixin = None) -> None:

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -280,7 +280,7 @@ class MarkupCommands:
         kind: str,
         preview: bool,
         verbose: bool,
-    ) -> list[str]:
+    ) -> list[str] | None:
         def predicate(p: Position) -> str:
             return self.filename(p)
 

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -11,7 +11,7 @@ from shutil import which
 import os
 import re
 import time
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 import leo.core.leoGlobals as g
 
 # Abbreviation.
@@ -22,7 +22,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position
 
-    File_List = Optional[list[str]]
+    File_List = list[str] | None
 # @-<< leoMarkup: imports & annotations >>
 # @+<< leoMarkup: cached functions >>
 # @+node:ekr.20260421071144.1: ** << leoMarkup: cached functions >>
@@ -30,22 +30,22 @@ if TYPE_CHECKING:  # pragma: no cover
 
 # PR #4615: Defer calls to `which` until needed.
 @functools.cache
-def _asciidoctor_exec() -> Optional[str]:
+def _asciidoctor_exec() -> str | None:
     return which('asciidoctor')
 
 
 @functools.cache
-def _asciidoc3_exec() -> Optional[str]:
+def _asciidoc3_exec() -> str | None:
     return which('asciidoc3')
 
 
 @functools.cache
-def _pandoc_exec() -> Optional[str]:
+def _pandoc_exec() -> str | None:
     return which('pandoc')
 
 
 @functools.cache
-def _sphinx_build() -> Optional[str]:
+def _sphinx_build() -> str | None:
     return which('sphinx-build')
 
 
@@ -342,7 +342,7 @@ class MarkupCommands:
     # @+node:ekr.20190515084219.1: *4* markup.filename
     adoc_pattern = re.compile(r'^@(adoc|asciidoctor)')
 
-    def filename(self, p: Position) -> Optional[str]:
+    def filename(self, p: Position) -> str | None:
         """Return the filename of the @adoc, @pandoc or @sphinx node, or None."""
         kind = self.kind
         h = p.h.rstrip()

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -696,11 +696,11 @@ class LeoMenu:
         pass
 
     def insert_cascade(
-        self, parent: Widget, index: int, label: str, menu: QtMenuWrapper, underline: int
+        self, parent: Any, index: int, label: str, menu: QtMenuWrapper, underline: int
     ) -> Widget:
         pass
 
-    def new_menu(self, parent: Widget, tearoff: int = 0, label: str = '') -> QtMenuWrapper:
+    def new_menu(self, Any: Widget, tearoff: int = 0, label: str = '') -> QtMenuWrapper:
         pass
 
     # @+node:ekr.20031218072017.3810: *4* LeoMenu.9 Routines with new spellings

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2746,7 +2746,7 @@ class VNode:
             v2.setDirty()
 
     # @+node:ekr.20040315032144: *4* v.setBodyString & v.setHeadString
-    def setBodyString(self, s: object) -> None:
+    def setBodyString(self, s: bytes | str) -> None:
         v = self
         if isinstance(s, str):
             v._bodyString = s
@@ -2756,7 +2756,7 @@ class VNode:
             signal_manager.emit(self.context, 'body_changed', self)
         v.updateIcon()
 
-    def setHeadString(self, s: object) -> None:
+    def setHeadString(self, s: bytes | str) -> None:
         v = self
         if isinstance(s, str):
             v._headString = s.replace('\n', '')

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2026,7 +2026,7 @@ class Position:
         self.v.saveCursorAndScroll()
 
     # @+node:ekr.20040315034158: *4* p.setBodyString & setHeadString
-    def setBodyString(self, s: str) -> None:
+    def setBodyString(self, s: bytes | str) -> None:
         p = self
         return p.v.setBodyString(s)
 
@@ -2034,11 +2034,11 @@ class Position:
     setTnodeText = setBodyString
     scriptSetBodyString = setBodyString
 
-    def initHeadString(self, s: str) -> None:
+    def initHeadString(self, s: bytes | str) -> None:
         p = self
         p.v.initHeadString(s)
 
-    def setHeadString(self, s: str) -> None:
+    def setHeadString(self, s: bytes | str) -> None:
         p = self
         p.v.initHeadString(s)
         p.setDirty()

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -11,7 +11,7 @@ import os
 import re
 import time
 import uuid
-from typing import Any, Generator, Iterable, Optional, TYPE_CHECKING
+from typing import Any, Generator, Iterable, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import signal_manager
 
@@ -272,7 +272,7 @@ class Position:
         return not self.__eq__(p2)
 
     # @+node:ekr.20080416161551.190: *4*  p.__init__
-    def __init__(self, v: VNode, childIndex: int = 0, stack: Optional[list] = None) -> None:
+    def __init__(self, v: VNode, childIndex: int = 0, stack: list = None) -> None:
         """Create a new position with the given childIndex and parent stack."""
         self._childIndex = childIndex
         self.v = v
@@ -356,7 +356,7 @@ class Position:
             if p.v not in all_unique_vnodes:
                 all_unique_vnodes.append(p.v)
 
-        def ref(v: VNode) -> Optional[str]:
+        def ref(v: VNode) -> str | None:
             if v == c.hiddenRootNode:
                 return None
             if v.gnx not in all_unique_vnodes:
@@ -392,7 +392,7 @@ class Position:
         }
 
     # @+node:ekr.20061006092649: *4* p.archivedPosition
-    def archivedPosition(self, root_p: Optional[Position] = None) -> list[int]:
+    def archivedPosition(self, root_p: Position | None = None) -> list[int]:
         """Return a representation of a position suitable for use in .leo files."""
         p = self
         if root_p is None:
@@ -409,7 +409,7 @@ class Position:
         return aList
 
     # @+node:ekr.20040310153624: *4* p.dump
-    def dumpLink(self, link: Optional[str]) -> str:  # pragma: no cover
+    def dumpLink(self, link: str | None) -> str:  # pragma: no cover
         return link if link else "<none>"
 
     def dump(self, label: str = "") -> None:  # pragma: no cover
@@ -525,7 +525,7 @@ class Position:
     following_siblings_iter = following_siblings
 
     # @+node:ekr.20161120105707.1: *4* p.nearest_roots
-    def nearest_roots(self, copy: bool = True, predicate: Optional[Callable] = None) -> Generator:
+    def nearest_roots(self, copy: bool = True, predicate: Callable | None = None) -> Generator:
         """
         A generator yielding all the root positions "near" p1 = self that
         satisfy the given predicate. p.isAnyAtFileNode is the default
@@ -976,7 +976,7 @@ class Position:
         """Return True if p is visible in c's outline."""
         p = self
 
-        def visible(p: Position, root: Optional[Position] = None) -> bool:
+        def visible(p: Position, root: Position | None = None) -> bool:
             for parent in p.parents(copy=False):
                 if parent and parent == root:
                     # #12.
@@ -1041,7 +1041,7 @@ class Position:
         return p.nodeAfterTree()
 
     # @+node:shadow.20080825171547.2: *4* p.textOffset
-    def textOffset(self) -> Optional[int]:
+    def textOffset(self) -> int | None:
         """
         Return the fcol offset of self.
         Return None if p is has no ancestor @<file> node.
@@ -1528,7 +1528,7 @@ class Position:
         limit: Position,
         limitIsVisible: bool,
         p: Position,
-    ) -> tuple[bool, Optional[Position]]:
+    ) -> tuple[bool, Position | None]:
         """Return done, p or None"""
         c = p.v.context
         if limit == p:
@@ -1648,7 +1648,7 @@ class Position:
             p.firstChild().doDelete()
 
     # @+node:ekr.20040303175026.2: *4* p.doDelete
-    def doDelete(self, newNode: Optional[Position] = None) -> None:
+    def doDelete(self, newNode: Position | None = None) -> None:
         """
         Deletes position p from the outline.
 
@@ -2166,7 +2166,7 @@ class VNode:
     # @+others
     # @+node:ekr.20031218072017.3342: *3* v.Birth & death
     # @+node:ekr.20031218072017.3344: *4* v.__init__
-    def __init__(self, context: Cmdr, gnx: Optional[str] = None):
+    def __init__(self, context: Cmdr, gnx: str | None = None):
         """
         Ctor for the VNode class.
         To support ZODB, the code must set v._p_changed = True whenever
@@ -2178,7 +2178,7 @@ class VNode:
         self.children: list[VNode] = []  # Ordered list of all children of this node.
         self.parents: list[VNode] = []  # Unordered list of all parents of this node.
         # The immutable fileIndex (gnx) for this node. Set below.
-        self.fileIndex: Optional[str] = None
+        self.fileIndex: str | None = None
         self.iconVal = 0  # The present value of the node's icon.
         self.statusBits = 0  # status bits
 
@@ -2189,8 +2189,8 @@ class VNode:
         # It is named .context rather than .c to emphasize its limited usage.
         self.context: Cmdr = context
         self.expandedPositions: list[Position] = []  # Positions that should be expanded.
-        self.insertSpot: Optional[int] = None  # Location of previous insert point.
-        self.scrollBarSpot: Optional[int] = None  # Previous value of scrollbar position.
+        self.insertSpot: int | None = None  # Location of previous insert point.
+        self.scrollBarSpot: int | None = None  # Previous value of scrollbar position.
         self.selectionLength = 0  # The length of the selected body text.
         self.selectionStart = 0  # The start of the selected body text.
 
@@ -2216,7 +2216,7 @@ class VNode:
     __str__ = __repr__
 
     # @+node:ekr.20040312145256: *4* v.dump
-    def dumpLink(self, link: Optional[str]) -> str:  # pragma: no cover
+    def dumpLink(self, link: str | None) -> str:  # pragma: no cover
         return link if link else "<none>"
 
     def dump(self, label: str = "") -> None:  # pragma: no cover
@@ -2236,7 +2236,7 @@ class VNode:
 
     # @+node:ekr.20031218072017.3346: *3* v.Comparisons
     # @+node:ekr.20040705201018: *4* v.findAtFileName
-    def findAtFileName(self, names: Iterable, h: Optional[str] = None) -> str:
+    def findAtFileName(self, names: Iterable, h: str | None = None) -> str:
         """Return the name following one of the names in nameList or"""
         # Allow h argument for unit testing.
         if not h:
@@ -2264,14 +2264,14 @@ class VNode:
     # These return the filename following @xxx, in v.headString.
     # Return the the empty string if v is not an @xxx node.
 
-    def atAutoNodeName(self, h: Optional[str] = None) -> str:
+    def atAutoNodeName(self, h: str | None = None) -> str:
         return self.findAtFileName(g.app.atAutoNames, h=h)
 
     # Retain this special case as part of the "escape hatch".
     # That is, we fall back on code in leoRst.py if no
     # importer or writer for reStructuredText exists.
 
-    def atAutoRstNodeName(self, h: Optional[str] = None) -> str:
+    def atAutoRstNodeName(self, h: str | None = None) -> str:
         names = ("@auto-rst",)
         return self.findAtFileName(names, h=h)
 
@@ -2448,7 +2448,7 @@ class VNode:
 
     # @+node:ekr.20031218072017.3360: *4* v.Children
     # @+node:ekr.20031218072017.3362: *5* v.firstChild
-    def firstChild(self) -> Optional[VNode]:
+    def firstChild(self) -> VNode | None:
         v = self
         return v.children[0] if v.children else None
 
@@ -2460,14 +2460,14 @@ class VNode:
     hasFirstChild = hasChildren
 
     # @+node:ekr.20031218072017.3364: *5* v.lastChild
-    def lastChild(self) -> Optional[VNode]:
+    def lastChild(self) -> VNode | None:
         v = self
         return v.children[-1] if v.children else None
 
     # @+node:ekr.20031218072017.3365: *5* v.nthChild
     # childIndex and nthChild are zero-based.
 
-    def nthChild(self, n: int) -> Optional[VNode]:
+    def nthChild(self, n: int) -> VNode | None:
         v = self
         if 0 <= n < len(v.children):
             return v.children[n]

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -153,7 +153,7 @@ class NodeIndices:
             v.fileIndex = ni.getNewIndex(v)
 
     # @+node:ekr.20031218072017.1997: *3* ni.scanGnx
-    def scanGnx(self, s: str) -> tuple[str, str, str]:
+    def scanGnx(self, s: str) -> tuple[str, str, str] | tuple[None, None, None]:
         """Create a gnx from its string representation."""
         if not isinstance(s, str):  # pragma: no cover
             g.error("scanGnx: unexpected index type:", type(s), '', s)
@@ -345,7 +345,7 @@ class Position:
     __repr__ = __str__
 
     # @+node:ekr.20230726063237.1: *4* p.archive
-    def archive(self) -> dict[str, Value]:
+    def archive(self) -> dict[str, Value] | None:
         """Return a json-like archival dictionary for p/v.unarchive."""
         p = self
         c = p.v.context
@@ -914,7 +914,7 @@ class Position:
         except Exception:  # pragma: no cover
             g.trace('*** Unexpected exception')
             g.es_exception()
-            return None
+            return False
 
     def hasParent(self) -> bool:
         p = self
@@ -1286,7 +1286,7 @@ class Position:
         return p
 
     # @+node:ekr.20080416161551.212: *4* p._parentVnode
-    def _parentVnode(self) -> VNode:
+    def _parentVnode(self) -> VNode | None:
         """
         Return the parent VNode.
         Return the hiddenRootNode if there is no other parent.
@@ -1540,7 +1540,7 @@ class Position:
         return True, None
 
     # @+node:ekr.20080416161551.211: *4* p.moveToVisNext & helper
-    def moveToVisNext(self, c: Cmdr) -> Position:
+    def moveToVisNext(self, c: Cmdr) -> Position | None:
         """Move a position to the position of the next visible node."""
         p = self
         limit, limitIsVisible = c.visLimit()

--- a/leo/core/leoPersistence.py
+++ b/leo/core/leoPersistence.py
@@ -82,7 +82,7 @@ class PersistenceDataController:
             c.redraw()
 
     # @+node:ekr.20140711111623.17804: *4* pd.update_before_write_foreign_file & helpers
-    def update_before_write_foreign_file(self, root: Position) -> Position:
+    def update_before_write_foreign_file(self, root: Position) -> Position | None:
         """
         Update the @data node for root, a foreign node.
         Create @gnxs nodes and @uas trees as needed.
@@ -253,7 +253,7 @@ class PersistenceDataController:
     # @+node:ekr.20140711111623.17854: *4* pd.find...
     # The find commands create the node if not found.
     # @+node:ekr.20140711111623.17856: *5* pd.find_at_data_node & helper
-    def find_at_data_node(self, root: Position) -> Position:
+    def find_at_data_node(self, root: Position) -> Position | None:
         """
         Return the @data node for root, a foreign node.
         Create the node if it does not exist.
@@ -272,7 +272,7 @@ class PersistenceDataController:
         return p
 
     # @+node:ekr.20140711111623.17857: *5* pd.find_at_gnxs_node
-    def find_at_gnxs_node(self, root: Position) -> Position:
+    def find_at_gnxs_node(self, root: Position) -> Position | None:
         """
         Find the @gnxs node for root, a foreign node.
         Create the @gnxs node if it does not exist.
@@ -527,7 +527,7 @@ class PersistenceDataController:
             return ''
 
     # @+node:ekr.20140713135856.17744: *5* pd.unpickle
-    def unpickle(self, s: str) -> Value:  # An actual uA.
+    def unpickle(self, s: str) -> Value | None:  # An actual uA.
         """Unhexlify and unpickle string s into p."""
         try:
             # Throws TypeError if s is not a hex string.

--- a/leo/core/leoPersistence.py
+++ b/leo/core/leoPersistence.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 import binascii
 import pickle
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -311,7 +311,7 @@ class PersistenceDataController:
         return p
 
     # @+node:ekr.20140711111623.17891: *5* pd.find_at_uas_node
-    def find_at_uas_node(self, root: Position) -> Optional[Position]:
+    def find_at_uas_node(self, root: Position) -> Position | None:
         """
         Find the @uas node for root, a foreign node.
         Create the @uas node if it does not exist.
@@ -341,7 +341,7 @@ class PersistenceDataController:
         return self.find_exact_match(root, unl_list)
 
     # @+node:ekr.20140716021139.17764: *6* pd.find_best_match
-    def find_best_match(self, root: Position, unl_list: list[str]) -> Optional[Position]:
+    def find_best_match(self, root: Position, unl_list: list[str]) -> Position | None:
         """Find the best partial matches of the tail in root's tree."""
         tail = unl_list[-1]
         matches = []
@@ -389,7 +389,7 @@ class PersistenceDataController:
         return parent
 
     # @+node:ekr.20140711111623.17862: *5* pd.find_representative_node
-    def find_representative_node(self, root: Position, target: Position) -> Optional[Position]:
+    def find_representative_node(self, root: Position, target: Position) -> Position | None:
         """
         root is a foreign node. target is a gnxs node within root's tree.
 
@@ -425,7 +425,7 @@ class PersistenceDataController:
         return None
 
     # @+node:ekr.20140712105818.16751: *4* pd.foreign_file_name
-    def foreign_file_name(self, p: Position) -> Optional[str]:
+    def foreign_file_name(self, p: Position) -> str | None:
         """Return the file name for p, a foreign file node."""
         for tag in ('@auto', '@org-mode', '@vim-outline'):
             if g.match_word(p.h, 0, tag):
@@ -435,7 +435,7 @@ class PersistenceDataController:
     # @+node:ekr.20140711111623.17864: *4* pd.has...
     # The has commands return None if the node does not exist.
     # @+node:ekr.20140711111623.17865: *5* pd.has_at_data_node
-    def has_at_data_node(self, root: Position) -> Optional[Position]:
+    def has_at_data_node(self, root: Position) -> Position | None:
         """
         Return the @data node corresponding to root, a foreign node.
         Return None if no such node exists.
@@ -454,7 +454,7 @@ class PersistenceDataController:
         return None
 
     # @+node:ekr.20140711111623.17890: *5* pd.has_at_gnxs_node
-    def has_at_gnxs_node(self, root: Position) -> Optional[Position]:
+    def has_at_gnxs_node(self, root: Position) -> Position | None:
         """
         Find the @gnxs node for an @data node with the given unl.
         Return None if it does not exist.
@@ -465,7 +465,7 @@ class PersistenceDataController:
         return None
 
     # @+node:ekr.20140711111623.17894: *5* pd.has_at_uas_node
-    def has_at_uas_node(self, root: Position) -> Optional[Position]:
+    def has_at_uas_node(self, root: Position) -> Position | None:
         """
         Find the @uas node for an @data node with the given unl.
         Return None if it does not exist.
@@ -476,7 +476,7 @@ class PersistenceDataController:
         return None
 
     # @+node:ekr.20140711111623.17869: *5* pd.has_at_persistence_node
-    def has_at_persistence_node(self) -> Optional[Position]:
+    def has_at_persistence_node(self) -> Position | None:
         """Return the @persistence node or None if it does not exist."""
         return g.findNodeAnywhere(self.c, '@persistence')
 

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -333,7 +333,7 @@ class LeoPluginsController:
                 g.doHook("idle", c=c)
 
     # @+node:ekr.20100908125007.6017: *4* plugins.doHandlersForTag & helper
-    def doHandlersForTag(self, tag: str, keywords: Keywords) -> Value:
+    def doHandlersForTag(self, tag: str, keywords: Keywords) -> Value | None:
         """
         Execute all handlers for a given tag, in alphabetical order.
         The caller, doHook, catches all exceptions.
@@ -354,7 +354,7 @@ class LeoPluginsController:
         return None
 
     # @+node:ekr.20100908125007.6016: *5* plugins.callTagHandler
-    def callTagHandler(self, bunch: g.Bunch, tag: str, keywords: Keywords) -> Value:
+    def callTagHandler(self, bunch: g.Bunch, tag: str, keywords: Keywords) -> Value | None:
         """Call the event handler."""
         handler, moduleName = bunch.fn, bunch.moduleName
         # Make sure the new commander exists.
@@ -376,7 +376,7 @@ class LeoPluginsController:
         return result
 
     # @+node:ekr.20100908125007.6018: *4* plugins.doPlugins (g.app.hookFunction)
-    def doPlugins(self, tag: str, keywords: Keywords) -> Value:
+    def doPlugins(self, tag: str, keywords: Keywords) -> Value | None:
         """The default g.app.hookFunction."""
         if g.app.killed:
             return None
@@ -515,7 +515,7 @@ class LeoPluginsController:
     # @+node:ekr.20100908125007.6024: *4* plugins.loadOnePlugin & helper functions
     def loadOnePlugin(
         self, moduleOrFileName: str, tag: str = 'open0', verbose: bool = False
-    ) -> Any:
+    ) -> Any | None:
         """
         Load one plugin from a file name or module.
         Use extensive tracing if --trace-plugins is in effect.
@@ -556,7 +556,7 @@ class LeoPluginsController:
             return result
 
         # @+node:ekr.20180528162604.1: *5* function:finishImport
-        def finishImport(result: Value) -> Value:
+        def finishImport(result: Value) -> Value | None:
             """Handle last-minute checks."""
             if tag == 'unit-test-load':
                 return result  # Keep the result, but do no more.

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:  # pragma: no cover
     Args = Any
     KWargs = Any
     Keywords = dict[str, list[g.Bunch]]
-    Tags = str | Sequence[str]
     Value = Any
 # @-<< leoPlugins imports & annotations >>
 
@@ -36,7 +35,7 @@ def init() -> None:
     g.app.pluginsController = LeoPluginsController()
 
 
-def registerHandler(tags: Tags, fn: Callable) -> None:
+def registerHandler(tags: str | Sequence[str], fn: Callable) -> None:
     """A wrapper so plugins can still call leoPlugins.registerHandler."""
     return g.app.pluginsController.registerHandler(tags, fn)
 
@@ -672,12 +671,13 @@ class LeoPluginsController:
 
     # @+node:ekr.20100909065501.5951: *3* plugins.Registration
     # @+node:ekr.20100908125007.6028: *4* plugins.registerExclusiveHandler
-    def registerExclusiveHandler(self, tags: Tags, fn: Callable) -> None:
+    def registerExclusiveHandler(self, tags: str | Sequence[str], fn: Callable) -> None:
         """Register one or more exclusive handlers"""
         if isinstance(tags, (list, tuple)):
             for tag in tags:
                 self.registerOneExclusiveHandler(tag, fn)
         else:
+            # We have just tested the type.
             self.registerOneExclusiveHandler(tags, fn)  # type:ignore[arg-type]
 
     def registerOneExclusiveHandler(self, tag: str, fn: Callable) -> None:
@@ -698,12 +698,13 @@ class LeoPluginsController:
             self.handlers[tag] = aList
 
     # @+node:ekr.20100908125007.6029: *4* plugins.registerHandler & registerOneHandler
-    def registerHandler(self, tags: Tags, fn: Callable) -> None:
+    def registerHandler(self, tags: str | Sequence[str], fn: Callable) -> None:
         """Register one or more handlers"""
         if isinstance(tags, (list, tuple)):
             for tag in tags:
                 self.registerOneHandler(tag, fn)
         else:
+            # We have just tested the type.
             self.registerOneHandler(tags, fn)  # type:ignore[arg-type]
 
     def registerOneHandler(self, tag: str, fn: Callable) -> None:
@@ -721,11 +722,12 @@ class LeoPluginsController:
         self.handlers[tag] = items
 
     # @+node:ekr.20100908125007.6031: *4* plugins.unregisterHandler
-    def unregisterHandler(self, tags: Tags, fn: Callable) -> None:
+    def unregisterHandler(self, tags: str | Sequence[str], fn: Callable) -> None:
         if isinstance(tags, (list, tuple)):
             for tag in tags:
                 self.unregisterOneHandler(tag, fn)
         else:
+            # We have just tested the type.
             self.unregisterOneHandler(tags, fn)  # type:ignore[arg-type]
 
     def unregisterOneHandler(self, tag: str, fn: Callable) -> None:

--- a/leo/core/leoPymacs.py
+++ b/leo/core/leoPymacs.py
@@ -26,6 +26,8 @@ Notes:
 
 # As in leo.py we must be very careful about imports.
 
+from typing import Any
+
 g = None  # set by init: do *not* import it here!
 inited = False
 pymacsFile = __file__
@@ -102,7 +104,7 @@ def init():
 
 
 # @+node:ekr.20061024075542.1: ** open (pymacs)
-def open(fileName=None):
+def open(fileName=None) -> Any | None:
     # global g
     init()
     if g.unitTesting:

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -20,7 +20,7 @@ import io
 import os
 import re
 import time
-from typing import Generator, Optional, TYPE_CHECKING
+from typing import Generator, TYPE_CHECKING
 
 # Third-part imports...
 try:
@@ -477,7 +477,7 @@ class RstCommands:
         return changed
 
     # @+node:ekr.20090502071837.65: *5* rst.writeToDocutils & helper
-    def writeToDocutils(self, s: str, ext: str) -> Optional[str]:
+    def writeToDocutils(self, s: str, ext: str) -> str | None:
         """Send s to docutils using the writer implied by ext and return the result."""
         c = self.c
         if not docutils:

--- a/leo/core/leoSessions.py
+++ b/leo/core/leoSessions.py
@@ -3,7 +3,7 @@
 """Support for sessions in Leo."""
 
 from __future__ import annotations
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -53,7 +53,7 @@ class SessionManager:
         return result
 
     # @+node:ekr.20120420054855.14416: *3* SessionManager.get_session_path
-    def get_session_path(self) -> Optional[str]:
+    def get_session_path(self) -> str | None:
         """Return the path to the session file."""
         for path in (g.app.homeLeoDir, g.app.homeDir):
             if g.os_path_exists(path):

--- a/leo/core/leoSessions.py
+++ b/leo/core/leoSessions.py
@@ -83,7 +83,7 @@ class SessionManager:
             g.openWithFileName(fn, gui=g.app.gui, old_c=c)
 
     # @+node:ekr.20120420054855.14248: *3* SessionManager.load_snapshot
-    def load_snapshot(self) -> list[str]:
+    def load_snapshot(self) -> list[str] | None:
         """
         Load a snapshot of a session from the leo.session file.
 

--- a/leo/core/leoShadow.py
+++ b/leo/core/leoShadow.py
@@ -31,7 +31,7 @@ Settings:
 from __future__ import annotations
 import difflib
 import os
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -97,7 +97,7 @@ class ShadowController:
 
     # @+node:ekr.20080711063656.1: *3* x.File utils
     # @+node:ekr.20080711063656.7: *4* x.baseDirName
-    def baseDirName(self) -> Optional[str]:
+    def baseDirName(self) -> str | None:
         c = self.c
         filename = c.fileName()
         if filename:

--- a/leo/core/leoShadow.py
+++ b/leo/core/leoShadow.py
@@ -487,7 +487,7 @@ class ShadowController:
         return ''
 
     # @+node:ekr.20080708094444.9: *4* x.markerFromFileName
-    def markerFromFileName(self, filename: str) -> Marker:
+    def markerFromFileName(self, filename: str) -> Marker | None:
         """Return the sentinel delimiter comment to be used for filename."""
         x = self
         if not filename:

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -65,7 +65,7 @@ def create_app(gui_name: str = 'null') -> Cmdr:
     g.app.config = leoConfig.GlobalConfigManager()
     g.app.jupytextManager = leoJupytext.JupytextManager()
     # Disable dangerous code.
-    g.app.db = g.NullObject('g.app.db')  # type:ignore
+    g.app.db = g.NullObject(ivars=['g.app.db'])
     g.app.pluginsController = g.NullObject('g.app.pluginsController')  # type:ignore
     if gui_name == 'null':
         g.app.gui = NullGui()

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -200,7 +200,7 @@ class Undoer:
         return '<no top bead>'
 
     # @+node:EKR.20040526150818: *4* u.getBead
-    def getBead(self, n: int) -> g.Bunch:
+    def getBead(self, n: int) -> g.Bunch | None:
         """Set Undoer ivars from the bunch at the top of the undo stack."""
         u = self
         if n < 0 or n >= len(u.beads):
@@ -212,7 +212,7 @@ class Undoer:
         return bunch
 
     # @+node:EKR.20040526150818.1: *4* u.peekBead
-    def peekBead(self, n: int) -> g.Bunch:
+    def peekBead(self, n: int) -> g.Bunch | None:
         u = self
         if n < 0 or n >= len(u.beads):
             return None

--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -132,8 +132,8 @@ def _get_action_list():
     middle: list = [
         ("!" + z, {}) for z in test_names if z not in head_names + tail_names + exclude_names
     ]
-    middle_names = [name for (name, package) in middle]  # type:ignore
-    all_tests = head + middle + tail  # type:ignore
+    middle_names = [name for (name, package) in middle]
+    all_tests = head + middle + tail
     if 0:
         g.printObj(middle_names, tag='middle_names')
         all_names = sorted([name for (name, package) in all_tests])

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -30,7 +30,7 @@ import textwrap
 import time
 import hmac
 import ssl
-from typing import Any, Generator, Iterable, Iterator, Optional
+from typing import Any, Generator, Iterable, Iterator
 import warnings
 
 # Third-party.
@@ -2847,7 +2847,7 @@ class LeoServer:
         """
         c = self._check_c(param)
         p = self._get_p(param)
-        parent: Optional[Position] = p.parent()
+        parent: Position | None = p.parent()
         if c.hoistStack:
             topHoistPos = c.hoistStack[-1].p
             if parent == topHoistPos:
@@ -3199,7 +3199,7 @@ class LeoServer:
         """
         c = self._check_c(param)
         p = self._get_p(param)
-        oldPosition: Optional[Position] = None if p == c.p else c.p
+        oldPosition: Position | None = None if p == c.p else c.p
 
         newHeadline = param.get('name')
         bunch = c.undoer.beforeInsertNode(p)
@@ -4852,7 +4852,7 @@ class LeoServer:
 
     # @+node:felix.20210621233316.78: *3* server.server utils
     # @+node:felix.20210621233316.79: *4* server._ap_to_p
-    def _ap_to_p(self, ap: dict[str, Any], c: Cmdr) -> Optional[Position]:
+    def _ap_to_p(self, ap: dict[str, Any], c: Cmdr) -> Position | None:
         """
         Convert ap (archived position, a dict) to a valid Leo position.
 
@@ -5069,17 +5069,17 @@ class LeoServer:
         tag = '_do_message'
         trace, verbose = 'request' in traces, 'verbose' in traces
         func: Callable
-        action: Optional[str]
+        action: str | None
 
         # Require "id" and "action" keys
-        id_: Optional[int] = d.get("id")
+        id_: int | None = d.get("id")
         if id_ is None:  # pragma: no cover
             raise ServerError(f"{tag}: no id")
         action = d.get("action")
         if action is None:  # pragma: no cover
             raise ServerError(f"{tag}: no action")
 
-        param: Optional[dict] = d.get('param', {})
+        param: dict | None = d.get('param', {})
         # Set log flag.
         if param:
             self.log_flag = param.get("log")
@@ -5212,7 +5212,7 @@ class LeoServer:
         return focus
 
     # @+node:ekr.20220817091731.1: *4* server._get_optional_p
-    def _get_optional_p(self, param: dict) -> Optional[Position]:
+    def _get_optional_p(self, param: dict) -> Position | None:
         """
         Return _ap_to_p(param["ap"]) or None.
         """
@@ -5473,7 +5473,7 @@ class LeoServer:
         }
 
     # @+node:felix.20210621233316.96: *4* server._positionFromGnx
-    def _positionFromGnx(self, gnx: str, c: Cmdr) -> Optional[Position]:
+    def _positionFromGnx(self, gnx: str, c: Cmdr) -> Position | None:
         """Return first p node with this gnx or false"""
         for p in c.all_unique_positions():
             if p.v.gnx == gnx:
@@ -5907,9 +5907,7 @@ def main() -> None:  # pragma: no cover (tested in client)
             wsLimit = 1
 
     # @+node:felix.20260523224253.1: *3* function: get_ssl_context
-    def get_ssl_context(
-        cert_path: Optional[str], key_path: Optional[str]
-    ) -> Optional[ssl.SSLContext]:
+    def get_ssl_context(cert_path: str | None, key_path: str | None) -> ssl.SSLContext | None:
         """Returns an SSLContext if paths are valid, otherwise returns None."""
         # Ensure both arguments were provided
         if not cert_path or not key_path:

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -30,7 +30,7 @@ free-layout-zoom
 # @+node:tbrown.20110203111907.5520: ** << free_layout imports >>
 from __future__ import annotations
 import json
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 #
@@ -198,7 +198,7 @@ class FreeLayoutController:
         c.redraw()
 
     # @+node:ekr.20160424035257.1: *3* flc.get_main_splitter
-    def get_main_splitter(self, w: QTextMixin = None) -> Optional[NestedSplitter]:
+    def get_main_splitter(self, w: QTextMixin = None) -> NestedSplitter | None:
         """
         Return the main splitter.
 
@@ -208,7 +208,7 @@ class FreeLayoutController:
         return top if top.objectName() == 'main_splitter' else None
 
     # @+node:ekr.20160424035254.1: *3* flc.get_secondary_splitter
-    def get_secondary_splitter(self) -> Optional[NestedSplitter]:
+    def get_secondary_splitter(self) -> NestedSplitter | None:
         """
         Return the secondary splitter, that is, the splitter containing the outline pane.
         """
@@ -221,7 +221,7 @@ class FreeLayoutController:
         return None
 
     # @+node:tbrown.20110621120042.22914: *3* flc.get_top_splitter
-    def get_top_splitter(self) -> Optional[NestedSplitter]:
+    def get_top_splitter(self) -> NestedSplitter | None:
         """Return the top splitter of c.frame.top."""
         f = self.c.frame
         if hasattr(f, 'top') and f.top:
@@ -369,7 +369,7 @@ class FreeLayoutController:
         return False
 
     # @+node:tbrown.20110628083641.11724: *3* flc.ns_provide
-    def ns_provide(self, id_: str) -> Optional[str | QTextMixin]:
+    def ns_provide(self, id_: str) -> str | QTextMixin | None:
         if id_.startswith('_leo_tab:'):
             id_ = id_.split(':', 1)[1]
             top = self.get_top_splitter()

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 import re
 import textwrap
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 import leo.core.leoGlobals as g
 from leo.plugins.importers.base_importer import Block, Importer
 
@@ -285,7 +285,7 @@ class Python_Importer(Importer):
                     child.h = f"function: {child.h[4:].strip()}"
 
     # @+node:ekr.20230825164231.1: *4* python_i.find_docstring
-    def find_docstring(self, p: Position) -> Optional[str]:
+    def find_docstring(self, p: Position) -> str | None:
         """Creating a regex that returns a docstring is too tricky."""
         delims = ('"""', "'''")
         s_strip = p.b.strip()

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -5,7 +5,7 @@
 # pylint: disable=undefined-loop-variable
 from __future__ import annotations
 import re
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from leo.plugins.importers.base_importer import Block, Importer
 from leo.core import leoGlobals as g
 
@@ -336,7 +336,7 @@ class Rust_Importer(Importer):
                        so there must be *no gaps* between blocks!
         """
 
-        def find_curly_bracket_line(i: int) -> Optional[int]:
+        def find_curly_bracket_line(i: int) -> int | None:
             """
             Scan the guide_lines from line i looking for a line ending with '{'.
             """

--- a/leo/plugins/nav_qt.py
+++ b/leo/plugins/nav_qt.py
@@ -20,7 +20,7 @@ the left side of toolbar.
 # @+<< nav_qt imports & annotations >>
 # @+node:ville.20090518182905.5422: ** << nav_qt imports & annotations >>
 from __future__ import annotations
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core.leoQt import QAction, StandardPixmap
 
@@ -78,7 +78,7 @@ def onClose(tag: str, keys: Any) -> None:
 class NavController:
     def __init__(self, c: Cmdr) -> None:
         self.c = c
-        self._buttons: Optional[tuple[Action, Action]] = self.makeButtons()
+        self._buttons: tuple[Action, Action] | None = self.makeButtons()
 
     # @+others
     # @+node:ville.20090518182905.5427: *3* NavController.makeButtons

--- a/leo/plugins/plugins_menu.py
+++ b/leo/plugins/plugins_menu.py
@@ -140,23 +140,25 @@ def createPluginsMenu(tag: str, keywords: KWargs) -> None:
     menu_name = keywords.get('menu_name', '&Plugins')
     pc = g.app.pluginsController
     lmd = pc.loadedModules
-    if lmd:
-        impModSpecList = list(lmd.keys())
+    if not lmd:
+        return
 
-        def key(aList: list) -> str:
-            return aList.split('.')[-1].lower()
+    impModSpecList = list(lmd.keys())
 
-        impModSpecList.sort(key=key)  # type:ignore
-        plgObList: list[PlugIn] = [PlugIn(lmd[impModSpec], c) for impModSpec in impModSpecList]
-        c.pluginsMenu = pluginMenu = c.frame.menu.createNewMenu(menu_name)
-        # 2013/12/13: Add any items in @menu plugins
-        add_menu_from_settings(c)
-        PluginDatabase.setMenu("Default", pluginMenu)
-        # Add group menus
-        for group_name in PluginDatabase.getGroups():
-            PluginDatabase.setMenu(group_name, c.frame.menu.createNewMenu(group_name, menu_name))
-        for plgObj in plgObList:
-            addPluginMenuItem(plgObj, c)
+    def key(s: str) -> str:
+        return s.split('.')[-1].lower()
+
+    impModSpecList.sort(key=key)
+    plgObList: list[PlugIn] = [PlugIn(lmd[impModSpec], c) for impModSpec in impModSpecList]
+    c.pluginsMenu = pluginMenu = c.frame.menu.createNewMenu(menu_name)
+    # 2013/12/13: Add any items in @menu plugins
+    add_menu_from_settings(c)
+    PluginDatabase.setMenu("Default", pluginMenu)
+    # Add group menus
+    for group_name in PluginDatabase.getGroups():
+        PluginDatabase.setMenu(group_name, c.frame.menu.createNewMenu(group_name, menu_name))
+    for plgObj in plgObList:
+        addPluginMenuItem(plgObj, c)
 
 
 # @+node:ekr.20131213072223.19531: *4* add_menu_from_settings

--- a/leo/plugins/plugins_menu.py
+++ b/leo/plugins/plugins_menu.py
@@ -141,7 +141,7 @@ def createPluginsMenu(tag: str, keywords: KWargs) -> None:
     pc = g.app.pluginsController
     lmd = pc.loadedModules
     if not lmd:
-        return
+        return  # #4753
 
     impModSpecList = list(lmd.keys())
 

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -585,7 +585,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
                 if type_ == Type.KeyPress:
                     return self.keyPress(event)
                 if type_ == Type.KeyRelease:
-                    return self.keyRelease(event)  # type:ignore[arg-type]
+                    return self.keyRelease(event)
                 return self.oldEvent(event)
 
             # @-others

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2819,7 +2819,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
     # @+node:ekr.20110605121601.18352: *5* LeoQtMenu.insert_cascade
     def insert_cascade(
         self,
-        parent: LeoQtFrame,
+        parent: QWidget,
         index: int,
         label: str,
         menu: QMenu,
@@ -2844,11 +2844,12 @@ class LeoQtMenu(leoMenu.LeoMenu):
     def new_menu(
         self, parent: QWidget, tearoff: int = 0, label: str = ''
     ) -> QtMenuWrapper:  # label is for debugging.
-        """Wrapper for the Tkinter new_menu menu method."""
-        c, leoFrame = self.c, self.frame
-        # Parent can be None, in which case it will be added to the menuBar.
-        menu = QtMenuWrapper(c, leoFrame, parent, label)
-        return menu
+        """
+        Wrapper for the Tkinter new_menu menu method.
+
+        Parent can be None, in which case it will be added to the menuBar.
+        """
+        return QtMenuWrapper(self.c, self.frame, parent, label)
 
     # @+node:ekr.20110605121601.18354: *4* LeoQtMenu.Methods with other spellings
     # @+node:ekr.20110605121601.18355: *5* LeoQtMenu.clearAccel
@@ -2881,7 +2882,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
         menu = self.getMenu('openwith')
         if not menu:
             menu = self.new_menu(parent, tearoff=False, label=label)
-            menu.insert_cascade(parent, index, label, menu, underline=amp_index)  # type:ignore
+            menu.insert_cascade(parent, index, label, menu, underline=amp_index)
         return menu
 
     # @+node:ekr.20110605121601.18358: *5* LeoQtMenu.disable/enableMenu (not used)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -730,10 +730,10 @@ class DynamicWindow(QtWidgets.QMainWindow):
         lineWidth: int = 0,
         shadow: Shadow = None,
         shape: Shape = None,
-    ) -> QWidget:
+    ) -> QWidget | Qsci.QsciScintilla:
         # Create a text widget.
         c = self.leo_c
-        w: QWidget
+        w: Any
         if name == 'richTextEdit' and self.useScintilla and Qsci:
             # Do this in finishCreate, when c.frame.body exists.
             w = Qsci.QsciScintilla(parent)
@@ -749,7 +749,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
             w.setLineWidth(lineWidth)
             self.setName(w, name)
         if not hasattr(w, 'leo_wrapper'):
-            w.leo_wrapper = QTextEditWrapper(widget=w, name=name, c=c)  # type:ignore
+            w.leo_wrapper = QTextEditWrapper(widget=w, name=name, c=c)
         return w
 
     # @+node:ekr.20110605121601.18164: *4* dw.createTreeWidget

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -13,7 +13,7 @@ import string
 import sys
 import time
 import urllib
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from leo.commands import gotoCommands
 from leo.core.leoAPI import StringTextWrapper
 from leo.core import (
@@ -2610,7 +2610,7 @@ class LeoQtLog(leoFrame.LeoLog):
         c.bodyWantsFocus()
 
     # @+node:ekr.20190603062456.1: *4* LeoQtLog.findTabIndex
-    def findTabIndex(self, tabName: str) -> Optional[int]:
+    def findTabIndex(self, tabName: str) -> int | None:
         """Return the tab index for tabName, or None."""
         w = self.tabWidget
         for i in range(w.count()):
@@ -4242,7 +4242,7 @@ class QtStatusLineClass:
         return col, fcol
 
     # @+node:chris.20180320072817.2: *4* qstatus.file_line (not used)
-    def file_line(self) -> Optional[int]:
+    def file_line(self) -> int | None:
         """
         Return the line of the first line of c.p in its external file.
         Return None if c.p is not part of an external file.

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -1146,7 +1146,7 @@ class LeoQtGui(leoGui.LeoGui):
         filter_ = self.makeFilter(filetypes)
         dialog = QtWidgets.QFileDialog()
         self.attachLeoIcon(dialog)
-        dialog_val: tuple[list[str], Any]
+        dialog_val: Any
         val = list[str]
         if c:
             try:
@@ -1162,7 +1162,7 @@ class LeoQtGui(leoGui.LeoGui):
                 parent=None, caption=title, directory=startpath, filter=filter_
             )
         # This is a *PyQt* change, not a Qt change.
-        val, _ = dialog_val  # type:ignore
+        val, _ = dialog_val
         files = [g.os_path_normslashes(s) for s in val]
         if c and files:
             c.last_dir = g.os_path_dirname(files[-1])

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -12,7 +12,7 @@ import re
 import sys
 import textwrap
 from time import sleep
-from typing import Any, Generator, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Generator, TYPE_CHECKING
 from leo.core import (
     leoColor,
     leoGlobals as g,
@@ -245,7 +245,7 @@ class LeoQtGui(leoGui.LeoGui):
         weight: str,
         defaultSize: int = 12,
         tag='',
-    ) -> Optional[QFont]:
+    ) -> QFont | None:
         """Required to handle syntax coloring."""
         if isinstance(size, str):
             if size.endswith('pt'):
@@ -702,7 +702,7 @@ class LeoQtGui(leoGui.LeoGui):
             return
 
         # Create the dialog.
-        top_frame: Optional[QWidget] = c.frame.top if c else None
+        top_frame: QWidget | None = c.frame.top if c else None
         dialog = QtWidgets.QMessageBox(top_frame)
         ssm = g.app.gui.styleSheetManagerClass(c)
         w = ssm.get_master_widget()
@@ -732,7 +732,7 @@ class LeoQtGui(leoGui.LeoGui):
         message: str = 'Select Date/Time',
         init: datetime.datetime = None,
         step_min: dict = None,
-    ) -> Optional[datetime.datetime]:
+    ) -> datetime.datetime | None:
         """Create and run a qt date/time selection dialog.
 
         init - a datetime, default now
@@ -807,7 +807,7 @@ class LeoQtGui(leoGui.LeoGui):
             step_min = {}
         if not init:
             init = datetime.datetime.now()
-        top_frame: Optional[QWidget] = c.frame.top if c else None
+        top_frame: QWidget | None = c.frame.top if c else None
         dialog = Calendar(top_frame, message=message, init=init, step_min=step_min)
         if c:
             ssm = g.app.gui.styleSheetManagerClass(c)
@@ -839,7 +839,7 @@ class LeoQtGui(leoGui.LeoGui):
         message: str,
         cancelButtonText: str = None,
         okButtonText: str = None,
-    ) -> Optional[int]:
+    ) -> int | None:
         """Create and run askOkCancelNumber dialog ."""
         if g.unitTesting:
             return None
@@ -862,7 +862,7 @@ class LeoQtGui(leoGui.LeoGui):
         if not ok:
             return None
         n = dialog.textValue()
-        int_n: Optional[int]
+        int_n: int | None
         try:
             int_n = int(n)
         except ValueError:
@@ -879,7 +879,7 @@ class LeoQtGui(leoGui.LeoGui):
         okButtonText: str = None,
         default: str = "",
         wide: bool = False,
-    ) -> Optional[str]:
+    ) -> str | None:
         """Create and run askOkCancelString dialog.
 
         wide - edit a long string
@@ -916,7 +916,7 @@ class LeoQtGui(leoGui.LeoGui):
             return
 
         # Create the dialog.
-        top_frame: Optional[QWidget] = c.frame.top if c else None
+        top_frame: QWidget | None = c.frame.top if c else None
         dialog = QtWidgets.QMessageBox(top_frame)
         dialog.setWindowTitle(title)
         if message:
@@ -957,7 +957,7 @@ class LeoQtGui(leoGui.LeoGui):
             return None
 
         # Create the dialog.
-        top_frame: Optional[QWidget] = c.frame.top if c else None
+        top_frame: QWidget | None = c.frame.top if c else None
         dialog = QtWidgets.QMessageBox(top_frame)
         if message:
             dialog.setText(message)
@@ -1020,7 +1020,7 @@ class LeoQtGui(leoGui.LeoGui):
             return None
 
         # Create the dialog.
-        top_frame: Optional[QWidget] = c.frame.top if c else None
+        top_frame: QWidget | None = c.frame.top if c else None
         dialog = QtWidgets.QMessageBox(top_frame)
 
         # #4012: set the button's name to the desired return value!
@@ -1067,7 +1067,7 @@ class LeoQtGui(leoGui.LeoGui):
         return button.objectName() or 'cancel'
 
     # @+node:ekr.20110605121601.18499: *4* LeoQtGui.runOpenDirectoryDialog
-    def runOpenDirectoryDialog(self, title: str, startdir: str) -> Optional[str]:
+    def runOpenDirectoryDialog(self, title: str, startdir: str) -> str | None:
         """Create and run an Qt open directory dialog ."""
         if g.unitTesting:
             return None
@@ -1448,7 +1448,7 @@ class LeoQtGui(leoGui.LeoGui):
             window.setWindowIcon(self.appIcon)
 
     # @+node:ekr.20110605121601.18516: *4* LeoQtGui.getIconImage
-    def getIconImage(self, name: str) -> Optional[QIcon]:
+    def getIconImage(self, name: str) -> QIcon | None:
         """Load the icon and return it."""
         # Return the image from the cache if possible.
         if name in self.iconimages:
@@ -1477,7 +1477,7 @@ class LeoQtGui(leoGui.LeoGui):
 
     # @+node:ekr.20110605121601.18517: *4* LeoQtGui.getImageImage
     @functools.lru_cache(maxsize=128)
-    def getImageImage(self, name: str) -> Optional[QPixmap]:
+    def getImageImage(self, name: str) -> QPixmap | None:
         """Load the image in file named `name` and return it."""
         fullname = self.getImageFinder(name)
         try:
@@ -1493,7 +1493,7 @@ class LeoQtGui(leoGui.LeoGui):
     dump_given = False
 
     @functools.lru_cache(maxsize=128)
-    def getImageFinder(self, name: str) -> Optional[str]:
+    def getImageFinder(self, name: str) -> str | None:
         """Theme aware image (icon) path searching."""
         trace = 'themes' in g.app.debug
         exists = g.os_path_exists
@@ -1639,7 +1639,7 @@ class LeoQtGui(leoGui.LeoGui):
             g.trace(f"Not a QSplitter: {splitter.__class__.__name__}")
 
     # @+node:ekr.20241027183453.1: *4* LeoQtGui.find_parent_splitter
-    def find_parent_splitter(self, widget: QWidget) -> Optional[Tuple[QSplitter, QWidget]]:
+    def find_parent_splitter(self, widget: QWidget) -> tuple[QSplitter, QWidget] | None:
         """
         Find the nearest parent QSplitter widget for the given widget.
 
@@ -1658,7 +1658,7 @@ class LeoQtGui(leoGui.LeoGui):
         return None
 
     # @+node:ekr.20240519115301.1: *4* LeoQtGui.find_widget_by_name
-    def find_widget_by_name(self, c: Cmdr, name: str) -> Optional[QWidget]:
+    def find_widget_by_name(self, c: Cmdr, name: str) -> QWidget | None:
         for w in self._self_and_subtree(c.frame.top):
             if w is not None and w.objectName() == name:
                 return w
@@ -1928,7 +1928,7 @@ class StyleSheetManager:
         return table
 
     # @+node:ekr.20170307083738.1: *4* StyleSheetManager.find_icon_path
-    def find_icon_path(self, setting: str) -> Optional[str]:
+    def find_icon_path(self, setting: str) -> str | None:
         """Return the path to the open/close indicator icon."""
         c = self.c
         s = c.config.getString(setting)

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -644,7 +644,7 @@ class LeoQtGui(leoGui.LeoGui):
     def createFindDialog(self, c: Cmdr) -> QDialog | None:
         """Create and init a non-modal Find dialog."""
         if not c:
-            return None
+            return None  # #4753
         g.app.globalFindTabManager = c.findCommands.ftm
         top = c.frame.top
         w = top.findTab

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -641,12 +641,13 @@ class LeoQtGui(leoGui.LeoGui):
             dialog.exec()
 
     # @+node:ekr.20150619053138.1: *5* LeoQtGui.createFindDialog
-    def createFindDialog(self, c: Cmdr) -> QDialog:
+    def createFindDialog(self, c: Cmdr) -> QDialog | None:
         """Create and init a non-modal Find dialog."""
-        if c:
-            g.app.globalFindTabManager = c.findCommands.ftm
-        top: Optional[QWidget] = c.frame.top if c else None
-        w = top.findTab  # type:ignore
+        if not c:
+            return None
+        g.app.globalFindTabManager = c.findCommands.ftm
+        top = c.frame.top
+        w = top.findTab
         dialog = QtWidgets.QDialog()
 
         # Fix #516: Hide the dialog. Never delete it.

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -477,10 +477,6 @@ class LeoQtGui(leoGui.LeoGui):
             self.leo_checked = True
             self.setObjectName('TipMessageBox')
             self.setIcon(Icon.Information)  # #2127.
-            # self.setMinimumSize(5000, 4000)
-            # Doesn't work.
-            # Prevent the dialog from jumping around when
-            # selecting multiple tips.
             self.setWindowTitle('Leo Tips')
             self.setText(repr(tip))
             self.next_tip_button = self.addButton('Show Next Tip', ButtonRole.ActionRole)
@@ -488,14 +484,14 @@ class LeoQtGui(leoGui.LeoGui):
             c.styleSheetManager.set_style_sheets(w=self)
             # Workaround #693.
             layout = self.layout()
-            cb = QtWidgets.QCheckBox()
-            cb.setObjectName('TipCheckbox')
-            cb.setText('Show Tip On Startup')
+            checkbox = QtWidgets.QCheckBox()
+            checkbox.setObjectName('TipCheckbox')
+            checkbox.setText('Show Tip On Startup')
             # #2383: State is a tri-state, so use the official constants.
-            state = Checked if checked else Unchecked
-            cb.setCheckState(state)  # #2127.
-            cb.stateChanged.connect(controller.onClick)
-            layout.addWidget(cb, 4, 0, -1, -1)  # type:ignore
+            checkbox.setCheckState(Checked if checked else Unchecked)  # #2127.
+            checkbox.stateChanged.connect(controller.onClick)
+            # A mypy bug? layout is a QGridLayout. mypy thinks it's a plain QLayout.
+            layout.addWidget(checkbox, 4, 0, -1, -1)  # type:ignore
             if 0:  # Does not work well.
                 sizePolicy = QtWidgets.QSizePolicy
                 vSpacer = QtWidgets.QSpacerItem(200, 200, sizePolicy.Minimum, sizePolicy.Expanding)

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import textwrap
 from collections import OrderedDict
-from typing import Dict, TYPE_CHECKING, Optional
+from typing import Dict, TYPE_CHECKING
 
 from leo.core.leoQt import QtWidgets, Orientation
 from leo.core import leoGlobals as g
@@ -482,7 +482,7 @@ class LayoutCacheWidget(QWidget):
         }
     """
 
-    def __init__(self, c: Cmdr, parent: Optional[QWidget]) -> None:
+    def __init__(self, c: Cmdr, parent: QWidget | None) -> None:
         super().__init__(parent)
         self.c = c
         self.setObjectName('leo-layout-cache')
@@ -581,7 +581,7 @@ class LayoutCacheWidget(QWidget):
         self.resize_pane(widget, delta=40)
 
     # @+node:tom.20240923194438.5: *4* LCW.find_splitter_by_name
-    def find_splitter_by_name(self, name: str) -> Optional[QSplitter]:
+    def find_splitter_by_name(self, name: str) -> QSplitter | None:
         """Return the splitter with the given objectName."""
 
         def is_splitter(obj: object) -> bool:
@@ -604,7 +604,7 @@ class LayoutCacheWidget(QWidget):
         return g.app.gui.find_widget_by_name(self.c, name)
 
     # @+node:tom.20240923194438.4: *4* LCW.find_widget_in_children
-    def find_widget_in_children(self, name: str) -> Optional[QWidget]:
+    def find_widget_in_children(self, name: str) -> QWidget | None:
         """Return a child widget with the given objectName."""
         w: QWidget = None
         for kid in self.children():

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -1357,7 +1357,7 @@ class QScintillaWrapper(QTextMixin):
     def set_config(self) -> None:
         """Set QScintillaWrapper configuration options."""
         c, w = self.c, self.widget
-        n = c.config.getInt('qt-scintilla-zoom-in')  # type:ignore
+        n = c.config.getInt('qt-scintilla-zoom-in')
         if n not in (None, 1, 0):
             w.zoomIn(n)
         w.setUtf8(True)  # Important.

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -6,7 +6,7 @@
 # @+node:ekr.20220416085845.1: ** << qt_text imports & annotations >>
 from __future__ import annotations
 from collections.abc import Callable
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core.leoQt import QtCore, QtGui, Qsci, QtWidgets
 from leo.core.leoQt import ContextMenuPolicy, Key, KeyboardModifier
@@ -429,9 +429,7 @@ class QLineEditWrapper(QTextMixin):
         w.setCursorPosition(i)
 
     # @+node:ekr.20110605121601.18130: *4* QLineEditWrapper.setSelectionRange
-    def setSelectionRange(
-        self, i: int, j: int, insert: Optional[int] = None, s: str = None
-    ) -> None:
+    def setSelectionRange(self, i: int, j: int, insert: int | None = None, s: str = None) -> None:
         """QHeadlineWrapper."""
         if not self.check():
             return

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -224,7 +224,7 @@ class QTextMixin:
         if Qsci:
             classes.append(Qsci.QsciScintilla)
         assert isinstance(self.widget, tuple(classes)), self.widget
-        QtWidgets.QTextBrowser.setFocus(self.widget)  # type:ignore
+        QtWidgets.QTextBrowser.setFocus(self.widget)  # type:ignore # required.
 
     # @+node:ekr.20140901062324.18717: *4* QTextMixin.Generic text
     # @+node:ekr.20140901062324.18703: *5* QTextMixin.appendText

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -68,7 +68,7 @@ import os
 import re
 import datetime
 import time
-from typing import Any, Iterable, Optional, TYPE_CHECKING
+from typing import Any, Iterable, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core.leoQt import Qt, QtCore, QtGui, QtWidgets, uic
 from leo.core.leoQt import Checked, Unchecked
@@ -497,7 +497,7 @@ class todoController:
             g.unregisterHandler(i[0], i[1])  # type:ignore
 
     # @+node:tbnorth.20170925093004.1: *3* todoController._date
-    def _date(self, d: str) -> Optional[datetime.date]:
+    def _date(self, d: str) -> datetime.date | None:
         """_date - convert a string to a date
 
         :param str d: date to convert
@@ -507,7 +507,7 @@ class todoController:
             return None  # Was ''
         return datetime.datetime.strptime(d.split('T')[0], "%Y-%m-%d").date()
 
-    def _time(self, d: str) -> Optional[datetime.time]:
+    def _time(self, d: str) -> datetime.time | None:
         """_time - convert a string to a time
 
         :param str d: time to convert

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -531,7 +531,7 @@ def toggle_keep_open(event: LeoKeyEvent) -> None:
         c = vr.c
         vr.hide()  # So the toggle below will work.
         vr.keep_open = not vr.keep_open
-        vr.update('keep-open', {'c': c, 'force': True})
+        vr.update_vr('keep-open', {'c': c, 'force': True})
 
 
 # @+node:ekr.20130412180825.10345: *3* g.command('vr-unlock')
@@ -550,7 +550,7 @@ def update_rendering_pane(event: LeoKeyEvent) -> None:
     vr = getVr(event=event)
     if vr:
         c = vr.c
-        vr.update(tag='view', keywords={'c': c, 'force': True})
+        vr.update_vr(tag='view', keywords={'c': c, 'force': True})
 
 
 # @+node:ekr.20110317024548.14375: ** class ViewRenderedController (QWidget)
@@ -757,8 +757,8 @@ class ViewRenderedController(QtWidgets.QWidget):
     def closeEvent(self, event: QCloseEvent) -> None:
         """Deactivate callbacks when an Outline closes."""
         self.active = False
-        g.unregisterHandler('select2', self.update)
-        g.unregisterHandler('idle', self.update)
+        g.unregisterHandler('select2', self.update_vr)
+        g.unregisterHandler('idle', self.update_vr)
         g.unregisterHandler('scrolledMessage', show_scrolled_message)
         self.destroy_widgets()
 
@@ -834,12 +834,12 @@ class ViewRenderedController(QtWidgets.QWidget):
             assert pos is not None
             sb.setSliderPosition(pos)
 
-    # @+node:ekr.20101112195628.5426: *3* vr.update & helpers
+    # @+node:ekr.20101112195628.5426: *3* vr.update_vr & helpers
     # Must have this signature: called by leoPlugins.callTagHandler.
 
-    def update(self, tag: str, keywords: Any) -> None:  # type:ignore
+    def update_vr(self, tag: str, keywords: Any) -> None:
         """
-        vr.update: Update the VR pane.
+        vr.update_vr: Update the VR pane.
         Called at idle time and by the vr-update command.
         """
         p = self.c.p
@@ -884,7 +884,7 @@ class ViewRenderedController(QtWidgets.QWidget):
         else:
             self.hide()
 
-    # @+node:ekr.20241227053437.1: *4* vr.update: helpers
+    # @+node:ekr.20241227053437.1: *4* vr.update_vr: helpers
     # @+node:ekr.20241224074331.1: *5* vr.create_web_engineview
     def create_web_engineview(self) -> QWidget:
         """

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -531,7 +531,7 @@ def toggle_keep_open(event: LeoKeyEvent) -> None:
         c = vr.c
         vr.hide()  # So the toggle below will work.
         vr.keep_open = not vr.keep_open
-        vr.update('keep-open', {'c': c, 'force': True})  # ty--pe:ignore
+        vr.update('keep-open', {'c': c, 'force': True})
 
 
 # @+node:ekr.20130412180825.10345: *3* g.command('vr-unlock')
@@ -550,7 +550,7 @@ def update_rendering_pane(event: LeoKeyEvent) -> None:
     vr = getVr(event=event)
     if vr:
         c = vr.c
-        vr.update(tag='view', keywords={'c': c, 'force': True})  # type:ignore
+        vr.update(tag='view', keywords={'c': c, 'force': True})
 
 
 # @+node:ekr.20110317024548.14375: ** class ViewRenderedController (QWidget)

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -353,8 +353,8 @@ def onCreate(tag: str, keys: dict) -> None:
     if not c:
         return
     vr = getVr(c=c)
-    g.registerHandler('select2', vr.update)
-    g.registerHandler('idle', vr.update)
+    g.registerHandler('select2', vr.update_vr)
+    g.registerHandler('idle', vr.update_vr)
     vr.active = True
     vr.is_visible = False
     vr.hide()

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -554,7 +554,7 @@ def update_rendering_pane(event: LeoKeyEvent) -> None:
 
 
 # @+node:ekr.20110317024548.14375: ** class ViewRenderedController (QWidget)
-class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
+class ViewRenderedController(QtWidgets.QWidget):
     """A class to control rendering in a rendering pane."""
 
     # @+<< vr: default templates >>

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -203,7 +203,7 @@ from pathlib import Path
 import shutil
 import sys
 import textwrap
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from urllib.request import urlopen
 from leo.core import leoGlobals as g
 from leo.core.leoQt import QtCore, QtWidgets
@@ -412,7 +412,7 @@ def preview(event: LeoKeyEvent) -> None:
 
 # @+node:tbrown.20100318101414.5998: *3* g.command('vr')
 @g.command('vr')
-def viewrendered(event: LeoKeyEvent) -> Optional[Any]:
+def viewrendered(event: LeoKeyEvent) -> Any | None:
     """Open render view for commander"""
     vr = getVr(event=event)
     if vr:
@@ -1488,14 +1488,14 @@ class ViewRenderedController(QtWidgets.QWidget):
         if not h.startswith('@jinja'):
             return
 
-        def find_root(p: Position) -> Optional[tuple[Position, Position]]:
+        def find_root(p: Position) -> tuple[Position, Position] | None:
             for newp in p.parents():
                 if newp.h.strip() == '@jinja':
                     oldp, p = p, newp
                     return oldp, p
             return None, None
 
-        def find_inputs(p: Position) -> Optional[tuple[Position, Position]]:
+        def find_inputs(p: Position) -> tuple[Position, Position] | None:
             for newp in p.parents():
                 if newp.h.strip() == '@jinja inputs':
                     oldp, p = p, newp
@@ -1696,7 +1696,7 @@ class ViewRenderedController(QtWidgets.QWidget):
         return w
 
     # @+node:ekr.20110320120020.14483: *4* vr.get_kind
-    def get_kind(self, p: Position) -> Optional[str]:
+    def get_kind(self, p: Position) -> str | None:
         """Return the proper rendering kind for node p."""
 
         p0 = p  # Special case selected position.

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -319,7 +319,7 @@ def init() -> bool:
 # @+node:ekr.20240727091022.1: *3* vr function: getVR
 def getVr(
     *, c: Any = None, event: Any = None, parent: QtWidgets.QWidget = None
-) -> Optional[QtWidgets.QWidget]:
+) -> ViewRenderedController | None:
     """Return the ViewRenderedController instance or None."""
     if g.app.gui.guiName() != 'qt':
         return None
@@ -531,7 +531,7 @@ def toggle_keep_open(event: LeoKeyEvent) -> None:
         c = vr.c
         vr.hide()  # So the toggle below will work.
         vr.keep_open = not vr.keep_open
-        vr.update('keep-open', {'c': c, 'force': True})  # type:ignore
+        vr.update('keep-open', {'c': c, 'force': True})  # ty--pe:ignore
 
 
 # @+node:ekr.20130412180825.10345: *3* g.command('vr-unlock')

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1026,7 +1026,7 @@ import string
 import subprocess
 import sys
 import textwrap
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 import webbrowser
 # from urllib.request import urlopen
@@ -3034,7 +3034,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             # @-<< is_numeric >>
             # @+<< get_data >>
             # @+node:tom.20211104105903.14: *6* << get_data >>
-            def get_data(pagelines) -> Tuple[Any, Any]:
+            def get_data(pagelines) -> tuple[Any, Any]:
                 num_cols = 0
 
                 # Skip lines starting with """ or '''

--- a/leo/plugins/zenity_file_dialogs.py
+++ b/leo/plugins/zenity_file_dialogs.py
@@ -13,7 +13,6 @@ tk dialogs.
 """
 
 import subprocess
-from typing import Optional
 from leo.core import leoGlobals as g
 from leo.core import leoPlugins
 
@@ -53,7 +52,7 @@ def onStart2(tag, keywords):
 
 
 # @+node:ekr.20101110095557.5892: ** callZenity
-def callZenity(title: str, save: bool = False, test: bool = False) -> Optional[bytes]:
+def callZenity(title: str, save: bool = False, test: bool = False) -> bytes | None:
     command = ['zenity', '--file-selection', '--title=%s' % title]
     if save:
         command.append('--save')

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -73,8 +73,8 @@ def _compare_asts(node1, node2):  # pragma: no cover
     # Compare the nodes themselves.
     _compare_nodes(node1, node2)
     # Get the list of fields.
-    fields1 = getattr(node1, "_fields", [])  # type:ignore
-    fields2 = getattr(node2, "_fields", [])  # type:ignore
+    fields1 = getattr(node1, "_fields", [])
+    fields2 = getattr(node2, "_fields", [])
     if fields1 != fields2:
         raise AstNotEqual(f"node1._fields: {fields1}\nnode2._fields: {fields2}")
     # Recursively compare each field.

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -1476,7 +1476,7 @@ class Optional_TestFiles(BaseTest):
         atok = asttokens.ASTTokens(contents, parse=True, filename=filename)
         t3 = get_time()
         # Create a patchable list of TestToken objects.
-        tokens = [TestToken(atok_name(z), atok_value(z)) for z in atok.tokens]  # type:ignore
+        tokens = [TestToken(atok_name(z), atok_value(z)) for z in atok.tokens]
         # Inject parent/child links into nodes.
         asttokens.util.visit_tree(atok.tree, previsit, postvisit)
         # Create token.token_list for each token.

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -1448,7 +1448,7 @@ class Optional_TestFiles(BaseTest):
             if stack:
                 parent = stack[-1]
                 children: list[ast.AST] = getattr(parent, 'children', [])
-                parent.children = children + [node]  # type:ignore
+                parent.children = children + [node]
                 node.parent = parent
             else:
                 node.parent = None
@@ -1884,7 +1884,7 @@ class TestTokens(BaseTest):
             if stack:
                 parent = stack[-1]
                 children: list[ast.AST] = getattr(parent, 'children', [])
-                parent.children = children + [node]  # type:ignore
+                parent.children = children + [node]
                 node.parent = parent
             else:
                 node.parent = None

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -1421,7 +1421,7 @@ class Optional_TestFiles(BaseTest):
         # @+node:ekr.20200124024159.3: *5* function: atok_name
         def atok_name(token):
             """Return a good looking name for the given 5-tuple"""
-            return token_module.tok_name[token[0]].lower()  # type:ignore
+            return token_module.tok_name[token[0]].lower()
 
         # @+node:ekr.20200124024159.4: *5* function: atok_value
         def atok_value(token):
@@ -1857,7 +1857,7 @@ class TestTokens(BaseTest):
         # @+node:ekr.20200122170101.1: *5* function: atok_name
         def atok_name(token):
             """Return a good looking name for the given 5-tuple"""
-            return token_module.tok_name[token[0]].lower()  # type:ignore
+            return token_module.tok_name[token[0]].lower()
 
         # @+node:ekr.20200122170101.2: *5* function: atok_value
         def atok_value(token):


### PR DESCRIPTION
This PR is a milestone. It removes most `type:ignore` suppressions in Leo's core and core qt plugins.

**The highlight of this PR**

I have wanted to fix the following signatures for *years*:

- [x] Use `s: bytes | str` in the signatures of:
    - `g.toEncodedString` and `g.toUnicode`.
    - `v.setBodyString` and `v.setHeadString`.
    The old annotations were confusing and **wrong**, and may have confused mypy.
 
**Code changes** Marked with `#4753`.

- [x] Remove `c.import_error_nodes` ivar and related code.
- [x] Fix apparent bugs in `cpp.indent`. More testing needed.
- [x] Fix bug in `create_app` function in `leoTest2.py`.
- [x] Rewrite `fc.writeZipFile`. See https://docs.python.org/3/library/zipfile.html#zipfile-objects
- [x] Revise `g.import_module`.
- [x] Rewrite `NullLog.put`.
- [x] `viewrendered.py`: fix a potentially serious bug:'
    rename `vr.update` to `vr.update_vr` to retain base-class `update` method!

**Annotation changes**

- [x] Replace all `Optional` annotations with new `|` syntax.
- [x] Annotate all methods that might return None as `-> whatever | None:`.
    This is a precursor to setting strict-optional to True.
- [x] Replace obsolete `Tuple` annotation with `tuple`.
- [x] Fix several annotation bugs that were previously masked by `type:ignore`.