### PR TITLE
PR: use the strict_optional mypy option on six core files

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -11,7 +11,7 @@ cache_dir = mypy_cache
 show_error_codes = True
 check_untyped_defs = True
 # mypyc: strict_optional must be true: use--strict-optional
-strict_optional = False
+strict_optional = True
 disable_error_code=attr-defined
 
 # For v0.931, per https://github.com/python/mypy/issues/11936

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -38,11 +38,16 @@ exclude =
 [mypy-leo.core.*]
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
+follow_imports  = skip
+strict_optional = False
+### strict_optional = True ### 1053 errors.
 
 # The default leo.commands: full annotation.
 [mypy-leo.commands.*]
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
+follow_imports  = skip
+strict_optional = False
 
 # All importer and writer plugins: full annotation.
 [mypy-leo.plugins.importers.*,leo.plugins.writers.*,leo.unittests.plugins.test_importers]

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -39,8 +39,7 @@ exclude =
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 follow_imports  = skip
-strict_optional = False
-### strict_optional = True ### 1053 errors.
+strict_optional = True
 
 # The default leo.commands: full annotation.
 [mypy-leo.commands.*]

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -686,7 +686,7 @@ class PylintCommand:
         return data[-1] if data and is_at_file else None
 
     # @+node:ekr.20150514125218.10: *3* 3. pylint.get_rc_file
-    def get_rc_file(self) -> str | None:
+    def get_rc_file(self) -> str:
         """Return the path to the pylint configuration file."""
         c = self.c
         base1 = '.pylintrc'  # Standard name.
@@ -716,10 +716,10 @@ class PylintCommand:
         table_s = '\n'.join(table)
         g.es_print(f"no pylint configuration file found in\n{table_s}")
         # g.es_print('Not found: .pylintrc and pylint-leo-rc.txt')
-        return None
+        return ''
 
     # @+node:ekr.20150514125218.9: *3* 4. pylint.get_fn
-    def get_fn(self, p: Position) -> str | None:
+    def get_fn(self, p: Position) -> str:
         """
         Finalize p's file name.
         Return if p is not an @file node for a python file.
@@ -728,7 +728,7 @@ class PylintCommand:
         fn = p.isAnyAtFileNode()
         if not fn:
             g.trace(f"not an @<file> node: {p.h!r}")
-            return None
+            return ''
         return c.fullPath(p)  # #1914
 
     # @+node:ekr.20150514125218.12: *3* 5. pylint.run_pylint

--- a/leo/commands/commanderEditCommands.py
+++ b/leo/commands/commanderEditCommands.py
@@ -518,12 +518,12 @@ def extractDef(c: Cmdr, s: str) -> str:
 
 
 # @+node:ekr.20171123135625.26: *3* function: extractDef_find
-def extractDef_find(c: Cmdr, lines: list[str]) -> str | None:
+def extractDef_find(c: Cmdr, lines: list[str]) -> str:
     for line in lines:
         def_h = extractDef(c, line.strip())
         if def_h:
             return def_h
-    return None
+    return ''
 
 
 # @+node:ekr.20171123135625.25: *3* function: extractRef
@@ -582,7 +582,7 @@ def extractSectionNames(self: Self, event: LeoKeyEvent = None) -> None:
 
 
 # @+node:ekr.20171123135625.28: *3* function: findSectionName
-def findSectionName(self: Self, s: str) -> str | None:
+def findSectionName(self: Self, s: str) -> str:
     head1 = s.find("<<")
     if head1 > -1:
         head2 = s.find(">>", head1)
@@ -591,7 +591,7 @@ def findSectionName(self: Self, s: str) -> str | None:
         if head1 > -1:
             head2 = s.find("@>", head1)
     if head1 == -1 or head2 == -1 or head1 > head2:
-        name = None
+        name = ''
     else:
         name = s[head1 : head2 + 2]
     return name

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -429,7 +429,9 @@ def refreshFromDisk(
     at.changed_roots = []
     c.fileCommands.handleNodeConflicts()
     c.setChanged()
-    c.redraw()
+    # We may be coming from idle_check_commander and not already have p selected,
+    # if the selected position was inside the expanded & refreshed outline, it may not be valid.
+    c.redraw(update_p)  # Select a valid update_p position or p
     c.undoer.clearAndWarn('refresh-from-disk')
 
 

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -960,7 +960,7 @@ def readFileIntoNode(self: Self, event: LeoKeyEvent = None) -> None:
     if isinstance(fileName, list):
         fileName = fileName[0]
     s, e = g.readFileIntoString(fileName)
-    if s is None:
+    if not s:
         return
     g.chdir(fileName)
     s = '@nocolor\n' + s

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -41,7 +41,7 @@ def copyOutline(self: Cmdr, event: LeoKeyEvent = None) -> str:
 
 # @+node:ekr.20220314071523.1: *3* c_oc.copyOutlineAsJson & helpers
 @g.commander_command('copy-node-as-json')
-def copyOutlineAsJSON(self: Cmdr, event: LeoKeyEvent = None) -> str | None:
+def copyOutlineAsJSON(self: Cmdr, event: LeoKeyEvent = None) -> str:
     """Copy the selected outline as JSON to the clipboard"""
     # Copying an outline has no undo consequences.
     c = self
@@ -51,7 +51,7 @@ def copyOutlineAsJSON(self: Cmdr, event: LeoKeyEvent = None) -> str | None:
     if g.app.inBridge:
         return s
     g.app.gui.replaceClipboardWith(s)
-    return None
+    return ''
 
 
 # @+node:ekr.20031218072017.1549: *3* c_oc.cutOutline

--- a/leo/commands/debugCommands.py
+++ b/leo/commands/debugCommands.py
@@ -63,7 +63,7 @@ class DebugCommandsClass(BaseEditCommandsClass):
         os.spawnv(os.P_NOWAIT, python, args)
 
     # @+node:ekr.20150514063305.105: *3* debug.findDebugger
-    def findDebugger(self) -> str | None:
+    def findDebugger(self) -> str:
         """Find the winpdb debugger."""
         c = self.c
         pythonDir = g.os_path_dirname(sys.executable)
@@ -85,7 +85,7 @@ class DebugCommandsClass(BaseEditCommandsClass):
         g.es_print('winpdb not found in...')
         for z in debuggers:
             print(z)
-        return None
+        return ''
 
     # @+node:ekr.20170713112849.1: ** debug.dump-node
     @cmd('dump-node')

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -518,10 +518,10 @@ class EditFileCommandsClass(BaseEditCommandsClass):
         if not fn2:
             return
         s1, e = g.readFileIntoString(fn)
-        if s1 is None:
+        if not s1:
             return
         s2, e = g.readFileIntoString(fn2)
-        if s2 is None:
+        if not s2:
             return
         lines1, lines2 = g.splitLines(s1), g.splitLines(s2)
         aList = difflib.ndiff(lines1, lines2)

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -1462,7 +1462,7 @@ class GitDiffController:
         filename = c.fileName()
         if not filename:
             print('git-diff: outline has no name')
-            return str
+            return ''
         directory = os.path.dirname(filename)
         if directory and not os.path.isdir(directory):
             directory = os.path.dirname(directory)

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -1411,7 +1411,7 @@ class GitDiffController:
         return None
 
     # @+node:ekr.20170806094321.3: *4* gdc.find_git_working_directory
-    def find_git_working_directory(self, directory: str) -> str | None:
+    def find_git_working_directory(self, directory: str) -> str:
         """Return the git working directory, starting at directory."""
         while directory:
             if g.os_path_exists(g.finalize_join(directory, '.git')):
@@ -1420,7 +1420,7 @@ class GitDiffController:
             if path2 == directory:
                 break
             directory = path2
-        return None
+        return ''
 
     # @+node:ekr.20170819132219.1: *4* gdc.find_gnx
     def find_gnx(self, c: Cmdr, gnx: str) -> Position | None:
@@ -1453,7 +1453,7 @@ class GitDiffController:
         c.treeWantsFocusNow()
 
     # @+node:ekr.20210819080657.1: *4* gdc.get_parent_of_git_directory
-    def get_parent_of_git_directory(self) -> str | None:
+    def get_parent_of_git_directory(self) -> str:
         """
         #2143.
         Resolve filename to the nearest directory containing a .git directory.
@@ -1462,18 +1462,18 @@ class GitDiffController:
         filename = c.fileName()
         if not filename:
             print('git-diff: outline has no name')
-            return None
+            return str
         directory = os.path.dirname(filename)
         if directory and not os.path.isdir(directory):
             directory = os.path.dirname(directory)
         if not directory:
             print(f"git-diff: outline has no directory. filename: {filename!r}")
-            return None
+            return ''
         # Does path/../ref exist?
         base_directory = g.gitHeadPath(directory)
         if not base_directory:
             print(f"git-diff: no .git directory: {directory!r} filename: {filename!r}")
-            return None
+            return ''
         # This should guarantee that the directory contains a .git directory.
         directory = g.finalize_join(base_directory, '..', '..')
         return directory

--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -122,7 +122,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         g.app.globalKillBuffer = []
 
     # @+node:ekr.20150514063305.415: *3* getClipboard
-    def getClipboard(self) -> str | None:
+    def getClipboard(self) -> str:
         """Return the contents of the clipboard."""
         try:
             ctxt = g.app.gui.getTextFromClipboard()
@@ -132,7 +132,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
                     return ctxt
         except Exception:
             g.es_exception()
-        return None
+        return ''
 
     # @+node:ekr.20150514063305.416: *3* class KillBufferIterClass
     class KillBufferIterClass:

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -255,7 +255,7 @@ class DefaultWrapper(BaseSpellWrapper):
         self.save_user_dict()
 
     # @+node:ekr.20180207100238.1: *3* DefaultWrapper.find_main_dict
-    def find_main_dict(self) -> str | None:
+    def find_main_dict(self) -> str:
         """Return the full path to the global dictionary."""
         c = self.c
         fn = c.config.getString('main-spelling-dictionary')
@@ -263,10 +263,10 @@ class DefaultWrapper(BaseSpellWrapper):
             return fn
         # Default to ~/.leo/main_spelling_dict.txt
         fn = g.finalize_join(g.app.homeDir, '.leo', 'main_spelling_dict.txt')
-        return fn if g.os_path_exists(fn) else None
+        return fn if g.os_path_exists(fn) else ''
 
     # @+node:ekr.20230926171905.1: *3* DefaultWrapper.find_user_dict
-    def find_user_dict(self) -> str | None:
+    def find_user_dict(self) -> str:
         """Return the full path to the global dictionary."""
         c = self.c
         fn = c.config.getString('enchant-local-dictionary')
@@ -274,7 +274,7 @@ class DefaultWrapper(BaseSpellWrapper):
             return fn
         # Default to ~/.leo/main_spelling_dict.txt
         fn = g.finalize_join(g.app.homeDir, '.leo', 'spellpyx.txt')
-        return fn if g.os_path_exists(fn) else None
+        return fn if g.os_path_exists(fn) else ''
 
     # @+node:ekr.20180207073815.1: *3* DefaultWrapper.read_words
     def read_words(self, kind: str, fn: str) -> set[str]:

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -707,14 +707,14 @@ class SpellTabHandler:
     re_part = re.compile(r'[a-zA-z]+')
     re_http = re.compile(r'.*?(http|https)://(.*?)$')
 
-    def find(self, event: LeoKeyEvent = None) -> str | None:
+    def find(self, event: LeoKeyEvent = None) -> str:
         """
         Find the next unknown word.
 
         Return the word for unit tests.
         """
         if not self.loaded:
-            return None
+            return ''
         c, p = self.c, self.c.p
         sc = self.spellController
         w = c.frame.body.wrapper
@@ -837,7 +837,7 @@ class SpellTabHandler:
                 self.seen.add(word)
             # No more misspellings in p
             if g.unitTesting:
-                return None
+                return ''
             p.moveToThreadNext()
             if p:
                 ins = 0
@@ -848,7 +848,7 @@ class SpellTabHandler:
                 self.tab.fillbox([])
                 c.invalidateFocus()
                 c.bodyWantsFocus()
-                return None
+                return ''
 
     # @+node:ekr.20160415033936.1: *5* SpellTabHandler.showMisspelled
     def showMisspelled(self, p: Position) -> None:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -148,8 +148,8 @@ class LeoApp:
         self.start_fullscreen = False  # For qt_frame plugin.
         self.start_maximized = False  # For qt_frame plugin.
         self.start_minimized = False  # For qt_frame plugin.
-        self.trace_binding: str | None = None  # The name of a binding to trace, or None.
-        self.trace_setting: str | None = None  # The name of a setting to trace, or None.
+        self.trace_binding: str = ''  # The name of a binding to trace, or None.
+        self.trace_setting: str = ''  # The name of a setting to trace, or None.
         self.translateToUpperCase = False  # Never set to True.
         self.use_splash_screen = True  # True: put up a splash screen.
 
@@ -220,7 +220,7 @@ class LeoApp:
         self.sessionManager: SessionManager | None = None
 
         # Global status vars for the Commands class...
-        self.commandName: str | None = None  # The name of the command being executed.
+        self.commandName: str = ''  # The name of the command being executed.
         self.commandInterruptFlag = False  # True: command within a command.
         # @-<< LeoApp: global controller/manager objects >>
         # @+<< LeoApp: global importer/reader/writer data >>

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -292,7 +292,7 @@ class LeoApp:
         # @+<< LeoApp: plugins and event handlers >>
         # @+node:ekr.20161028040229.1: *5* << LeoApp: plugins and event handlers >>
         self.hookError = False  # True: suppress further calls to hooks.
-        self.hookFunction = None  # Application wide hook function.
+        self.hookFunction: Callable | None = None  # Application wide hook function.
         self.idle_time_hooks_enabled = True  # True: idle-time hooks are enabled.
         # @-<< LeoApp: plugins and event handlers >>
         # @+<< LeoApp: scripting ivars >>

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1922,14 +1922,13 @@ class LoadManager:
         Return None if testing, or in batch mode, or if the containing
         directory does not exist.
         """
-        # lm = self
+
         # Never create a workbook during unit tests or in batch mode.
         if g.unitTesting or g.app.batchMode:
-            return None
+            return ''
         fn = g.app.config.getString(setting='default_leo_file') or '~/.leo/workbook.leo'
         fn = g.finalize(fn)
         directory = g.finalize(os.path.dirname(fn))
-
         return fn if os.path.exists(directory) else ''
 
     # @+node:ekr.20120219154958.10485: *4* LM.reportDirectories
@@ -2020,7 +2019,7 @@ class LoadManager:
         return None, None
 
     # @+node:ekr.20120223062418.10414: *4* LM.getPreviousSettings
-    def getPreviousSettings(self, fn: str) -> "PreviousSettings":
+    def getPreviousSettings(self, fn: str) -> PreviousSettings:
         """
         Return the settings in effect for fn. Typically, this involves
         pre-reading fn.
@@ -2028,6 +2027,7 @@ class LoadManager:
         lm = self
         settingsName = f"settings dict for {g.shortFileName(fn)}"
         shortcutsName = f"shortcuts dict for {g.shortFileName(fn)}"
+
         # A special case: settings in leoSettings.leo do *not* override
         # the global settings, that is, settings in myLeoSettings.leo.
         isLeoSettings = fn and g.shortFileName(fn).lower() == 'leosettings.leo'
@@ -2046,14 +2046,14 @@ class LoadManager:
             d1.setName(settingsName)
             d2.setName(shortcutsName)
             return PreviousSettings(d1, d2)
-        #
+
         # The file does not exist, or is not valid.
         # Get the settings from the globals settings dicts.
         if lm.globalSettingsDict and lm.globalBindingsDict:  # #1766.
             d1 = lm.globalSettingsDict.copy()
             d2 = lm.globalBindingsDict.copy()
         else:
-            d1 = d2 = None
+            d1 = d2 = None  # type:ignore # strict_optional
         return PreviousSettings(d1, d2)
 
     # @+node:ekr.20120214132927.10723: *4* LM.mergeShortcutsDicts & helpers
@@ -2121,9 +2121,8 @@ class LoadManager:
         Duplicates happen only if panes conflict.
         """
         # Fix bug 951921: check for duplicate shortcuts only in the new file.
-        for ks in sorted(list(d.keys())):
+        for ks, aList in sorted(list(d.items())):  # strict_optional
             duplicates, panes = [], ['all']
-            aList = d.get(ks)  # A list of bi objects.
             aList2 = [z for z in aList if not z.pane.startswith('mode')]
             if len(aList) > 1:
                 for bi in aList2:
@@ -2261,8 +2260,7 @@ class LoadManager:
     def traceSettingsDict(self, d: dict[str, str], verbose: bool = False) -> None:
         if verbose:
             print(d)
-            for key in sorted(list(d.keys())):
-                gs = d.get(key)
+            for key, gs in sorted(list(d.items())):  # strict_optional
                 print(f"{key:35} {g.shortFileName(gs.path):17} {gs.val}")
             if d:
                 print('')
@@ -3493,7 +3491,9 @@ class PreviousSettings:
 
     __slots__ = ('settingsDict', 'shortcutsDict')
 
-    def __init__(self, settingsDict: g.SettingsDict, shortcutsDict: g.SettingsDict) -> None:
+    def __init__(
+        self, settingsDict: g.SettingsDict | None, shortcutsDict: g.SettingsDict | None
+    ) -> None:
         if not shortcutsDict or not settingsDict:  # #1766: unit tests.
             lm = g.app.loadManager
             settingsDict, shortcutsDict = lm.createDefaultSettingsDicts()

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3096,7 +3096,7 @@ class LoadManager:
                 color: str = d.get('color', '')  # strict_optional
                 if color == 'suppress':
                     return
-                if log and color is None:
+                if log and not color:  # strict_optional
                     color = g.actualColor('black')
                 color = g.actualColor(color)
                 tabName = d.get('tabName') or 'Log'

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -172,16 +172,16 @@ class LeoApp:
         # @-<< LeoApp: error messages >>
         # @+<< LeoApp: global directories >>
         # @+node:ekr.20161028035924.1: *5* << LeoApp: global directories >>
-        self.extensionsDir: str = None  # The leo/extensions directory
-        self.globalConfigDir: str = None  # leo/config directory
-        self.globalOpenDir: str = None  # The directory last used to open a file.
-        self.homeDir: str = None  # The user's home directory.
-        self.homeLeoDir: str = None  # The user's home/.leo directory.
-        self.leoEditorDir: str = None  # The leo-editor directory.
-        self.loadDir: str = None  # The leo/core directory.
-        self.machineDir: str = None  # The machine-specific directory.
+        self.extensionsDir: str = ''  # The leo/extensions directory
+        self.globalConfigDir: str = ''  # leo/config directory
+        self.globalOpenDir: str = ''  # The directory last used to open a file.
+        self.homeDir: str = ''  # The user's home directory.
+        self.homeLeoDir: str = ''  # The user's home/.leo directory.
+        self.leoEditorDir: str = ''  # The leo-editor directory.
+        self.loadDir: str = ''  # The leo/core directory.
+        self.machineDir: str = ''  # The machine-specific directory.
         # The directory from which the theme file was loaded, if any.
-        self.theme_directory: str = None
+        self.theme_directory: str = ''
         # @-<< LeoApp: global directories >>
         # @+<< LeoApp: global data >>
         # @+node:ekr.20161028035956.1: *5* << LeoApp: global data >>

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3135,7 +3135,7 @@ class LoadManager:
             return False
 
     # @+node:ekr.20120223062418.10393: *4* LM.openWithFileName & helpers
-    def openWithFileName(self, fn: str, gui: LeoGui, old_c: Cmdr) -> Cmdr | None:
+    def openWithFileName(self, fn: str, gui: LeoGui | None, old_c: Cmdr | None) -> Cmdr | None:
         """
         Completely read a file, creating the corresponding outline.
 

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -20,12 +20,6 @@ from leo.core import leoExternalFiles
 from leo.core.leoCache import GlobalCacher
 from leo.core.leoQt import QCloseEvent
 
-
-if TYPE_CHECKING:
-    from leo.core.leoJupytext import JupytextManager
-
-    StringIO = io.StringIO
-    SpellDict = Any  # dict[str, list[str]]
 # @-<< leoApp imports >>
 # @+<< leoApp annotations >>
 # @+node:ekr.20220819191617.1: ** << leoApp annotations >>
@@ -38,12 +32,15 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoConfig import GlobalConfigManager
     from leo.core.leoExternalFiles import ExternalFilesController
     from leo.core.leoGui import LeoKeyEvent, LeoFrame, LeoGui
+    from leo.core.leoJupytext import JupytextManager
     from leo.core.leoNodes import NodeIndices, Position
     from leo.core.leoPlugins import LeoPluginsController
     from leo.core.leoSessions import SessionManager
     from leo.plugins.qt_events import LossageData
     from leo.plugins.qt_idle_time import IdleTime
 
+    StringIO = io.StringIO
+    SpellDict = Any  # dict[str, list[str]]
     Value = Any
 
 

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -12,7 +12,7 @@ import string
 import sys
 import textwrap
 import time
-from typing import Any, TYPE_CHECKING
+from typing import cast, Any, TYPE_CHECKING
 import zipfile
 import platform
 from leo.core import leoGlobals as g
@@ -190,7 +190,7 @@ class LeoApp:
         self.globalKillBuffer: list[str] = []  # The global kill buffer.
         self.globalRegisters: dict[str, str] = {}  # The global register list.
         self.initial_cwd: str = os.getcwd()  # For restart-leo.
-        self.leoID: str = None  # The id part of gnx's.
+        self.leoID: str = ''  # The id part of gnx's.
         self.lossage: list[LossageData] = []  # List of last 100 keystrokes.
         self.paste_c: Cmdr = None  # The commander that pasted the last outline.
         self.spellDict: SpellDict = None  # A pyenchant dict or a DefaultDict.
@@ -1029,7 +1029,7 @@ class LeoApp:
             sys.exit(message)
 
     # @+node:ekr.20031218072017.1938: *5* app.createNullGuiWithScript
-    def createNullGuiWithScript(self, script: str = None) -> None:
+    def createNullGuiWithScript(self, script: str = '') -> None:
         app = self
         app.batchMode = True
         app.gui = g.app.nullGui
@@ -1077,7 +1077,7 @@ class LeoApp:
     # @+node:ekr.20031218072017.1978: *4* app.setLeoID & helpers
     def setLeoID(self, useDialog: bool = True, verbose: bool = True) -> str:
         """Get g.app.leoID from various sources."""
-        self.leoID = None
+        self.leoID = ''
         assert self == g.app
         verbose = verbose and not g.unitTesting and not self.silentMode
         table = (self.setIDFromSys, self.setIDFromFile, self.setIDFromEnv)
@@ -1120,7 +1120,7 @@ class LeoApp:
 
         This might be set by in Python's sitecustomize.py file.
         """
-        id_ = getattr(sys, "leoID", None)
+        id_ = getattr(sys, "leoID", '')  # strict_optional
         if id_:
             # Careful: periods in the id field of a gnx will corrupt the .leo file!
             # cleanLeoID raises a warning dialog.
@@ -1548,8 +1548,8 @@ class LeoApp:
         fileName: str,
         gui: LeoGui = None,
         parentFrame: Any = None,
-        previousSettings: "PreviousSettings" = None,
-        relativeFileName: str = None,
+        previousSettings: PreviousSettings | None = None,
+        relativeFileName: str = '',
     ) -> Cmdr:
         """Create a commander and its view frame for the Leo main window."""
         # Create the commander and its subcommanders.
@@ -1616,9 +1616,9 @@ class LoadManager:
         # The are the defaults for computing settings and shortcuts for all loaded files.
 
         # A g.SettingsDict: the join of settings in leoSettings.leo & myLeoSettings.leo
-        self.globalSettingsDict: g.SettingsDict = None
+        self.globalSettingsDict: g.SettingsDict = None  # type:ignore
         # A g.SettingsDict: the join of shortcuts in leoSettings.leo & myLeoSettings.leo.
-        self.globalBindingsDict: g.SettingsDict = None
+        self.globalBindingsDict: g.SettingsDict = None  # type:ignore
 
         # LoadManager ivars corresponding to user options...
 
@@ -1635,11 +1635,11 @@ class LoadManager:
 
         # Themes...
         self.leo_settings_c: Cmdr = None
-        self.leo_settings_path: str = None
+        self.leo_settings_path: str = ''
         self.my_settings_c: Cmdr = None
-        self.my_settings_path: str = None
+        self.my_settings_path: str = ''
         self.theme_c: Cmdr = None  # #1374.
-        self.theme_path: str = None
+        self.theme_path: str = ''
 
     # @+node:ekr.20120211121736.10812: *3* LM.Directory & file utils
     # @+node:ekr.20120219154958.10481: *4* LM.completeFileName
@@ -1741,7 +1741,7 @@ class LoadManager:
         home = os.path.expanduser("~")
         if home and len(home) > 1 and home[0] == '%' and home[-1] == '%':
             # Get the indirect reference to the true home.
-            home = os.getenv(home[1:-1], default=None)
+            home = os.getenv(home[1:-1], default='')
         if home:
             # Important: This returns the _working_ directory if home is None!
             # This was the source of the 4.3 .leoID.txt problems.
@@ -1859,7 +1859,7 @@ class LoadManager:
         resolve = self.resolve_theme_path
 
         # Step 1: Use the --theme command-line options if it exists
-        path = resolve(lm.options.get('theme_path'), tag='--theme')
+        path = resolve(lm.options.get('theme_path', ''), tag='--theme')
         if path:
             # Caller (LM.readGlobalSettingsFiles) sets lm.theme_path
             if trace:
@@ -1901,7 +1901,7 @@ class LoadManager:
     def resolve_theme_path(self, fn: str, tag: str) -> str:
         """Search theme directories for the given .leo file."""
         if not fn:
-            return None
+            return ''
         # Make --theme and theme-name setting do the same thing for "None"
         if fn.lower().strip() == 'none':
             return LoadManager.LM_NOTHEME_FLAG
@@ -1971,8 +1971,8 @@ class LoadManager:
     def computeLocalSettings(
         self,
         c: Cmdr,
-        settings_d: g.SettingsDict,
-        bindings_d: g.SettingsDict,
+        settings_d: g.SettingsDict | None,
+        bindings_d: g.SettingsDict | None,
         localFlag: bool,
     ) -> tuple[g.SettingsDict, g.SettingsDict]:
         """
@@ -1983,6 +1983,8 @@ class LoadManager:
         shortcuts_d2, settings_d2 = lm.createSettingsDicts(c, localFlag)
         if not bindings_d:  # #1766: unit tests.
             settings_d, bindings_d = lm.createDefaultSettingsDicts()
+        bindings_d = cast(g.SettingsDict, bindings_d)  # strict_optional
+        settings_d = cast(g.SettingsDict, settings_d)  # strict_optional
         if settings_d2:
             if g.app.trace_setting:
                 key = g.app.config.munge(g.app.trace_setting)
@@ -2008,15 +2010,13 @@ class LoadManager:
     # @+node:ekr.20120214165710.10726: *4* LM.createSettingsDicts
     def createSettingsDicts(
         self, c: Cmdr, localFlag: bool
-    ) -> tuple[g.SettingsDict, g.SettingsDict] | tuple[None, None]:
+    ) -> tuple[g.SettingsDict, g.SettingsDict]:
         from leo.core import leoConfig
 
-        if c:
-            # returns the *raw* shortcutsDict, not a *merged* shortcuts dict.
-            parser = leoConfig.SettingsTreeParser(c, localFlag)
-            shortcutsDict, settingsDict = parser.traverse()
-            return shortcutsDict, settingsDict
-        return None, None
+        # returns the *raw* shortcutsDict, not a *merged* shortcuts dict.
+        parser = leoConfig.SettingsTreeParser(c, localFlag)
+        shortcutsDict, settingsDict = parser.traverse()
+        return shortcutsDict, settingsDict
 
     # @+node:ekr.20120223062418.10414: *4* LM.getPreviousSettings
     def getPreviousSettings(self, fn: str) -> PreviousSettings:
@@ -2040,9 +2040,10 @@ class LoadManager:
             finally:
                 g.app.preReadFlag = False
             # Merge the settings from c into *copies* of the global dicts.
+            # d1 and d2 are copies.
             d1, d2 = lm.computeLocalSettings(
                 c, lm.globalSettingsDict, lm.globalBindingsDict, localFlag=True
-            )  # d1 and d2 are copies.
+            )
             d1.setName(settingsName)
             d2.setName(shortcutsName)
             return PreviousSettings(d1, d2)

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -136,7 +136,7 @@ class LeoApp:
         self.enablePlugins = True  # True: run start1 hook to load plugins. --no-plugins
         self.failFast = False  # True: Use the failfast option in unit tests.
         self.gui: LeoGui = None  # The gui class.
-        self.guiArgName: str = None  # The gui name given in --gui option.
+        self.guiArgName: str = ''  # The gui name given in --gui option.
         self.isTheme = False  # True: load files as theme files (ignore myLeoSettings.leo).
         self.listen_to_log_flag = False  # True: execute listen-to-log command.
         # Set by startup logic to True if no files specified on the command line.
@@ -2273,14 +2273,13 @@ class LoadManager:
     def traceShortcutsDict(self, d: dict[str, str], verbose: bool = True) -> None:
         print(d)
         if verbose:
-            for key in sorted(list(d.keys())):
-                val = d.get(key)
+            for key, val in sorted(list(d.items())):  # strict_optional
                 print(f"{key:35} {[z.stroke for z in val]}")
             if d:
                 print('')
 
     # @+node:ekr.20120219154958.10452: *3* LM.load & helpers
-    def load(self, fileName: str = None, pymacs: bool = None) -> None:
+    def load(self, fileName: str = '', pymacs: bool = False) -> None:
         """This is Leo's main startup method."""
         lm = self
 
@@ -2455,7 +2454,6 @@ class LoadManager:
         if g.unitTesting or g.app.batchMode:
             return None
         fn = self.computeWorkbookFileName()
-        exists = fn and os.path.exists(fn)
         if not fn:
             # The usual directory does not exist. Create an empty file.
             c = self.openEmptyLeoFile(fn, gui=g.app.gui, old_c=None)
@@ -2464,7 +2462,9 @@ class LoadManager:
         else:
             # Open the workbook or create an empty file.
             c = g.openWithFileName(fn, gui=g.app.gui, old_c=None)
-            if not exists:
+            if not c:
+                return None  # strict_optional
+            if not os.path.exists(c.fileName()):  # strict_optional
                 c.rootPosition().h = 'Workbook'
                 g.app.numberOfUntitledWindows += 1
         # Create the outline with workbook's name.
@@ -2525,6 +2525,7 @@ class LoadManager:
     def createImporterData(self) -> None:
         """Create the data structures describing importer plugins."""
         # Allow plugins to be defined in ~/.leo/plugins.
+        m: Any
         for pattern in (
             # ~/.leo/plugins.
             g.finalize_join(g.app.homeDir, '.leo', 'plugins'),
@@ -2550,6 +2551,8 @@ class LoadManager:
         # Leo 6.7.8: Create g.app.importerClassesDict.
         for language_name in g.app.importerModulesDict:
             m = g.app.importerModulesDict.get(language_name)
+            if not m:  # strict_optional
+                continue
             for z in dir(m):
                 # A hack: all importer subclasses should end with '_Importer'.
                 if z.endswith('_Importer'):
@@ -2660,8 +2663,8 @@ class LoadManager:
     def createGui(self, pymacs: bool) -> None:
         lm = self
         gui_option = lm.options.get('gui')
-        windowFlag = lm.options.get('windowFlag')
-        script = lm.options.get('script')
+        windowFlag = lm.options.get('windowFlag', False)
+        script = lm.options.get('script', '')
         if g.app.gui:
             if g.app.gui == g.app.nullGui:
                 g.app.gui = None  # Enable g.app.createDefaultGui
@@ -2682,7 +2685,7 @@ class LoadManager:
     def createSpecialGui(self, gui: str, pymacs: bool, script: str, windowFlag: bool) -> None:
         # lm = self
         if pymacs:
-            g.app.createNullGuiWithScript(script=None)
+            g.app.createNullGuiWithScript(script='')
         elif script:
             if windowFlag:
                 g.app.createDefaultGui()
@@ -2911,7 +2914,7 @@ class LoadManager:
         def doThemeOption() -> str:
             """Handle --theme=path"""
             m = utils.find_complex_option(r'--theme=(.+)')
-            return m.group(1).replace('"', '') if m else None
+            return m.group(1).replace('"', '') if m else ''
 
         # @+node:ekr.20230615075314.1: *6* function: doTraceOptions
         def doTraceOptions() -> None:
@@ -3082,7 +3085,7 @@ class LoadManager:
                 }
                 # Handle keywords for g.pr and g.es_print.
                 d = g.doKeywordArgs(keys, d)
-                color: str = d.get('color')
+                color: str = d.get('color') or ''  # strict_optional
                 if color == 'suppress':
                     return
                 if log and color is None:
@@ -3152,7 +3155,7 @@ class LoadManager:
         """
         lm = self
 
-        file_name = g.finalize(fn) if fn else None
+        file_name = g.finalize(fn) if fn else ''
 
         # #2489: If file_name is empty, open an empty, untitled .leo file.
         if not file_name:
@@ -3175,7 +3178,7 @@ class LoadManager:
     loadLocalFile = openWithFileName  # Compatibility.
 
     # @+node:ekr.20120223062418.10405: *5* LM.createMenu
-    def createMenu(self, c: Cmdr, fn: str = None) -> None:
+    def createMenu(self, c: Cmdr, fn: str = '') -> None:
         # lm = self
         # Create the menu as late as possible so it can use user commands.
         if not g.doHook("menu1", c=c, p=c.p, v=c.p):
@@ -3253,7 +3256,7 @@ class LoadManager:
         c = g.app.newCommander(
             fileName=fn,
             gui=gui,
-            previousSettings=lm.getPreviousSettings(None),
+            previousSettings=lm.getPreviousSettings(''),  # strict_optional
         )
         # Use the config params to set the size and location of the window.
         g.doHook('open0')
@@ -3617,11 +3620,11 @@ class RecentFilesManager:
         rf_always = c.config.getBool("recent-files-group-always")
         groupedEntries = rf_group or rf_always
         if groupedEntries:  # if so, make dict of groups
-            dirCount: dict[str, dict[str, list[str]]] | None = {}
+            dirCount: dict[str, dict[str, list[str]]] = {}
             for fileName in rf.getRecentFiles()[:n]:
                 dirName, baseName = g.os_path_split(fileName)
                 if baseName not in dirCount:
-                    dirCount[baseName] = {'dirs': [], 'entry': None}
+                    dirCount[baseName] = {'dirs': [], 'entry': []}  # strict_optional
                 dirCount[baseName]['dirs'].append(dirName)
         for name in rf.getRecentFiles()[:n]:
             if name.strip() == "":
@@ -3830,7 +3833,7 @@ class RecentFilesManager:
             files = [z for z in p.b.splitlines() if z and g.os_path_exists(z)]
             rf.recentFiles = files
             rf.writeRecentFilesFile(c)
-            rf.updateRecentFiles(None)
+            rf.updateRecentFiles('')
             c.selectPosition(p)
             c.deleteOutline()
         else:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3772,14 +3772,14 @@ class RecentFilesManager:
         return True
 
     # @+node:ekr.20120225072226.10285: *3* rf.sanitize
-    def sanitize(self, name: str) -> str | None:
+    def sanitize(self, name: str) -> str:
         """Return a sanitized file name."""
         if name is None:
             return None
         name = name.lower()
         for ch in ('-', '_', ' ', '\n'):
             name = name.replace(ch, '')
-        return name or None
+        return name or ''
 
     # @+node:ekr.20120215072959.12478: *3* rf.setRecentFiles
     def setRecentFiles(self, files: list[str]) -> None:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -68,7 +68,7 @@ class IdleTimeManager:
         """Ctor for IdleTimeManager class."""
         self.callback_list: list[Callable] = []
         self.on_idle_count = 0
-        self.timer: IdleTime = None
+        self.timer: IdleTime | None = None
 
     # @+others
     # @+node:ekr.20161026125611.1: *3* itm.add_callback

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3992,7 +3992,7 @@ def openUrl(event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20150514125218.6: *3* open-url-under-cursor
 @g.command('open-url-under-cursor')
-def openUrlUnderCursor(event: LeoKeyEvent = None) -> str | None:
+def openUrlUnderCursor(event: LeoKeyEvent = None) -> str:
     """Open the url under the cursor."""
     return g.openUrlOnClick(event)
 

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2832,11 +2832,11 @@ class LoadManager:
             return gui
 
         # @+node:ekr.20210927034148.7: *6* function: doScriptOption
-        def doScriptOption() -> str | None:
+        def doScriptOption() -> str:
             """Handle --script=path"""
             m = utils.find_complex_option(r'--script=(.+)')
             if not m:
-                return None
+                return ''
             fn = m.group(1).replace('"', '')
             # #1090: use cwd, not g.app.loadDir, to find scripts.
             path = g.finalize_join(os.getcwd(), fn)
@@ -2847,10 +2847,10 @@ class LoadManager:
             return script
 
         # @+node:ekr.20230615055158.1: *6* function: doSelectOption
-        def doSelectOption() -> str | None:
+        def doSelectOption() -> str:
             """Handle --select=headline"""
             m = utils.find_complex_option(r'--select=(.+)')
-            return m.group(1) if m else None
+            return m.group(1) if m else ''
 
         # @+node:ekr.20230615034517.1: *6* function: doSimpleOptions
         def doSimpleOptions() -> None:
@@ -2912,7 +2912,7 @@ class LoadManager:
                     helper()
 
         # @+node:ekr.20230615060055.1: *6* function: doThemeOption
-        def doThemeOption() -> str | None:
+        def doThemeOption() -> str:
             """Handle --theme=path"""
             m = utils.find_complex_option(r'--theme=(.+)')
             return m.group(1).replace('"', '') if m else None
@@ -3030,7 +3030,7 @@ class LoadManager:
         # Set the LoadManager.files ivar.
         self.files = computeFilesList(fileName)
         # Return a dictionary of complex options.
-        script = None if pymacs else doScriptOption()  # Used twice below.
+        script = '' if pymacs else doScriptOption()  # Used twice below.
         return {
             'gui': doGuiOption(),
             'script': script,

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1652,7 +1652,7 @@ class LoadManager:
         return fileName
 
     # @+node:ekr.20120209051836.10372: *4* LM.computeLeoSettingsPath
-    def computeLeoSettingsPath(self) -> str | None:
+    def computeLeoSettingsPath(self) -> str:
         """Return the full path to leoSettings.leo."""
         # lm = self
         join = g.finalize_join
@@ -1666,13 +1666,11 @@ class LoadManager:
         )
         for path in table:
             if g.os_path_exists(path):
-                break
-        else:
-            path = None
-        return path
+                return path
+        return ''
 
     # @+node:ekr.20120209051836.10373: *4* LM.computeMyLeoSettingsPath
-    def computeMyLeoSettingsPath(self) -> str | None:
+    def computeMyLeoSettingsPath(self) -> str:
         """
         Return the full path to either myLeoSettings.leo or myLeoSettings.leojs.
 
@@ -1704,7 +1702,7 @@ class LoadManager:
                 return path + ".leo"
             if g.os_path_exists(path + ".leojs"):
                 return path + ".leojs"
-        return None
+        return ''
 
     # @+node:ekr.20120209051836.10252: *4* LM.computeStandardDirectories & helpers
     def computeStandardDirectories(self) -> None:
@@ -1725,7 +1723,7 @@ class LoadManager:
         g.app.testDir = join(g.app.loadDir, '..', 'test')
 
     # @+node:ekr.20120209051836.10253: *5* LM.computeGlobalConfigDir
-    def computeGlobalConfigDir(self) -> str | None:
+    def computeGlobalConfigDir(self) -> str:
         leo_config_dir = getattr(sys, 'leo_config_directory', None)
         if leo_config_dir:
             theDir = leo_config_dir
@@ -1734,11 +1732,11 @@ class LoadManager:
         if theDir:
             theDir = os.path.abspath(theDir)
         if not theDir or not g.os_path_exists(theDir) or not g.os_path_isdir(theDir):
-            theDir = None
+            theDir = ''
         return theDir
 
     # @+node:ekr.20120209051836.10254: *5* LM.computeHomeDir
-    def computeHomeDir(self) -> str | None:
+    def computeHomeDir(self) -> str:
         """Returns the user's home directory."""
         # Windows searches the HOME, HOMEPATH and HOMEDRIVE
         # environment vars, then gives up.
@@ -1751,7 +1749,7 @@ class LoadManager:
             # This was the source of the 4.3 .leoID.txt problems.
             home = g.finalize(home)
             if not g.os_path_exists(home) or not g.os_path_isdir(home):
-                home = None
+                home = ''
         return home
 
     # @+node:ekr.20120209051836.10260: *5* LM.computeHomeLeoDir
@@ -1846,7 +1844,7 @@ class LoadManager:
         return [g.os_path_normslashes(z) for z in table if g.os_path_exists(z)]
 
     # @+node:ekr.20180318133620.1: *4* LM.computeThemeFilePath & helper
-    def computeThemeFilePath(self) -> str | None:
+    def computeThemeFilePath(self) -> str:
         """
         Return the absolute path to the theme .leo file, resolved using the search order for themes.
 
@@ -1902,7 +1900,7 @@ class LoadManager:
         return path
 
     # @+node:ekr.20180321124503.1: *5* LM.resolve_theme_path
-    def resolve_theme_path(self, fn: str, tag: str) -> str | None:
+    def resolve_theme_path(self, fn: str, tag: str) -> str:
         """Search theme directories for the given .leo file."""
         if not fn:
             return None
@@ -1916,10 +1914,10 @@ class LoadManager:
             if g.os_path_exists(path):
                 return path
         print(f"theme .leo file not found: {fn}")
-        return None
+        return ''
 
     # @+node:ekr.20120211121736.10772: *4* LM.computeWorkbookFileName
-    def computeWorkbookFileName(self) -> str | None:
+    def computeWorkbookFileName(self) -> str:
         """
         Return full path to the workbook.
 
@@ -1934,7 +1932,7 @@ class LoadManager:
         fn = g.finalize(fn)
         directory = g.finalize(os.path.dirname(fn))
 
-        return fn if os.path.exists(directory) else None
+        return fn if os.path.exists(directory) else ''
 
     # @+node:ekr.20120219154958.10485: *4* LM.reportDirectories
     def reportDirectories(self) -> None:
@@ -2698,12 +2696,12 @@ class LoadManager:
             g.app.createDefaultGui()
 
     # @+node:ekr.20120219154958.10482: *5* LM.getDefaultFile
-    def getDefaultFile(self) -> str | None:
+    def getDefaultFile(self) -> str:
         # Get the name of the workbook.
         fn = g.app.config.getString('default-leo-file')
         fn = g.finalize(fn)
         if not fn:
-            return None
+            return ''
         if g.os_path_exists(fn):
             return fn
         if g.os_path_isabs(fn):
@@ -2711,7 +2709,7 @@ class LoadManager:
             g.error(f"Using default leo file name:\n{fn}")
             return fn
         # It's too risky to open a default file if it is relative.
-        return None
+        return ''
 
     # @+node:ekr.20120219154958.10484: *5* LM.initApp
     def initApp(self, verbose: bool) -> None:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -202,19 +202,20 @@ class LeoApp:
         # @+node:ekr.20161028040028.1: *5* << LeoApp: global controller/manager objects >>
         # Singleton applications objects...
 
-        # A BackgroundProcessManager.
-        self.backgroundProcessManager: BackgroundProcessManager = None
+        # We can't use casts here because they would create circular imports.
+        # As a workaround, we suppress the otherwise-valid mypy complaints.
+
+        self.backgroundProcessManager: BackgroundProcessManager = None  # type:ignore
         self.config: GlobalConfigManager = None  # g.app.config.
-        # A global db, managed by g.app.global_cacher.
-        self.db: dict | SqlitePickleShare | g.NullObject = None
-        self.externalFilesController: ExternalFilesController | None = None
-        self.global_cacher: dict | GlobalCacher | g.NullObject | None = None
-        self.idleTimeManager: IdleTimeManager | None = None
-        self.jupytextManager: JupytextManager = None
-        self.loadManager: LoadManager | None = None
-        self.nodeIndices: NodeIndices | None = None
-        self.pluginsController: LeoPluginsController | None = None
-        self.sessionManager: SessionManager | None = None
+        self.db: dict | SqlitePickleShare | g.NullObject = None  # type:ignore
+        self.externalFilesController: ExternalFilesController = None  # type:ignore
+        self.global_cacher: dict | GlobalCacher | g.NullObject = None  # type:ignore
+        self.idleTimeManager: IdleTimeManager = None  # type:ignore
+        self.jupytextManager: JupytextManager = None  # type:ignore
+        self.loadManager: LoadManager = None  # type:ignore
+        self.nodeIndices: NodeIndices = None  # type:ignore
+        self.pluginsController: LeoPluginsController = None  # type:ignore
+        self.sessionManager: SessionManager = None  # type:ignore
 
         # Global status vars for the Commands class...
         self.commandName: str = ''  # The name of the command being executed.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -192,7 +192,7 @@ class LeoApp:
         self.initial_cwd: str = os.getcwd()  # For restart-leo.
         self.leoID: str = ''  # The id part of gnx's.
         self.lossage: list[LossageData] = []  # List of last 100 keystrokes.
-        self.paste_c: Cmdr = None  # The commander that pasted the last outline.
+        self.paste_c: Cmdr | None = None  # The commander that pasted the last outline.
         self.spellDict: SpellDict = None  # A pyenchant dict or a DefaultDict.
         self.numberOfUntitledWindows = 0  # Number of opened untitled windows.
         self.windowList: list[LeoFrame] = []  # Global list of all frames.
@@ -1281,7 +1281,9 @@ class LeoApp:
 
     # @+node:ekr.20171127111053.1: *3* app.Closing
     # @+node:ekr.20031218072017.2609: *4* app.closeLeoWindow
-    def closeLeoWindow(self, frame: LeoFrame, new_c: Cmdr = None, finish_quit: bool = True) -> bool:
+    def closeLeoWindow(
+        self, frame: LeoFrame, new_c: Cmdr | None = None, finish_quit: bool = True
+    ) -> bool:
         """
         Attempt to close a Leo window.
 
@@ -1634,11 +1636,11 @@ class LoadManager:
         self.more_cmdline_files = False
 
         # Themes...
-        self.leo_settings_c: Cmdr = None
+        self.leo_settings_c: Cmdr | None = None
         self.leo_settings_path: str = ''
-        self.my_settings_c: Cmdr = None
+        self.my_settings_c: Cmdr | None = None
         self.my_settings_path: str = ''
-        self.theme_c: Cmdr = None  # #1374.
+        self.theme_c: Cmdr | None = None  # #1374.
         self.theme_path: str = ''
 
     # @+node:ekr.20120211121736.10812: *3* LM.Directory & file utils
@@ -2042,7 +2044,10 @@ class LoadManager:
             # Merge the settings from c into *copies* of the global dicts.
             # d1 and d2 are copies.
             d1, d2 = lm.computeLocalSettings(
-                c, lm.globalSettingsDict, lm.globalBindingsDict, localFlag=True
+                c,  # type:ignore # c is not None.
+                lm.globalSettingsDict,
+                lm.globalBindingsDict,
+                localFlag=True,
             )
             d1.setName(settingsName)
             d2.setName(shortcutsName)
@@ -2230,7 +2235,10 @@ class LoadManager:
             # Merge the settings dicts from c's outline into
             # *new copies of* settings_d and bindings_d.
             settings_d, bindings_d = lm.computeLocalSettings(
-                c, settings_d, bindings_d, localFlag=False
+                c,  # type:ignore # c is not None.
+                settings_d,
+                bindings_d,
+                localFlag=False,
             )
         # Adjust the name.
         bindings_d.setName('lm.globalBindingsDict')
@@ -2240,7 +2248,7 @@ class LoadManager:
         # This must be done *after* reading myLeoSettings.leo.
         lm.theme_path = lm.computeThemeFilePath()
         if lm.theme_path and lm.theme_path != LoadManager.LM_NOTHEME_FLAG:
-            lm.theme_c = lm.openSettingsFile(lm.theme_path)
+            lm.theme_c = lm.openSettingsFile(lm.theme_path)  # type:ignore # theme_c is a Cmdr if used below.
             if lm.theme_c:
                 # Merge theme_c's settings into globalSettingsDict.
                 settings_d, junk_shortcuts_d = lm.computeLocalSettings(
@@ -2255,7 +2263,7 @@ class LoadManager:
         # This allows this method to be called outside the startup logic.
         for c in commanders:
             if c not in old_commanders:
-                g.app.forgetOpenFile(c.fileName())
+                g.app.forgetOpenFile(c.fileName())  # type:ignore # Not sure why mypy complains.
 
     # @+node:ekr.20120214165710.10838: *4* LM.traceSettingsDict
     def traceSettingsDict(self, d: dict[str, str], verbose: bool = False) -> None:
@@ -2417,7 +2425,7 @@ class LoadManager:
         if not c:
             # Leo is out of options: Force an immediate exit.
             return False
-        g.app.runAlreadyOpenDialog(c1)  # #199.
+        g.app.runAlreadyOpenDialog(c)  # #199. # strict_optional
 
         # Final inits...
         try:  # qt only: select the first-loaded tab.
@@ -2453,6 +2461,7 @@ class LoadManager:
         if g.unitTesting or g.app.batchMode:
             return None
         fn = self.computeWorkbookFileName()
+        c: Cmdr | None
         if not fn:
             # The usual directory does not exist. Create an empty file.
             c = self.openEmptyLeoFile(fn, gui=g.app.gui, old_c=None)
@@ -3294,7 +3303,7 @@ class LoadManager:
             p.h = f"@auto {fn}" if func else f"@edit {fn}"
             c.refreshFromDisk(p)  # pylint: disable=no-member
 
-        c.mFileName = None  # #3546: Do *not* automatically save the .leo file.
+        c.mFileName = ''  # #3546: Do *not* automatically save the .leo file.
         c.frame.title = c.computeTabTitle()
         c.frame.setTitle(c.frame.title)
 

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3093,7 +3093,7 @@ class LoadManager:
                 }
                 # Handle keywords for g.pr and g.es_print.
                 d = g.doKeywordArgs(keys, d)
-                color: str = d.get('color') or ''  # strict_optional
+                color: str = d.get('color', '')  # strict_optional
                 if color == 'suppress':
                     return
                 if log and color is None:

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -327,7 +327,7 @@ class AtFile:
             g.red(f"file not found: {fn}")
             return
         s, e = g.readFileIntoString(fn)
-        if s is None:
+        if not s:
             g.red(f"empty file: {fn}")
             return
         #
@@ -678,7 +678,7 @@ class AtFile:
         # Remember the full fileName.
         at.rememberReadPath(fn, p)
         s, e = g.readFileIntoString(fn, kind='@edit')
-        if s is None:
+        if not s:
             return
         encoding = 'utf-8' if e is None else e
         # Delete all children.
@@ -842,7 +842,7 @@ class AtFile:
         # Fix bug 889175: Remember the full fileName.
         at.rememberReadPath(fn, p)
         s, e = g.readFileIntoString(fn, kind='@edit')
-        if s is None:
+        if not s:
             return
         encoding = 'utf-8' if e is None else e
         # Delete all children.

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -1657,7 +1657,7 @@ class AtFile:
             if c.persistenceController:
                 c.persistenceController.update_before_write_foreign_file(root)
             contents = at.writeAtAutoContents(fileName, root)
-            if contents is None:
+            if not contents:  # strict_optional
                 g.es("not written:", fileName)
                 at.addToOrphanList(root)
                 return False
@@ -2028,7 +2028,7 @@ class AtFile:
             if not fileName:
                 at.addToOrphanList(root)
                 return ''
-            return at.writeAtAutoContents(fileName, root) or ''
+            return at.writeAtAutoContents(fileName, root)
         except Exception:
             at.writeException(fileName, root)
             return ''

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -426,7 +426,7 @@ class AtFile:
 
         # Open the file.
         fileName, file_s = at.openFileForReading(fromString=fromString)
-        if file_s is None:  # #1798:
+        if not file_s:  # #1798: # strict_optional
             return False  # pragma: no cover
 
         # Set the time stamp.
@@ -3374,7 +3374,7 @@ class AtFile:
                     root.h = h
                     c.redraw()
                     return False
-        if message is None:
+        if not message:  # strict_optional
             message = (
                 f"{g.splitLongFileName(fileName)}\n"
                 f"{g.tr('already exists.')}\n"

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -18,12 +18,11 @@ import typing
 from typing import cast, Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoNodes
-from leo.core.leoNodes import Position
+from leo.core.leoNodes import Position, VNode
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
-    from leo.core.leoNodes import VNode
 
     Args = Any
     Value = Any
@@ -499,7 +498,7 @@ class AtFile:
         c.raise_error_dialogs()
 
     # @+node:ekr.20250711132317.1: *6* at.clone_all_changed_vnodes
-    def clone_all_changed_vnodes(self) -> Position:
+    def clone_all_changed_vnodes(self) -> Position | None:
         """
         Make clones of all changed VNodes.
 
@@ -3602,7 +3601,7 @@ class FastAtRead:
         #
         # Simple vars...
         afterref = False  # True: the next line follows @afterref.
-        clone_v: VNode = None  # The root of the clone tree.
+        clone_v = cast(VNode, None)  # The root of the clone tree.
         # The start/end *comment* delims.
         # Important: scan_header ends comment_delim1 with a blank when using black sentinels.
         comment_delim1, comment_delim2 = comment_delims
@@ -3634,7 +3633,7 @@ class FastAtRead:
         context = self.c
         parent_v = self.root.v
         root_v = parent_v  # Does not change.
-        level_stack.append((root_v, None))
+        level_stack.append((root_v, cast(VNode, None)))
 
         # Init the gnx dict last.
         gnx2vnode = self.gnx2vnode  # Keys are gnx's, values are vnodes.
@@ -3755,7 +3754,7 @@ class FastAtRead:
                 #         #3931: Always use root_v, but use the gnx from external file!
                 if not root_seen:
                     root_seen = True
-                    clone_v = None
+                    clone_v = cast(VNode, None)
                     v = root_v
                     if root_v.gnx != gnx:
                         # Delete all traces of root_v.gnx.

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -137,8 +137,8 @@ class AtFile:
         self.readVersion = ''
         self.read_i = 0
         self.read_lines: list[str] = []
-        self.startSentinelComment: str | None = ""
-        self.endSentinelComment: str | None = ""
+        self.startSentinelComment: str = ''
+        self.endSentinelComment: str = ''
         # Writing.
         self.indent = 0  # write indentation, in blanks.
         self.outputFile: io.StringIO | None = None
@@ -217,14 +217,14 @@ class AtFile:
         self.initAllIvars(root)
 
     # @+node:ekr.20041005105605.15: *4* at.initWriteIvars
-    def initWriteIvars(self, root: Position) -> str | None:
+    def initWriteIvars(self, root: Position) -> str:
         """
         Compute default values of all write-related ivars.
         Return the finalized name of the output file.
         """
         at, c = self, self.c
         if not c or not c.config:
-            return None  # pragma: no cover
+            return ''  # pragma: no cover
 
         make_dirs = c.config.getBool('create-nonexistent-directories', default=False)
         assert at.checkPythonCodeOnWrite is not None
@@ -280,7 +280,7 @@ class AtFile:
             ok = g.makeAllNonExistentDirectories(root_dir)
             if not ok:
                 g.error(f"Error creating directories: {root_dir}")
-                return None
+                return ''
 
         # Return the target file name, regardless of future problems.
         return targetFileName
@@ -356,7 +356,7 @@ class AtFile:
             g.red(f"file not found: {path}")
 
     # @+node:ekr.20041005105605.19: *5* at.openFileForReading & helper
-    def openFileForReading(self, fromString: str | None = None) -> tuple[str | None, str | None]:
+    def openFileForReading(self, fromString: str = '') -> tuple[str, str]:
         """
         Open the file given by at.root.
         This will be the private file for @shadow nodes.
@@ -366,9 +366,9 @@ class AtFile:
         if fromString:  # pragma: no cover
             if is_at_shadow:  # pragma: no cover
                 at.error('can not call at.read from string for @shadow files')
-                return None, None
+                return '', ''
             at.initReadLine(fromString)
-            return None, None
+            return '', ''
         #
         # Not from a string. Carefully read the file.
         # Returns full path, including file name.
@@ -378,7 +378,7 @@ class AtFile:
         if is_at_shadow:  # pragma: no cover
             fn = at.openAtShadowFileForReading(fn)
             if not fn:
-                return None, None
+                return '', ''
         assert fn
         try:
             # Sets at.encoding, regularizes whitespace and calls at.initReadLines.
@@ -386,15 +386,15 @@ class AtFile:
             # #1466.
             if s is None:  # pragma: no cover
                 # The error has been given.
-                return None, None
+                return '', ''
             at.warnOnReadOnlyFile(fn)
         except Exception:  # pragma: no cover
             at.error(f"unexpected exception opening: '@file {fn}'")
-            fn, s = None, None
+            fn, s = '', ''
         return fn, s
 
     # @+node:ekr.20150204165040.4: *6* at.openAtShadowFileForReading
-    def openAtShadowFileForReading(self, fn: str) -> str | None:  # pragma: no cover
+    def openAtShadowFileForReading(self, fn: str) -> str:  # pragma: no cover
         """Open an @shadow for reading and return shadow_fn."""
         at = self
         x = at.c.shadowController
@@ -404,13 +404,13 @@ class AtFile:
         if not shadow_exists:
             g.trace('can not happen: no private file', shadow_fn, g.callers())
             at.error(f"can not happen: private file does not exist: {shadow_fn}")
-            return None
+            return ''
         # This method is the gateway to the shadow algorithm.
         x.updatePublicAndPrivateFiles(at.root, fn, shadow_fn)
         return shadow_fn
 
     # @+node:ekr.20041005105605.21: *5* at.read & helpers
-    def read(self, root: Position, fromString: str | None = None) -> bool:
+    def read(self, root: Position, fromString: str = '') -> bool:
         """Read an @thin or @file tree."""
         at, c = self, self.c
         fileName = c.fullPath(root)
@@ -727,7 +727,7 @@ class AtFile:
         return p  # For #451: return p.
 
     # @+node:ekr.20150204165040.5: *5* at.readOneAtCleanNode & helpers
-    def readOneAtCleanNode(self, root: Position, *, new_contents: str | None = None) -> None:
+    def readOneAtCleanNode(self, root: Position, *, new_contents: str = '') -> None:
         """Update the @clean/@nosent node at root."""
         at, c, x = self, self.c, self.c.shadowController
 
@@ -1049,7 +1049,7 @@ class AtFile:
         return valid, new_df, start, end, isThin
 
     # @+node:ekr.20130911110233.11284: *5* at.readFileToUnicode & helpers
-    def readFileToUnicode(self, fileName: str) -> str | None:  # pragma: no cover
+    def readFileToUnicode(self, fileName: str) -> str:  # pragma: no cover
         """
         Carefully sets at.encoding, then uses at.encoding to convert the file
         to a unicode string.
@@ -1066,7 +1066,7 @@ class AtFile:
         s_bytes = at.openFileHelper(fileName)  # Catches all exceptions.
         # #1798.
         if not s_bytes:
-            return None  # Not ''.
+            return ''  # #4755
         e, s_bytes = g.stripBOM(s_bytes)
         if e:
             # The BOM determines the encoding unambiguously.
@@ -1493,7 +1493,7 @@ class AtFile:
         at.setPathUa(p, newPath)  # Remember that we have changed paths.
 
     # @+node:ekr.20190109172025.1: *5* at.writeAtAutoContents
-    def writeAtAutoContents(self, fileName: str, root: Position) -> str | None:  # pragma: no cover
+    def writeAtAutoContents(self, fileName: str, root: Position) -> str:  # pragma: no cover
         """Common helper for atAutoToString and writeOneAtAutoNode."""
         at, c = self, self.c
         # Dispatch the proper writer.
@@ -1520,7 +1520,7 @@ class AtFile:
             at.putFile(root, sentinels=False)
             return '' if at.errors else ''.join(at.outputList)
         except Exception:
-            return None
+            return ''
         finally:
             g.app.allow_undefined_refs = False
 
@@ -1690,14 +1690,14 @@ class AtFile:
             aClass = d.get(key)
             if aClass and g.match_word(root.h, 0, key):
 
-                def writer_for_at_auto_cb(root: Position) -> str | None:
+                def writer_for_at_auto_cb(root: Position) -> str:
                     try:
                         writer = aClass(at.c)  # noqa
                         s = writer.write(root)
                         return s
                     except Exception:
                         g.es_exception()
-                        return None
+                        return ''
 
                 return writer_for_at_auto_cb
         return None
@@ -1710,12 +1710,12 @@ class AtFile:
         aClass = d.get(ext)
         if aClass:
 
-            def writer_for_ext_cb(root: Position) -> str | None:
+            def writer_for_ext_cb(root: Position) -> str:
                 try:
                     return aClass(at.c).write(root)
                 except Exception:
                     g.es_exception()
-                    return None
+                    return ''
 
             return writer_for_ext_cb
 
@@ -1929,7 +1929,7 @@ class AtFile:
             at.initWriteIvars(root)
             # Force python sentinels to suppress an error message.
             # The actual sentinels will be set below.
-            at.endSentinelComment = None
+            at.endSentinelComment = ''
             at.startSentinelComment = "#"
             # Make sure we can compute the shadow directory.
             private_fn = x.shadowPathName(full_path)
@@ -2109,7 +2109,7 @@ class AtFile:
             c.endEditing()
             at.initWriteIvars(root)
             if forcePythonSentinels:
-                at.endSentinelComment = None
+                at.endSentinelComment = ''
                 at.startSentinelComment = "#"
                 at.language = "python"
             at.sentinels = sentinels
@@ -2324,7 +2324,7 @@ class AtFile:
         return True
 
     # @+node:ekr.20041005105605.199: *6* at.findSectionName
-    def findSectionName(self, s: str, i: int, p: Position) -> tuple[str | None, int, int]:
+    def findSectionName(self, s: str, i: int, p: Position) -> tuple[str, int, int]:
         """
         Return n1, n2 representing a section name.
 
@@ -2355,7 +2355,7 @@ class AtFile:
                 g.es_print('Ignoring apparent section reference:', color='red')
                 g.es_print('Node: ', p.h)
                 g.es_print('Line: ', s[i1:i2].rstrip())
-        return None, 0, 0
+        return '', 0, 0
 
     # @+node:ekr.20041005105605.174: *6* at.putCodeLine
     def putCodeLine(self, s: str, i: int) -> None:
@@ -3072,7 +3072,7 @@ class AtFile:
     def replaceFile(
         self,
         contents: str,
-        encoding: str | None,
+        encoding: str,
         fileName: str,
         root: Position,
         ignoreBlankLines: bool = False,
@@ -3354,9 +3354,7 @@ class AtFile:
         p.v.tempAttributes['read-path'] = d
 
     # @+node:ekr.20090712050729.6017: *4* at.promptForDangerousWrite
-    def promptForDangerousWrite(
-        self, fileName: str, message: str | None = None
-    ) -> bool:  # pragma: no cover
+    def promptForDangerousWrite(self, fileName: str, message: str = '') -> bool:
         """Raise a dialog asking the user whether to overwrite an existing file."""
         at, c, root = self, self.c, self.root
         if at.cancelFlag:

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -262,7 +262,7 @@ class AtFile:
 
         # targetFileName can be empty for unit tests & @command nodes.
         if not targetFileName:  # pragma: no cover
-            targetFileName = root.h if g.unitTesting else ''  # #4755
+            targetFileName = root.h if g.unitTesting else ''
             at.targetFileName = targetFileName  # For at.writeError only.
             return targetFileName
 
@@ -2645,7 +2645,7 @@ class AtFile:
         """Report a syntax error."""
         g.error(f"Syntax error in: {p.h}")
         typ, val, tb = sys.exc_info()
-        message = getattr(val, 'message', None)  # #4755
+        message = getattr(val, 'message', '')  # #4755
         if message:
             g.es_print(message)
         if val is None:

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -4064,7 +4064,7 @@ class FastAtRead:
         # Set the body text.
         assert root_v.gnx in gnx2vnode, root_v
         assert root_v.gnx in gnx2body, root_v
-        for key, body in gnx2body.items():  # #4755
+        for key, body in gnx2body.items():  # strict_optional
             v = gnx2vnode.get(key)
             assert v, (key, v)
             v._bodyString = g.toUnicode(''.join(body))

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -150,10 +150,10 @@ class AtFile:
         # User settings.
         self.at_auto_encoding = 'utf-8'
         self.encoding: str = 'utf-8'
-        self.explicitLineEnding = False  # #4755
+        self.explicitLineEnding = False  # strict_optional
         self.force_newlines_in_at_nosent_bodies = False
         self.output_newline = g.getOutputNewline(c=c)
-        self.page_width = 0  # #4755
+        self.page_width = 0  # strict_optional
         self.tab_width: int = c.tab_width or -4
         # User switches: set in reloadSettings.
         self.beautifyOnWrite = False
@@ -197,12 +197,12 @@ class AtFile:
         at.sentinels = False
         at.section_delim1 = '<<'
         at.section_delim2 = '>>'
-        at.targetFileName = ''  # #4755
+        at.targetFileName = ''  # strict_optional
         # at.unchangedFiles = 0  # Only at.writeAll should init this ivar.
         # User settings.
         at.at_auto_encoding = c.config.default_at_auto_file_encoding or 'utf-8'
         at.encoding = c.config.default_derived_file_encoding or 'utf-8'
-        at.explicitLineEnding = False  # #4755
+        at.explicitLineEnding = False  # strict_optional
         at.force_newlines_in_at_nosent_bodies = False
         at.output_newline = g.getOutputNewline(c=c)
         at.page_width = c.page_width or 132
@@ -1065,7 +1065,7 @@ class AtFile:
         s_bytes = at.openFileHelper(fileName)  # Catches all exceptions.
         # #1798.
         if not s_bytes:
-            return ''  # #4755
+            return ''  # strict_optional
         e, s_bytes = g.stripBOM(s_bytes)
         if e:
             # The BOM determines the encoding unambiguously.
@@ -1093,7 +1093,7 @@ class AtFile:
         except Exception:  # pragma: no cover
             at.error(f"Exception reading {fileName}")
             g.es_exception()
-        return b''  # #4755
+        return b''  # strict_optional
 
     # @+node:ekr.20130911110233.11287: *6* at.getEncodingFromHeader
     def getEncodingFromHeader(self, fileName: str, s: str) -> str:
@@ -1111,7 +1111,7 @@ class AtFile:
             at.initReadLine(s)
             old_encoding = at.encoding
             assert old_encoding
-            at.encoding = ''  # #4755
+            at.encoding = ''  # strict_optional
             # Execute scanHeader merely to set at.encoding.
             at.scanHeader(fileName, giveErrors=False)
             e = at.encoding or old_encoding
@@ -1190,7 +1190,7 @@ class AtFile:
         at.readFileToUnicode(fileName)
         # scanHeader uses at.readline instead of its args.
         # scanHeader also sets at.encoding.
-        junk1, junk2, isThin = at.scanHeader('')  # #4755
+        junk1, junk2, isThin = at.scanHeader('')  # strict_optional
         return isThin
 
     # @+node:ekr.20041005105605.132: *3* at.Writing
@@ -1481,7 +1481,7 @@ class AtFile:
         if not changed:
             return
         ok = at.promptForDangerousWrite(
-            fileName='',  # #4755
+            fileName='',  # strict_optional
             message=(
                 f"{g.tr('path changed for %s' % (p.h))}\n"
                 f"{g.tr('write this file anyway?')}"
@@ -2645,7 +2645,7 @@ class AtFile:
         """Report a syntax error."""
         g.error(f"Syntax error in: {p.h}")
         typ, val, tb = sys.exc_info()
-        message = getattr(val, 'message', '')  # #4755
+        message = getattr(val, 'message', '')  # strict_optional
         if message:
             g.es_print(message)
         if val is None:

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -14,14 +14,16 @@ import sys
 import tabnanny
 import time
 import tokenize
-from typing import Any, TYPE_CHECKING
+import typing
+from typing import cast, Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoNodes
+from leo.core.leoNodes import Position
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
-    from leo.core.leoNodes import Position, VNode
+    from leo.core.leoNodes import VNode
 
     Args = Any
     Value = Any
@@ -122,8 +124,8 @@ class AtFile:
         self.fileCommands = c.fileCommands
         # Basic status vars.
         self.errors = 0
-        self.language: str = None
-        self.root: Position = None
+        self.language = cast(str, None)
+        self.root = cast(Position, None)
         # Dialogs.
         self.canCancelFlag = False
         self.cancelFlag = False
@@ -135,11 +137,11 @@ class AtFile:
         self.readVersion = ''
         self.read_i = 0
         self.read_lines: list[str] = []
-        self.startSentinelComment = ""
-        self.endSentinelComment = ""
+        self.startSentinelComment: str | None = ""
+        self.endSentinelComment: str | None = ""
         # Writing.
         self.indent = 0  # write indentation, in blanks.
-        self.outputFile: io.StringIO = None
+        self.outputFile: io.StringIO | None = None
         self.outputList: list[str] = []
         self.sentinels = False
         self.section_delim1 = '<<'
@@ -148,11 +150,11 @@ class AtFile:
         self.unchangedFiles = 0
         # User settings.
         self.at_auto_encoding = 'utf-8'
-        self.encoding = 'utf-8'
-        self.explicitLineEnding: bool = None
+        self.encoding: str = 'utf-8'
+        self.explicitLineEnding = False  # #4755
         self.force_newlines_in_at_nosent_bodies = False
         self.output_newline = g.getOutputNewline(c=c)
-        self.page_width: int = None
+        self.page_width = 0  # #4755
         self.tab_width: int = c.tab_width or -4
         # User switches: set in reloadSettings.
         self.beautifyOnWrite = False
@@ -196,12 +198,12 @@ class AtFile:
         at.sentinels = False
         at.section_delim1 = '<<'
         at.section_delim2 = '>>'
-        at.targetFileName = None
+        at.targetFileName = ''  # #4755
         # at.unchangedFiles = 0  # Only at.writeAll should init this ivar.
         # User settings.
         at.at_auto_encoding = c.config.default_at_auto_file_encoding or 'utf-8'
         at.encoding = c.config.default_derived_file_encoding or 'utf-8'
-        at.explicitLineEnding = None
+        at.explicitLineEnding = False  # #4755
         at.force_newlines_in_at_nosent_bodies = False
         at.output_newline = g.getOutputNewline(c=c)
         at.page_width = c.page_width or 132
@@ -261,7 +263,7 @@ class AtFile:
 
         # targetFileName can be empty for unit tests & @command nodes.
         if not targetFileName:  # pragma: no cover
-            targetFileName = root.h if g.unitTesting else None
+            targetFileName = root.h if g.unitTesting else ''  # #4755
             at.targetFileName = targetFileName  # For at.writeError only.
             return targetFileName
 
@@ -354,7 +356,7 @@ class AtFile:
             g.red(f"file not found: {path}")
 
     # @+node:ekr.20041005105605.19: *5* at.openFileForReading & helper
-    def openFileForReading(self, fromString: str = None) -> tuple[str | None, str | None]:
+    def openFileForReading(self, fromString: str | None = None) -> tuple[str | None, str | None]:
         """
         Open the file given by at.root.
         This will be the private file for @shadow nodes.
@@ -408,7 +410,7 @@ class AtFile:
         return shadow_fn
 
     # @+node:ekr.20041005105605.21: *5* at.read & helpers
-    def read(self, root: Position, fromString: str = None) -> bool:
+    def read(self, root: Position, fromString: str | None = None) -> bool:
         """Read an @thin or @file tree."""
         at, c = self, self.c
         fileName = c.fullPath(root)
@@ -435,6 +437,8 @@ class AtFile:
             return False
 
         # Read the file!
+        fileName = cast(str, fileName)
+        file_s = cast(str, file_s)
         root.clearVisitedInTree()
         gnx2vnode = c.fileCommands.gnxDict
         contents = fromString or file_s
@@ -723,7 +727,7 @@ class AtFile:
         return p  # For #451: return p.
 
     # @+node:ekr.20150204165040.5: *5* at.readOneAtCleanNode & helpers
-    def readOneAtCleanNode(self, root: Position, *, new_contents: str = None) -> None:
+    def readOneAtCleanNode(self, root: Position, *, new_contents: str | None = None) -> None:
         """Update the @clean/@nosent node at root."""
         at, c, x = self, self.c, self.c.shadowController
 
@@ -990,6 +994,7 @@ class AtFile:
         at.read_lines = g.splitLines(s)
 
     # @+node:ekr.20041005105605.120: *5* at.parseLeoSentinel
+    @typing.no_type_check
     def parseLeoSentinel(self, s: str) -> tuple[bool, bool, str, str, bool]:
         """
         Parse the sentinel line s.
@@ -1080,18 +1085,16 @@ class AtFile:
     def openFileHelper(self, fileName: str) -> bytes:  # *not* str!
         """Open a file, reporting all exceptions."""
         at = self
-        # #1798: return None as a flag on any error.
-        s = None
         try:
             with open(fileName, 'rb') as f:
-                s = f.read()
+                return f.read()
         except IOError:  # pragma: no cover
             if not g.unitTesting:
                 at.error(f"can not open {fileName}")
         except Exception:  # pragma: no cover
             at.error(f"Exception reading {fileName}")
             g.es_exception()
-        return s
+        return b''  # #4755
 
     # @+node:ekr.20130911110233.11287: *6* at.getEncodingFromHeader
     def getEncodingFromHeader(self, fileName: str, s: str) -> str:
@@ -1109,7 +1112,7 @@ class AtFile:
             at.initReadLine(s)
             old_encoding = at.encoding
             assert old_encoding
-            at.encoding = None
+            at.encoding = ''  # #4755
             # Execute scanHeader merely to set at.encoding.
             at.scanHeader(fileName, giveErrors=False)
             e = at.encoding or old_encoding
@@ -1188,7 +1191,7 @@ class AtFile:
         at.readFileToUnicode(fileName)
         # scanHeader uses at.readline instead of its args.
         # scanHeader also sets at.encoding.
-        junk1, junk2, isThin = at.scanHeader(None)
+        junk1, junk2, isThin = at.scanHeader('')  # #4755
         return isThin
 
     # @+node:ekr.20041005105605.132: *3* at.Writing
@@ -1479,7 +1482,7 @@ class AtFile:
         if not changed:
             return
         ok = at.promptForDangerousWrite(
-            fileName=None,
+            fileName='',  # #4755
             message=(
                 f"{g.tr('path changed for %s' % (p.h))}\n"
                 f"{g.tr('write this file anyway?')}"
@@ -1490,7 +1493,7 @@ class AtFile:
         at.setPathUa(p, newPath)  # Remember that we have changed paths.
 
     # @+node:ekr.20190109172025.1: *5* at.writeAtAutoContents
-    def writeAtAutoContents(self, fileName: str, root: Position) -> str:  # pragma: no cover
+    def writeAtAutoContents(self, fileName: str, root: Position) -> str | None:  # pragma: no cover
         """Common helper for atAutoToString and writeOneAtAutoNode."""
         at, c = self, self.c
         # Dispatch the proper writer.
@@ -2321,7 +2324,7 @@ class AtFile:
         return True
 
     # @+node:ekr.20041005105605.199: *6* at.findSectionName
-    def findSectionName(self, s: str, i: int, p: Position) -> tuple[str, int, int]:
+    def findSectionName(self, s: str, i: int, p: Position) -> tuple[str | None, int, int]:
         """
         Return n1, n2 representing a section name.
 
@@ -2376,7 +2379,7 @@ class AtFile:
             # Python sentinels *only* may contain a space between '#' and '@'
             if g.match(s, k, '#@') or g.match(s, k, '# @'):
                 put_verbatim_sentinel()
-        elif g.match(s, k, self.startSentinelComment + "@"):
+        elif g.match(s, k, self.startSentinelComment + "@"):  # type:ignore
             put_verbatim_sentinel()
 
         # Don't put any whitespace in otherwise blank lines.
@@ -2430,7 +2433,7 @@ class AtFile:
         at = self
         if not at.endSentinelComment:
             at.putIndent(at.indent)
-            at.os(at.startSentinelComment)
+            at.os(at.startSentinelComment)  # type:ignore
             # #1496: Retire the @doc convention.
             #        Remove the blank.
             # at.oblank()
@@ -2453,7 +2456,7 @@ class AtFile:
         # Write the line as it is.
         at.putIndent(at.indent)
         if not at.endSentinelComment:
-            at.os(at.startSentinelComment)
+            at.os(at.startSentinelComment)  # type:ignore
             # #1496: Retire the @doc convention.
             #        Leave this blank. The line is not blank.
             at.oblank()
@@ -2487,7 +2490,7 @@ class AtFile:
         # Put the opening comment if we are using block comments.
         if at.endSentinelComment:
             at.putIndent(at.indent)
-            at.os(at.startSentinelComment)
+            at.os(at.startSentinelComment)  # type:ignore
             at.onl()
 
     # @+node:ekr.20041005105605.187: *4* Writing sentinels...
@@ -2564,6 +2567,7 @@ class AtFile:
         # Leo 4.7: we never write tnodeLists.
 
     # @+node:ekr.20041005105605.194: *5* at.putSentinel (applies cweb hack) 4.x
+    @typing.no_type_check
     def putSentinel(self, s: str) -> None:
         """
         Write a sentinel whose text is s, applying the CWEB hack if needed.
@@ -2642,7 +2646,7 @@ class AtFile:
         """Report a syntax error."""
         g.error(f"Syntax error in: {p.h}")
         typ, val, tb = sys.exc_info()
-        message = hasattr(val, 'message') and val.message
+        message = getattr(val, 'message', None)  # #4755
         if message:
             g.es_print(message)
         if val is None:
@@ -3068,7 +3072,7 @@ class AtFile:
     def replaceFile(
         self,
         contents: str,
-        encoding: str,
+        encoding: str | None,
         fileName: str,
         root: Position,
         ignoreBlankLines: bool = False,
@@ -3202,6 +3206,7 @@ class AtFile:
             at.section_delim2 = '>>'
 
     # @+node:ekr.20090514111518.5665: *5* at.tabNannyNode
+    @typing.no_type_check
     def tabNannyNode(self, p: Position, body: str) -> None:
         try:
             readline = g.ReadLinesClass(body).next
@@ -3265,6 +3270,7 @@ class AtFile:
         at.addToOrphanList(at.root)
 
     # @+node:ekr.20041005105605.218: *5* at.writeException
+    @typing.no_type_check
     def writeException(self, fileName: str, root: Position) -> None:  # pragma: no cover
         at = self
         g.error("exception writing:", fileName)
@@ -3324,7 +3330,7 @@ class AtFile:
             return False
 
     # @+node:ekr.20050104132026: *5* at.stat
-    def stat(self, fileName: str) -> int:  # pragma: no cover
+    def stat(self, fileName: str) -> int | None:  # pragma: no cover
         """Return the access mode of named file, removing any setuid, setgid, and sticky bits."""
         # Do _not_ call self.error here.
         try:
@@ -3349,7 +3355,7 @@ class AtFile:
 
     # @+node:ekr.20090712050729.6017: *4* at.promptForDangerousWrite
     def promptForDangerousWrite(
-        self, fileName: str, message: str = None
+        self, fileName: str, message: str | None = None
     ) -> bool:  # pragma: no cover
         """Raise a dialog asking the user whether to overwrite an existing file."""
         at, c, root = self, self.c, self.root
@@ -3497,21 +3503,21 @@ class FastAtRead:
         assert gnx2vnode is not None
         # The global fc.gnxDict. Keys are gnx's, values are vnodes.
         self.gnx2vnode: dict[str, VNode] = gnx2vnode
-        self.path: str = None
-        self.root: Position = None
+        self.path = cast(str, None)
+        self.root = cast(Position, None)
         # compiled patterns...
-        self.after_pat: re.Pattern = None
-        self.all_pat: re.Pattern = None
-        self.code_pat: re.Pattern = None
-        self.comment_pat: re.Pattern = None
-        self.delims_pat: re.Pattern = None
-        self.doc_pat: re.Pattern = None
-        self.first_pat: re.Pattern = None
-        self.last_pat: re.Pattern = None
-        self.node_start_pat: re.Pattern = None
-        self.others_pat: re.Pattern = None
-        self.ref_pat: re.Pattern = None
-        self.section_delims_pat: re.Pattern = None
+        self.after_pat = cast(re.Pattern, None)
+        self.all_pat = cast(re.Pattern, None)
+        self.code_pat = cast(re.Pattern, None)
+        self.comment_pat = cast(re.Pattern, None)
+        self.delims_pat = cast(re.Pattern, None)
+        self.doc_pat = cast(re.Pattern, None)
+        self.first_pat = cast(re.Pattern, None)
+        self.last_pat = cast(re.Pattern, None)
+        self.node_start_pat = cast(re.Pattern, None)
+        self.others_pat = cast(re.Pattern, None)
+        self.ref_pat = cast(re.Pattern, None)
+        self.section_delims_pat = cast(re.Pattern, None)
 
     # @+node:ekr.20180602103135.3: *3* fast_at.get_patterns
     def get_patterns(self, comment_delims: tuple) -> None:
@@ -4061,8 +4067,7 @@ class FastAtRead:
         # Set the body text.
         assert root_v.gnx in gnx2vnode, root_v
         assert root_v.gnx in gnx2body, root_v
-        for key in gnx2body:
-            body = gnx2body.get(key)
+        for key, body in gnx2body.items():  # #4755
             v = gnx2vnode.get(key)
             assert v, (key, v)
             v._bodyString = g.toUnicode(''.join(body))

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -152,7 +152,7 @@ class BridgeController:
             g.app = leoApp.LeoApp()
         except ImportError:
             print("Error importing leoApp.py")
-        g.app.leoID = None
+        g.app.leoID = ''
         if self.tracePlugins:
             g.app.debug.append('plugins')
         g.app.silentMode = self.silentMode

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -294,7 +294,7 @@ class ChapterController:
             if binding:
                 binding = binding.strip()
         else:
-            chapterName = binding = None
+            chapterName = binding = ''  # strict_optional
         return chapterName, binding
 
     # @+node:ekr.20160414183716.1: *4* cc.sanitize

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -287,14 +287,13 @@ class ChapterController:
             # @verbatim
             # @chapter (all up to @) (@key=(binding))?
             # name=group(1), binding=group(3)
+        chapterName = binding = ''  # strict_optional
         if m := self.re_chapter.search(p.h):
             chapterName, binding = m.group(1), m.group(3)
             if chapterName:
                 chapterName = self.sanitize(chapterName)
             if binding:
                 binding = binding.strip()
-        else:
-            chapterName = binding = ''  # strict_optional
         return chapterName, binding
 
     # @+node:ekr.20160414183716.1: *4* cc.sanitize

--- a/leo/core/leoColor.py
+++ b/leo/core/leoColor.py
@@ -32,6 +32,8 @@ will return None.
 """
 
 # @-<< leoColor docstring >>
+import typing
+
 # @+<< define leo_color_database >>
 # @+node:bob.20080115070511.2: ** << define leo_color_database >>
 # Names should be lower case, without spaces or special characters.
@@ -734,6 +736,7 @@ for key in leo_color_database:
 # @+others
 # @+node:bob.20080115070511.3: ** color database functions
 # @+node:bob.20071231111744.2: *3* function: leoColor.get / getColor
+@typing.no_type_check
 def getColor(name: str, default: str = None) -> str | None:
     """Translate a named color into #rrggbb' format.
 

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -3243,7 +3243,7 @@ if QtGui:
             """Returns a QTextCharFormat for token or None."""
             if token in self._formats:
                 return self._formats[token]
-            if self._style is None:
+            if not self._style:
                 result = self._get_format_from_document(token, self._document)
             else:
                 result = self._get_format_from_style(token, self._style)
@@ -3312,7 +3312,7 @@ if QtGui:
         def _get_brush(self, color: str) -> QtGui.QBrush:
             """Returns a brush for the color."""
             result = self._brushes.get(color)
-            if result is None:
+            if not result:  # strict_optional
                 qcolor = self._get_color(color)
                 result = QtGui.QBrush(qcolor)
                 self._brushes[color] = result

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1005,7 +1005,7 @@ class JEditColorizer(BaseColorizer):
 
         # @+<< function: resolve_color_key >>
         # @+node:ekr.20230314052558.1: *6* << function: resolve_color_key >>
-        def resolve_color_key(key: str) -> str | None:
+        def resolve_color_key(key: str) -> str:
             """
             Resolve the given color name to a *valid* color.
             """
@@ -1030,7 +1030,7 @@ class JEditColorizer(BaseColorizer):
                     else:
                         g.trace('Invalid @color setting:', key, color1)
                         break
-            return None  # Reasonable default.
+            return ''
 
         # @-<< function: resolve_color_key >>
 

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -659,7 +659,7 @@ class Commands:
         """
         c, p, tag = self, self.p, 'execute-general-script'
 
-        def get_setting_for_language(setting: str) -> str | None:
+        def get_setting_for_language(setting: str) -> str:
             """
             Return the setting from the given @data setting.
             The first colon ends each key.
@@ -668,7 +668,7 @@ class Commands:
                 key, val = s.split(':', 1)
                 if key.strip() == 'language':  # 2025/04/05.
                     return val.strip()
-            return None
+            return ''
 
         # Get the language and extension.
         language = c.getLanguage(p)
@@ -1756,7 +1756,7 @@ class Commands:
 
         # Passes 3 & 4: Use the file extension in @<file> nodes.
 
-        def get_language_from_headline(v: VNode) -> str | None:
+        def get_language_from_headline(v: VNode) -> str:
             """Return the extension for @<file> nodes."""
             if v.isAnyAtFileNode():
                 name = v.anyAtFileNodeName()
@@ -1765,7 +1765,7 @@ class Commands:
                 language = g.app.extension_dict.get(ext)
                 if g.isValidLanguage(language):
                     return language
-            return None
+            return ''
 
         # Pass 3: Use file extension in headline of @<file> in direct parents.
         for p2 in p.self_and_parents(copy=False):
@@ -1852,15 +1852,15 @@ class Commands:
     # https://en.wikipedia.org/wiki/Filename
     at_path_pattern = re.compile(r'^@path\s+(.+)$', re.MULTILINE)
 
-    def getPathFromNode(self, p: Position) -> str | None:
+    def getPathFromNode(self, p: Position) -> str:
         """
         Scan p.h then p.b for @path directives.
         """
         c = self
         c.scanAtPathDirectivesCount += 1  # An important statistic.
 
-        def get_path(m: re.Match) -> str | None:
-            return g.stripPathCruft(m.group(1)) if m else None
+        def get_path(m: re.Match) -> str:
+            return g.stripPathCruft(m.group(1)) if m else ''
 
         # The headline has higher precedence because it is more visible.
         paths: list[str] = []
@@ -1879,7 +1879,7 @@ class Commands:
                 f"Using the first path: @path {paths[0]}"
             )  # fmt: skip
             g.print_unique_message(message)
-        return paths[0] if paths else None
+        return paths[0] if paths else ''
 
     # @+node:ekr.20250404153250.1: *5* c.getTabWidth
     # Use a regex to avoid allocating temp strings.
@@ -3619,7 +3619,7 @@ class Commands:
         prefix: str = None,
         silent: bool = False,
         useTimeStamp: bool = True,
-    ) -> str | None:
+    ) -> str:
         """
         Back up given fileName or c.fileName().
         If useTimeStamp is True, append a timestamp to the filename.
@@ -3627,7 +3627,7 @@ class Commands:
         c = self
         fn = fileName or c.fileName()
         if not fn:
-            return None
+            return ''
         theDir, base = g.os_path_split(fn)
         if useTimeStamp:
             if base.endswith('.leo'):
@@ -5427,7 +5427,7 @@ class Commands:
     undoableDeletePositions = deletePositionsInList
 
     # @+node:ekr.20091211111443.6265: *4* c.doBatchOperations & helpers
-    def doBatchOperations(self, aList: list = None) -> None:
+    def doBatchOperations(self, aList: list | None = None) -> None:
         # Validate aList and create the parents dict
         if aList is None:
             aList = []
@@ -5469,7 +5469,7 @@ class Commands:
         self,
         regex: re.Pattern,
         flags: re.RegexFlag = re.IGNORECASE,
-        it: Iterable[Position] = None,
+        it: Iterable[Position] | None = None,
     ) -> list[Position]:
         """
         Return list of all Positions whose body matches the regex at least once.
@@ -5490,7 +5490,7 @@ class Commands:
         self,
         regex: re.Pattern,
         flags: re.RegexFlag = re.IGNORECASE,
-        it: Iterable[Position] = None,
+        it: Iterable[Position] | None = None,
     ) -> list[Position]:
         """
         Return list of all Positions whose headline matches the regex.

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1644,7 +1644,8 @@ class Commands:
         if getattr(c, '_currentPosition', None):
             # *Always* return a copy.
             return c._currentPosition.copy()  # type:ignore
-        # Returns a new copy of the root position or None
+        # Returns a new copy of the root position.
+        # In theory, c.rootPosition() could return None, but that shouldn't happen.
         return c.rootPosition()
 
     # For compatibility with old scripts...
@@ -2087,7 +2088,7 @@ class Commands:
         if c.hiddenRootNode.children:
             v = c.hiddenRootNode.children[0]
             return leoNodes.Position(v, childIndex=0, stack=None)
-        return None  # type:ignore #This should never happen.
+        return None  # type:ignore # This should never happen.
 
     # For compatibility with old scripts...
 

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -23,7 +23,7 @@ from leo.core import leoGlobals as g
 
 # The leoCommands ctor now does most leo.core.leo* imports,
 # thereby breaking circular dependencies.
-from leo.core import leoNodes
+from leo.core.leoNodes import Position, VNode
 
 # @-<< leoCommands imports >>
 # @+<< leoCommands annotations >>
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr  # pylint: disable=import-self
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoConfig import LocalConfigManager
-    from leo.core.leoNodes import Position, VNode
 
     # The following imports are required, but flake8 won't know that without the asserts.
 
@@ -339,7 +338,7 @@ class Commands:
     # @+node:ekr.20120217070122.10470: *5* c.initObjects
     def initObjects(self, gui: LeoGui) -> None:
         c = self
-        self.hiddenRootNode = leoNodes.VNode(context=c, gnx='hidden-root-vnode-gnx')
+        self.hiddenRootNode = VNode(context=c, gnx='hidden-root-vnode-gnx')
         self.hiddenRootNode.h = '<hidden root vnode>'
         # Create the gui frame.
         title = c.computeTabTitle()
@@ -1531,7 +1530,7 @@ class Commands:
         if stack is None:
             stack = []
 
-        if not isinstance(v, leoNodes.VNode):
+        if not isinstance(v, VNode):
             g.es_print(f"not a VNode: {v!r}")
             return  # Stop the generator.
 
@@ -1544,7 +1543,7 @@ class Commands:
         def stack2pos(stack: list[tuple]) -> Position:
             """Convert the stack to a position."""
             v, i = stack[-1]
-            return leoNodes.Position(v, i, stack[:-1])
+            return Position(v, i, stack[:-1])
 
         for v2 in set(v.parents):
             for i in allinds(v2, v):
@@ -1638,15 +1637,11 @@ class Commands:
     def currentPosition(self) -> Position:
         """
         Return a copy of the presently selected position or None.
-        So c.p.copy() is never necessary.
+        As a result, c.p.copy() is never necessary.
         """
         c = self
-        if getattr(c, '_currentPosition', None):
-            # *Always* return a copy.
-            return c._currentPosition.copy()  # type:ignore
-        # Returns a new copy of the root position.
-        # In theory, c.rootPosition() could return None, but that shouldn't happen.
-        return c.rootPosition()
+        # strict_optional
+        return c._currentPosition.copy() if c._currentPosition else c.rootPosition()
 
     # For compatibility with old scripts...
 
@@ -2083,16 +2078,11 @@ class Commands:
     _rootCount = 0
 
     def rootPosition(self) -> Position:
-        """
-        Return a new *copy* of the root position.
-
-        Note: the code returns None by default, but that should not happen in practice.
-        """
+        """Return a new *copy* of the root position."""
         c = self
-        if c.hiddenRootNode.children:
-            v = c.hiddenRootNode.children[0]
-            return leoNodes.Position(v, childIndex=0, stack=None)
-        return None  # type:ignore # This should never happen.
+        # strict_optional
+        v = c.hiddenRootNode.children[0] if c.hiddenRootNode.children else cast(VNode, None)
+        return Position(v=v, childIndex=0, stack=None)
 
     # For compatibility with old scripts...
 
@@ -2159,7 +2149,7 @@ class Commands:
                 immediate = parent
             else:
                 v, n = stack.pop()
-                p = leoNodes.Position(v, n, stack)
+                p = Position(v, n, stack)
                 positions.append(p)
         return positions
 
@@ -2185,7 +2175,7 @@ class Commands:
             # a VNode not in the tree
             return None
         v, n = stack.pop()
-        p = leoNodes.Position(v, n, stack)
+        p = Position(v, n, stack)
         return p
 
     # @+node:ekr.20090130135126.1: *4* c.Properties
@@ -5517,7 +5507,7 @@ class Commands:
                 op, p, n = z
                 ok = (
                     op in ('insert', 'delete')
-                    and isinstance(p, leoNodes.position)
+                    and isinstance(p, Position)  # strict_optional # Bug fix!
                     and isinstance(n, int)
                 )
                 if ok:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -15,7 +15,8 @@ import tabnanny
 import tempfile
 import time
 import tokenize
-from typing import Any, Generator, Iterable, Sequence, TYPE_CHECKING
+import typing
+from typing import cast, Any, Generator, Iterable, Sequence, TYPE_CHECKING
 import xml.etree.ElementTree as ElementTree
 
 from leo.core import leoGlobals as g
@@ -27,46 +28,49 @@ from leo.core import leoNodes
 # @-<< leoCommands imports >>
 # @+<< leoCommands annotations >>
 # @+node:ekr.20220820051212.1: ** << leoCommands annotations >>
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from leo.core.leoApp import PreviousSettings
+    from leo.core.leoCommands import Commands as Cmdr  # pylint: disable=import-self
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoConfig import LocalConfigManager
     from leo.core.leoNodes import Position, VNode
 
+    # The following imports are required, but flake8 doesn't know that.
+
     # 11 subcommanders...
-    from leo.core.leoAtFile import AtFile
-    from leo.core.leoChapters import ChapterController
-    from leo.core.leoFileCommands import FileCommands
-    from leo.core.leoFind import LeoFind
-    from leo.core.leoImport import LeoImportCommands
-    from leo.core.leoKeys import KeyHandlerClass
-    from leo.core.leoHistory import NodeHistory
-    from leo.core.leoPersistence import PersistenceDataController
-    from leo.core.leoPrinting import PrintingController
-    from leo.core.leoShadow import ShadowController
-    from leo.core.leoUndo import Undoer
-    from leo.core.leoVim import VimCommands
+    from leo.core.leoAtFile import AtFile  # noqa
+    from leo.core.leoChapters import ChapterController  # noqa
+    from leo.core.leoFileCommands import FileCommands  # noqa
+    from leo.core.leoFind import LeoFind  # noqa
+    from leo.core.leoImport import LeoImportCommands  # noqa
+    from leo.core.leoKeys import KeyHandlerClass  # noqa
+    from leo.core.leoHistory import NodeHistory  # noqa
+    from leo.core.leoPersistence import PersistenceDataController  # noqa
+    from leo.core.leoPrinting import PrintingController  # noqa
+    from leo.core.leoShadow import ShadowController  # noqa
+    from leo.core.leoUndo import Undoer  # noqa
+    from leo.core.leoVim import VimCommands  # noqa
 
     # 14 command handlers...
-    from leo.commands.abbrevCommands import AbbrevCommandsClass
-    from leo.commands.bufferCommands import BufferCommandsClass
-    from leo.commands.controlCommands import ControlCommandsClass
-    from leo.commands.convertCommands import ConvertCommandsClass
-    from leo.commands.debugCommands import DebugCommandsClass
-    from leo.commands.editCommands import EditCommandsClass
-    from leo.commands.editFileCommands import EditFileCommandsClass
-    from leo.commands.gotoCommands import GoToCommands
-    from leo.commands.helpCommands import HelpCommandsClass
-    from leo.commands.keyCommands import KeyHandlerCommandsClass
-    from leo.commands.killBufferCommands import KillBufferCommandsClass
-    from leo.commands.rectangleCommands import RectangleCommandsClass
-    from leo.core.leoRst import RstCommands
-    from leo.commands.spellCommands import SpellCommandsClass
+    from leo.commands.abbrevCommands import AbbrevCommandsClass  # noqa
+    from leo.commands.bufferCommands import BufferCommandsClass  # noqa
+    from leo.commands.controlCommands import ControlCommandsClass  # noqa
+    from leo.commands.convertCommands import ConvertCommandsClass  # noqa
+    from leo.commands.debugCommands import DebugCommandsClass  # noqa
+    from leo.commands.editCommands import EditCommandsClass  # noqa
+    from leo.commands.editFileCommands import EditFileCommandsClass  # noqa
+    from leo.commands.gotoCommands import GoToCommands  # noqa
+    from leo.commands.helpCommands import HelpCommandsClass  # noqa
+    from leo.commands.keyCommands import KeyHandlerCommandsClass  # noqa
+    from leo.commands.killBufferCommands import KillBufferCommandsClass  # noqa
+    from leo.commands.rectangleCommands import RectangleCommandsClass  # noqa
+    from leo.core.leoRst import RstCommands  # noqa
+    from leo.commands.spellCommands import SpellCommandsClass  # noqa
 
     # Other objects...
     from leo.core.leoGui import LeoGui
     from leo.core.qt_frame import LeoQtMenu
-    from leo.plugins.qt_gui import StyleSheetManager
+    from leo.plugins.qt_gui import StyleSheetManager  # noqa
     from leo.plugins.qt_text import QTextMixin
 
     Args = Any
@@ -114,7 +118,7 @@ class Commands:
         gui: LeoGui = None,
         parentFrame: Any = None,
         previousSettings: "PreviousSettings" = None,
-        relativeFileName: str = None,
+        relativeFileName: str = '',
     ) -> None:
         t1 = time.process_time()
         c = self
@@ -127,38 +131,8 @@ class Commands:
         self.gui: LeoGui = gui or g.app.gui
         # New ivars
         self.config: LocalConfigManager = None
-        # Declare subcommanders (and one alias) (created later).
-        self.atFileCommands: AtFile = None
-        self.chapterController: ChapterController = None
-        self.fileCommands: FileCommands = None
-        self.findCommands: LeoFind = None
-        self.importCommands: LeoImportCommands = None
-        self.keyHandler: KeyHandlerClass = None
-        self.nodeHistory: NodeHistory = None
-        self.persistenceController: PersistenceDataController = None
-        self.printingController: PrintingController = None
-        self.shadowController: ShadowController = None
-        self.undoer: Undoer = None
-        self.vimCommands: VimCommands = None
-        # Declare command handlers (created later).
-        self.abbrevCommands: AbbrevCommandsClass = None
-        self.bufferCommands: BufferCommandsClass = None
-        self.controlCommands: ControlCommandsClass = None
-        self.convertCommands: ConvertCommandsClass = None
-        self.debugCommands: DebugCommandsClass = None
-        self.editCommands: EditCommandsClass = None
-        self.editFileCommands: EditFileCommandsClass = None
-        self.gotoCommands: GoToCommands = None
-        self.helpCommands: HelpCommandsClass = None
-        self.keyHandlerCommands: KeyHandlerCommandsClass = None
-        self.killBufferCommands: KillBufferCommandsClass = None
-        self.rectangleCommands: RectangleCommandsClass = None
-        self.rstCommands: RstCommands = None
-        self.spellCommands: SpellCommandsClass = None
-        # Declare alias for self.keyHandler.
-        self.k: KeyHandlerClass = None
         # The stylesheet manager does not exist in all guis.
-        self.styleSheetManager: StyleSheetManager = None
+        self.styleSheetManager = None  ###(StyleSheetManager, None)
         # The order of these calls does not matter.
         c.initCommandIvars()
         c.initDebugIvars()
@@ -201,7 +175,7 @@ class Commands:
         return title
 
     # @+node:ekr.20120217070122.10475: *5* c.computeWindowTitle
-    def computeWindowTitle(self, fileName: str = None) -> str:
+    def computeWindowTitle(self, fileName: str = '') -> str:
         """
         Return the title for the top-level window.
         """
@@ -252,7 +226,7 @@ class Commands:
         self.expansionLevel = 0  # The expansion level of this outline.
         self.expansionNode = None  # The last node we expanded or contracted.
         self.nodeConflictList: list[Position] = []  # List of nodes with conflicting read-time data.
-        self.nodeConflictFileName: str = None  # The fileName for c.nodeConflictList.
+        self.nodeConflictFileName: str = ''  # The fileName for c.nodeConflictList.
         # Non-persistent dictionary for free use by scripts and plugins.
         self.user_dict: dict[str, Value] = {}
 
@@ -277,7 +251,7 @@ class Commands:
         """Init file-related ivars of the commander."""
         self.changed = False  # True: the outline has changed since the last save.
         self.ignored_at_file_nodes: list[str] = []  # List of headlines for c.raise_error_dialogs.
-        self.last_dir: str = None  # The last used directory.
+        self.last_dir: str = ''  # The last used directory.
         # Do _not_ use os_path_norm: it converts an empty path to '.' (!!)
         self.mFileName: str = fileName or ''
         self.mRelativeFileName = relativeFileName or ''
@@ -688,7 +662,7 @@ class Commands:
             path = c.fullPath(p)
             directory = os.path.dirname(path)
         else:
-            directory = None
+            directory = ''
         c.general_script_helper(command, ext, language, directory=directory, regex=regex, root=p)
 
     # @+node:tom.20241014154415.1: *4* @cmd c.execute-external-file
@@ -891,7 +865,7 @@ class Commands:
             If there is a language directive in effect, return it,
             otherwise use the file extension.
             """
-            return c.getLanguage(c.p) or LANGUAGE_EXTENSION_MAP.get(ext, None)
+            return c.getLanguage(c.p) or LANGUAGE_EXTENSION_MAP.get(ext, None) or ''
 
         # @+node:tom.20241014154415.10: *5* getProcessor
         def getProcessor(language: str, path: str, extension: str) -> str:
@@ -997,7 +971,7 @@ class Commands:
                 names = (names,)
             term = ''
             for name in names:
-                term = which(name)
+                term = which(name) or ''
                 if term:
                     break
             return term
@@ -1137,11 +1111,11 @@ class Commands:
             # Check terminal from MAP_SETTING_NODE setting
             setting_terminal = terminal
             if setting_terminal:
-                terminal = which(terminal)
+                terminal = which(terminal) or ''
                 if not terminal:
                     g.es(f'Cannot find terminal specified in setting: {setting_terminal}')
                     g.es('Trying an alternative')
-                    terminal = getTerminal()
+                    terminal = getTerminal() or ''
                     g.es('using', terminal)
 
             path = c.fullPath(root)
@@ -1222,13 +1196,13 @@ class Commands:
         *,
         event: LeoKeyEvent = None,
         args: Args = None,
-        p: Position = None,
-        script: str = None,
+        p: Position | None = None,
+        script: str = '',
         useSelectedText: bool = True,
         define_g: bool = True,
         define_name: str = '__main__',
         silent: bool = False,
-        namespace: dict = None,
+        namespace: dict | None = None,
         raiseFlag: bool = False,
         runPyflakes: bool = True,
     ) -> Value:
@@ -1464,7 +1438,7 @@ class Commands:
     safe_all_positions = all_positions
 
     # @+node:ekr.20191014093239.1: *5* c.all_positions_for_v
-    def all_positions_for_v(self, v: VNode, stack: list[tuple] = None) -> Generator:
+    def all_positions_for_v(self, v: VNode, stack: list[tuple] | None = None) -> Generator:
         """
         Generates all positions p in this outline where p.v is v.
 
@@ -1504,7 +1478,7 @@ class Commands:
                 stack.pop(0)
 
     # @+node:ekr.20161120121226.1: *5* c.all_roots
-    def all_roots(self, copy: bool = True, predicate: Callable = None) -> Generator:
+    def all_roots(self, copy: bool = True, predicate: Callable | None = None) -> Generator:
         """
         A generator yielding *all* the root positions in the outline that
         satisfy the given predicate. p.isAnyAtFileNode is the default
@@ -1547,7 +1521,7 @@ class Commands:
     all_positions_with_unique_vnodes_iter = all_unique_positions
 
     # @+node:ekr.20161120125322.1: *5* c.all_unique_roots
-    def all_unique_roots(self, copy: bool = True, predicate: Callable = None) -> Generator:
+    def all_unique_roots(self, copy: bool = True, predicate: Callable | None = None) -> Generator:
         """
         A generator yielding all unique root positions in the outline that
         satisfy the given predicate. p.isAnyAtFileNode is the default
@@ -1591,7 +1565,7 @@ class Commands:
         c = self
         if getattr(c, '_currentPosition', None):
             # *Always* return a copy.
-            return c._currentPosition.copy()
+            return c._currentPosition.copy()  # type:ignore
         # Returns a new copy of the root position or None
         return c.rootPosition()
 
@@ -1791,7 +1765,7 @@ class Commands:
     def getLineEnding(self, p: Position) -> str:
         """
         Scan p and all ancestors for the first @lineending direcive.
-        Return None (*not* '\n') by default.
+        Return '' (*not* '\n') by default.
         """
         c = self
         # The headline has higher precedence because it is more visible.
@@ -1801,7 +1775,7 @@ class Commands:
                     ending = m.group(1)
                     if ending in ("cr", "crlf", "lf", "nl", "platform"):
                         return g.getOutputNewline(name=ending)
-        return None
+        return ''
 
     # @+node:ekr.20250404153234.1: *5* c.getPageWidth
     # Use a regex to avoid allocating temp strings.
@@ -1995,7 +1969,9 @@ class Commands:
         return p
 
     # @+node:ekr.20040307104131.3: *5* c.positionExists
-    def positionExists(self, p: Position, root: Position = None, trace: bool = False) -> bool:
+    def positionExists(
+        self, p: Position, root: Position | None = None, trace: bool = False
+    ) -> bool:
         """Return True if a position exists in c's tree"""
         if not p or not p.v:
             return False
@@ -2027,13 +2003,13 @@ class Commands:
     # @+node:ekr.20040803140033.2: *5* c.rootPosition
     _rootCount = 0
 
-    def rootPosition(self) -> Position | None:
+    def rootPosition(self) -> Position:
         """Return a new *copy* of the root position or None."""
         c = self
         if c.hiddenRootNode.children:
             v = c.hiddenRootNode.children[0]
             return leoNodes.Position(v, childIndex=0, stack=None)
-        return None
+        return None  # type:ignore #This should never happen.
 
     # For compatibility with old scripts...
 
@@ -2105,7 +2081,7 @@ class Commands:
         return positions
 
     # @+node:ekr.20090107113956.1: *5* c.vnode2position
-    def vnode2position(self, v: VNode) -> Position:
+    def vnode2position(self, v: VNode) -> Position | None:
         """
         Given a VNode v, construct a valid position p such that p.v = v.
         """
@@ -2297,7 +2273,7 @@ class Commands:
         g.doHook("set-mark", c=c, p=p)
 
     # @+node:ekr.20040803140033.3: *5* c.setRootPosition (A do-nothing)
-    def setRootPosition(self, unused_p: Position = None) -> None:
+    def setRootPosition(self, unused_p: Position | None = None) -> None:
         """Set c._rootPosition."""
         # 2011/03/03: No longer used.
 
@@ -2360,7 +2336,7 @@ class Commands:
                 new_gnx(v)
                 g.es_print(f"empty v.fileIndex: {v} new: {p.v.gnx!r}", color='red')
         for gnx in sorted(vnode_d.keys()):
-            aList = list(vnode_d.get(gnx))
+            aList = list(vnode_d.get(gnx, []))
             ids = [id_ for (id_, v) in aList]
             if len(ids) > 1:
                 print('\nc.checkGnxs...')
@@ -2402,6 +2378,7 @@ class Commands:
         return errors
 
     # @+node:ekr.20040314035615.2: *5* c.checkParentAndChildren
+    @typing.no_type_check
     def checkParentAndChildren(self, p: Position) -> bool:
         """Check consistency of parent and child data structures."""
         c = self
@@ -2812,7 +2789,7 @@ class Commands:
 
     # @+node:ekr.20040723094220.6: *4* c.tabNannyNode
     # This code is based on tabnanny.check.
-
+    @typing.no_type_check
     def tabNannyNode(self, p: Position, headline: str, body: str) -> None:
         """Check indentation using tabnanny."""
         try:
@@ -3068,6 +3045,7 @@ class Commands:
 
     # @+node:ekr.20250404014922.1: *4* --- c: Legacy scanners (deprecated)
     # @+node:ekr.20080827175609.39: *5* c.scanAllDirectives (deprecated)
+    @typing.no_type_check
     def scanAllDirectives(self, p: Position) -> dict[str, Value]:
         """
         Scan p and ancestors for directives.
@@ -3262,8 +3240,8 @@ class Commands:
         ext: str,
         language: str,
         root: Position,
-        directory: str = None,
-        regex: str = None,
+        directory: str = '',
+        regex: str = '',
     ) -> None:
         """
         The official helper for the execute-general-script command.
@@ -3585,7 +3563,7 @@ class Commands:
 
     # @+node:ekr.20171124101444.1: *3* c.File
     # @+node:ekr.20200305104646.1: *4* c.archivedPositionToPosition
-    def archivedPositionToPosition(self, s: str) -> Position:
+    def archivedPositionToPosition(self, s: str) -> Position | None:
         """Convert an archived position (a string) to a position."""
         c = self
         s = g.toUnicode(s)
@@ -3615,8 +3593,8 @@ class Commands:
     # @+node:ekr.20150422080541.1: *4* c.backup
     def backup(
         self,
-        fileName: str = None,
-        prefix: str = None,
+        fileName: str = '',
+        prefix: str = '',
         silent: bool = False,
         useTimeStamp: bool = True,
     ) -> str:
@@ -3648,9 +3626,9 @@ class Commands:
     # @+node:ekr.20180210092235.1: *4* c.backup_helper
     def backup_helper(
         self,
-        base_dir: str = None,
+        base_dir: str = '',
         env_key: str = 'LEO_BACKUP',
-        sub_dir: str = None,
+        sub_dir: str = '',
         use_git_prefix: bool = True,
     ) -> None:
         """
@@ -3667,12 +3645,12 @@ class Commands:
                     base_dir = os.environ[env_key]
                 except KeyError:
                     print(f"No environment var: {env_key}")
-                    base_dir = None
+                    base_dir = ''
         if base_dir and g.os_path_exists(base_dir):
             if use_git_prefix:
                 git_branch, junk = g.gitInfo()
             else:
-                git_branch = None
+                git_branch = ''
             theDir, fn = g.os_path_split(c.fileName())
             backup_dir = join(base_dir, sub_dir) if sub_dir else base_dir
             path = join(backup_dir, fn)
@@ -3725,8 +3703,8 @@ class Commands:
         top_directory: str,
         kind: str = '@clean',  # Any @<file> type. @clean is recommended.
         report_changed_at_clean_nodes: bool = True,  # Recommended.
-        sub_directories: list[str] = None,
-        top_outline_name: str = None,
+        sub_directories: list[str] | None = None,
+        top_outline_name: str = '',
     ) -> None:
         # @+<< c.makeLinkLeoFiles: docstring >>
         # @+node:ekr.20250717132150.1: *5* << c.makeLinkLeoFiles: docstring >>
@@ -3840,7 +3818,7 @@ class Commands:
             self._create_link_file(
                 directory=top_directory,
                 extensions=extensions,
-                files=None,
+                files=cast(list[str], None),
                 kind='@leo',
                 links=top_links,
                 outline_name=top_outline_name,
@@ -3974,10 +3952,10 @@ class Commands:
                 if p.isAtLeoNode():
                     fileName = p.atLeoNodeName()
                     if fileName not in todo and fileName not in scanned:
-                        c2 = g.openWithFileName(fileName, gui=gui)
-                        todo.append(fileName)
-                        assert c2 not in result
-                        result.append(c2)
+                        if c2 := g.openWithFileName(fileName, gui=gui):  # #4755
+                            todo.append(fileName)
+                            assert c2 not in result
+                            result.append(c2)
 
         # Create the initial to-do list.
         scan(c.fileName())
@@ -3996,7 +3974,7 @@ class Commands:
         return result
 
     # @+node:ekr.20031218072017.2081: *4* c.openRecentFile
-    def openRecentFile(self, event: LeoKeyEvent = None, fn: str = None) -> None:
+    def openRecentFile(self, event: LeoKeyEvent | None = None, fn: str = '') -> None:
         """
         c.openRecentFile: This is not a command!
 
@@ -4012,7 +3990,7 @@ class Commands:
             g.doHook("recentfiles2", c=c2, p=c2.p, v=c2.p, fileName=fn)
 
     # @+node:ekr.20031218072017.2823: *4* c.openWith
-    def openWith(self, event: LeoKeyEvent = None, d: dict[str, Any] = None) -> None:
+    def openWith(self, event: LeoKeyEvent | None = None, d: dict[str, Any] | None = None) -> None:
         """
         This is *not* a command.
 
@@ -4066,7 +4044,7 @@ class Commands:
         x.diff_file(fn=fn, rev1=rev1, rev2=rev2)
 
     # @+node:ekr.20180508110755.1: *4* c.diff_two_revs
-    def diff_two_revs(self, directory: str = None, rev1: str = '', rev2: str = '') -> None:
+    def diff_two_revs(self, directory: str = '', rev1: str = '', rev2: str = '') -> None:
         """
         Create an outline describing the git diffs for all files changed
         between rev1 and rev2.
@@ -4215,11 +4193,11 @@ class Commands:
         c.updateSyntaxColorer(p)  # Dragging can change syntax coloring.
 
     # @+node:ekr.20031218072017.2353: *5* c.dragAfter
-    def dragAfter(self, p: Position, after: Position | None) -> None:
+    def dragAfter(self, p: Position, after: Position) -> None:
         c, p, u = self, self.p, self.undoer
         if not c.checkDrag(p, after):
             return
-        if not c.checkMoveWithParentWithWarning(p, after.parent(), True):
+        if not c.checkMoveWithParentWithWarning(p, after.parent(), True):  # type:ignore
             return
         c.endEditing()
         undoData = u.beforeMoveNode(p)
@@ -4259,7 +4237,10 @@ class Commands:
         undoType = 'Clone Drag'
         current = c.p
         clone = p.clone()  # Creates clone.  Does not set undo.
-        if c.checkDrag(p, after) and c.checkMoveWithParentWithWarning(clone, after.parent(), True):
+        if (
+            c.checkDrag(p, after) and
+            c.checkMoveWithParentWithWarning(clone, after.parent(), True)  # type:ignore
+        ):  # fmt: skip
             c.endEditing()
             undoData = u.beforeInsertNode(current)
             clone.setDirty()
@@ -4275,7 +4256,7 @@ class Commands:
 
     # @+node:ekr.20031218072017.2949: *4* c.Drawing
     # @+node:ekr.20080514131122.8: *5* c.bringToFront
-    def bringToFront(self, c2: "Commands" = None) -> None:
+    def bringToFront(self, c2: Cmdr | None = None) -> None:
         c = self
         c2 = c2 or c
         g.app.gui.ensure_commander_visible(c2)
@@ -4334,7 +4315,7 @@ class Commands:
                 mods.clear()
 
     # @+node:ekr.20080514131122.13: *5* c.recolor
-    def recolor(self, p: Position = None) -> None:
+    def recolor(self, p: Position | None = None) -> None:
         """
         Force a full recolor when using the Scintilla text widget.
         This method has no effect when using the default Qt colorizer.
@@ -4366,7 +4347,7 @@ class Commands:
         c.enableRedrawFlag = True
 
     # @+node:ekr.20090110073010.1: *6* c.redraw
-    def redraw(self, p: Position = None) -> None:
+    def redraw(self, p: Position | None = None) -> None:
         """
         Redraw the screen immediately.
         If p is given, set c.p to p.
@@ -4697,9 +4678,9 @@ class Commands:
         self,
         menu: LeoQtMenu,
         accelerator: str = '',  # Not used.
-        command: Callable = None,
-        commandName: str = None,  # Not used.
-        label: str = None,  # Not used.
+        command: Callable | None = None,
+        commandName: str = '',  # Not used.
+        label: str = '',  # Not used.
         underline: int = 0,
     ) -> None:
         c = self
@@ -4897,11 +4878,11 @@ class Commands:
             if limitIsVisible:  # A hoist
                 return current != limit
             # A chapter.
-            return current != limit.firstChild()
+            return current != limit.firstChild()  # type:ignore # limit is a Position, not None.
         return current != c.rootPosition()
 
     # @+node:ekr.20031218072017.2974: *6* c.canPasteOutline
-    def canPasteOutline(self, s: str = None) -> bool:
+    def canPasteOutline(self, s: str = '') -> bool:
         # c = self
         if not s:
             s = g.app.gui.getTextFromClipboard()
@@ -5030,7 +5011,7 @@ class Commands:
         self,
         p: Position,
         selectAll: bool = False,
-        selection: tuple = None,
+        selection: tuple | None = None,
         keepMinibuffer: bool = False,
     ) -> None:
         """Redraw the screen and edit p's headline."""
@@ -5111,12 +5092,12 @@ class Commands:
     def recursiveImport(
         self,
         *,  # All arguments are kwargs.
-        dir_: str = None,  # A directory or file name.
-        ignore_pattern: re.Pattern = None,  # Ignore files matching this regex pattern.
+        dir_: str = '',  # A directory or file name.
+        ignore_pattern: re.Pattern | None = None,  # Ignore files matching this regex pattern.
         kind: str = '@file',
         recursive: bool = True,
         safe_at_file: bool = True,
-        theTypes: list[str] = None,
+        theTypes: list[str] | None = None,
         verbose: bool = True,
     ) -> None:
         # @+<< docstring >>
@@ -5228,7 +5209,7 @@ class Commands:
 
         # Update root's tree.
         d: dict[str, VNode] = {p.v.gnx: p.v for p in root.self_and_subtree()}
-        ok = at.fast_read_into_root(c, results, gnx2vnode=d, path=None, root=root)
+        ok = at.fast_read_into_root(c, results, gnx2vnode=d, path='', root=root)
         if ok:
             c.redraw()
             g.es_print(f"beautified: {root.h}", color='blue')
@@ -5240,11 +5221,11 @@ class Commands:
         self,
         generator: Callable,
         predicate: Callable,
-        failMsg: str = None,
+        failMsg: str = '',
         flatten: bool = False,
-        iconPath: str = None,
-        undoType: str = None,
-    ) -> Position:
+        iconPath: str = '',
+        undoType: str = '',
+    ) -> Position | None:
         """
         Traverse the tree given using the generator, cloning all positions for
         which predicate(p) is True. Undoably move all clones to a new node, created
@@ -5260,7 +5241,7 @@ class Commands:
         """
         c = self
         u, undoType = c.undoer, undoType or 'clone-find-predicate'
-        clones, root, seen = [], None, set()
+        clones, seen = [], set()
         for p in generator():
             if predicate(p) and p.v not in seen:
                 c.setCloneFindByPredicateIcon(iconPath, p)
@@ -5283,9 +5264,10 @@ class Commands:
             c.setChanged()
             c.contractAllHeadlines()
             root.expand()
-        elif failMsg:
+            return root  # #4755
+        if failMsg:
             g.es(failMsg, color='red')
-        return root
+        return None
 
     # @+node:ekr.20160304054950.1: *5* c.setCloneFindByPredicateIcon
     def setCloneFindByPredicateIcon(self, iconPath: str, p: Position) -> None:
@@ -5321,10 +5303,11 @@ class Commands:
         return root
 
     # @+node:peckj.20131023115434.10114: *4* c.createNodeHierarchy
+    @typing.no_type_check
     def createNodeHierarchy(
         self,
         heads: list[str],
-        parent: Position = None,
+        parent: Position | None = None,
         forcecreate: bool = False,
     ) -> Position:
         """
@@ -5364,9 +5347,9 @@ class Commands:
                     parent = n
             else:  # else, simply create child nodes each round
                 if not forcecreate:
-                    for ch in parent.children():
-                        if ch.h == head:
-                            parent = ch
+                    for child in parent.children():
+                        if child.h == head:
+                            parent = child
                             changed_node = True
                             break
                 if parent.h != head or not changed_node or forcecreate:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -149,7 +149,7 @@ if TYPE_CHECKING:
     from leo.plugins.qt_gui import StyleSheetManager
     from leo.plugins.qt_text import QTextMixin
 
-    assert StyleSheetManager
+    assert StyleSheetManager is not None
 
     Args = Any
     KWargs = Any

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1057,13 +1057,13 @@ class Commands:
         # @-others
 
         def getTerminal() -> str:
-            if term := os.environ.get('TERMINAL', ''):
-                return term
             return (
-                getCommonTerminal(PREFERRED_TERMINALS)
+                os.environ.get('TERMINAL', '')
+                or getCommonTerminal(PREFERRED_TERMINALS)
                 or getTerminalFromDirectory('/usr/bin')
                 or getTerminalFromDirectory('/usr/local/bin')
                 or getTerminalFromDirectory('/bin')
+                or ''
             )
 
         # @+node:tom.20241014154415.16: *5* getTermExecuteCmd
@@ -1193,7 +1193,7 @@ class Commands:
                 if not terminal:
                     g.es(f'Cannot find terminal specified in setting: {setting_terminal}')
                     g.es('Trying an alternative')
-                    terminal = getTerminal() or ''
+                    terminal = getTerminal()
                     g.es('using', terminal)
 
             path = c.fullPath(root)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -35,43 +35,121 @@ if TYPE_CHECKING:
     from leo.core.leoConfig import LocalConfigManager
     from leo.core.leoNodes import Position, VNode
 
-    # The following imports are required, but flake8 doesn't know that.
+    # The following imports are required, but flake8 won't know that without the asserts.
 
     # 11 subcommanders...
-    from leo.core.leoAtFile import AtFile  # noqa
-    from leo.core.leoChapters import ChapterController  # noqa
-    from leo.core.leoFileCommands import FileCommands  # noqa
-    from leo.core.leoFind import LeoFind  # noqa
-    from leo.core.leoImport import LeoImportCommands  # noqa
-    from leo.core.leoKeys import KeyHandlerClass  # noqa
-    from leo.core.leoHistory import NodeHistory  # noqa
-    from leo.core.leoPersistence import PersistenceDataController  # noqa
-    from leo.core.leoPrinting import PrintingController  # noqa
-    from leo.core.leoShadow import ShadowController  # noqa
-    from leo.core.leoUndo import Undoer  # noqa
-    from leo.core.leoVim import VimCommands  # noqa
+    from leo.core.leoAtFile import AtFile
+
+    assert AtFile  # type:ignore
+
+    from leo.core.leoChapters import ChapterController
+
+    assert ChapterController
+
+    from leo.core.leoFileCommands import FileCommands
+
+    assert FileCommands
+
+    from leo.core.leoFind import LeoFind
+
+    assert LeoFind
+
+    from leo.core.leoImport import LeoImportCommands
+
+    assert LeoImportCommands
+
+    from leo.core.leoKeys import KeyHandlerClass
+
+    assert KeyHandlerClass  # type:ignore
+
+    from leo.core.leoHistory import NodeHistory
+
+    assert NodeHistory
+
+    from leo.core.leoPersistence import PersistenceDataController
+
+    assert PersistenceDataController
+
+    from leo.core.leoPrinting import PrintingController
+
+    assert PrintingController
+
+    from leo.core.leoShadow import ShadowController
+
+    assert ShadowController
+
+    from leo.core.leoUndo import Undoer
+
+    assert Undoer
+
+    from leo.core.leoVim import VimCommands
+
+    assert VimCommands
 
     # 14 command handlers...
-    from leo.commands.abbrevCommands import AbbrevCommandsClass  # noqa
-    from leo.commands.bufferCommands import BufferCommandsClass  # noqa
-    from leo.commands.controlCommands import ControlCommandsClass  # noqa
-    from leo.commands.convertCommands import ConvertCommandsClass  # noqa
-    from leo.commands.debugCommands import DebugCommandsClass  # noqa
-    from leo.commands.editCommands import EditCommandsClass  # noqa
-    from leo.commands.editFileCommands import EditFileCommandsClass  # noqa
-    from leo.commands.gotoCommands import GoToCommands  # noqa
-    from leo.commands.helpCommands import HelpCommandsClass  # noqa
-    from leo.commands.keyCommands import KeyHandlerCommandsClass  # noqa
-    from leo.commands.killBufferCommands import KillBufferCommandsClass  # noqa
-    from leo.commands.rectangleCommands import RectangleCommandsClass  # noqa
-    from leo.core.leoRst import RstCommands  # noqa
-    from leo.commands.spellCommands import SpellCommandsClass  # noqa
+    from leo.commands.abbrevCommands import AbbrevCommandsClass
+
+    assert AbbrevCommandsClass
+
+    from leo.commands.bufferCommands import BufferCommandsClass
+
+    assert BufferCommandsClass
+
+    from leo.commands.controlCommands import ControlCommandsClass
+
+    assert ControlCommandsClass
+
+    from leo.commands.convertCommands import ConvertCommandsClass
+
+    assert ConvertCommandsClass
+
+    from leo.commands.debugCommands import DebugCommandsClass
+
+    assert DebugCommandsClass
+
+    from leo.commands.editCommands import EditCommandsClass
+
+    assert EditCommandsClass
+
+    from leo.commands.editFileCommands import EditFileCommandsClass
+
+    assert EditFileCommandsClass
+
+    from leo.commands.gotoCommands import GoToCommands
+
+    assert GoToCommands
+
+    from leo.commands.helpCommands import HelpCommandsClass
+
+    assert HelpCommandsClass
+
+    from leo.commands.keyCommands import KeyHandlerCommandsClass
+
+    assert KeyHandlerCommandsClass
+
+    from leo.commands.killBufferCommands import KillBufferCommandsClass
+
+    assert KillBufferCommandsClass
+
+    from leo.commands.rectangleCommands import RectangleCommandsClass
+
+    assert RectangleCommandsClass
+
+    from leo.core.leoRst import RstCommands
+
+    assert RstCommands
+
+    from leo.commands.spellCommands import SpellCommandsClass
+
+    assert SpellCommandsClass
 
     # Other objects...
     from leo.core.leoGui import LeoGui
     from leo.core.qt_frame import LeoQtMenu
-    from leo.plugins.qt_gui import StyleSheetManager  # noqa
+    from leo.plugins.qt_gui import StyleSheetManager
     from leo.plugins.qt_text import QTextMixin
+
+    assert StyleSheetManager
 
     Args = Any
     KWargs = Any

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4030,7 +4030,9 @@ class Commands:
                 if p.isAtLeoNode():
                     fileName = p.atLeoNodeName()
                     if fileName not in todo and fileName not in scanned:
-                        if c2 := g.openWithFileName(fileName, gui=gui):  # #4755 # Bug fix!
+                        if c2 := g.openWithFileName(
+                            fileName, gui=gui
+                        ):  # strict_optional # Bug fix!
                             todo.append(fileName)
                             assert c2 not in result
                             result.append(c2)
@@ -5342,7 +5344,7 @@ class Commands:
             c.setChanged()
             c.contractAllHeadlines()
             root.expand()
-            return root  # #4755
+            return root  # strict_optional
         if failMsg:
             g.es(failMsg, color='red')
         return None

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1997,9 +1997,7 @@ class Commands:
     # @+node:ekr.20040803112450: *6* c.isCurrentPosition
     def isCurrentPosition(self, p: Position) -> bool:
         c = self
-        if p is None or c._currentPosition is None:
-            return False
-        return p == c._currentPosition
+        return bool(p and c._currentPosition and p == c._currentPosition)  # strict_optional
 
     # @+node:ekr.20040803112450.1: *6* c.isRootPosition
     def isRootPosition(self, p: Position) -> bool:
@@ -2927,7 +2925,7 @@ class Commands:
         else:
             format = c.config.getString("headline-time-format-string")
             gmt = c.config.getBool("headline-gmt-time")
-        if format is None:
+        if not format:  # strict_optional
             format = default_format
         try:
             # import time

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3988,7 +3988,7 @@ class Commands:
                 p.moveToThreadNext()
 
     # @+node:ekr.20250717080554.1: *4* c.openAllLinkedFiles (transitive closure)
-    def openAllLinkedFiles(self, gui: LeoGui = None) -> list[Commands]:
+    def openAllLinkedFiles(self, gui: LeoGui | None = None) -> list[Commands]:
         """
         Open the transitive closure of all outlines reachable from any @leo
         node in this outline.

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2083,7 +2083,11 @@ class Commands:
     _rootCount = 0
 
     def rootPosition(self) -> Position:
-        """Return a new *copy* of the root position or None."""
+        """
+        Return a new *copy* of the root position.
+
+        Note: the code returns None by default, but that should not happen in practice.
+        """
         c = self
         if c.hiddenRootNode.children:
             v = c.hiddenRootNode.children[0]

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2422,7 +2422,7 @@ class Commands:
             aList = list(vnode_d.get(gnx, []))
             ids = [id_ for (id_, v) in aList]
             if len(ids) > 1:
-                print('\nc.checkGnxs...')
+                g.es_print('\nc.checkGnxs...')
                 g.es_print(f"multiple vnodes with gnx: {gnx!r}", color='red')
                 for id_, v in aList:
                     gnx_errors += 1

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -943,7 +943,7 @@ class Commands:
             If there is a language directive in effect, return it,
             otherwise use the file extension.
             """
-            return c.getLanguage(c.p) or LANGUAGE_EXTENSION_MAP.get(ext, None) or ''
+            return c.getLanguage(c.p) or LANGUAGE_EXTENSION_MAP.get(ext, '')
 
         # @+node:tom.20241014154415.10: *5* getProcessor
         def getProcessor(language: str, path: str, extension: str) -> str:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4037,10 +4037,10 @@ class Commands:
                     if fileName not in todo and fileName not in scanned:
                         if c2 := g.openWithFileName(
                             fileName, gui=gui
-                        ):  # strict_optional # Bug fix!
+                        ):  # strict_optional # bug fix!
                             todo.append(fileName)
-                            assert c2 not in result
-                            result.append(c2)
+                            if c2 not in result:  # strict_optional: bug fix!
+                                result.append(c2)
 
         # Create the initial to-do list.
         scan(c.fileName())

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -195,7 +195,7 @@ class Commands:
         fileName: str,
         gui: LeoGui = None,
         parentFrame: Any = None,
-        previousSettings: "PreviousSettings" = None,
+        previousSettings: PreviousSettings | None = None,
         relativeFileName: str = '',
     ) -> None:
         t1 = time.process_time()
@@ -518,7 +518,7 @@ class Commands:
         self.vim_mode = False
 
     # @+node:ekr.20140815160132.18837: *5* c.initSettings
-    def initSettings(self, previousSettings: "PreviousSettings") -> None:
+    def initSettings(self, previousSettings: PreviousSettings | None) -> None:
         """Instantiate c.config from previous settings."""
         c = self
         from leo.core import leoConfig
@@ -1814,7 +1814,7 @@ class Commands:
                 name = v.anyAtFileNodeName()
                 junk, ext = g.os_path_splitext(name)
                 ext = ext[1:]  # strip the leading period.
-                language = g.app.extension_dict.get(ext)
+                language = g.app.extension_dict.get(ext, '')
                 if g.isValidLanguage(language):
                     return language
             return ''

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4030,7 +4030,7 @@ class Commands:
                 if p.isAtLeoNode():
                     fileName = p.atLeoNodeName()
                     if fileName not in todo and fileName not in scanned:
-                        if c2 := g.openWithFileName(fileName, gui=gui):  # #4755
+                        if c2 := g.openWithFileName(fileName, gui=gui):  # #4755 # Bug fix!
                             todo.append(fileName)
                             assert c2 not in result
                             result.append(c2)

--- a/leo/core/leoCompare.py
+++ b/leo/core/leoCompare.py
@@ -234,7 +234,6 @@ class BaseLeoCompare:
             lines1 += 1
             s2 = g.readlineForceUnixNewline(f2)
             lines2 += 1
-            # Note: isLeoHeader may return None.
             sentinelComment1 = self.isLeoHeader(s1)
             sentinelComment2 = self.isLeoHeader(s2)
             if not sentinelComment1:
@@ -398,14 +397,14 @@ class BaseLeoCompare:
     # sentinel line.
     # @@c
 
-    def isLeoHeader(self, s: str) -> str | None:
+    def isLeoHeader(self, s: str) -> str:
         tag = "@+leo"
         j = s.find(tag)
         if j > 0:
             i = g.skip_ws(s, 0)
             if i < j:
                 return s[i:j]
-        return None
+        return ''
 
     def isSentinel(self, s: str, sentinelComment: str) -> bool:
         i = g.skip_ws(s, 0)

--- a/leo/core/leoCompare.py
+++ b/leo/core/leoCompare.py
@@ -412,7 +412,7 @@ class BaseLeoCompare:
 
     # @+node:ekr.20031218072017.1144: *4* compare.openOutputFile
     def openOutputFile(self) -> bool:  # Bug fix: return a bool.
-        if self.outputFileName is None:
+        if not self.outputFileName:  # strict_optional
             return False
         theDir, name = g.os_path_split(self.outputFileName)
         if not theDir:

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1310,7 +1310,7 @@ class GlobalConfigManager:
         lm = g.app.loadManager
         d = c.config.settingsDict if c else lm.globalSettingsDict
         limit = c.config.getInt('print-settings-at-data-limit')
-        if limit is None:
+        if not limit:  # strict_optional
             limit = 20  # A reasonable default.
         for key in sorted(list(d.keys())):
             gs = d.get(key)  # gs is a GeneralSetting or None

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1338,7 +1338,7 @@ class GlobalConfigManager:
 
     # @+node:ekr.20041123070429: *3* gcm.canonicalizeSettingName (munge)
     def canonicalizeSettingName(self, name: str) -> str:
-        if not name:  # #4755
+        if not name:  # strict_optional
             return ''
         name = name.lower()
         for ch in ('-', '_', ' ', '\n'):

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -2272,7 +2272,7 @@ class SettingsTreeParser(ParserBaseClass):
     # @+others
     # @+node:ekr.20041119204103: *3* ctor (SettingsTreeParser)
     # @+node:ekr.20041119204714: *3* visitNode (SettingsTreeParser)
-    def visitNode(self, p: Position) -> str | None:
+    def visitNode(self, p: Position) -> str:
         """Init any settings found in node p."""
         p = p.copy()
         munge = g.app.config.munge
@@ -2296,7 +2296,7 @@ class SettingsTreeParser(ParserBaseClass):
                     g.es_exception()
             else:
                 g.pr("*** no handler", kind)
-        return None
+        return ''
 
     # @-others
 

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1337,13 +1337,13 @@ class GlobalConfigManager:
                 yield key2, val, c, letter
 
     # @+node:ekr.20041123070429: *3* gcm.canonicalizeSettingName (munge)
-    def canonicalizeSettingName(self, name: str) -> str | None:
-        if name is None:
-            return None
+    def canonicalizeSettingName(self, name: str) -> str:
+        if not name:  # #4755
+            return ''
         name = name.lower()
         for ch in ('-', '_', ' ', '\n'):
             name = name.replace(ch, '')
-        return name if name else None
+        return name if name else ''
 
     munge = canonicalizeSettingName
 
@@ -1487,13 +1487,13 @@ class GlobalConfigManager:
         return self.get(setting, "outlinedata")
 
     # @+node:ekr.20041117093009.1: *4* gcm.getDirectory
-    def getDirectory(self, setting: str) -> str | None:
+    def getDirectory(self, setting: str) -> str:
         """Return the value of @directory setting, or None if the directory does not exist."""
         # Fix https://bugs.launchpad.net/leo-editor/+bug/1173763
         theDir = self.get(setting, 'directory')
         if g.os_path_exists(theDir) and g.os_path_isdir(theDir):
             return theDir
-        return None
+        return ''
 
     # @+node:ekr.20070224075914.1: *4* gcm.getEnabledPlugins
     def getEnabledPlugins(self) -> str:

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -859,7 +859,7 @@ class ParserBaseClass:
         command-name --> same = binding
         """
         s = s.replace('\x7f', '')  # Can happen on MacOS. Very weird.
-        name = val = nextMode = None
+        name = val = None
         nextMode = 'none'
         i = g.skip_ws(s, 0)
         if g.match(s, i, '-->'):  # New in 4.4.1: allow mode-entry commands.

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -253,19 +253,18 @@ class ParserBaseClass:
         return 'skip'
 
     # @+node:ekr.20131114051702.16546: *5* pbc.getOutlineDataHelper
-    def getOutlineDataHelper(self, p: Position) -> str | None:
+    def getOutlineDataHelper(self, p: Position) -> str:
         c = self.c
         if not p:
-            return None
+            return ''
         try:
             # Copy the entire tree to s.
             c.fileCommands.leo_file_encoding = 'utf-8'
             s = c.fileCommands.outline_to_clipboard_string(p)
-            s = g.toUnicode(s, encoding='utf-8')
+            return g.toUnicode(s, encoding='utf-8')
         except Exception:
             g.es_exception()
-            s = None
-        return s
+            return ''
 
     # @+node:ekr.20041120094940.3: *4* pbc.doDirectory & doPath
     def doDirectory(self, p: Position, kind: str, name: str, val: Any) -> None:
@@ -314,7 +313,7 @@ class ParserBaseClass:
                 self.set(p, setKind, name, val)
 
     # @+node:ekr.20150426034813.1: *4* pbc.doIfEnv
-    def doIfEnv(self, p: Position, kind: str, name: str, val: Any) -> str | None:
+    def doIfEnv(self, p: Position, kind: str, name: str, val: Any) -> str:
         """
         Support @ifenv in @settings trees.
 
@@ -328,11 +327,11 @@ class ParserBaseClass:
         env = env.lower().strip() if env else 'none'
         for s in aList[1:]:
             if s.lower().strip() == env:
-                return None
+                return ''
         return 'skip'
 
     # @+node:dan.20080410121257.2: *4* pbc.doIfHostname
-    def doIfHostname(self, p: Position, kind: str, name: str, val: Any) -> str | None:
+    def doIfHostname(self, p: Position, kind: str, name: str, val: Any) -> str:
         """
         Support @ifhostname in @settings trees.
 
@@ -351,15 +350,15 @@ class ParserBaseClass:
                 return 'skip'
         elif h != s:
             return 'skip'
-        return None
+        return ''
 
     # @+node:ekr.20041120104215: *4* pbc.doIfPlatform
-    def doIfPlatform(self, p: Position, kind: str, name: str, val: Any) -> str | None:
+    def doIfPlatform(self, p: Position, kind: str, name: str, val: Any) -> str:
         """Support @ifplatform in @settings trees."""
         platform = sys.platform.lower()
         for s in name.split(','):
             if platform == s.lower():
-                return None
+                return ''
         return "skip"
 
     # @+node:ekr.20041120104215.1: *4* pbc.doIgnore
@@ -866,7 +865,9 @@ class ParserBaseClass:
             j = g.skip_ws(s, i + 3)
             i = g.skip_id(s, j, '-')
             entryCommandName = s[j:i]
-            return None, g.BindingInfo('*entry-command*', commandName=entryCommandName)
+            return '', g.BindingInfo(
+                '*entry-command*', commandName=entryCommandName
+            )  # strict_optional
         j = i
         i = g.skip_id(s, j, '-@')  # #718.
         name = s[j:i]
@@ -876,7 +877,7 @@ class ParserBaseClass:
                 name = name[len(tag) :]
                 break
         if not name:
-            return None, None
+            return '', None
         # New in Leo 4.4b2.
         i = g.skip_ws(s, i)
         if g.match(s, i, '->'):  # New in 4.4: allow pane-specific shortcuts.

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -688,7 +688,7 @@ class ParserBaseClass:
             line = line.strip()
             if line and not g.match(line, 0, '#'):
                 commandName, bi = self.parseShortcutLine(fn, line)
-                if bi is None:  # Fix #718.
+                if not commandName or bi is None:  # Fix #718.
                     print(f"\nWarning: bad shortcut specifier: {line!r}\n")
                 else:
                     if bi and bi.stroke not in (None, 'none', 'None'):
@@ -848,7 +848,7 @@ class ParserBaseClass:
             d[tag] = val
 
     # @+node:ekr.20041120112043: *4* pbc.parseShortcutLine
-    def parseShortcutLine(self, kind: str, s: str) -> tuple[str | None, Any]:
+    def parseShortcutLine(self, kind: str, s: str) -> tuple[str, Any]:
         """Parse a shortcut line.  Valid forms:
 
         --> entry-command

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -122,18 +122,12 @@ class ExternalFilesController:
         self.files = [z for z in self.files if z.path not in paths]
 
     # @+node:ekr.20150407141838.1: *4* efc.find_path_for_node (called from vim.py)
-    def find_path_for_node(self, p: Position) -> str | None:
-        """
-        Find the path corresponding to node p.
-        called from vim.py.
-        """
+    def find_path_for_node(self, p: Position) -> str:
+        """Return the path corresponding to node p."""
         for ef in self.files:
             if ef.p and ef.p.v == p.v:
-                path = ef.path
-                break
-        else:
-            path = None
-        return path
+                return ef.path
+        return ''
 
     # @+node:ekr.20150330033306.1: *4* efc.on_idle & helpers
     on_idle_count = 0

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -186,6 +186,7 @@ class ExternalFilesController:
         # #1134: Nested @<file> nodes are no longer valid, but this will do no harm.
         changed = False
         state = 'no'
+        changed_roots: set[str] = set()
         for p in c.all_unique_positions():
             if not p.isAnyAtFileNode():
                 continue
@@ -215,6 +216,7 @@ class ExternalFilesController:
                         p2.v.setDirty()
                 # #4565: set all ancestor file nodes dirty and redraw.
                 p.v.setDirty()
+                changed_roots.add(p.h)
                 to_do_set: set[VNode] = set()
                 for p2 in c.all_positions():
                     if p2.v.isDirty():
@@ -224,10 +226,6 @@ class ExternalFilesController:
             return
         # #4570: Write all update messages here, and only here.
         if not g.unitTesting:
-            changed_roots: set[str] = set()
-            for p2 in c.all_positions():
-                if p2.isAnyAtFileNode() and p2.isDirty():
-                    changed_roots.add(p2.h)
             for s in sorted(list(changed_roots)):
                 g.es_print('update:', s, color='blue')
         c.redraw()

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -669,7 +669,7 @@ class LeoFind:
         w.returnPressed()
 
     # @+node:ekr.20150629084611.1: *6* find._compute_find_def_word
-    def _compute_find_def_word(self, event: LeoKeyEvent) -> str | None:  # pragma: no cover (cmd)
+    def _compute_find_def_word(self, event: LeoKeyEvent) -> str:  # pragma: no cover (cmd)
         """Init the find-def command. Return the word to find or None."""
         c = self.c
         w = c.frame.body.wrapper
@@ -679,9 +679,9 @@ class LeoFind:
             c.editCommands.extendToWord(event, select=True)
         word = w.getSelectedText().strip()
         if not word:
-            return None
+            return ''
         if keyword.iskeyword(word):
-            return None
+            return ''
         # Return word, stripped of preceding class or def.
         for tag in ('class ', 'def '):
             found = word.startswith(tag) and len(word) > len(tag)
@@ -828,16 +828,16 @@ class LeoFind:
         return results
 
     # @+node:ekr.20180511045458.1: *6* find._switch_style
-    def _switch_style(self, word: str) -> str | None:
+    def _switch_style(self, word: str) -> str:
         """
         Switch between camelCase and underscore_style function definitions.
         Return None if there would be no change.
         """
         s = word
         if not s:
-            return None
+            return ''
         if s[0].isupper():
-            return None  # Don't convert class names.
+            return ''  # Don't convert class names.
         if s.find('_') > -1:
             # Convert to CamelCase
             s = s.lower()
@@ -854,7 +854,7 @@ class LeoFind:
                 result.append('_')
             result.append(ch.lower())
         s = ''.join(result)
-        return None if s == word else s
+        return '' if s == word else s
 
     # @+node:ekr.20031218072017.3063: *4* find.find-next, find-prev & do_find_*
     @cmd('find-next')

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -696,13 +696,13 @@ class GeneralSetting:
     def __init__(
         self,
         kind: str,
-        encoding: str = '',  # #4755
-        ivar: str = '',  # #4755
-        source: str = '',  # #4755
+        encoding: str = '',
+        ivar: str = '',
+        source: str = '',
         val: Value | None = None,
-        path: str = '',  # #4755
+        path: str = '',
         tag: str = 'setting',
-        unl: str = '',  # #4755
+        unl: str = '',
     ) -> None:
         self.encoding = encoding
         self.ivar = ivar

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -8381,7 +8381,7 @@ def openUrlOnClick(event: QMouseEvent, url: str = '') -> str:  # pragma: no cove
 
 
 # @+node:ekr.20170216091704.1: *4* g.openUrlHelper
-def openUrlHelper(event: LeoKeyEvent, url: str = '') -> str:
+def openUrlHelper(event: LeoKeyEvent, url: str) -> str:
     """Open the unl, url or gnx under the cursor.  Return it for unit testing."""
     if not event:
         return ''
@@ -8391,12 +8391,12 @@ def openUrlHelper(event: LeoKeyEvent, url: str = '') -> str:
     if not g.app.gui.isTextWrapper(w):
         return ''
     # Part 1: get the url.
-    if url is None:
+    if not url:  # strict_optional
         s = w.getAllText()
         ins = w.getInsertPoint()
         i, j = w.getSelectionRange()
         if i != j:
-            return None  # So find doesn't open the url.
+            return ''  # So find doesn't open the url.
         row, col = g.convertPythonIndexToRowCol(s, ins)
         i, j = g.getLine(s, ins)
         line = s[i:j]
@@ -8417,7 +8417,7 @@ def openUrlHelper(event: LeoKeyEvent, url: str = '') -> str:
                 c.redraw()
             return ''
         # @-<< look for section ref >>
-        url = unl = None
+        url = unl = ''  # strict_optional
         # @+<< look for url >>
         # @+node:tom.20220328141544.1: *5* << look for url  >>
         # Find the url on the line.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -407,7 +407,7 @@ url_regex = re.compile(rf"""\b{url_kinds}://[^\s'"]+""")
 # @-<< define regexes >>
 tree_popup_handlers: list[Callable] = []  # Set later.
 user_dict: dict[str, Value] = {}  # Non-persistent dictionary for scripts and plugins.
-app: LeoApp = None  # The singleton app object. Set by runLeo.py.
+app: LeoApp = None  # type:ignore #The singleton app object. Set by runLeo.py.
 # Global status vars.
 inScript = False  # A synonym for app.inScript
 unitTesting = False  # A synonym for app.unitTesting.
@@ -2163,7 +2163,7 @@ class TestLeoGlobals(unittest.TestCase):
         from leo.core import leoGlobals as leo_g  # pylint: disable=import-self,reimported
         from leo.core import leoApp
 
-        leo_g.app = leoApp.LeoApp()
+        leo_g.app = leoApp.LeoApp()  # type:ignore
         assert leo_g.comment_delims_from_extension(".py") == ('#', '', '')
         assert leo_g.comment_delims_from_extension(".c") == ('//', '/*', '*/')
         assert leo_g.comment_delims_from_extension(".html") == ('', '<!--', '-->')
@@ -2883,7 +2883,7 @@ def comment_delims_from_extension(filename: str) -> tuple[str, str, str]:
         root, ext = os.path.splitext(filename)
     if ext == '.tmp':
         root, ext = os.path.splitext(root)
-    language = g.app.extension_dict.get(ext[1:])
+    language = g.app.extension_dict.get(ext[1:]) or ''
     if ext:
         return g.set_delims_from_language(language)
     g.trace(f"unknown extension: {ext!r}, filename: {filename!r}, root: {root!r}")

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2805,9 +2805,9 @@ def printStats(event: LeoKeyEvent | None = None) -> None:
             print(f"  {d.get(key):4}: {key_s}")
 
     # Print the other stats: calls to g.stat(whatever)
-    for key in sorted(d.keys()):
+    for key, value in sorted(d.items()):  # strict_optional
         if not key.startswith(_int_stat_prefix):
-            inner_keys = (z if isinstance(z, str) else repr(z) for z in d.get(key))
+            inner_keys = (z if isinstance(z, str) else repr(z) for z in value)
             print(f"{key}:")
             for z in sorted(inner_keys):
                 print(f"    {z.strip()}")

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -38,7 +38,7 @@ import time
 import traceback
 import types
 from types import ModuleType
-from typing import Any, IO, Iterable, Sequence, TYPE_CHECKING
+from typing import cast, Any, IO, Iterable, Sequence, TYPE_CHECKING
 import unittest
 import urllib
 import urllib.parse as urlparse
@@ -5440,7 +5440,7 @@ def convertPythonIndexToRowCol(s: str, i: int) -> tuple[int, int]:
 
 
 # @+node:ekr.20050315071727: *4* g.convertRowColToPythonIndex
-def convertRowColToPythonIndex(s: str, row: int, col: int, lines: list[str] = None) -> int:
+def convertRowColToPythonIndex(s: str, row: int, col: int, lines: list[str] | None = None) -> int:
     """Convert zero-based row/col indices into a python index into string s."""
     if row < 0:
         return 0
@@ -5706,7 +5706,7 @@ def checkUnicode(s: str, encoding: str | None = None) -> str:
 
 
 # @+node:ekr.20100125073206.8709: *4* g.getPythonEncodingFromString
-def getPythonEncodingFromString(s: object) -> str:
+def getPythonEncodingFromString(s: bytes | str) -> str:
     """Return the encoding given by Python's encoding line.
     s is the entire file.
     """
@@ -6219,10 +6219,10 @@ def es(*args: Args, **kwargs: KWargs) -> None:
         'nodeLink': None,
     }
     d = g.doKeywordArgs(kwargs, d)
-    color = d.get('color')
+    color = cast(str, d.get('color'))
     if color == 'suppress':
         return  # New in 4.3.
-    color = g.actualColor(color)
+    actual_color = g.actualColor(color)
     tabName = d.get('tabName') or 'Log'
     newline = d.get('newline')
     s = g.translateArgs(args, d)
@@ -6233,7 +6233,7 @@ def es(*args: Args, **kwargs: KWargs) -> None:
     if log and (app.logInited or g.unitTesting):
         if newline:
             s += '\n'
-        log.put(s, color=color, tabName=tabName, nodeLink=d['nodeLink'])
+        log.put(s, color=actual_color, tabName=tabName, nodeLink=d['nodeLink'])
         # Count the number of *trailing* newlines.
         for ch in s:
             if ch == '\n':
@@ -6241,9 +6241,7 @@ def es(*args: Args, **kwargs: KWargs) -> None:
             else:
                 log.newlines = 0
     else:
-        app.logWaiting.append(
-            (s, color, newline, d),
-        )
+        app.logWaiting.append((s, actual_color, newline, d))
 
 
 log = es
@@ -6296,13 +6294,6 @@ def es_exception(*args: Sequence, **kwargs: Sequence) -> None:
     typ, val, tb = sys.exc_info()
     for line in traceback.format_exception(typ, val, tb):
         g.es_print_error(line)
-
-
-# @+node:ekr.20061015090538: *3* g.es_exception_type
-def es_exception_type(c: Cmdr | None = None, color: str = "red") -> None:
-    # exctype is a Exception class object; value is the error message.
-    exctype, value = sys.exc_info()[:2]
-    g.es_print('', f"{exctype.__name__}, {value}", color=color)
 
 
 # @+node:ekr.20050707064040: *3* g.es_print
@@ -6361,10 +6352,10 @@ def get_ctor_name(self: object, file_name: str, width: int = 25) -> str:
 # @+node:ekr.20040731204831: *3* g.getLastTracebackFileAndLineNumber
 def getLastTracebackFileAndLineNumber() -> tuple[str, int]:
     typ, val, tb = sys.exc_info()
-    if typ is SyntaxError:
+    if isinstance(type, SyntaxError):
         # IndentationError is a subclass of SyntaxError.
         return val.filename, val.lineno
-    #
+
     # Data is a list of tuples, one per stack entry.
     # Tuples have the form (filename,lineNumber,functionName,text).
     data = traceback.extract_tb(tb)
@@ -7379,25 +7370,30 @@ def getDocStringForFunction(func: Callable) -> str:
 
     def get_defaults(func: Callable, i: int) -> Value:
         defaults = inspect.getfullargspec(func)[3]
-        return defaults[i]
+        return defaults[i] if defaults else None
 
     # Fix bug 1251252: https://bugs.launchpad.net/leo-editor/+bug/1251252
     # Minibuffer commands created by mod_scripting.py have no docstrings.
     # Do special cases first.
 
     s = ''
+
     if name(func) == 'minibufferCallback':
         func = get_defaults(func, 0)
-        if hasattr(func, '__doc__') and func.__doc__.strip():
-            s = func.__doc__
-    if not s and name(func) == 'commonCommandCallback':
+        if val := getattr(func, '__doc__', None):
+            if isinstance(val, str) and val:
+                return val
+
+    if name(func) == 'commonCommandCallback':
         script = get_defaults(func, 1)
-        s = g.getDocString(script)  # Do a text scan for the function.
-    # Now the general cases.  Prefer __doc__ to docstring()
-    if not s and hasattr(func, '__doc__'):
-        s = func.__doc__
-    if not s and hasattr(func, 'docstring'):
-        s = func.docstring
+        if val := g.getDocString(script):  # Do a text scan for the function.
+            return val
+
+    # Now the general cases.  Prefer __doc__ to docstring
+    for attr in ('__doc__', '__docstring'):
+        val = getattr(func, attr, None)
+        if isinstance(val, str) and val:
+            return val
     return s
 
 
@@ -7472,89 +7468,6 @@ def execute_shell_commands(
         proc = subprocess.Popen(command, shell=shell)
         if wait:
             proc.communicate()
-
-
-# @+node:ekr.20180217113719.1: *3* g.execute_shell_commands_with_options & helpers
-def execute_shell_commands_with_options(
-    base_dir: str | None = None,
-    c: Cmdr | None = None,
-    command_setting: str | None = None,
-    commands: list | None = None,
-    path_setting: str | None = None,
-    trace: bool = False,
-    warning: str | None = None,
-) -> None:
-    """
-    A helper for prototype commands or any other code that
-    runs programs in a separate process.
-
-    base_dir:           Base directory to use if no config path given.
-    commands:           A list of commands, for g.execute_shell_commands.
-    commands_setting:   Name of @data setting for commands.
-    path_setting:       Name of @string setting for the base directory.
-    warning:            A warning to be printed before executing the commands.
-    """
-    base_dir = g.computeBaseDir(c, base_dir, path_setting)
-    if not base_dir:
-        return
-    commands = g.computeCommands(c, commands, command_setting)
-    if not commands:
-        return
-    if warning:
-        g.es_print(warning)
-    os.chdir(base_dir)  # Can't do this in the commands list.
-    g.execute_shell_commands(commands, trace=trace)
-
-
-# @+node:ekr.20180217152624.1: *4* g.computeBaseDir
-def computeBaseDir(c: Cmdr, base_dir: str | None, path_setting: str | None) -> str | None:
-    """
-    Compute a base_directory.
-    If given, @string path_setting takes precedence.
-    """
-    # Prefer the path setting to the base_dir argument.
-    if path_setting:
-        if not c:
-            g.es_print('@string path_setting requires valid c arg')
-            return None
-        # It's not an error for the setting to be empty.
-        base_dir2 = c.config.getString(path_setting)
-        if base_dir2:
-            base_dir2 = base_dir2.replace('\\', '/')
-            if g.os_path_exists(base_dir2):
-                return base_dir2
-            g.es_print(f"@string {path_setting} not found: {base_dir2!r}")
-            return None
-    # Fall back to given base_dir.
-    if base_dir:
-        base_dir = base_dir.replace('\\', '/')
-        if g.os_path_exists(base_dir):
-            return base_dir
-        g.es_print(f"base_dir not found: {base_dir!r}")
-        return None
-    g.es_print(f"Please use @string {path_setting}")
-    return None
-
-
-# @+node:ekr.20180217153459.1: *4* g.computeCommands
-def computeCommands(c: Cmdr | None, commands: list[str], command_setting: str | None) -> list[str]:
-    """
-    Get the list of commands.
-    If given, @data command_setting takes precedence.
-    """
-    if not commands and not command_setting:
-        g.es_print('Please use commands, command_setting or both')
-        return []
-    # Prefer the setting to the static commands.
-    if command_setting:
-        if c:
-            aList = c.config.getData(command_setting)
-            # It's not an error for the setting to be empty.
-            # Fall back to the commands.
-            return aList or commands
-        g.es_print('@data command_setting requires valid c arg')
-        return []
-    return commands
 
 
 # @+node:ekr.20050503112513.7: *3* g.executeFile

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -38,7 +38,7 @@ import time
 import traceback
 import types
 from types import ModuleType
-from typing import Any, IO, Iterable, Optional, Sequence, TYPE_CHECKING
+from typing import Any, IO, Iterable, Sequence, TYPE_CHECKING
 import unittest
 import urllib
 import urllib.parse as urlparse
@@ -48,11 +48,14 @@ import urllib.parse as urlparse
 # Third-party tools.
 import webbrowser
 
+from leo.core import leoGlobals as g  # pylint: disable=import-self
+
+Tk: Any
 try:
     import tkinter as Tk
 except Exception:
     Tk = None
-#
+
 # Abbreviations...
 StringIO = io.StringIO
 # @-<< leoGlobals: imports >>
@@ -207,11 +210,12 @@ def check_cmd_instance_dict(c: Cmdr, g: LeoGlobals) -> None:
     for key in d:
         ivars = d.get(key)
         # Produces warnings.
-        obj = ivars2instance(c, g, ivars)
-        if obj:
-            name = obj.__class__.__name__
-            if name != key:
-                g.trace('class mismatch', key, name)
+        if ivars:
+            obj = ivars2instance(c, g, ivars)
+            if obj:
+                name = obj.__class__.__name__
+                if name != key:
+                    g.trace('class mismatch', key, name)
 
 
 # @+node:ville.20090521164644.5924: *3* g.command (decorator)
@@ -281,13 +285,14 @@ class CommanderCommand:
         """Ctor for command decorator class."""
         self.name = name
 
-    def __call__(self, func: Callable) -> Callable:
+    def __call__(self, func: Callable) -> Callable | None:
         """Register command for all future commanders."""
 
         def commander_command_wrapper(event: LeoKeyEvent) -> Any:
             c = event.get('c')
             method = getattr(c, func.__name__, None)
-            return method(event=event)  # Return value to caller (for doCommand, doCommandByName...)
+            # Return value to caller (for doCommand, doCommandByName...)
+            return method(event=event) if method else None
 
         # Inject ivars for plugins_menu.py.
         commander_command_wrapper.__func_name__ = func.__name__  # For leoInteg.
@@ -310,7 +315,7 @@ commander_command = CommanderCommand
 
 
 # @+node:ekr.20150508164812.1: *3* g.ivars2instance
-def ivars2instance(c: Cmdr, g: LeoGlobals, ivars: list[str]) -> Any:
+def ivars2instance(c: Cmdr, g: LeoGlobals, ivars: list[str]) -> Any | None:
     """
     Return the instance of c given by ivars.
     ivars is a list of strings.
@@ -417,7 +422,7 @@ def standard_timestamp() -> str:
 
 
 # @+node:ekr.20201211183100.1: *3* g.get_backup_directory
-def get_backup_path(sub_directory: str) -> Optional[str]:
+def get_backup_path(sub_directory: str) -> str | None:
     """
     Return the full path to the subdirectory of the main backup directory.
 
@@ -468,10 +473,10 @@ class BindingInfo:
         self,
         kind: str,
         commandName: str = '',
-        func: Callable = None,
-        nextMode: str = None,
-        pane: str = None,
-        stroke: KeyStroke = None,
+        func: Callable | None = None,
+        nextMode: str | None = None,
+        pane: str | None = None,
+        stroke: KeyStroke | None = None,
     ) -> None:
         if not g.isStrokeOrNone(stroke):
             g.trace('***** (BindingInfo) oops', repr(stroke))
@@ -573,7 +578,7 @@ class Bunch:
         """Support aBunch[key]"""
         return operator.getitem(self.__dict__, key)
 
-    def get(self, key: str, theDefault: Value = None) -> Value:
+    def get(self, key: str, theDefault: Value | None = None) -> Value:
         return self.__dict__.get(key, theDefault)
 
     def __contains__(self, key: str) -> bool:
@@ -691,13 +696,13 @@ class GeneralSetting:
     def __init__(
         self,
         kind: str,
-        encoding: str = None,
-        ivar: str = None,
-        source: str = None,
-        val: Value = None,
-        path: str = None,
+        encoding: str | None = None,
+        ivar: str | None = None,
+        source: str | None = None,
+        val: Value | None = None,
+        path: str | None = None,
         tag: str = 'setting',
-        unl: str = None,
+        unl: str | None = None,
     ) -> None:
         self.encoding = encoding
         self.ivar = ivar
@@ -732,19 +737,19 @@ class KeyStroke:
     # @+others
     # @+node:ekr.20180414195401.2: *4*  ks.__init__
     def __init__(self, binding: str) -> None:
-        self.s: str
-        if binding:
-            self.s = self.finalize_binding(binding)
-        else:
-            self.s = None
+        self.s = self.finalize_binding(binding)
+        ###
+        # if binding:
+        #     self.s = self.finalize_binding(binding)
+        # else:
+        #     self.s = None
 
     # @+node:ekr.20120203053243.10117: *4* ks.__eq__, etc
-    # @+at All these must be defined in order to say, for example:
-    #     for key in sorted(d)
+    # All these must be defined in order to say, for example:
+    #   for key in sorted(d)
     # where the keys of d are KeyStroke objects.
-    # @@c
 
-    def __eq__(self, other: object) -> bool:
+    def __eq__(self, other: object) -> bool:  # other must be annotated as object.
         if not other:
             return False
         if hasattr(other, 's'):
@@ -755,8 +760,8 @@ class KeyStroke:
         if not other:
             return False
         if hasattr(other, 's'):
-            return self.s < other.s
-        return self.s < other  # type:ignore
+            return self.s < other.s  # type:ignore  # Required.
+        return self.s < other  # type:ignore  # Required.
 
     def __le__(self, other: KeyStroke) -> bool:
         return self.__lt__(other) or self.__eq__(other)
@@ -810,7 +815,6 @@ class KeyStroke:
     # @+node:ekr.20180415083926.1: *4* ks.finalize_char & helper
     def finalize_char(self, s: str) -> str:
         """Perform very-last-minute translations on bindings."""
-        #
         # Retain "bigger" spelling for gang-of-four bindings with modifiers.
         shift_d = {
             'bksp': 'BackSpace',
@@ -823,14 +827,13 @@ class KeyStroke:
         }
         if self.mods and s.lower() in shift_d:
             # Returning '' breaks existing code.
-            return shift_d.get(s.lower())
-        #
+            return shift_d.get(s.lower())  # type:ignore  # s.lower() is in shift_d!
+
         # Make all other translations...
         #
         # This dict ensures proper capitalization.
         # It also translates legacy Tk binding names to ascii chars.
         translate_d = {
-            #
             # The gang of four...
             'bksp': 'BackSpace',
             'backspace': 'BackSpace',
@@ -839,7 +842,6 @@ class KeyStroke:
             '\r': '\n',
             'return': '\n',
             'tab': 'Tab',
-            #
             # Special chars...
             'delete': 'Delete',
             'down': 'Down',
@@ -853,7 +855,6 @@ class KeyStroke:
             'prior': 'Prior',
             'right': 'Right',
             'up': 'Up',
-            #
             # Qt key names...
             'del': 'Delete',
             'dnarrow': 'Down',
@@ -866,7 +867,6 @@ class KeyStroke:
             'pgup': 'Prior',
             'rtarrow': 'Right',
             'uparrow': 'Up',
-            #
             # Legacy Tk binding names...
             "ampersand": "&",
             "asciicircum": "^",
@@ -905,7 +905,7 @@ class KeyStroke:
         if s in (None, 'none', 'None'):
             return 'None'
         if s.lower() in translate_d:
-            s = translate_d.get(s.lower())
+            s = translate_d.get(s.lower())  # type:ignore # s.lower() is in translate_d!
             return self.strip_shift(s)
         if len(s) > 1 and s.find(' ') > -1:
             # #917: not a pure, but should be ignored.
@@ -929,7 +929,7 @@ class KeyStroke:
                         if s.capitalize() in g.app.gui.specialChars:
                             s = s.capitalize()
             return s
-        #
+
         # Translate shifted keys to their appropriate alternatives.
         return self.strip_shift(s)
 
@@ -974,7 +974,7 @@ class KeyStroke:
         }  # fmt: skip
         if 'shift' in self.mods and s in shift_d:
             self.mods.remove('shift')
-            s = shift_d.get(s)
+            s = shift_d.get(s)  # type:ignore # s is in shift_d!
         return s
 
     # @+node:ekr.20120203053243.10124: *4* ks.find, lower & startswith
@@ -1120,7 +1120,7 @@ class KeyStroke:
             'Tab': '\t',
         }
         if s in d:
-            return d.get(s)
+            return d.get(s)  # type:ignore # Yes, s is in d.
         return s if len(s) == 1 else ''
 
     # @-others
@@ -1241,7 +1241,7 @@ class MatchBrackets:
         right: int,
         max_right: int,
         expand: bool = False,
-    ) -> tuple[Optional[int], Optional[int], Optional[str], Optional[int]]:
+    ) -> tuple[int, int, str, int] | tuple[None, None, None, None]:
         """
         Find the bracket nearest the cursor searching outwards left and right.
 
@@ -1288,7 +1288,7 @@ class MatchBrackets:
         return None, None, None, None
 
     # @+node:ekr.20061113221414: *4* mb.find_matching_bracket
-    def find_matching_bracket(self, ch1: str, s: str, i: int) -> Optional[int]:
+    def find_matching_bracket(self, ch1: str, s: str, i: int) -> int | None:
         """Find the bracket matching s[i] for self.language."""
         self.forward = ch1 in self.open_brackets
         # Find the character matching the initial bracket.
@@ -1302,7 +1302,7 @@ class MatchBrackets:
         return f(ch1, target, s, i)
 
     # @+node:ekr.20160121164556.1: *4* mb.scan & helpers
-    def scan(self, ch1: str, target: str, s: str, i: int) -> Optional[int]:
+    def scan(self, ch1: str, target: str, s: str, i: int) -> int | None:
         """Scan forward for target."""
         level = 0
         while 0 <= i < len(s):
@@ -1312,7 +1312,7 @@ class MatchBrackets:
                 # Scan to the end/beginning of the string.
                 i = self.scan_string(s, i)
             elif self.starts_comment(s, i):
-                i = self.scan_comment(s, i)
+                i = self.scan_comment(s, i)  # type:ignore # i can't be None.
             elif ch == '/' and self.is_regex(s, i):
                 i = self.scan_regex(s, i)
             elif ch == ch1:
@@ -1330,7 +1330,7 @@ class MatchBrackets:
         return None
 
     # @+node:ekr.20160119090634.1: *5* mb.scan_comment
-    def scan_comment(self, s: str, i: int) -> Optional[int]:
+    def scan_comment(self, s: str, i: int) -> int | None:
         """Return the index of the character after a comment."""
         i1 = i
         start = self.start_comment if self.forward else self.end_comment
@@ -1374,9 +1374,11 @@ class MatchBrackets:
         """Return True if s[i] starts a comment."""
         assert 0 <= i < len(s)
         if self.forward:
-            if self.single_comment and g.match(s, i, self.single_comment):
+            if bool(self.single_comment and g.match(s, i, self.single_comment)):
                 return True
-            return self.start_comment and self.end_comment and g.match(s, i, self.start_comment)
+            return bool(
+                self.start_comment and self.end_comment and g.match(s, i, self.start_comment)
+            )
         if s[i] == '\n':
             if self.single_comment:
                 # Scan backward for any single-comment delim.
@@ -1386,10 +1388,10 @@ class MatchBrackets:
                         return True
                     i -= 1
             return False
-        return self.start_comment and self.end_comment and g.match(s, i, self.end_comment)
+        return bool(self.start_comment and self.end_comment and g.match(s, i, self.end_comment))
 
     # @+node:ekr.20160119230141.1: *4* mb.scan_back & helpers
-    def scan_back(self, ch1: str, target: str, s: str, i: int) -> Optional[int]:
+    def scan_back(self, ch1: str, target: str, s: str, i: int) -> int | None:
         """Scan backwards for delim."""
         level = 0
         while i >= 0:
@@ -1483,7 +1485,7 @@ class MatchBrackets:
                         i -= 1
                     assert progress > i
             return False
-        return self.start_comment and self.end_comment and g.match(s, i, self.end_comment)
+        return bool(self.start_comment and self.end_comment and g.match(s, i, self.end_comment))
 
     # @+node:ekr.20160119104148.1: *4* mb.oops
     def oops(self, s: str) -> None:
@@ -1523,7 +1525,7 @@ class MatchBrackets:
         if left is None:
             g.es("Bracket not found")
             return
-        index2 = self.find_matching_bracket(ch, s, index)
+        index2 = self.find_matching_bracket(ch, s, index)  # type:ignore # ch is not None!
         if index2 is None:
             g.es("No matching bracket.")  # #1447.
             return
@@ -1532,7 +1534,7 @@ class MatchBrackets:
         # nothing extra.  The second time, move cursor to other end (requires
         # no special action here), and the third time, try to expand the range
         # to any enclosing brackets
-        minmax = (min(index, index2), max(index, index2) + 1)
+        minmax = (min(index, index2), max(index, index2) + 1)  # type:ignore # index is not None!
         # the range, +1 to match w.getSelectionRange()
         if _mb['range'] == minmax:  # count how many times this has been the answer
             _mb['count'] += 1
@@ -1622,7 +1624,7 @@ class OptionsUtils:
         return sorted(list(set(valid)))
 
     # @+node:ekr.20230615084117.1: *4* OptionsUtils.find_complex_option
-    def find_complex_option(self, regex: str) -> Optional[re.Match]:
+    def find_complex_option(self, regex: str) -> re.Match | None:
         """
         Check arguments that take an argument.
 
@@ -1804,7 +1806,7 @@ class SettingsDict(dict):
 
     # @+others
     # @+node:ekr.20120223062418.10422: *4* SettingsDict.copy
-    def copy(self, name: str = None) -> Value:
+    def copy(self, name: str | None = None) -> Value:
         """Return a new dict with the same contents."""
         # The result is a g.SettingsDict.
         return copy.deepcopy(self)
@@ -1821,14 +1823,14 @@ class SettingsDict(dict):
             self[key] = aList
 
     # @+node:ekr.20190903181030.1: *4* SettingsDict.get_setting & get_string_setting
-    def get_setting(self, key: str) -> Optional[str]:
+    def get_setting(self, key: str) -> str | None:
         """Return the canonical setting name."""
         key = key.replace('-', '').replace('_', '')
         gs = self.get(key)
         val = gs and gs.val
         return val
 
-    def get_string_setting(self, key: str) -> Optional[str]:
+    def get_string_setting(self, key: str) -> str | None:
         val = self.get_setting(key)
         return val if val and isinstance(val, str) else None
 
@@ -1965,7 +1967,7 @@ class Tracer:
         self.report()
 
     # @+node:ekr.20080531075119.6: *4* tracer
-    def tracer(self, frame: LeoFrame, event: QEvent, arg: object) -> Optional[Callable]:
+    def tracer(self, frame: LeoFrame, event: QEvent, arg: object) -> Callable | None:
         """A function to be passed to sys.settrace."""
         n = len(self.stack)
         if event == 'return':
@@ -2164,7 +2166,7 @@ class TestLeoGlobals(unittest.TestCase):
     # @+others
     # @+node:ekr.20200219071958.1: *4* TestLeoGlobals.test_comment_delims_from_extension
     def test_comment_delims_from_extension(self) -> None:
-        from leo.core import leoGlobals as leo_g  # pylint: disable=import-self
+        from leo.core import leoGlobals as leo_g  # pylint: disable=import-self,reimported
         from leo.core import leoApp
 
         leo_g.app = leoApp.LeoApp()
@@ -2174,7 +2176,7 @@ class TestLeoGlobals(unittest.TestCase):
 
     # @+node:ekr.20200219072957.1: *4* TestLeoGlobals.test_is_sentinel
     def test_is_sentinel(self) -> None:
-        from leo.core import leoGlobals as leo_g  # pylint: disable=import-self
+        from leo.core import leoGlobals as leo_g  # pylint: disable=import-self,reimported
 
         # Python. Test regular and blackened sentinels.
         py_delims = leo_g.comment_delims_from_extension('.py')
@@ -2466,7 +2468,7 @@ def oldDump(s: str) -> str:
 
 
 # @+node:ekr.20210904114446.1: *4* g.dump_tree & g.tree_to_string
-def dump_tree(c: Cmdr, dump_body: bool = False, msg: str = None) -> None:
+def dump_tree(c: Cmdr, dump_body: bool = False, msg: str | None = None) -> None:
     if msg:
         print(msg.rstrip())
     else:
@@ -2478,7 +2480,7 @@ def dump_tree(c: Cmdr, dump_body: bool = False, msg: str = None) -> None:
                 print(z.rstrip())
 
 
-def tree_to_string(c: Cmdr, dump_body: bool = False, msg: str = None) -> str:
+def tree_to_string(c: Cmdr, dump_body: bool = False, msg: str | None = None) -> str:
     result = ['\n']
     if msg:
         result.append(msg)
@@ -2508,19 +2510,19 @@ def dump_encoded_string(encoding: str, s: str) -> None:
 
 
 # @+node:ekr.20031218072017.1317: *4* g.file/module/plugin_date
-def module_date(mod: ModuleType, format: str = None) -> str:
+def module_date(mod: ModuleType, format: str | None = None) -> str:
     theFile = g.os_path_join(app.loadDir, mod.__file__)
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=format)
 
 
-def plugin_date(plugin_mod: ModuleType, format: str = None) -> str:
+def plugin_date(plugin_mod: ModuleType, format: str | None = None) -> str:
     theFile = g.os_path_join(app.loadDir, "..", "plugins", plugin_mod.__file__)
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=str)
 
 
-def file_date(theFile: IO, format: str = None) -> str:
+def file_date(theFile: IO, format: str | None = None) -> str:
     if theFile and g.os_path_exists(theFile):
         try:
             n = g.os_path_getmtime(theFile)
@@ -2624,7 +2626,7 @@ def objToString(
     obj: object,
     *,
     indent: int = 0,
-    tag: str = None,
+    tag: str | None = None,
     width: int = 120,
     offset: int = 0,  # Offset into array-like objects.
 ) -> str:
@@ -2681,7 +2683,7 @@ def sleep(n: float) -> None:
 
 
 # @+node:ekr.20171023140544.1: *4* g.printObj & aliases
-def printObj(obj: object, *, tag: str = None, indent: int = 0, offset: int = 0) -> None:
+def printObj(obj: object, *, tag: str | None = None, indent: int = 0, offset: int = 0) -> None:
     """Pretty print any Python object using g.pr."""
     g.pr(objToString(obj, indent=indent, tag=tag, offset=offset))
 
@@ -2748,9 +2750,9 @@ def printGcObjects() -> int:
     print(f"{count:7} objects...")
     # Invert the dict.
     d2: dict[int, str] = {v: k for k, v in d.items()}
-    for key in reversed(sorted(d2.keys())):  # type:ignore
-        val = d2.get(key)  # type:ignore
-        print(f"{key:7} {val}")
+    for key2 in reversed(sorted(d2.keys())):
+        val2 = d2.get(key2)
+        print(f"{key2:7} {val2}")
     lastObjectCount = count
     return delta
 
@@ -2794,7 +2796,7 @@ def clearStats() -> None:
 
 # @+node:ekr.20031218072017.3135: *4* g.printStats
 @command('show-stats')
-def printStats(event: LeoKeyEvent = None) -> None:
+def printStats(event: LeoKeyEvent | None = None) -> None:
     """
     Print all stats created by g.stat(), counts first.
     """
@@ -2823,7 +2825,7 @@ def printStats(event: LeoKeyEvent = None) -> None:
 _int_stat_prefix = 'stat_count: '
 
 
-def stat(obj: Any = None) -> None:
+def stat(obj: Any | None = None) -> None:
     """
     Add another count stat to g.app.statsDict.
     g.printStats() prints all such stats.
@@ -2913,7 +2915,7 @@ def findAllValidLanguageDirectives(s: str) -> list:
 
 
 # @+node:ekr.20090214075058.8: *3* g.findAtTabWidthDirectives (must be fast)
-def findTabWidthDirectives(c: Cmdr, p: Position) -> Optional[str]:
+def findTabWidthDirectives(c: Cmdr, p: Position) -> str | None:
     """Return the tab width in effect at position p."""
     if c is None:
         return None  # c may be None for testing.
@@ -2937,7 +2939,7 @@ def findTabWidthDirectives(c: Cmdr, p: Position) -> Optional[str]:
 
 
 # @+node:ekr.20170127142001.5: *3* g.findFirstAtLanguageDirective
-def findFirstValidAtLanguageDirective(s: str) -> Optional[str]:
+def findFirstValidAtLanguageDirective(s: str) -> str | None:
     """
     Return the first language for which there is a valid @language
     directive in s.
@@ -2952,14 +2954,14 @@ def findFirstValidAtLanguageDirective(s: str) -> Optional[str]:
 
 
 # @+node:ekr.20090214075058.6: *3* g.findLanguageDirectives (must be fast)
-def findLanguageDirectives(c: Cmdr, p: Position) -> Optional[str]:
+def findLanguageDirectives(c: Cmdr, p: Position) -> str | None:
     """Return the language in effect at position p."""
     if c is None or p is None:
         return None  # c may be None for testing.
 
     v0 = p.v
 
-    def find_language(p_or_v: Position | VNode) -> Optional[str]:
+    def find_language(p_or_v: Position | VNode) -> str | None:
         for s in p_or_v.h, p_or_v.b:
             for m in g_language_pat.finditer(s):
                 language = m.group(1)
@@ -2995,7 +2997,7 @@ def findLanguageDirectives(c: Cmdr, p: Position) -> Optional[str]:
 # Also called from write at.putRefAt.
 
 
-def findReference(name: str, root: Position) -> Optional[Position]:
+def findReference(name: str, root: Position) -> Position | None:
     """Return the position containing the section definition for name."""
     for p in root.subtree(copy=False):
         assert p != root
@@ -3054,7 +3056,7 @@ def get_directives_dict_list(p: Position) -> list[dict]:
 
 
 # @+node:ekr.20111010082822.15545: *3* g.getLanguageFromAncestorAtFileNode (deprecated)
-def getLanguageFromAncestorAtFileNode(p: Position) -> Optional[str]:
+def getLanguageFromAncestorAtFileNode(p: Position) -> str | None:
     """Return the language in effect at node p."""
     g.deprecated()
     c = p.v.context
@@ -3072,7 +3074,7 @@ def getLanguageAtPosition(c: Cmdr, p: Position) -> str:
 
 
 # @+node:ekr.20031218072017.1386: *3* g.getOutputNewline
-def getOutputNewline(c: Cmdr = None, name: str = None) -> str:
+def getOutputNewline(c: Cmdr | None = None, name: str | None = None) -> str:
     """Convert the name of a line ending to the line ending itself.
 
     Priority:
@@ -3136,7 +3138,7 @@ def isValidLanguage(language: str) -> bool:
 
 # @+node:ekr.20250403040834.1: *3* --- to be deprecated! Using directives list
 # @+node:ekr.20080827175609.52: *4* g.scanAtCommentAndLanguageDirectives (deprecated)
-def scanAtCommentAndAtLanguageDirectives(aList: list) -> Optional[dict[str, str]]:
+def scanAtCommentAndAtLanguageDirectives(aList: list) -> dict[str, str] | None:
     """
     Scan aList for @comment and @language directives.
 
@@ -3160,7 +3162,7 @@ def scanAtCommentAndAtLanguageDirectives(aList: list) -> Optional[dict[str, str]
 
 
 # @+node:ekr.20080827175609.32: *4* g.scanAtEncodingDirectives (deprecated)
-def scanAtEncodingDirectives(aList: list) -> Optional[str]:
+def scanAtEncodingDirectives(aList: list) -> str | None:
     """Scan aList for @encoding directives."""
     g.deprecated()
     for d in aList:
@@ -3182,7 +3184,7 @@ def scanAtHeaderDirectives(aList: list) -> None:
 
 
 # @+node:ekr.20080827175609.33: *4* g.scanAtLineendingDirectives (deprecated)
-def scanAtLineendingDirectives(aList: list) -> Optional[str]:
+def scanAtLineendingDirectives(aList: list) -> str | None:
     """Scan aList for @lineending directives."""
     g.deprecated()
     for d in aList:
@@ -3196,7 +3198,7 @@ def scanAtLineendingDirectives(aList: list) -> Optional[str]:
 
 
 # @+node:ekr.20080827175609.34: *4* g.scanAtPagewidthDirectives (deprecated)
-def scanAtPagewidthDirectives(aList: list, issue_error_flag: bool = False) -> Optional[int]:
+def scanAtPagewidthDirectives(aList: list, issue_error_flag: bool = False) -> int | None:
     """Scan aList for @pagewidth directives. Return the page width or None"""
     g.deprecated()
     for d in aList:
@@ -3225,7 +3227,7 @@ def scanAllAtPathDirectives(c: Cmdr, p: Position) -> str:
 
 
 # @+node:ekr.20080827175609.37: *4* g.scanAtTabwidthDirectives & scanAllAtTabWidthDirectives (deprecated)
-def scanAtTabwidthDirectives(aList: list, issue_error_flag: bool = False) -> Optional[int]:
+def scanAtTabwidthDirectives(aList: list, issue_error_flag: bool = False) -> int | None:
     """Scan aList for @tabwidth directives."""
     g.deprecated()
     for d in aList:
@@ -3239,7 +3241,7 @@ def scanAtTabwidthDirectives(aList: list, issue_error_flag: bool = False) -> Opt
     return None
 
 
-def scanAllAtTabWidthDirectives(c: Cmdr, p: Position) -> Optional[int]:
+def scanAllAtTabWidthDirectives(c: Cmdr, p: Position) -> int | None:
     """Scan p and all ancestors looking for @tabwidth directives."""
     g.deprecated()
     if c and p:
@@ -3252,7 +3254,7 @@ def scanAllAtTabWidthDirectives(c: Cmdr, p: Position) -> Optional[int]:
 
 
 # @+node:ekr.20080831084419.4: *4* g.scanAtWrapDirectives & scanAllAtWrapDirectives (deprecated)
-def scanAtWrapDirectives(aList: list, issue_error_flag: bool = False) -> Optional[bool]:
+def scanAtWrapDirectives(aList: list, issue_error_flag: bool = False) -> bool | None:
     """Scan aList for @wrap and @nowrap directives."""
     g.deprecated()
     for d in aList:
@@ -3263,7 +3265,7 @@ def scanAtWrapDirectives(aList: list, issue_error_flag: bool = False) -> Optiona
     return None
 
 
-def scanAllAtWrapDirectives(c: Cmdr, p: Position) -> Optional[bool]:
+def scanAllAtWrapDirectives(c: Cmdr, p: Position) -> bool | None:
     """Scan p and all ancestors looking for @wrap/@nowrap directives."""
     g.deprecated()
     if c and p:
@@ -3328,7 +3330,7 @@ def set_delims_from_language(language: str) -> tuple[str, str, str]:
 
 
 # @+node:ekr.20031218072017.1383: *3* g.set_delims_from_string
-def set_delims_from_string(s: str) -> tuple[str, str, str]:
+def set_delims_from_string(s: str) -> tuple[str, str, str] | tuple[None, None, None]:
     """
     Return (delim1, delim2, delim2), the delims following the @comment
     directive.
@@ -3366,8 +3368,7 @@ def set_delims_from_string(s: str) -> tuple[str, str, str]:
                     g.warning(f"'{delims[i]}' delimiter is invalid")
                     return None, None, None
                 try:
-                    delims[i] = binascii.unhexlify(delims[i][3:])  # type:ignore
-                    delims[i] = g.toUnicode(delims[i])
+                    delims[i] = g.toUnicode(binascii.unhexlify(delims[i][3:]))
                 except Exception as e:
                     g.warning(f"'{delims[i]}' delimiter is invalid: {e}")
                     return None, None, None
@@ -3379,7 +3380,9 @@ def set_delims_from_string(s: str) -> tuple[str, str, str]:
 
 
 # @+node:ekr.20031218072017.1384: *3* g.set_language
-def set_language(s: str, i: int, issue_errors_flag: bool = False) -> tuple:
+def set_language(
+    s: str, i: int, issue_errors_flag: bool = False
+) -> tuple[str, str, str, str] | tuple[None, None, None, None]:
     """Scan the @language directive that appears at s[i:].
 
     The @language may have been stripped away.
@@ -3495,7 +3498,7 @@ def create_temp_file(textMode: bool = False) -> tuple[IO, str]:
 
 
 # @+node:ekr.20210307060731.1: *3* g.createHiddenCommander
-def createHiddenCommander(fn: str) -> Cmdr:
+def createHiddenCommander(fn: str) -> Cmdr | None:
     """Read the given outline into a hidden commander."""
     lm = g.app.loadManager
     if lm.isLeoFile(fn):
@@ -3504,7 +3507,7 @@ def createHiddenCommander(fn: str) -> Cmdr:
 
 
 # @+node:vitalije.20170714085545.1: *3* g.defaultLeoFileExtension
-def defaultLeoFileExtension(c: Cmdr = None) -> str:
+def defaultLeoFileExtension(c: Cmdr | None = None) -> str:
     conf = c.config if c else g.app.config
     return conf.getString('default-leo-extension') or '.leo'
 
@@ -3535,7 +3538,9 @@ def fullPath(c: Cmdr, p: Position) -> str:
 
 
 # @+node:ekr.20190327192721.1: *3* g.get_files_in_directory
-def get_files_in_directory(directory: str, kinds: list = None, recursive: bool = True) -> list[str]:
+def get_files_in_directory(
+    directory: str, kinds: list | None = None, recursive: bool = True
+) -> list[str]:
     """
     Return a list of all files of the given file extensions in the directory.
     Default kinds: ['*.py'].
@@ -3577,7 +3582,7 @@ def getBaseDirectory(c: Cmdr) -> str:
 
 
 # @+node:ekr.20170223093758.1: *3* g.getEncodingAt (deprecated)
-def getEncodingAt(p: Position, b: bytes = None) -> str:
+def getEncodingAt(p: Position, b: bytes | None = None) -> str:
     """
     Return the encoding in effect at p and/or for string s.
 
@@ -3598,7 +3603,7 @@ def getEncodingAt(p: Position, b: bytes = None) -> str:
 
 
 # @+node:ville.20090701144325.14942: *3* g.guessExternalEditor
-def guessExternalEditor(c: Cmdr = None) -> Optional[str]:
+def guessExternalEditor(c: Cmdr | None = None) -> str | None:
     """Return a 'sensible' external editor"""
     editor = (
         c
@@ -3664,11 +3669,12 @@ def is_binary_string(s: str) -> bool:
     # http://stackoverflow.com/questions/898669
     # aList is a list of all non-binary characters.
     aList = [7, 8, 9, 10, 12, 13, 27] + list(range(0x20, 0x100))
+    # mypy bug?
     return bool(s.translate(None, bytes(aList)))  # type:ignore
 
 
 # @+node:ekr.20031218072017.3119: *3* g.makeAllNonExistentDirectories
-def makeAllNonExistentDirectories(theDir: str) -> Optional[str]:
+def makeAllNonExistentDirectories(theDir: str) -> str | None:
     """
     A wrapper from os.makedirs.
     Attempt to make all non-existent directories.
@@ -3699,7 +3705,9 @@ def makePathRelativeTo(fullPath: str, basePath: str) -> str:
 
 
 # @+node:ekr.20090520055433.5945: *3* g.openWithFileName
-def openWithFileName(fileName: str, old_c: Cmdr = None, gui: LeoGui = None) -> Optional[Cmdr]:
+def openWithFileName(
+    fileName: str, old_c: Cmdr | None = None, gui: LeoGui | None = None
+) -> Cmdr | None:
     """
     Load any kind of file in the appropriate way:
 
@@ -3747,9 +3755,9 @@ def readFileIntoEncodedString(fn: str, silent: bool = False) -> bytes:
 def readFileIntoString(
     fileName: str,
     encoding: str = 'utf-8',  # BOM may override this.
-    kind: str = None,  # @file, @edit, ...
+    kind: str | None = None,  # @file, @edit, ...
     verbose: bool = True,
-) -> tuple[str, str]:
+) -> tuple[str, str] | tuple[None, None]:
     """
     Return the contents of the file whose full path is fileName.
 
@@ -3802,9 +3810,9 @@ def readFileIntoString(
 # @+node:ekr.20160504062833.1: *3* g.readFileIntoUnicodeString
 def readFileIntoUnicodeString(
     fn: str,
-    encoding: Optional[str] = None,
+    encoding: str | None = None,
     silent: bool = False,
-) -> Optional[str]:
+) -> str | None:
     """Return the raw contents of the file whose full path is fn."""
     try:
         with open(fn, 'rb') as f:
@@ -3829,7 +3837,7 @@ def readFileIntoUnicodeString(
 # @@c
 
 
-def readlineForceUnixNewline(f: IO, fileName: Optional[str] = None) -> str:
+def readlineForceUnixNewline(f: IO, fileName: str | None = None) -> str:
     try:
         s = f.readline()
     except UnicodeDecodeError:
@@ -3913,7 +3921,7 @@ def setGlobalOpenDir(fileName: str) -> None:
 
 
 # @+node:ekr.20031218072017.3125: *3* g.shortFileName & shortFilename
-def shortFileName(fileName: str, n: int = None) -> str:
+def shortFileName(fileName: str, n: int | None = None) -> str:
     """Return the base name of a path."""
     if n is not None:
         g.trace('"n" keyword argument is no longer used')
@@ -3944,11 +3952,12 @@ def splitLongFileName(fn: str, limit: int = 40) -> str:
 def writeFile(contents: bytes | str, encoding: str, fileName: str) -> bool:
     """Create a file with the given contents."""
     try:
-        if isinstance(contents, str):
-            contents = g.toEncodedString(contents, encoding=encoding)
-        # 'wb' preserves line endings.
+        bytes_contents = (
+            contents if isinstance(contents, bytes)
+            else g.toEncodedString(contents, encoding=encoding)
+        )  # fmt: skip
         with open(fileName, 'wb') as f:
-            f.write(contents)  # type:ignore
+            f.write(bytes_contents)
         return True
     except Exception as e:
         print(f"exception writing: {fileName}:\n{e}")
@@ -4007,7 +4016,7 @@ def find_word(s: str, word: str, i: int = 0) -> int:
 
 
 # @+node:ekr.20211029090118.1: *3* g.findAncestorVnodeByPredicate
-def findAncestorVnodeByPredicate(p: Position, v_predicate: Optional[Callable]) -> Optional[VNode]:
+def findAncestorVnodeByPredicate(p: Position, v_predicate: Callable | None) -> VNode | None:
     """
     Return first ancestor vnode matching the predicate.
 
@@ -4038,7 +4047,9 @@ def findAncestorVnodeByPredicate(p: Position, v_predicate: Optional[Callable]) -
 
 
 # @+node:ekr.20170220103251.1: *3* g.findRootsWithPredicate
-def findRootsWithPredicate(c: Cmdr, root: Position, predicate: Callable = None) -> list[Position]:
+def findRootsWithPredicate(
+    c: Cmdr, root: Position, predicate: Callable | None = None
+) -> list[Position]:
     """
     Commands often want to find one or more **roots**, given a position p.
     A root is the position of any node matching a predicate.
@@ -4434,7 +4445,7 @@ def see_more_lines(s: str, ins: int, n: int = 4) -> int:
 
 
 # @+node:ekr.20031218072017.3195: *3* g.splitLines
-def splitLines(s: str) -> list[str]:
+def splitLines(s: str | None) -> list[str]:
     """
     Split s into lines, preserving the number of lines and
     the endings of all lines, including the last line.
@@ -4607,7 +4618,7 @@ def skip_c_id(s: str, i: int) -> int:
 
 
 # @+node:ekr.20040705195048: *4* g.skip_id
-def skip_id(s: str, i: int, chars: str = None) -> int:
+def skip_id(s: str, i: int, chars: str | None = None) -> int:
     chars = g.toUnicode(chars) if chars else ''
     n = len(s)
     while i < n and (g.isWordChar(s[i]) or s[i] in chars):
@@ -4658,7 +4669,7 @@ def skip_to_start_of_line(s: str, i: int) -> int:
 
 
 # @+node:ekr.20031218072017.3188: *4* g.skip_long
-def skip_long(s: str, i: int) -> tuple[int, Optional[int]]:
+def skip_long(s: str, i: int) -> tuple[int, int | None]:
     """
     Scan s[i:] for a valid int.
     Return (i, val) or (i, None) if s[i] does not point at a number.
@@ -4768,7 +4779,7 @@ def skip_ws_and_nl(s: str, i: int) -> int:
 
 # @+node:ekr.20170414034616.1: ** g.Git
 # @+node:ekr.20180325025502.1: *3* g.backupGitIssues
-def backupGitIssues(c: Cmdr, base_url: str = None) -> None:
+def backupGitIssues(c: Cmdr, base_url: str | None = None) -> None:
     """Get a list of issues from Leo's GitHub site."""
     if base_url is None:
         base_url = 'https://api.github.com/repos/leo-editor/leo-editor/issues'
@@ -4816,10 +4827,10 @@ def execGitCommand(command: str, directory: str) -> list[str]:
 # @+node:ekr.20180126043905.1: *3* g.getGitIssues
 def getGitIssues(
     c: Cmdr,
-    base_url: str = None,
-    label_list: list = None,
-    milestone: str = None,
-    state: Optional[str] = None,  # in (None, 'closed', 'open')
+    base_url: str | None = None,
+    label_list: list | None = None,
+    milestone: str | None = None,
+    state: str | None = None,  # in (None, 'closed', 'open')
 ) -> None:
     """Get a list of issues from Leo's GitHub site."""
     if base_url is None:
@@ -4852,7 +4863,7 @@ class GitIssueController:
         c: Cmdr,
         label_list: list[str],
         root: Position,
-        state: str = None,
+        state: str | None = None,
     ) -> None:
         self.base_url = base_url
         self.root = root
@@ -5008,7 +5019,7 @@ class GitIssueController:
 
 
 # @+node:ekr.20190428173354.1: *3* g.getGitVersion
-def getGitVersion(directory: str = None) -> tuple[str, str, str]:
+def getGitVersion(directory: str | None = None) -> tuple[str, str, str]:
     """Return a tuple (author, build, date) from the git log, or None."""
 
     # -n: Get only the last log.
@@ -5072,7 +5083,7 @@ def getModifiedFiles(repo_path: str) -> list[str]:
 
 
 # @+node:ekr.20170414034616.2: *3* g.gitBranchName
-def gitBranchName(path: str = None) -> str:
+def gitBranchName(path: str | None = None) -> str:
     """
     Return the git branch name associated with path/.git, or the empty
     string if path/.git does not exist. If path is None, use the leo-editor
@@ -5083,7 +5094,7 @@ def gitBranchName(path: str = None) -> str:
 
 
 # @+node:ekr.20170414034616.4: *3* g.gitCommitNumber
-def gitCommitNumber(path: str = None) -> str:
+def gitCommitNumber(path: str | None = None) -> str:
     """
     Return the git commit number associated with path/.git, or the empty
     string if path/.git does not exist. If path is None, use the leo-editor
@@ -5094,7 +5105,7 @@ def gitCommitNumber(path: str = None) -> str:
 
 
 # @+node:maphew.20171112205129.1: *3* g.gitDescribe
-def gitDescribe(path: str = None) -> tuple[str, str, str]:
+def gitDescribe(path: str | None = None) -> tuple[str, str, str]:
     """
     Return the Git tag, distance-from-tag, and commit hash for the
     associated path. If path is None, use the leo-editor directory.
@@ -5113,7 +5124,7 @@ def gitDescribe(path: str = None) -> tuple[str, str, str]:
 
 
 # @+node:ekr.20170414034616.6: *3* g.gitHeadPath
-def gitHeadPath(path_s: str) -> Optional[str]:
+def gitHeadPath(path_s: str) -> str | None:
     """
     Compute the path to .git/HEAD given the path.
     """
@@ -5130,7 +5141,7 @@ def gitHeadPath(path_s: str) -> Optional[str]:
 
 
 # @+node:ekr.20170414034616.3: *3* g.gitInfo
-def gitInfo(path: str = None) -> tuple[str, str]:
+def gitInfo(path: str | None = None) -> tuple[str, str]:
     """
     Path may be a directory or file.
 
@@ -5214,7 +5225,7 @@ contentModifiedSet: set[VNode] = set()
 
 
 # @+node:ekr.20031218072017.1596: *3* g.doHook
-def doHook(tag: str, *args: Args, **kwargs: KWargs) -> Value:
+def doHook(tag: str, *args: Args, **kwargs: KWargs) -> Value | None:
     """
     This global function calls a hook routine. Hooks are identified by the
     tag param.
@@ -5300,7 +5311,7 @@ def getLoadedPlugins() -> list:
     return pc.getLoadedPlugins()
 
 
-def getPluginModule(moduleName: str) -> Optional[ModuleType]:
+def getPluginModule(moduleName: str) -> ModuleType | None:
     pc = g.app.pluginsController
     return pc.getPluginModule(moduleName)
 
@@ -5324,7 +5335,7 @@ def enableIdleTimeHook(*args: Args, **kwargs: KWargs) -> None:
 
 
 # @+node:ekr.20140825042850.18410: *3* g.IdleTime
-def IdleTime(handler: Callable, delay: int = 500, tag: str = None) -> QtIdleTime:
+def IdleTime(handler: Callable, delay: int = 500, tag: str | None = None) -> QtIdleTime | None:
     """
     A thin wrapper for the LeoQtGui.IdleTime class.
 
@@ -5380,7 +5391,7 @@ def idleTimeHookHandler(timer: Callable) -> None:
 
 # @+node:ekr.20041219095213: ** g.Importing
 # @+node:ekr.20040917061619: *3* g.cantImport
-def cantImport(moduleName: str, pluginName: str = None, verbose: bool = True) -> None:
+def cantImport(moduleName: str, pluginName: str | None = None, verbose: bool = True) -> None:
     """Print a "Can't Import" message and return None."""
     s = f"Can not import {moduleName}"
     if pluginName:
@@ -5394,24 +5405,21 @@ def cantImport(moduleName: str, pluginName: str = None, verbose: bool = True) ->
 
 
 # @+node:ekr.20191220044128.1: *3* g.import_module
-def import_module(name: str, package: str = None) -> Optional[ModuleType]:
+def import_module(name: str, package: str | None = None) -> ModuleType | None:
     """
     A thin wrapper over importlib.import_module.
     """
     trace = 'plugins' in g.app.debug and not g.unitTesting
-    exceptions = []
+    exceptions: list[str] = []
     try:
         m = importlib.import_module(name, package=package)
     except Exception as e:
         m = None
         if trace:
-            t, v, tb = sys.exc_info()
-            del tb  # don't need the traceback
-            # In case v is empty, we'll at least have the exception type
-            v = v or str(t)  # type:ignore
-            if v not in exceptions:
-                exceptions.append(v)
-                g.trace(f"Can not import {name}: {e}")
+            message = f"Can not import {name}: {e}"
+            if message not in exceptions:
+                exceptions.append(message)
+                g.trace(message)
     return m
 
 
@@ -5658,7 +5666,7 @@ def bytesToStr(b: bytes, reportErrors: bool = False) -> str:
 
 
 # @+node:ekr.20190505052756.1: *4* g.checkUnicode
-def checkUnicode(s: str, encoding: str = None) -> str:
+def checkUnicode(s: str, encoding: str | None = None) -> str:
     """
     Warn when converting bytes. Report *all* errors.
 
@@ -5757,7 +5765,7 @@ def isWordChar1(ch: str) -> bool:
 
 
 # @+node:ekr.20130910044521.11304: *4* g.stripBOM
-def stripBOM(s_bytes: bytes) -> tuple[str, bytes]:
+def stripBOM(s_bytes: bytes) -> tuple[str | None, bytes]:
     """
     If there is a BOM, return (e,s2) where e is the encoding
     implied by the BOM and s2 is the s stripped of the BOM.
@@ -5798,25 +5806,25 @@ def strToBytes(s: str, reportErrors: bool = False) -> bytes:
 
 
 # @+node:ekr.20050208093800: *4* g.toEncodedString
-def toEncodedString(s: str, encoding: str = 'utf-8', reportErrors: bool = False) -> bytes:
+def toEncodedString(s: bytes | str, encoding: str = 'utf-8', reportErrors: bool = False) -> bytes:
     """Convert unicode string to an encoded string."""
     if not isinstance(s, str):
         return s
     if not encoding:
         encoding = 'utf-8'
     # These are the only significant calls to s.encode in Leo.
-    try:
-        s = s.encode(encoding, "strict")  # type:ignore
-    except UnicodeError:
-        s = s.encode(encoding, "replace")  # type:ignore
-        if reportErrors:
-            g.error(f"Error converting {s} from unicode to {encoding} encoding")
     # Tracing these calls directly yields thousands of calls.
-    return s  # type:ignore
+    try:
+        return s.encode(encoding, "strict")
+    except UnicodeError:
+        s2 = s.encode(encoding, "replace")
+        if reportErrors:
+            g.error(f"Error converting {s2!r} from unicode to {encoding} encoding")
+        return s2
 
 
 # @+node:ekr.20050208093800.1: *4* g.toUnicode
-def toUnicode(s: object, encoding: str = None, reportErrors: bool = False) -> str:
+def toUnicode(s: bytes | str, encoding: str | None = None, reportErrors: bool = False) -> str:
     """Convert bytes to unicode if necessary."""
     if isinstance(s, str):
         return s
@@ -5833,7 +5841,7 @@ def toUnicode(s: object, encoding: str = None, reportErrors: bool = False) -> st
         encoding = 'utf-8'
     try:
         return s.decode(encoding, 'strict')
-    except (UnicodeDecodeError, UnicodeError):  # noqa
+    except (UnicodeDecodeError, UnicodeError):
         # https://wiki.python.org/moin/UnicodeDecodeError
         s = s.decode(encoding, 'replace')
         if g.unitTesting:
@@ -5912,7 +5920,7 @@ def computeWidth(s: str, tab_width: int) -> int:
 # @@language python
 
 
-def wrap_lines(lines: list[str], pageWidth: int, firstLineWidth: int = None) -> list[str]:
+def wrap_lines(lines: list[str], pageWidth: int, firstLineWidth: int | None = None) -> list[str]:
     """Returns a list of lines, consisting of the input lines wrapped to the given pageWidth."""
     if pageWidth < 10:
         pageWidth = 10
@@ -6128,7 +6136,7 @@ def stripBlankLines(s: str) -> str:
 # g.pr prints to the console.
 # g.es_print and related print to both the Log window and the console.
 # @+node:ekr.20080821073134.2: *3* g.doKeywordArgs
-def doKeywordArgs(keys: dict, d: dict = None) -> dict:
+def doKeywordArgs(keys: dict, d: dict | None = None) -> dict:
     """
     Return a result dict that is a copy of the keys dict
     with missing items replaced by defaults in d dict.
@@ -6242,7 +6250,7 @@ log = es
 
 
 # @+node:ekr.20060917120951: *3* g.es_dump
-def es_dump(s: str, n: int = 30, title: str = None) -> None:
+def es_dump(s: str, n: int = 30, title: str | None = None) -> None:
     if title:
         g.es_print('', title)
     i = 0
@@ -6291,7 +6299,7 @@ def es_exception(*args: Sequence, **kwargs: Sequence) -> None:
 
 
 # @+node:ekr.20061015090538: *3* g.es_exception_type
-def es_exception_type(c: Cmdr = None, color: str = "red") -> None:
+def es_exception_type(c: Cmdr | None = None, color: str = "red") -> None:
     # exctype is a Exception class object; value is the error message.
     exctype, value = sys.exc_info()[:2]
     g.es_print('', f"{exctype.__name__}, {value}", color=color)
@@ -6427,7 +6435,7 @@ is_unique_class = isUniqueClass
 
 
 # @+node:ekr.20150127060254.5: *3* g.log_to_file
-def log_to_file(s: str, fn: str = None) -> None:
+def log_to_file(s: str, fn: str | None = None) -> None:
     """Write a message to ~/test/leo_log.txt."""
     if fn is None:
         fn = g.finalize('~/test/leo_log.txt')
@@ -6492,7 +6500,7 @@ def prettyPrintType(obj: object) -> str:
     if t in [types.MethodType, types.BuiltinMethodType]:
         return 'method'
     # Fall back to a hack.
-    t = str(type(obj))  # type:ignore
+    t = str(type(obj))
     if t.startswith("<type '"):
         t = t[7:]
     if t.endswith("'>"):
@@ -6503,7 +6511,7 @@ def prettyPrintType(obj: object) -> str:
 # @+node:ekr.20111107181638.9741: *3* g.print_exception
 def print_exception(
     full: bool = True,
-    c: Cmdr = None,
+    c: Cmdr | None = None,
     flush: bool = False,
     color: str = "red",
 ) -> tuple[str, int]:
@@ -6539,7 +6547,7 @@ def printEntireTree(c: Cmdr, tag: str = '') -> None:
 
 
 # @+node:ekr.20031218072017.3114: *3* g.printGlobals
-def printGlobals(message: str = None) -> None:
+def printGlobals(message: str | None = None) -> None:
     # Get the list of globals.
     globs = list(globals())
     globs.sort()
@@ -6552,7 +6560,7 @@ def printGlobals(message: str = None) -> None:
 
 
 # @+node:ekr.20031218072017.3115: *3* g.printLeoModules
-def printLeoModules(message: str = None) -> None:
+def printLeoModules(message: str | None = None) -> None:
     # Create the list.
     mods = []
     for name in sys.modules:
@@ -6764,7 +6772,7 @@ def CheckVersion(
     s1: str,
     s2: str,
     condition: str = ">=",
-    stringCompare: bool = None,
+    stringCompare: bool | None = None,
     delimiter: str = '.',
     trace: bool = False,
 ) -> bool:
@@ -6816,7 +6824,7 @@ def CheckVersionToInt(s: str) -> int:
 
 # @+node:ekr.20111103205308.9657: *3* g.cls
 @command('cls')
-def cls(event: LeoKeyEvent = None) -> None:
+def cls(event: LeoKeyEvent | None = None) -> None:
     """Clear the screen."""
     if g.isWindows:
         # Leo 6.7.5: Two calls seem to be required!
@@ -6827,7 +6835,7 @@ def cls(event: LeoKeyEvent = None) -> None:
 
 
 # @+node:ekr.20131114124839.16665: *3* g.createScratchCommander
-def createScratchCommander(fileName: str = None) -> None:
+def createScratchCommander(fileName: str | None = None) -> None:
     c = g.app.newCommander(fileName)
     frame = c.frame
     frame.createFirstTreeNode()
@@ -6848,7 +6856,7 @@ def deprecated() -> None:
 
 
 # @+node:ekr.20031218072017.3126: *3* g.funcToMethod (Python Cookbook)
-def funcToMethod(f: Callable, theClass: object, name: str = None) -> None:
+def funcToMethod(f: Callable, theClass: object, name: str | None = None) -> None:
     """
     From the Python Cookbook...
 
@@ -6873,7 +6881,7 @@ init_zodb_failed: dict[str, bool] = {}  # Keys are paths, values are True.
 init_zodb_db: dict[str, Value] = {}  # Keys are paths, values are ZODB.DB instances.
 
 
-def init_zodb(pathToZodbStorage: str, verbose: bool = True) -> Value:
+def init_zodb(pathToZodbStorage: str, verbose: bool = True) -> Value | None:
     """
     Return an ZODB.DB instance from the given path.
     return None on any error.
@@ -6908,7 +6916,7 @@ def init_zodb(pathToZodbStorage: str, verbose: bool = True) -> Value:
 
 
 # @+node:ekr.20170206080908.1: *3* g.input_
-def input_(message: str = '', c: Cmdr = None) -> str:
+def input_(message: str = '', c: Cmdr | None = None) -> str:
     """
     Safely execute python's input statement.
 
@@ -6994,7 +7002,7 @@ def truncate(s: str, n: int) -> str:
 
 
 # @+node:ekr.20031218072017.3150: *3* g.windows
-def windows() -> Optional[list]:
+def windows() -> list | None:
     return app.windowList if app else None
 
 
@@ -7325,7 +7333,7 @@ def os_startfile(fname: str) -> None:
 
 # @+node:ekr.20111115155710.9859: ** g.Parsing & Tokenizing
 # @+node:ekr.20031218072017.822: *3* g.createTopologyList
-def createTopologyList(c: Cmdr, root: Position = None, useHeadlines: bool = False) -> list:
+def createTopologyList(c: Cmdr, root: Position | None = None, useHeadlines: bool = False) -> list:
     """Creates a list describing a node and all its descendants"""
     if not root:
         root = c.rootPosition()
@@ -7431,7 +7439,7 @@ def python_tokenize(s: str) -> list:
 
 # @+node:ekr.20040327103735.2: ** g.Scripting
 # @+node:ekr.20161223090721.1: *3* g.exec_file
-def exec_file(path: str, d: dict[str, Value], script: str = None) -> None:
+def exec_file(path: str, d: dict[str, Value], script: str | None = None) -> None:
     """Simulate python's execfile statement for python 3."""
     if script is None:
         with open(path) as f:
@@ -7468,13 +7476,13 @@ def execute_shell_commands(
 
 # @+node:ekr.20180217113719.1: *3* g.execute_shell_commands_with_options & helpers
 def execute_shell_commands_with_options(
-    base_dir: str = None,
-    c: Cmdr = None,
-    command_setting: str = None,
-    commands: list = None,
-    path_setting: str = None,
+    base_dir: str | None = None,
+    c: Cmdr | None = None,
+    command_setting: str | None = None,
+    commands: list | None = None,
+    path_setting: str | None = None,
     trace: bool = False,
-    warning: str = None,
+    warning: str | None = None,
 ) -> None:
     """
     A helper for prototype commands or any other code that
@@ -7499,7 +7507,7 @@ def execute_shell_commands_with_options(
 
 
 # @+node:ekr.20180217152624.1: *4* g.computeBaseDir
-def computeBaseDir(c: Cmdr, base_dir: str, path_setting: str) -> Optional[str]:
+def computeBaseDir(c: Cmdr, base_dir: str | None, path_setting: str | None) -> str | None:
     """
     Compute a base_directory.
     If given, @string path_setting takes precedence.
@@ -7529,7 +7537,7 @@ def computeBaseDir(c: Cmdr, base_dir: str, path_setting: str) -> Optional[str]:
 
 
 # @+node:ekr.20180217153459.1: *4* g.computeCommands
-def computeCommands(c: Cmdr, commands: list[str], command_setting: str) -> list[str]:
+def computeCommands(c: Cmdr | None, commands: list[str], command_setting: str | None) -> list[str]:
     """
     Get the list of commands.
     If given, @data command_setting takes precedence.
@@ -7576,7 +7584,7 @@ def executeFile(filename: str, options: str = '') -> None:
 # @+node:ekr.20040321065415: *3* g.find*Node*
 # @+others
 # @+node:ekr.20210303123423.3: *4* g.findNodeAnywhere
-def findNodeAnywhere(c: Cmdr, headline: str, exact: bool = True) -> Optional[Position]:
+def findNodeAnywhere(c: Cmdr, headline: str, exact: bool = True) -> Position | None:
     h = headline.strip()
     for p in c.all_unique_positions(copy=False):
         if p.h.strip() == h:
@@ -7589,7 +7597,7 @@ def findNodeAnywhere(c: Cmdr, headline: str, exact: bool = True) -> Optional[Pos
 
 
 # @+node:ekr.20210303123525.1: *4* g.findNodeByPath
-def findNodeByPath(c: Cmdr, path: str) -> Optional[Position]:
+def findNodeByPath(c: Cmdr, path: str) -> Position | None:
     """Return the first @<file> node in Cmdr c whose path is given."""
     if not os.path.isabs(path):  # #2049. Only absolute paths could possibly work.
         g.trace(f"path not absolute: {repr(path)}")
@@ -7604,9 +7612,7 @@ def findNodeByPath(c: Cmdr, path: str) -> Optional[Position]:
 
 
 # @+node:ekr.20210303123423.1: *4* g.findNodeInChildren
-def findNodeInChildren(
-    c: Cmdr, p: Position, headline: str, exact: bool = True
-) -> Optional[Position]:
+def findNodeInChildren(c: Cmdr, p: Position, headline: str, exact: bool = True) -> Position | None:
     """Search for a node in v's tree matching the given headline."""
     p1 = p.copy()
     h = headline.strip()
@@ -7621,7 +7627,7 @@ def findNodeInChildren(
 
 
 # @+node:ekr.20210303123423.2: *4* g.findNodeInTree
-def findNodeInTree(c: Cmdr, p: Position, headline: str, exact: bool = True) -> Optional[Position]:
+def findNodeInTree(c: Cmdr, p: Position, headline: str, exact: bool = True) -> Position | None:
     """Search for a node in v's tree matching the given headline."""
     h = headline.strip()
     p1 = p.copy()
@@ -7636,7 +7642,7 @@ def findNodeInTree(c: Cmdr, p: Position, headline: str, exact: bool = True) -> O
 
 
 # @+node:ekr.20210303123423.4: *4* g.findTopLevelNode
-def findTopLevelNode(c: Cmdr, headline: str, exact: bool = True) -> Optional[Position]:
+def findTopLevelNode(c: Cmdr, headline: str, exact: bool = True) -> Position | None:
     h = headline.strip()
     for p in c.rootPosition().self_and_siblings(copy=False):
         if p.h.strip() == h:
@@ -7758,8 +7764,8 @@ def extractExecutableString(c: Cmdr, p: Position, s: str) -> str:
 def handleScriptException(
     c: Cmdr,
     p: Position,
-    script: str = None,  # No longer used.
-    script1: str = None,  # No longer used.
+    script: str | None = None,  # No longer used.
+    script1: str | None = None,  # No longer used.
 ) -> None:
     g.warning("exception executing script")
     g.es_exception()
@@ -7877,7 +7883,7 @@ def run_coverage_tests(module: str = '', filename: str = '') -> None:
 
 
 # @+node:ekr.20210901065224.1: *3* g.run_unit_tests
-def run_unit_tests(tests: str = None, verbose: bool = False) -> None:
+def run_unit_tests(tests: str | None = None, verbose: bool = False) -> None:
     """
     Run the unit tests given by the "tests" string.
 
@@ -7965,7 +7971,7 @@ def run_unit_tests(tests: str = None, verbose: bool = False) -> None:
 #    For example, Leo's forum: https://leo-editor.github.io/leo-editor/
 # @-<< About clickable links >>
 # @+node:ekr.20120320053907.9776: *3* g.computeFileUrl
-def computeFileUrl(fn: str, c: Cmdr = None, p: Position = None) -> str:
+def computeFileUrl(fn: str, c: Cmdr | None = None, p: Position | None = None) -> str:
     """
     Compute finalized url for filename fn.
     """
@@ -8013,7 +8019,7 @@ def es_clickable_link(
 
 
 # @+node:ekr.20230628072620.1: *3* g.findAnyUnl
-def findAnyUnl(unl_s: str, c: Cmdr) -> Optional[Position]:
+def findAnyUnl(unl_s: str, c: Cmdr) -> Position | None:
     """
     Find the Position corresponding to an UNL.
 
@@ -8092,7 +8098,7 @@ def findAnyUnl(unl_s: str, c: Cmdr) -> Optional[Position]:
 find_gnx_pat = re.compile(r'^(.*)::([-\d]+)?$')
 
 
-def findGnx(gnx: str, c: Cmdr) -> Optional[Position]:
+def findGnx(gnx: str, c: Cmdr) -> Position | None:
     """
     gnx: the gnx part of a gnx-based unl.
 
@@ -8120,7 +8126,7 @@ def findGnx(gnx: str, c: Cmdr) -> Optional[Position]:
 
 
 # @+node:tbrown.20140311095634.15188: *3* g.findUnl & helpers (legacy unls)
-def findUnl(unlList1: list[str], c: Cmdr) -> Optional[Position]:
+def findUnl(unlList1: list[str], c: Cmdr) -> Position | None:
     """
     g.findUnl: support for legacy UNLs.
     unlList is a list of headlines.
@@ -8222,7 +8228,7 @@ findUNL = findUnl  # Compatibility.
 
 
 # @+node:ekr.20120311151914.9917: *3* g.getUrlFromNode
-def getUrlFromNode(p: Position) -> Optional[str]:
+def getUrlFromNode(p: Position) -> str | None:
     """
     Get an url from node p:
     1. Use the headline if it contains a valid url.
@@ -8258,7 +8264,7 @@ def getUrlFromNode(p: Position) -> Optional[str]:
 
 
 # @+node:ekr.20170221063527.1: *3* g.handleUnl
-def handleUnl(unl_s: str, c: Cmdr) -> Optional[Cmdr]:
+def handleUnl(unl_s: str, c: Cmdr) -> Cmdr | None:
     """
     Select the node given by any kind of unl.
     This must *never* open a browser.
@@ -8304,7 +8310,7 @@ def handleUnl(unl_s: str, c: Cmdr) -> Optional[Cmdr]:
 
 
 # @+node:tbrown.20090219095555.63: *3* g.handleUrl & helpers
-def handleUrl(url: str, c: Cmdr = None, p: Position = None) -> Optional[str]:
+def handleUrl(url: str, c: Cmdr | None = None, p: Position | None = None) -> str | None:
     """Open a url or a unl."""
     if c and not p:
         p = c.p
@@ -8453,7 +8459,7 @@ def openUrl(p: Position) -> None:  # pragma: no cover
 
 
 # @+node:ekr.20110605121601.18135: *3* g.openUrlOnClick (open-url-under-cursor)
-def openUrlOnClick(event: QMouseEvent, url: str = None) -> Optional[str]:  # pragma: no cover
+def openUrlOnClick(event: QMouseEvent, url: str | None = None) -> str | None:  # pragma: no cover
     """Open the URL under the cursor.  Return it for unit testing."""
     from leo.core.leoGui import LeoKeyEvent
     from leo.plugins.qt_text import QTextEditWrapper
@@ -8472,7 +8478,7 @@ def openUrlOnClick(event: QMouseEvent, url: str = None) -> Optional[str]:  # pra
 
 
 # @+node:ekr.20170216091704.1: *4* g.openUrlHelper
-def openUrlHelper(event: LeoKeyEvent, url: str = None) -> Optional[str]:
+def openUrlHelper(event: LeoKeyEvent, url: str | None = None) -> str | None:
     """Open the unl, url or gnx under the cursor.  Return it for unit testing."""
     if not event:
         return None
@@ -8632,7 +8638,7 @@ def getUNLFilePart(s: str) -> str:
 
 
 # @+node:ekr.20230630132340.1: *4* g.openUNLFile
-def openUNLFile(c: Cmdr, s: str) -> Cmdr:
+def openUNLFile(c: Cmdr, s: str) -> Cmdr | None:
     """
     Open the commander for filename s, the file part of an unl.
     Return None if the file can not be found.
@@ -8728,12 +8734,6 @@ def parsePathData(c: Cmdr) -> dict[str, str]:
 
 
 # @-others
-# set g when the import is about to complete.
-g = sys.modules.get('leo.core.leoGlobals')
-assert g, sorted(sys.modules.keys())
-if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
-
 # @@language python
 # @@tabwidth -4
 # @@pagewidth 70

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6301,6 +6301,14 @@ def es_exception(*args: Sequence, **kwargs: Sequence) -> None:
         g.es_print_error(line)
 
 
+# @+node:ekr.20061015090538: *3* g.es_exception_type
+def es_exception_type(color: str = "red") -> None:
+    # exctype is a Exception class object; value is the error message.
+    exctype, value = sys.exc_info()[:2]
+    name = exctype.__name__ if exctype else ''
+    g.es_print('', f"{name}, {value}", color=color)
+
+
 # @+node:ekr.20050707064040: *3* g.es_print
 # see: http://www.diveintopython.org/xml_processing/unicode.html
 
@@ -6526,6 +6534,32 @@ def print_exception(
         return "<no file>", 0
 
 
+# @+node:ekr.20241104143456.1: *3* g.print_unique_message & es_print_unique_message
+g_unique_message_d: dict[str, bool] = {}
+
+
+def print_unique_message(message: str) -> bool:
+    """
+    Print the given message once. Return True if the message was printed.
+    """
+    if message not in g_unique_message_d:
+        g_unique_message_d[message] = True
+        print(message)
+        return True
+    return False
+
+
+def es_print_unique_message(message: str, *, color: str = 'error') -> bool:
+    """
+    Print the given message once. Return True if the message was printed.
+    """
+    if message not in g_unique_message_d:
+        g_unique_message_d[message] = True
+        g.es_print(message, color=color)
+        return True
+    return False
+
+
 # @+node:ekr.20031218072017.3113: *3* g.printBindings
 def print_bindings(name: str, window: QWidget) -> None:
     bindings = window.bind()
@@ -6584,32 +6618,6 @@ def trace(*args: Args, **kwargs: KWargs) -> None:
     if name.endswith(".pyc"):
         name = name[:-1]
     g.pr(name, *args)
-
-
-# @+node:ekr.20241104143456.1: *3* g.print_unique_message & es_print_unique_message
-g_unique_message_d: dict[str, bool] = {}
-
-
-def print_unique_message(message: str) -> bool:
-    """
-    Print the given message once. Return True if the message was printed.
-    """
-    if message not in g_unique_message_d:
-        g_unique_message_d[message] = True
-        print(message)
-        return True
-    return False
-
-
-def es_print_unique_message(message: str, *, color: str = 'error') -> bool:
-    """
-    Print the given message once. Return True if the message was printed.
-    """
-    if message not in g_unique_message_d:
-        g_unique_message_d[message] = True
-        g.es_print(message, color=color)
-        return True
-    return False
 
 
 # @+node:ekr.20240325064618.1: *3* g.traceUnique & traceUniqueClass

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -474,7 +474,7 @@ class BindingInfo:
         kind: str,
         commandName: str = '',
         func: Callable | None = None,
-        nextMode: str | None = None,
+        nextMode: str = 'none',  # #4755
         pane: str | None = None,
         stroke: KeyStroke | None = None,
     ) -> None:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1823,7 +1823,7 @@ class SettingsDict(dict):
         return gs.val if gs else ''  # strict_optional
 
     def get_string_setting(self, key: str) -> str:
-        return self.get_setting(key)
+        return self.get_setting(key) or ''  # strict_optional
 
     # @+node:ekr.20190904103552.1: *4* SettingsDict.name & setName
     def name(self) -> str:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1174,7 +1174,7 @@ class MatchBrackets:
         offset = 1 if self.forward else -1
         i1 = i
         i += offset
-        found: int | bool = False
+        found: int | None = None  # strict_optional
         while 0 <= i < len(s) and s[i] != '\n':
             ch = s[i]
             i2 = i - 1  # in case we have to look behind.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -738,11 +738,6 @@ class KeyStroke:
     # @+node:ekr.20180414195401.2: *4*  ks.__init__
     def __init__(self, binding: str) -> None:
         self.s = self.finalize_binding(binding)
-        ###
-        # if binding:
-        #     self.s = self.finalize_binding(binding)
-        # else:
-        #     self.s = None
 
     # @+node:ekr.20120203053243.10117: *4* ks.__eq__, etc
     # All these must be defined in order to say, for example:
@@ -5843,15 +5838,7 @@ def toUnicode(s: bytes | str, encoding: str | None = None, reportErrors: bool = 
         return s.decode(encoding, 'strict')
     except (UnicodeDecodeError, UnicodeError):
         # https://wiki.python.org/moin/UnicodeDecodeError
-        s = s.decode(encoding, 'replace')
-        ###
-        if g.unitTesting:
-            g.trace(f"{tag} unicode error. encoding: {encoding!r} len(s): {len(s)}")
-            g.trace(g.callers())
-        elif reportErrors:
-            g.printObj(s, tag=f"{tag} unicode error. encoding: {encoding!r}")
-            g.trace(g.callers())
-        return s
+        return s.decode(encoding, 'replace')
     except Exception:
         g.es_exception()
         g.error(f"{tag}: unexpected error! encoding: {encoding!r}, s:\n{s!r}")

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -353,7 +353,7 @@ def new_cmd_decorator(name: str, ivars: list[str]) -> Callable:
                 c = event.get('c')
             else:
                 c = event.c
-            self = g.ivars2instance(c, g, ivars)
+            self = g.ivars2instance(c, g, ivars)  # type:ignore # c exists.
             try:
                 # Don't use a keyword for self.
                 # This allows the VimCommands class to use vc instead.
@@ -7898,7 +7898,7 @@ def computeFileUrl(fn: str, c: Cmdr | None = None, p: Position | None = None) ->
             path = url
         # Handle ancestor @path directives.
         if c and c.fileName():
-            base = c.getPath(p)
+            base = c.getPath(p)  # type:ignore # c.getPath(p) is not empty.
             path = g.finalize_join(g.os_path_dirname(c.fileName()), base, path)
         else:
             path = g.finalize(path)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7559,7 +7559,7 @@ def findTopLevelNode(c: Cmdr, headline: str, exact: bool = True) -> Position | N
 # @+node:EKR.20040614071102.1: *3* g.getScript & helpers
 def getScript(
     c: Cmdr,
-    p: Position,
+    p: Position | None,
     useSelectedText: bool = True,
     forcePythonSentinels: bool = True,
     useSentinels: bool = True,

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2951,7 +2951,7 @@ def findFirstValidAtLanguageDirective(s: str) -> str:
 def findLanguageDirectives(c: Cmdr, p: Position) -> str:
     """Return the language in effect at position p."""
     if c is None or p is None:
-        return ''  # c may be None for testing.
+        return ''
 
     v0 = p.v
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -822,9 +822,7 @@ class KeyStroke:
         }
         if self.mods and s.lower() in shift_d:
             # Returning '' breaks existing code.
-            val = shift_d.get(s.lower())
-            if isinstance(val, str):
-                return val
+            return shift_d.get(s.lower())
 
         # Make all other translations...
         #

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2948,7 +2948,7 @@ def findFirstValidAtLanguageDirective(s: str) -> str:
 # @+node:ekr.20090214075058.6: *3* g.findLanguageDirectives (must be fast)
 def findLanguageDirectives(c: Cmdr, p: Position) -> str:
     """Return the language in effect at position p."""
-    if c is None or p is None:
+    if c is None or not p:  # strict_optional # Bug fix!
         return ''
 
     v0 = p.v
@@ -4821,7 +4821,7 @@ def getGitIssues(
     state: str = '',  # in ('', 'closed', 'open')
 ) -> None:
     """Get a list of issues from Leo's GitHub site."""
-    if base_url is None:
+    if not base_url:
         base_url = 'https://api.github.com/repos/leo-editor/leo-editor/issues'
     if isinstance(label_list, (list, tuple)):
         root = c.lastTopLevel().insertAfter()
@@ -4860,7 +4860,7 @@ class GitIssueController:
             for state in ('closed', 'open'):
                 for label in label_list:
                     self.get_one_issue(label, state)
-        elif state is None:
+        elif not state:  # strict_optional
             for state in ('closed', 'open'):
                 organizer = root.insertAsLastChild()
                 organizer.h = f"{state} issues..."
@@ -5137,7 +5137,7 @@ def gitInfo(path: str = '') -> tuple[str, str]:
     Return the branch and commit number or ('', '').
     """
     branch, commit = '', ''  # Set defaults.
-    if path is None:
+    if not path:  # strict_optional
         # Default to leo/core.
         path = os.path.dirname(__file__)
     if not os.path.isdir(path):
@@ -5493,7 +5493,7 @@ def toPythonIndex(s: str, index: str) -> int:
 
     index may be a Tk index (x.y) or 'end'.
     """
-    if index is None:
+    if not index:  # strict_optional
         return 0
     if isinstance(index, int):
         return index
@@ -6416,7 +6416,7 @@ is_unique_class = isUniqueClass
 # @+node:ekr.20150127060254.5: *3* g.log_to_file
 def log_to_file(s: str, fn: str = '') -> None:
     """Write a message to ~/test/leo_log.txt."""
-    if fn is None:
+    if not fn:  # strict_optional
         fn = g.finalize('~/test/leo_log.txt')
     if not s.endswith('\n'):
         s = s + '\n'
@@ -6602,7 +6602,7 @@ trace_unique_dict: dict[str, list[str]] = {}
 
 def traceUnique(value: object, *, n: int = 2, pad: int = 30) -> None:
     """Print unique values associated with g.callers(n)."""
-    if pad is None:
+    if not pad:  # strict_optional
         pad = 30
     key = g.callers(n)
     value_s = str(value)
@@ -8008,7 +8008,7 @@ def findGnx(gnx: str, c: Cmdr) -> Position | None:
     Return the first position in c with the actual gnx.
     """
     # Get the actual gnx and line number.
-    n: int = 0  # The line number.
+    n = 0  # The line number.
     if m := find_gnx_pat.match(gnx):
         # Get the actual gnx and line number.
         gnx = m.group(1)
@@ -8019,7 +8019,7 @@ def findGnx(gnx: str, c: Cmdr) -> Position | None:
     # Search forwards, setting p2.
     for p in c.all_unique_positions():
         if p.gnx == gnx:
-            if n is None:
+            if n == 0:  # strict_optional
                 return p
             p2, offset = c.gotoCommands.find_file_line(-n, p)
             return p2 or p

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -827,7 +827,9 @@ class KeyStroke:
         }
         if self.mods and s.lower() in shift_d:
             # Returning '' breaks existing code.
-            return shift_d.get(s.lower())  # type:ignore  # s.lower() is in shift_d!
+            val = shift_d.get(s.lower())
+            if isinstance(val, str):
+                return val
 
         # Make all other translations...
         #
@@ -923,11 +925,6 @@ class KeyStroke:
             else:
                 # 917: Ignore multi-byte alphas not in the table.
                 s = ''
-                if 0:
-                    # Make sure all special chars are in translate_d.
-                    if g.app.gui:  # It may not exist yet.
-                        if s.capitalize() in g.app.gui.specialChars:
-                            s = s.capitalize()
             return s
 
         # Translate shifted keys to their appropriate alternatives.
@@ -1502,10 +1499,10 @@ class MatchBrackets:
         With selected range: the first time, move cursor back to other end of
         range. The second time, select enclosing range.
         """
-        #
-        # A partial fix for bug 127: Bracket matching is buggy.
+
+        # #127: Bracket matching is buggy.
         w = self.c.frame.body.wrapper
-        s = w.getAllText()
+        s = cast(str, w.getAllText())
         _mb = self.c.user_dict['_match_brackets']
         sel_range = w.getSelectionRange()
         if not w.hasSelection():
@@ -1525,7 +1522,9 @@ class MatchBrackets:
         if left is None:
             g.es("Bracket not found")
             return
-        index2 = self.find_matching_bracket(ch, s, index)  # type:ignore # ch is not None!
+        ch = cast(str, ch)
+        index = cast(int, index)
+        index2 = cast(int, self.find_matching_bracket(ch, s, index))
         if index2 is None:
             g.es("No matching bracket.")  # #1447.
             return
@@ -1534,7 +1533,7 @@ class MatchBrackets:
         # nothing extra.  The second time, move cursor to other end (requires
         # no special action here), and the third time, try to expand the range
         # to any enclosing brackets
-        minmax = (min(index, index2), max(index, index2) + 1)  # type:ignore # index is not None!
+        minmax = (min(index, index2), max(index, index2) + 1)
         # the range, +1 to match w.getSelectionRange()
         if _mb['range'] == minmax:  # count how many times this has been the answer
             _mb['count'] += 1
@@ -1546,20 +1545,21 @@ class MatchBrackets:
                 s, max(minmax[0], 0), min(minmax[1], max_right), max_right, expand=True
             )
             if index3 is not None:  # found nearest bracket outside range
+                ch = cast(str, ch)
                 index4 = self.find_matching_bracket(ch, s, index3)
                 if index4 is not None:  # found matching bracket, expand range
                     index, index2 = index3, index4
                     _mb['count'] = 1
                     _mb['range'] = (min(index3, index4), max(index3, index4) + 1)
 
-        if index2 is not None:
-            if index2 < index:
-                w.setSelectionRange(index2, index + 1, insert=index2)
-            else:
-                w.setSelectionRange(index, index2 + 1, insert=min(len(s), index2 + 1))
-            w.see(index2)
-        else:
+        if index is None or index2 is None:
             g.es("unmatched", repr(ch))
+            return
+        if index2 < index:
+            w.setSelectionRange(index2, index + 1, insert=index2)
+        else:
+            w.setSelectionRange(index, index2 + 1, insert=min(len(s), index2 + 1))
+        w.see(index2)
 
     # @-others
 
@@ -1572,7 +1572,7 @@ class OptionsUtils:
     This class *calculates* valid options from the usage message.
     """
 
-    def __init__(self, usage: str, obsolete_options: list[str] = None) -> None:
+    def __init__(self, usage: str, obsolete_options: list[str]) -> None:
         # This class is essentially stateless because these ivars never change.
         self.usage = usage
         self.obsolete_options = obsolete_options
@@ -1909,7 +1909,7 @@ class Tracer:
     def __init__(self, limit: int = 0, trace: bool = False, verbose: bool = False) -> None:
         # Keys are function names.
         # Values are the number of times the function was called by the caller.
-        self.callDict: dict[str, dict] = {}
+        self.callDict: dict[str, dict[str, int]] = {}
         # Keys are function names.
         # Values are the total number of times the function was called.
         self.calledDict: dict[str, int] = {}
@@ -1955,11 +1955,12 @@ class Tracer:
         g.pr('\ncallDict...')
         for key in sorted(self.callDict):
             # Print the calling function.
-            g.pr(f"{self.calledDict.get(key, 0):d}", key)  # noqa  # conflict between flake8 and black.
+            g.pr(f"{self.calledDict.get(key, 0):d}", key)
             # Print the called functions.
             d = self.callDict.get(key)
-            for key2 in sorted(d):
-                g.pr(f"{d.get(key2):8d}", key2)
+            if isinstance(d, dict):
+                for key2 in sorted(d):
+                    g.pr(f"{d.get(key2):8d}", key2)
 
     # @+node:ekr.20080531075119.5: *4* stop
     def stop(self) -> None:
@@ -2021,10 +2022,10 @@ class Tracer:
     # @-others
 
 
-def startTracer(limit: int = 0, trace: bool = False, verbose: bool = False) -> Callable:
-    t = g.Tracer(limit=limit, trace=trace, verbose=verbose)
-    sys.settrace(t.tracer)
-    return t
+def startTracer(limit: int = 0, trace: bool = False, verbose: bool = False) -> Tracer:
+    tracer = g.Tracer(limit=limit, trace=trace, verbose=verbose)
+    sys.settrace(tracer.tracer)
+    return tracer
 
 
 # @+node:ekr.20031219074948.1: *3* class g.Tracing/NullObject & helpers
@@ -2034,7 +2035,7 @@ tracing_tags: dict[int, str] = {}  # Keys are id's, values are tags.
 class NullObject:
     """An object that does nothing, and does it very well."""
 
-    def __init__(self, ivars: list[str] = None, *args: Args, **kwargs: KWargs) -> None:
+    def __init__(self, ivars: list[str] | None = None, *args: Args, **kwargs: KWargs) -> None:
         pass
 
     def __call__(self, *args: Args, **kwargs: KWargs) -> "NullObject":
@@ -2083,7 +2084,9 @@ class NullObject:
 class TracingNullObject:
     """Tracing NullObject."""
 
-    def __init__(self, tag: str, ivars: list[str] = None, *args: Args, **kwargs: KWargs) -> None:
+    def __init__(
+        self, tag: str, ivars: list[str] | None = None, *args: Args, **kwargs: KWargs
+    ) -> None:
         tracing_tags[id(self)] = tag  # noqa  # conflict between flake8 and black.
 
     def __call__(self, *args: Args, **kwargs: KWargs) -> "TracingNullObject":
@@ -2366,7 +2369,7 @@ qt_text_classes = [
 ]
 
 
-def checkQtTextWidget(obj: Any, *, other_classes: list[str] = None) -> None:
+def checkQtTextWidget(obj: Any, *, other_classes: list[str]) -> None:
     """
     Check that an object has the appropriate class.
     """
@@ -2510,28 +2513,28 @@ def dump_encoded_string(encoding: str, s: str) -> None:
 
 
 # @+node:ekr.20031218072017.1317: *4* g.file/module/plugin_date
-def module_date(mod: ModuleType, format: str | None = None) -> str:
+def module_date(mod: ModuleType, format: str) -> str:
     theFile = g.os_path_join(app.loadDir, mod.__file__)
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=format)
 
 
-def plugin_date(plugin_mod: ModuleType, format: str | None = None) -> str:
+def plugin_date(plugin_mod: ModuleType, format: str) -> str:
     theFile = g.os_path_join(app.loadDir, "..", "plugins", plugin_mod.__file__)
     root, ext = g.os_path_splitext(theFile)
-    return g.file_date(root + ".py", format=str)
+    return g.file_date(root + ".py", format=format)
 
 
-def file_date(theFile: IO, format: str | None = None) -> str:
-    if theFile and g.os_path_exists(theFile):
-        try:
-            n = g.os_path_getmtime(theFile)
-            if format is None:
-                format = "%m/%d/%y %H:%M:%S"
-            return time.strftime(format, time.gmtime(n))
-        except (ImportError, NameError):
-            pass  # Time module is platform dependent.
-    return ""
+def file_date(theFile: str, format: str) -> str:
+    if not g.os_path_exists(theFile):
+        return ''
+    try:
+        n = g.os_path_getmtime(theFile)
+        if format is None:
+            format = "%m/%d/%y %H:%M:%S"
+        return time.strftime(format, time.gmtime(n))
+    except (ImportError, NameError):
+        return ''  # Time module is platform dependent.
 
 
 # @+node:ekr.20031218072017.3127: *4* g.get_line & get_line__after
@@ -2578,9 +2581,7 @@ def getIvarsDict(obj: object) -> dict[str, Value]:
 
 
 def checkUnchangedIvars(
-    obj: object,
-    d: dict[str, Value],
-    exceptions: Sequence[str] = None,
+    obj: object, d: dict[str, Value], exceptions: Sequence[str] | None = None
 ) -> bool:
     if not exceptions:
         exceptions = []
@@ -2886,7 +2887,7 @@ def comment_delims_from_extension(filename: str) -> tuple[str, str, str]:
     Return the comment delims corresponding to the filename's extension.
     """
     if filename.startswith('.'):
-        root, ext = None, filename
+        root, ext = '', filename
     else:
         root, ext = os.path.splitext(filename)
     if ext == '.tmp':
@@ -2915,7 +2916,7 @@ def findAllValidLanguageDirectives(s: str) -> list:
 
 
 # @+node:ekr.20090214075058.8: *3* g.findAtTabWidthDirectives (must be fast)
-def findTabWidthDirectives(c: Cmdr, p: Position) -> str | None:
+def findTabWidthDirectives(c: Cmdr, p: Position) -> int | None:
     """Return the tab width in effect at position p."""
     if c is None:
         return None  # c may be None for testing.
@@ -3330,7 +3331,7 @@ def set_delims_from_language(language: str) -> tuple[str, str, str]:
 
 
 # @+node:ekr.20031218072017.1383: *3* g.set_delims_from_string
-def set_delims_from_string(s: str) -> tuple[str, str, str] | tuple[None, None, None]:
+def set_delims_from_string(s: str) -> tuple[str, str, str]:
     """
     Return (delim1, delim2, delim2), the delims following the @comment
     directive.
@@ -3366,12 +3367,12 @@ def set_delims_from_string(s: str) -> tuple[str, str, str] | tuple[None, None, N
                 # If used, whole delimiter must be encoded.
                 if len(delims[i]) == 3:
                     g.warning(f"'{delims[i]}' delimiter is invalid")
-                    return None, None, None
+                    return '', '', ''
                 try:
                     delims[i] = g.toUnicode(binascii.unhexlify(delims[i][3:]))
                 except Exception as e:
                     g.warning(f"'{delims[i]}' delimiter is invalid: {e}")
-                    return None, None, None
+                    return '', '', ''
             else:
                 # 7/8/02: The "REM hack": replace underscores by blanks.
                 # 9/25/02: The "perlpod hack": replace double underscores by newlines.
@@ -3380,9 +3381,7 @@ def set_delims_from_string(s: str) -> tuple[str, str, str] | tuple[None, None, N
 
 
 # @+node:ekr.20031218072017.1384: *3* g.set_language
-def set_language(
-    s: str, i: int, issue_errors_flag: bool = False
-) -> tuple[str, str, str, str] | tuple[None, None, None, None]:
+def set_language(s: str, i: int, issue_errors_flag: bool = False) -> tuple[str, str, str, str]:
     """Scan the @language directive that appears at s[i:].
 
     The @language may have been stripped away.
@@ -3405,7 +3404,7 @@ def set_language(
         return language, delim1, delim2, delim3
     if issue_errors_flag:
         g.es("ignoring:", g.get_line(s, i))
-    return None, None, None, None
+    return '', '', '', ''
 
 
 # @+node:ekr.20071109165315: *3* g.stripPathCruft
@@ -3478,7 +3477,7 @@ def computeStandardDirectories() -> str:
 
 
 # @+node:ekr.20031218072017.3117: *3* g.create_temp_file
-def create_temp_file(textMode: bool = False) -> tuple[IO, str]:
+def create_temp_file(textMode: bool = False) -> tuple[IO | None, str]:
     """
     Return a tuple (theFile,theFileName)
 
@@ -3582,7 +3581,7 @@ def getBaseDirectory(c: Cmdr) -> str:
 
 
 # @+node:ekr.20170223093758.1: *3* g.getEncodingAt (deprecated)
-def getEncodingAt(p: Position, b: bytes | None = None) -> str:
+def getEncodingAt(p: Position, b: bytes) -> str | None:
     """
     Return the encoding in effect at p and/or for string s.
 
@@ -3591,6 +3590,7 @@ def getEncodingAt(p: Position, b: bytes | None = None) -> str:
     """
     g.deprecated()
     # A BOM overrides everything.
+    e: bytes | str | None
     if b:
         e, junk_s = g.stripBOM(b)
         if e:
@@ -3665,7 +3665,7 @@ def is_binary_external_file(fileName: str) -> bool:
         return False
 
 
-def is_binary_string(s: str) -> bool:
+def is_binary_string(s: bytes | str) -> bool:
     # http://stackoverflow.com/questions/898669
     # aList is a list of all non-binary characters.
     aList = [7, 8, 9, 10, 12, 13, 27] + list(range(0x20, 0x100))
@@ -3736,7 +3736,7 @@ def readFile(file_name: str) -> str:
 
 
 # @+node:ekr.20150306035851.7: *3* g.readFileIntoEncodedString
-def readFileIntoEncodedString(fn: str, silent: bool = False) -> bytes:
+def readFileIntoEncodedString(fn: str, silent: bool = False) -> bytes | None:
     """Return the raw contents of the file whose full path is fn."""
     try:
         with open(fn, 'rb') as f:
@@ -3757,7 +3757,7 @@ def readFileIntoString(
     encoding: str = 'utf-8',  # BOM may override this.
     kind: str | None = None,  # @file, @edit, ...
     verbose: bool = True,
-) -> tuple[str, str] | tuple[None, None]:
+) -> tuple[str | None, str | None]:
     """
     Return the contents of the file whose full path is fileName.
 
@@ -3782,7 +3782,7 @@ def readFileIntoString(
             g.error('file not found:', fileName)
         return None, None
     try:
-        e = None
+        e: Any
         with open(fileName, 'rb') as f:
             bytes_s = f.read()
         # Fix #391.
@@ -4016,7 +4016,7 @@ def find_word(s: str, word: str, i: int = 0) -> int:
 
 
 # @+node:ekr.20211029090118.1: *3* g.findAncestorVnodeByPredicate
-def findAncestorVnodeByPredicate(p: Position, v_predicate: Callable | None) -> VNode | None:
+def findAncestorVnodeByPredicate(p: Position, v_predicate: Callable) -> VNode | None:
     """
     Return first ancestor vnode matching the predicate.
 
@@ -4818,7 +4818,11 @@ def execGitCommand(command: str, directory: str) -> list[str]:
             shlex.split(command), stdout=subprocess.PIPE, stderr=None, shell=True
         )
         out, err = proc.communicate()
-        lines = [g.toUnicode(z) for z in g.splitLines(out or '')]
+        lines: list[str]
+        if isinstance(out, str) and out:
+            lines = [g.toUnicode(z) for z in g.splitLines(out)]
+        else:
+            lines = []
     finally:
         os.chdir(old_dir)
     return lines
@@ -4867,7 +4871,7 @@ class GitIssueController:
     ) -> None:
         self.base_url = base_url
         self.root = root
-        self.milestone = None
+        self.milestone = ''
         if label_list:
             for state in ('closed', 'open'):
                 for label in label_list:
@@ -4892,7 +4896,7 @@ class GitIssueController:
         except Exception:
             g.trace('requests not found: `pip install requests`')
             return
-        label = None
+        label = ''
         assert state in ('open', 'closed')
         page_url = self.base_url + '?&state=%s&page=%s'
         page, total = 1, 0
@@ -4923,7 +4927,7 @@ class GitIssueController:
     def get_issues(
         self,
         base_url: str,
-        label_list: list,
+        label_list: list[str],
         milestone: str,
         root: Position,
         state: str,
@@ -5024,6 +5028,7 @@ def getGitVersion(directory: str | None = None) -> tuple[str, str, str]:
 
     # -n: Get only the last log.
     trace = 'git' in g.app.debug
+    s: bytes | str
     try:
         s = subprocess.check_output(
             'git log -n 1 --date=iso',
@@ -5105,7 +5110,7 @@ def gitCommitNumber(path: str | None = None) -> str:
 
 
 # @+node:maphew.20171112205129.1: *3* g.gitDescribe
-def gitDescribe(path: str | None = None) -> tuple[str, str, str]:
+def gitDescribe(path: str) -> tuple[str, str, str]:
     """
     Return the Git tag, distance-from-tag, and commit hash for the
     associated path. If path is None, use the leo-editor directory.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2521,7 +2521,7 @@ def file_date(theFile: str, format: str = '') -> str:
         return ''
     try:
         n = g.os_path_getmtime(theFile)
-        if format is None:
+        if not format:  # strict_optional
             format = "%m/%d/%y %H:%M:%S"
         return time.strftime(format, time.gmtime(n))
     except (ImportError, NameError):
@@ -2907,7 +2907,7 @@ def findAllValidLanguageDirectives(s: str) -> list:
 
 
 # @+node:ekr.20090214075058.8: *3* g.findAtTabWidthDirectives (must be fast)
-def findTabWidthDirectives(c: Cmdr, p: Position) -> int | None:
+def findTabWidthDirectives(c: Cmdr | None, p: Position) -> int | None:
     """Return the tab width in effect at position p."""
     if c is None:
         return None  # c may be None for testing.
@@ -4769,7 +4769,7 @@ def skip_ws_and_nl(s: str, i: int) -> int:
 # @+node:ekr.20180325025502.1: *3* g.backupGitIssues
 def backupGitIssues(c: Cmdr, base_url: str = '') -> None:
     """Get a list of issues from Leo's GitHub site."""
-    if base_url is None:
+    if not base_url:  # strict_optional
         base_url = 'https://api.github.com/repos/leo-editor/leo-editor/issues'
 
     root = c.lastTopLevel().insertAfter()
@@ -6723,7 +6723,7 @@ def actualColor(color: str) -> str:
     if color and color.startswith('#'):
         return color
     # #788: Translate colors to theme-defined colors.
-    if color is None:
+    if not color:  # strict_optional
         # Prefer text_foreground_color'
         color2 = c.config.getColor('log-text-foreground-color')
         if color2:
@@ -7425,7 +7425,7 @@ def python_tokenize(s: str) -> list:
 # @+node:ekr.20161223090721.1: *3* g.exec_file
 def exec_file(path: str, d: dict[str, Value], script: str = '') -> None:
     """Simulate python's execfile statement for python 3."""
-    if script is None:
+    if not script:  # strict_optional
         with open(path) as f:
             script = f.read()
     exec(compile(script, path, 'exec'), d)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2513,19 +2513,19 @@ def dump_encoded_string(encoding: str, s: str) -> None:
 
 
 # @+node:ekr.20031218072017.1317: *4* g.file/module/plugin_date
-def module_date(mod: ModuleType, format: str) -> str:
+def module_date(mod: ModuleType, format: str | None = None) -> str:
     theFile = g.os_path_join(app.loadDir, mod.__file__)
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=format)
 
 
-def plugin_date(plugin_mod: ModuleType, format: str) -> str:
+def plugin_date(plugin_mod: ModuleType, format: str | None = None) -> str:
     theFile = g.os_path_join(app.loadDir, "..", "plugins", plugin_mod.__file__)
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=format)
 
 
-def file_date(theFile: str, format: str) -> str:
+def file_date(theFile: str, format: str | None = None) -> str:
     if not g.os_path_exists(theFile):
         return ''
     try:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -422,7 +422,7 @@ def standard_timestamp() -> str:
 
 
 # @+node:ekr.20201211183100.1: *3* g.get_backup_directory
-def get_backup_path(sub_directory: str) -> str | None:
+def get_backup_path(sub_directory: str) -> str:
     """
     Return the full path to the subdirectory of the main backup directory.
 
@@ -433,11 +433,11 @@ def get_backup_path(sub_directory: str) -> str | None:
     """
     # Compute the main backup directory.
     # First, try the LEO_BACKUP directory.
-    backup = None
+    backup = ''
     try:
         backup = os.environ['LEO_BACKUP']
         if not os.path.exists(backup):
-            backup = None
+            backup = ''
     except KeyError:
         pass
     except Exception:
@@ -446,12 +446,12 @@ def get_backup_path(sub_directory: str) -> str | None:
     if not backup:
         backup = os.path.join(str(Path.home()), 'Backup')
         if not os.path.exists(backup):
-            backup = None
+            backup = ''
     if not backup:
-        return None
+        return ''
     # Compute the path to backup/sub_directory
     directory = os.path.join(backup, sub_directory)
-    return directory if os.path.exists(directory) else None
+    return directory if os.path.exists(directory) else ''
 
 
 # @+node:ekr.20140711071454.17644: ** g.Classes & class accessors
@@ -475,7 +475,7 @@ class BindingInfo:
         commandName: str = '',
         func: Callable | None = None,
         nextMode: str = 'none',  # #4755
-        pane: str | None = None,
+        pane: str = '',  # #4755
         stroke: KeyStroke | None = None,
     ) -> None:
         if not g.isStrokeOrNone(stroke):
@@ -696,13 +696,13 @@ class GeneralSetting:
     def __init__(
         self,
         kind: str,
-        encoding: str | None = None,
-        ivar: str | None = None,
-        source: str | None = None,
+        encoding: str = '',  # #4755
+        ivar: str = '',  # #4755
+        source: str = '',  # #4755
         val: Value | None = None,
         path: str | None = None,
         tag: str = 'setting',
-        unl: str | None = None,
+        unl: str = '',  # #4755
     ) -> None:
         self.encoding = encoding
         self.ivar = ivar
@@ -1801,7 +1801,7 @@ class SettingsDict(dict):
 
     # @+others
     # @+node:ekr.20120223062418.10422: *4* SettingsDict.copy
-    def copy(self, name: str | None = None) -> Value:
+    def copy(self, name: str = '') -> Value:
         """Return a new dict with the same contents."""
         # The result is a g.SettingsDict.
         return copy.deepcopy(self)
@@ -1818,16 +1818,14 @@ class SettingsDict(dict):
             self[key] = aList
 
     # @+node:ekr.20190903181030.1: *4* SettingsDict.get_setting & get_string_setting
-    def get_setting(self, key: str) -> str | None:
+    def get_setting(self, key: str) -> str:
         """Return the canonical setting name."""
         key = key.replace('-', '').replace('_', '')
         gs = self.get(key)
-        val = gs and gs.val
-        return val
+        return gs.val if gs else ''  # #4755
 
-    def get_string_setting(self, key: str) -> str | None:
-        val = self.get_setting(key)
-        return val if val and isinstance(val, str) else None
+    def get_string_setting(self, key: str) -> str:
+        return self.get_setting(key)
 
     # @+node:ekr.20190904103552.1: *4* SettingsDict.name & setName
     def name(self) -> str:
@@ -2466,7 +2464,7 @@ def oldDump(s: str) -> str:
 
 
 # @+node:ekr.20210904114446.1: *4* g.dump_tree & g.tree_to_string
-def dump_tree(c: Cmdr, dump_body: bool = False, msg: str | None = None) -> None:
+def dump_tree(c: Cmdr, dump_body: bool = False, msg: str = '') -> None:
     if msg:
         print(msg.rstrip())
     else:
@@ -2478,7 +2476,7 @@ def dump_tree(c: Cmdr, dump_body: bool = False, msg: str | None = None) -> None:
                 print(z.rstrip())
 
 
-def tree_to_string(c: Cmdr, dump_body: bool = False, msg: str | None = None) -> str:
+def tree_to_string(c: Cmdr, dump_body: bool = False, msg: str = '') -> str:
     result = ['\n']
     if msg:
         result.append(msg)
@@ -2508,19 +2506,19 @@ def dump_encoded_string(encoding: str, s: str) -> None:
 
 
 # @+node:ekr.20031218072017.1317: *4* g.file/module/plugin_date
-def module_date(mod: ModuleType, format: str | None = None) -> str:
+def module_date(mod: ModuleType, format: str = '') -> str:
     theFile = g.os_path_join(app.loadDir, mod.__file__)
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=format)
 
 
-def plugin_date(plugin_mod: ModuleType, format: str | None = None) -> str:
+def plugin_date(plugin_mod: ModuleType, format: str = '') -> str:
     theFile = g.os_path_join(app.loadDir, "..", "plugins", plugin_mod.__file__)
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=format)
 
 
-def file_date(theFile: str, format: str | None = None) -> str:
+def file_date(theFile: str, format: str = '') -> str:
     if not g.os_path_exists(theFile):
         return ''
     try:
@@ -2622,7 +2620,7 @@ def objToString(
     obj: object,
     *,
     indent: int = 0,
-    tag: str | None = None,
+    tag: str = '',
     width: int = 120,
     offset: int = 0,  # Offset into array-like objects.
 ) -> str:
@@ -2679,7 +2677,7 @@ def sleep(n: float) -> None:
 
 
 # @+node:ekr.20171023140544.1: *4* g.printObj & aliases
-def printObj(obj: object, *, tag: str | None = None, indent: int = 0, offset: int = 0) -> None:
+def printObj(obj: object, *, tag: str = '', indent: int = 0, offset: int = 0) -> None:
     """Pretty print any Python object using g.pr."""
     g.pr(objToString(obj, indent=indent, tag=tag, offset=offset))
 
@@ -2935,35 +2933,35 @@ def findTabWidthDirectives(c: Cmdr, p: Position) -> int | None:
 
 
 # @+node:ekr.20170127142001.5: *3* g.findFirstAtLanguageDirective
-def findFirstValidAtLanguageDirective(s: str) -> str | None:
+def findFirstValidAtLanguageDirective(s: str) -> str:
     """
     Return the first language for which there is a valid @language
     directive in s.
     """
     if not s.strip():
-        return None
+        return ''
     for m in g.g_language_pat.finditer(s):
         language = m.group(1)
         if g.isValidLanguage(language):
             return language
-    return None
+    return ''
 
 
 # @+node:ekr.20090214075058.6: *3* g.findLanguageDirectives (must be fast)
-def findLanguageDirectives(c: Cmdr, p: Position) -> str | None:
+def findLanguageDirectives(c: Cmdr, p: Position) -> str:
     """Return the language in effect at position p."""
     if c is None or p is None:
-        return None  # c may be None for testing.
+        return ''  # c may be None for testing.
 
     v0 = p.v
 
-    def find_language(p_or_v: Position | VNode) -> str | None:
+    def find_language(p_or_v: Position | VNode) -> str:
         for s in p_or_v.h, p_or_v.b:
             for m in g_language_pat.finditer(s):
                 language = m.group(1)
                 if g.isValidLanguage(language):
                     return language
-        return None
+        return ''
 
     # First, search up the tree.
     for p in p.self_and_parents(copy=False):
@@ -3052,7 +3050,7 @@ def get_directives_dict_list(p: Position) -> list[dict]:
 
 
 # @+node:ekr.20111010082822.15545: *3* g.getLanguageFromAncestorAtFileNode (deprecated)
-def getLanguageFromAncestorAtFileNode(p: Position) -> str | None:
+def getLanguageFromAncestorAtFileNode(p: Position) -> str:
     """Return the language in effect at node p."""
     g.deprecated()
     c = p.v.context
@@ -3070,7 +3068,7 @@ def getLanguageAtPosition(c: Cmdr, p: Position) -> str:
 
 
 # @+node:ekr.20031218072017.1386: *3* g.getOutputNewline
-def getOutputNewline(c: Cmdr | None = None, name: str | None = None) -> str:
+def getOutputNewline(c: Cmdr | None = None, name: str = '') -> str:
     """Convert the name of a line ending to the line ending itself.
 
     Priority:
@@ -3158,7 +3156,7 @@ def scanAtCommentAndAtLanguageDirectives(aList: list) -> dict[str, str] | None:
 
 
 # @+node:ekr.20080827175609.32: *4* g.scanAtEncodingDirectives (deprecated)
-def scanAtEncodingDirectives(aList: list) -> str | None:
+def scanAtEncodingDirectives(aList: list) -> str:
     """Scan aList for @encoding directives."""
     g.deprecated()
     for d in aList:
@@ -3167,7 +3165,7 @@ def scanAtEncodingDirectives(aList: list) -> str | None:
             return encoding
         if encoding and not g.unitTesting:
             g.error("invalid @encoding:", encoding)
-    return None
+    return ''
 
 
 # @+node:ekr.20080827175609.53: *4* g.scanAtHeaderDirectives (deprecated)
@@ -3180,7 +3178,7 @@ def scanAtHeaderDirectives(aList: list) -> None:
 
 
 # @+node:ekr.20080827175609.33: *4* g.scanAtLineendingDirectives (deprecated)
-def scanAtLineendingDirectives(aList: list) -> str | None:
+def scanAtLineendingDirectives(aList: list) -> str:
     """Scan aList for @lineending directives."""
     g.deprecated()
     for d in aList:
@@ -3188,9 +3186,7 @@ def scanAtLineendingDirectives(aList: list) -> str | None:
         if e in ("cr", "crlf", "lf", "nl", "platform"):
             lineending = g.getOutputNewline(name=e)
             return lineending
-        # else:
-        # g.error("invalid @lineending directive:",e)
-    return None
+    return ''
 
 
 # @+node:ekr.20080827175609.34: *4* g.scanAtPagewidthDirectives (deprecated)
@@ -3576,7 +3572,7 @@ def getBaseDirectory(c: Cmdr) -> str:
 
 
 # @+node:ekr.20170223093758.1: *3* g.getEncodingAt (deprecated)
-def getEncodingAt(p: Position, b: bytes) -> str | None:
+def getEncodingAt(p: Position, b: bytes) -> str:
     """
     Return the encoding in effect at p and/or for string s.
 
@@ -3585,7 +3581,6 @@ def getEncodingAt(p: Position, b: bytes) -> str | None:
     """
     g.deprecated()
     # A BOM overrides everything.
-    e: bytes | str | None
     if b:
         e, junk_s = g.stripBOM(b)
         if e:
@@ -3598,7 +3593,7 @@ def getEncodingAt(p: Position, b: bytes) -> str | None:
 
 
 # @+node:ville.20090701144325.14942: *3* g.guessExternalEditor
-def guessExternalEditor(c: Cmdr | None = None) -> str | None:
+def guessExternalEditor(c: Cmdr | None = None) -> str:
     """Return a 'sensible' external editor"""
     editor = (
         c
@@ -3621,7 +3616,7 @@ def guessExternalEditor(c: Cmdr | None = None) -> str | None:
 Please set LEO_EDITOR or EDITOR environment variable,
 or do g.app.db['LEO_EDITOR'] = "gvim"''',
     )
-    return None
+    return ''
 
 
 # @+node:ekr.20160330204014.1: *3* g.init_dialog_folder
@@ -3669,7 +3664,7 @@ def is_binary_string(s: bytes | str) -> bool:
 
 
 # @+node:ekr.20031218072017.3119: *3* g.makeAllNonExistentDirectories
-def makeAllNonExistentDirectories(theDir: str) -> str | None:
+def makeAllNonExistentDirectories(theDir: str) -> str:
     """
     A wrapper from os.makedirs.
     Attempt to make all non-existent directories.
@@ -3686,7 +3681,7 @@ def makeAllNonExistentDirectories(theDir: str) -> str | None:
         os.makedirs(theDir, mode=0o777, exist_ok=False)
         return theDir
     except Exception:
-        return None
+        return ''
 
 
 # @+node:ekr.20071114113736: *3* g.makePathRelativeTo
@@ -3750,10 +3745,9 @@ def readFileIntoEncodedString(fn: str, silent: bool = False) -> bytes | None:
 def readFileIntoString(
     fileName: str,
     encoding: str = 'utf-8',  # BOM may override this.
-    kind: str | None = None,  # @file, @edit, ...
+    kind: str = '',  # @file, @edit, ...
     verbose: bool = True,
-) -> tuple[str | None, str | None]:
-    ### ) -> tuple[str, str] | tuple[None, None]:
+) -> tuple[str, str]:
     """
     Return the contents of the file whose full path is fileName.
 
@@ -3768,22 +3762,22 @@ def readFileIntoString(
     if not fileName:
         if verbose:
             g.trace('no fileName arg given')
-        return None, None
+        return '', ''
     if g.os_path_isdir(fileName):
         if verbose:
             g.trace('not a file:', fileName)
-        return None, None
+        return '', ''
     if not g.os_path_exists(fileName):
         if verbose:
             g.error('file not found:', fileName)
-        return None, None
+        return '', ''
     try:
         e: Any
         with open(fileName, 'rb') as f:
             bytes_s = f.read()
         # Fix #391.
         if not bytes_s:
-            return '', None
+            return '', ''
         # New in Leo 4.11: check for unicode BOM first.
         e, bytes_s = g.stripBOM(bytes_s)
         if not e:
@@ -3800,15 +3794,15 @@ def readFileIntoString(
     except Exception:
         g.error(f"readFileIntoString: unexpected exception reading {fileName}")
         g.es_exception()
-    return None, None
+    return '', ''
 
 
 # @+node:ekr.20160504062833.1: *3* g.readFileIntoUnicodeString
 def readFileIntoUnicodeString(
     fn: str,
-    encoding: str | None = None,
+    encoding: str = '',
     silent: bool = False,
-) -> str | None:
+) -> str:
     """Return the raw contents of the file whose full path is fn."""
     try:
         with open(fn, 'rb') as f:
@@ -3820,7 +3814,7 @@ def readFileIntoUnicodeString(
     except Exception:
         g.error(f"readFileIntoUnicodeString: unexpected exception reading {fn}")
         g.es_exception()
-    return None
+    return ''
 
 
 # @+node:ekr.20031218072017.3120: *3* g.readlineForceUnixNewline
@@ -3833,7 +3827,7 @@ def readFileIntoUnicodeString(
 # @@c
 
 
-def readlineForceUnixNewline(f: IO, fileName: str | None = None) -> str:
+def readlineForceUnixNewline(f: IO, fileName: str = '') -> str:
     try:
         s = f.readline()
     except UnicodeDecodeError:
@@ -4441,7 +4435,7 @@ def see_more_lines(s: str, ins: int, n: int = 4) -> int:
 
 
 # @+node:ekr.20031218072017.3195: *3* g.splitLines
-def splitLines(s: str | None) -> list[str]:
+def splitLines(s: str) -> list[str]:
     """
     Split s into lines, preserving the number of lines and
     the endings of all lines, including the last line.
@@ -4614,7 +4608,7 @@ def skip_c_id(s: str, i: int) -> int:
 
 
 # @+node:ekr.20040705195048: *4* g.skip_id
-def skip_id(s: str, i: int, chars: str | None = None) -> int:
+def skip_id(s: str, i: int, chars: str = '') -> int:
     chars = g.toUnicode(chars) if chars else ''
     n = len(s)
     while i < n and (g.isWordChar(s[i]) or s[i] in chars):
@@ -4775,7 +4769,7 @@ def skip_ws_and_nl(s: str, i: int) -> int:
 
 # @+node:ekr.20170414034616.1: ** g.Git
 # @+node:ekr.20180325025502.1: *3* g.backupGitIssues
-def backupGitIssues(c: Cmdr, base_url: str | None = None) -> None:
+def backupGitIssues(c: Cmdr, base_url: str = '') -> None:
     """Get a list of issues from Leo's GitHub site."""
     if base_url is None:
         base_url = 'https://api.github.com/repos/leo-editor/leo-editor/issues'
@@ -4823,10 +4817,10 @@ def execGitCommand(command: str, directory: str) -> list[str]:
 # @+node:ekr.20180126043905.1: *3* g.getGitIssues
 def getGitIssues(
     c: Cmdr,
-    base_url: str | None = None,
+    base_url: str = '',
     label_list: list | None = None,
-    milestone: str | None = None,
-    state: str | None = None,  # in (None, 'closed', 'open')
+    milestone: str = '',
+    state: str = '',  # in ('', 'closed', 'open')
 ) -> None:
     """Get a list of issues from Leo's GitHub site."""
     if base_url is None:
@@ -4859,7 +4853,7 @@ class GitIssueController:
         c: Cmdr,
         label_list: list[str],
         root: Position,
-        state: str | None = None,
+        state: str = '',
     ) -> None:
         self.base_url = base_url
         self.root = root
@@ -5015,7 +5009,7 @@ class GitIssueController:
 
 
 # @+node:ekr.20190428173354.1: *3* g.getGitVersion
-def getGitVersion(directory: str | None = None) -> tuple[str, str, str]:
+def getGitVersion(directory: str = '') -> tuple[str, str, str]:
     """Return a tuple (author, build, date) from the git log, or None."""
 
     # -n: Get only the last log.
@@ -5080,7 +5074,7 @@ def getModifiedFiles(repo_path: str) -> list[str]:
 
 
 # @+node:ekr.20170414034616.2: *3* g.gitBranchName
-def gitBranchName(path: str | None = None) -> str:
+def gitBranchName(path: str = '') -> str:
     """
     Return the git branch name associated with path/.git, or the empty
     string if path/.git does not exist. If path is None, use the leo-editor
@@ -5091,7 +5085,7 @@ def gitBranchName(path: str | None = None) -> str:
 
 
 # @+node:ekr.20170414034616.4: *3* g.gitCommitNumber
-def gitCommitNumber(path: str | None = None) -> str:
+def gitCommitNumber(path: str = '') -> str:
     """
     Return the git commit number associated with path/.git, or the empty
     string if path/.git does not exist. If path is None, use the leo-editor
@@ -5121,7 +5115,7 @@ def gitDescribe(path: str) -> tuple[str, str, str]:
 
 
 # @+node:ekr.20170414034616.6: *3* g.gitHeadPath
-def gitHeadPath(path_s: str) -> str | None:
+def gitHeadPath(path_s: str) -> str:
     """
     Compute the path to .git/HEAD given the path.
     """
@@ -5134,11 +5128,11 @@ def gitHeadPath(path_s: str) -> str | None:
         if path == path.parent:
             break
         path = path.parent
-    return None
+    return ''
 
 
 # @+node:ekr.20170414034616.3: *3* g.gitInfo
-def gitInfo(path: str | None = None) -> tuple[str, str]:
+def gitInfo(path: str = '') -> tuple[str, str]:
     """
     Path may be a directory or file.
 
@@ -5331,7 +5325,7 @@ def enableIdleTimeHook(*args: Args, **kwargs: KWargs) -> None:
 
 
 # @+node:ekr.20140825042850.18410: *3* g.IdleTime
-def IdleTime(handler: Callable, delay: int = 500, tag: str | None = None) -> QtIdleTime | None:
+def IdleTime(handler: Callable, delay: int = 500, tag: str = '') -> QtIdleTime | None:
     """
     A thin wrapper for the LeoQtGui.IdleTime class.
 
@@ -5387,7 +5381,7 @@ def idleTimeHookHandler(timer: Callable) -> None:
 
 # @+node:ekr.20041219095213: ** g.Importing
 # @+node:ekr.20040917061619: *3* g.cantImport
-def cantImport(moduleName: str, pluginName: str | None = None, verbose: bool = True) -> None:
+def cantImport(moduleName: str, pluginName: str = '', verbose: bool = True) -> None:
     """Print a "Can't Import" message and return None."""
     s = f"Can not import {moduleName}"
     if pluginName:
@@ -5401,7 +5395,7 @@ def cantImport(moduleName: str, pluginName: str | None = None, verbose: bool = T
 
 
 # @+node:ekr.20191220044128.1: *3* g.import_module
-def import_module(name: str, package: str | None = None) -> ModuleType | None:
+def import_module(name: str, package: str = '') -> ModuleType | None:
     """
     A thin wrapper over importlib.import_module.
     """
@@ -5662,7 +5656,7 @@ def bytesToStr(b: bytes, reportErrors: bool = False) -> str:
 
 
 # @+node:ekr.20190505052756.1: *4* g.checkUnicode
-def checkUnicode(s: str, encoding: str | None = None) -> str:
+def checkUnicode(s: str, encoding: str = '') -> str:
     """
     Warn when converting bytes. Report *all* errors.
 
@@ -5761,7 +5755,7 @@ def isWordChar1(ch: str) -> bool:
 
 
 # @+node:ekr.20130910044521.11304: *4* g.stripBOM
-def stripBOM(s_bytes: bytes) -> tuple[str | None, bytes]:
+def stripBOM(s_bytes: bytes) -> tuple[str, bytes]:
     """
     If there is a BOM, return (e,s2) where e is the encoding
     implied by the BOM and s2 is the s stripped of the BOM.
@@ -5783,7 +5777,7 @@ def stripBOM(s_bytes: bytes) -> tuple[str | None, bytes]:
             assert len(bom) == n
             if bom == s_bytes[: len(bom)]:
                 return e, s_bytes[len(bom) :]
-    return None, s_bytes
+    return '', s_bytes
 
 
 # @+node:ekr.20240325175449.1: *4* g.strToBytes
@@ -5819,7 +5813,7 @@ def toEncodedString(s: bytes | str, encoding: str = 'utf-8', reportErrors: bool 
 
 
 # @+node:ekr.20050208093800.1: *4* g.toUnicode
-def toUnicode(s: bytes | str, encoding: str | None = None, reportErrors: bool = False) -> str:
+def toUnicode(s: bytes | str, encoding: str = '', reportErrors: bool = False) -> str:
     """Convert bytes to unicode if necessary."""
     if isinstance(s, str):
         return s
@@ -6236,7 +6230,7 @@ log = es
 
 
 # @+node:ekr.20060917120951: *3* g.es_dump
-def es_dump(s: str, n: int = 30, title: str | None = None) -> None:
+def es_dump(s: str, n: int = 30, title: str = '') -> None:
     if title:
         g.es_print('', title)
     i = 0
@@ -6422,7 +6416,7 @@ is_unique_class = isUniqueClass
 
 
 # @+node:ekr.20150127060254.5: *3* g.log_to_file
-def log_to_file(s: str, fn: str | None = None) -> None:
+def log_to_file(s: str, fn: str = '') -> None:
     """Write a message to ~/test/leo_log.txt."""
     if fn is None:
         fn = g.finalize('~/test/leo_log.txt')
@@ -6560,7 +6554,7 @@ def printEntireTree(c: Cmdr, tag: str = '') -> None:
 
 
 # @+node:ekr.20031218072017.3114: *3* g.printGlobals
-def printGlobals(message: str | None = None) -> None:
+def printGlobals(message: str = '') -> None:
     # Get the list of globals.
     globs = list(globals())
     globs.sort()
@@ -6573,7 +6567,7 @@ def printGlobals(message: str | None = None) -> None:
 
 
 # @+node:ekr.20031218072017.3115: *3* g.printLeoModules
-def printLeoModules(message: str | None = None) -> None:
+def printLeoModules(message: str = '') -> None:
     # Create the list.
     mods = []
     for name in sys.modules:
@@ -6822,7 +6816,7 @@ def cls(event: LeoKeyEvent | None = None) -> None:
 
 
 # @+node:ekr.20131114124839.16665: *3* g.createScratchCommander
-def createScratchCommander(fileName: str | None = None) -> None:
+def createScratchCommander(fileName: str = '') -> None:
     c = g.app.newCommander(fileName)
     frame = c.frame
     frame.createFirstTreeNode()
@@ -6843,7 +6837,7 @@ def deprecated() -> None:
 
 
 # @+node:ekr.20031218072017.3126: *3* g.funcToMethod (Python Cookbook)
-def funcToMethod(f: Callable, theClass: object, name: str | None = None) -> None:
+def funcToMethod(f: Callable, theClass: object, name: str = '') -> None:
     """
     From the Python Cookbook...
 
@@ -7431,7 +7425,7 @@ def python_tokenize(s: str) -> list:
 
 # @+node:ekr.20040327103735.2: ** g.Scripting
 # @+node:ekr.20161223090721.1: *3* g.exec_file
-def exec_file(path: str, d: dict[str, Value], script: str | None = None) -> None:
+def exec_file(path: str, d: dict[str, Value], script: str = '') -> None:
     """Simulate python's execfile statement for python 3."""
     if script is None:
         with open(path) as f:
@@ -7673,8 +7667,8 @@ def extractExecutableString(c: Cmdr, p: Position, s: str) -> str:
 def handleScriptException(
     c: Cmdr,
     p: Position,
-    script: str | None = None,  # No longer used.
-    script1: str | None = None,  # No longer used.
+    script: str = '',  # No longer used.
+    script1: str = '',  # No longer used.
 ) -> None:
     g.warning("exception executing script")
     g.es_exception()
@@ -7792,7 +7786,7 @@ def run_coverage_tests(module: str = '', filename: str = '') -> None:
 
 
 # @+node:ekr.20210901065224.1: *3* g.run_unit_tests
-def run_unit_tests(tests: str | None = None, verbose: bool = False) -> None:
+def run_unit_tests(tests: str = '', verbose: bool = False) -> None:
     """
     Run the unit tests given by the "tests" string.
 
@@ -8137,14 +8131,14 @@ findUNL = findUnl  # Compatibility.
 
 
 # @+node:ekr.20120311151914.9917: *3* g.getUrlFromNode
-def getUrlFromNode(p: Position) -> str | None:
+def getUrlFromNode(p: Position) -> str:
     """
     Get an url from node p:
     1. Use the headline if it contains a valid url.
     2. Otherwise, look *only* at the first line of the body.
     """
     if not p:
-        return None
+        return ''
     c = p.v.context
     assert c
     table = [p.h, g.splitLines(p.b)[0] if p.b else '']
@@ -8169,7 +8163,7 @@ def getUrlFromNode(p: Position) -> str | None:
     for s in table:
         if s.startswith("#"):
             return s
-    return None
+    return ''
 
 
 # @+node:ekr.20170221063527.1: *3* g.handleUnl
@@ -8367,7 +8361,7 @@ def openUrl(p: Position) -> None:  # pragma: no cover
 
 
 # @+node:ekr.20110605121601.18135: *3* g.openUrlOnClick (open-url-under-cursor)
-def openUrlOnClick(event: QMouseEvent, url: str | None = None) -> str | None:  # pragma: no cover
+def openUrlOnClick(event: QMouseEvent, url: str = '') -> str:  # pragma: no cover
     """Open the URL under the cursor.  Return it for unit testing."""
     from leo.core.leoGui import LeoKeyEvent
     from leo.plugins.qt_text import QTextEditWrapper
@@ -8382,19 +8376,19 @@ def openUrlOnClick(event: QMouseEvent, url: str | None = None) -> str | None:  #
         return openUrlHelper(leo_event, url)
     except Exception:
         g.es_exception()
-        return None
+        return ''
 
 
 # @+node:ekr.20170216091704.1: *4* g.openUrlHelper
-def openUrlHelper(event: LeoKeyEvent, url: str | None = None) -> str | None:
+def openUrlHelper(event: LeoKeyEvent, url: str = '') -> str:
     """Open the unl, url or gnx under the cursor.  Return it for unit testing."""
     if not event:
-        return None
+        return ''
     c, w = event.c, event.w
     if not c:
-        return None
+        return ''
     if not g.app.gui.isTextWrapper(w):
-        return None
+        return ''
     # Part 1: get the url.
     if url is None:
         s = w.getAllText()
@@ -8420,7 +8414,7 @@ def openUrlHelper(event: LeoKeyEvent, url: str | None = None) -> str | None:
             if px:
                 c.selectPosition(px)
                 c.redraw()
-            return None
+            return ''
         # @-<< look for section ref >>
         url = unl = None
         # @+<< look for url >>
@@ -8441,7 +8435,7 @@ def openUrlHelper(event: LeoKeyEvent, url: str | None = None) -> str | None:
                 if match.start() <= col < match.end():
                     unl = match.group()
                     g.handleUnl(unl, c)
-                    return None
+                    return ''
             # @-<< look for unl >>
             if not unl:
                 # @+<< look for gnx >>
@@ -8461,7 +8455,7 @@ def openUrlHelper(event: LeoKeyEvent, url: str | None = None) -> str | None:
                             c.selectPosition(p)
                             c.redraw()
                             return target
-                    return None
+                    return ''
                 # @-<< look for gnx >>
     elif not isinstance(url, str):
         url = url.toString()
@@ -8478,10 +8472,10 @@ def openUrlHelper(event: LeoKeyEvent, url: str | None = None) -> str | None:
         c.editCommands.extendToWord(event, select=True)
     word = w.getSelectedText().strip()
     if not word:
-        return None
+        return ''
     matches = c.findCommands.find_def(event)
     if matches:
-        return None
+        return ''
     # @+<< look for filename or import>>
     # @+node:tom.20230130102836.1: *5* << look for filename or import >>
     # Part 4: #2546: look for a file name.
@@ -8519,7 +8513,7 @@ def openUrlHelper(event: LeoKeyEvent, url: str | None = None) -> str | None:
                 c.redraw(p)
                 break
     # @-<< look for filename or import>>
-    return None
+    return ''
 
 
 # @+node:ekr.20170226093349.1: *3* g.unquoteUrl

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -700,7 +700,7 @@ class GeneralSetting:
         ivar: str = '',  # #4755
         source: str = '',  # #4755
         val: Value | None = None,
-        path: str | None = None,
+        path: str = '',  # #4755
         tag: str = 'setting',
         unl: str = '',  # #4755
     ) -> None:
@@ -3013,7 +3013,7 @@ def get_directives_dict(p: Position) -> dict[str, str]:
     d = {}
     # The headline has higher precedence because it is more visible.
     for kind, s in (('head', p.h), ('body', p.b)):
-        anIter = g.directives_pat.finditer(s)
+        anIter = g.directives_pat.finditer(s)  # type:ignore # anIter will exist
         for m in anIter:
             word = m.group(1).strip()
             i = m.start(1)
@@ -8213,10 +8213,13 @@ def handleUnl(unl_s: str, c: Cmdr) -> Cmdr | None:
 
 
 # @+node:tbrown.20090219095555.63: *3* g.handleUrl & helpers
-def handleUrl(url: str, c: Cmdr | None = None, p: Position | None = None) -> None:
+def handleUrl(url: str, c: Cmdr, p: Position | None = None) -> None:
     """Open a url or a unl."""
+    from leo.core.leoNodes import Position  # necessary for the cast.
+
     if c and not p:
         p = c.p
+    p = cast(Position, p)
     # These two special cases should match the hacks in jedit.match_any_url.
     if url.endswith('.'):
         url = url[:-1]

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3331,7 +3331,7 @@ def set_delims_from_language(language: str) -> tuple[str, str, str]:
 
 
 # @+node:ekr.20031218072017.1383: *3* g.set_delims_from_string
-def set_delims_from_string(s: str) -> tuple[str, str, str] | tuple[None, None, None]:
+def set_delims_from_string(s: str) -> tuple[str, str, str]:
     """
     Return (delim1, delim2, delim2), the delims following the @comment
     directive.
@@ -3381,9 +3381,7 @@ def set_delims_from_string(s: str) -> tuple[str, str, str] | tuple[None, None, N
 
 
 # @+node:ekr.20031218072017.1384: *3* g.set_language
-def set_language(
-    s: str, i: int, issue_errors_flag: bool = False
-) -> tuple[str, str, str, str] | tuple[None, None, None, None]:
+def set_language(s: str, i: int, issue_errors_flag: bool = False) -> tuple[str, str, str, str]:
     """Scan the @language directive that appears at s[i:].
 
     The @language may have been stripped away.
@@ -3640,7 +3638,7 @@ def init_dialog_folder(c: Cmdr, p: Position, use_at_path: bool = True) -> str:
             dir_ = g.os_path_dirname(path)
             if dir_ and g.os_path_exists(dir_):
                 return dir_
-    table = (
+    table: tuple = (
         c.last_dir if c else None,
         g.os_path_abspath(os.curdir),
     )
@@ -4019,7 +4017,7 @@ def find_word(s: str, word: str, i: int = 0) -> int:
 
 
 # @+node:ekr.20211029090118.1: *3* g.findAncestorVnodeByPredicate
-def findAncestorVnodeByPredicate(p: Position, v_predicate: Callable | None) -> VNode | None:
+def findAncestorVnodeByPredicate(p: Position, v_predicate: Callable) -> VNode | None:
     """
     Return first ancestor vnode matching the predicate.
 
@@ -5820,9 +5818,10 @@ def toEncodedString(s: bytes | str, encoding: str = 'utf-8', reportErrors: bool 
     try:
         return s.encode(encoding, "strict")
     except UnicodeError:
-         if reportErrors:  # #4753.
+        if reportErrors:  # #4753.
             g.error(f"Error converting {s!r} from unicode to {encoding} encoding")
         return s.encode(encoding, "replace")
+
 
 # @+node:ekr.20050208093800.1: *4* g.toUnicode
 def toUnicode(s: bytes | str, encoding: str | None = None, reportErrors: bool = False) -> str:
@@ -7478,6 +7477,7 @@ def execute_shell_commands(
         proc = subprocess.Popen(command, shell=shell)
         if wait:
             proc.communicate()
+
 
 # @+node:ekr.20050503112513.7: *3* g.executeFile
 def executeFile(filename: str, options: str = '') -> None:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1110,7 +1110,7 @@ class KeyStroke:
             'Tab': '\t',
         }
         if s in d:
-            return d.get(s)  # type:ignore # Yes, s is in d.
+            return cast(str, d.get(s))  # The cast is valid: s is in d.
         return s if len(s) == 1 else ''
 
     # @-others

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -822,7 +822,7 @@ class KeyStroke:
         }
         if self.mods and s.lower() in shift_d:
             # Returning '' breaks existing code.
-            return shift_d.get(s.lower())
+            return cast(str, shift_d.get(s.lower()))
 
         # Make all other translations...
         #

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -474,8 +474,8 @@ class BindingInfo:
         kind: str,
         commandName: str = '',
         func: Callable | None = None,
-        nextMode: str = 'none',  # #4755
-        pane: str = '',  # #4755
+        nextMode: str = 'none',  # strict_optional
+        pane: str = '',  # strict_optional
         stroke: KeyStroke | None = None,
     ) -> None:
         if not g.isStrokeOrNone(stroke):
@@ -1820,7 +1820,7 @@ class SettingsDict(dict):
         """Return the canonical setting name."""
         key = key.replace('-', '').replace('_', '')
         gs = self.get(key)
-        return gs.val if gs else ''  # #4755
+        return gs.val if gs else ''  # strict_optional
 
     def get_string_setting(self, key: str) -> str:
         return self.get_setting(key)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -8232,7 +8232,7 @@ def handleUnl(unl_s: str, c: Cmdr) -> Cmdr | None:
 
 
 # @+node:tbrown.20090219095555.63: *3* g.handleUrl & helpers
-def handleUrl(url: str, c: Cmdr | None = None, p: Position | None = None) -> str | None:
+def handleUrl(url: str, c: Cmdr | None = None, p: Position | None = None) -> None:
     """Open a url or a unl."""
     if c and not p:
         p = c.p
@@ -8249,14 +8249,13 @@ def handleUrl(url: str, c: Cmdr | None = None, p: Position | None = None) -> str
         urll.startswith(('#', 'unl://', 'unl:gnx:')) or
         urll.startswith('file://') and '-->' in urll
     ):  # fmt: skip
-        return g.handleUnl(url, c)
+        g.handleUnl(url, c)
+        return
     try:
         g.handleUrlHelper(url, c, p)
-        return urll  # For unit tests.
     except Exception:
         g.es_print("g.handleUrl: exception opening", repr(url))
         g.es_exception()
-        return None
 
 
 # @+node:ekr.20170226054459.1: *4* g.handleUrlHelper

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -4818,11 +4818,7 @@ def execGitCommand(command: str, directory: str) -> list[str]:
             shlex.split(command), stdout=subprocess.PIPE, stderr=None, shell=True
         )
         out, err = proc.communicate()
-        lines: list[str]
-        if isinstance(out, str) and out:
-            lines = [g.toUnicode(z) for z in g.splitLines(out)]
-        else:
-            lines = []
+        lines = [g.toUnicode(z) for z in g.splitLines(out or '')]
     finally:
         os.chdir(old_dir)
     return lines

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3618,7 +3618,7 @@ or do g.app.db['LEO_EDITOR'] = "gvim"''',
 
 
 # @+node:ekr.20160330204014.1: *3* g.init_dialog_folder
-def init_dialog_folder(c: Cmdr, p: Position, use_at_path: bool = True) -> str:
+def init_dialog_folder(c: Cmdr | None, p: Position | None, use_at_path: bool = True) -> str:
     """Return the most convenient folder to open or save a file."""
     if c and p and use_at_path:
         path = c.fullPath(p)
@@ -6981,8 +6981,8 @@ def truncate(s: str, n: int) -> str:
 
 
 # @+node:ekr.20031218072017.3150: *3* g.windows
-def windows() -> list | None:
-    return app.windowList if app else None
+def windows() -> list:
+    return app.windowList if app else []
 
 
 # @+node:ekr.20031218072017.2145: ** g.os_path_ Wrappers

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3472,8 +3472,8 @@ def computeMachineName() -> str:
     return g.app.loadManager.computeMachineName()
 
 
-def computeStandardDirectories() -> str:
-    return g.app.loadManager.computeStandardDirectories()
+def computeStandardDirectories() -> None:
+    g.app.loadManager.computeStandardDirectories()
 
 
 # @+node:ekr.20031218072017.3117: *3* g.create_temp_file
@@ -3639,7 +3639,7 @@ def init_dialog_folder(c: Cmdr, p: Position, use_at_path: bool = True) -> str:
             if dir_ and g.os_path_exists(dir_):
                 return dir_
     table = (
-        c and c.last_dir,
+        c.last_dir if c else None,
         g.os_path_abspath(os.curdir),
     )
     for dir_ in table:
@@ -4818,7 +4818,7 @@ def execGitCommand(command: str, directory: str) -> list[str]:
             shlex.split(command), stdout=subprocess.PIPE, stderr=None, shell=True
         )
         out, err = proc.communicate()
-        lines = [g.toUnicode(z) for z in g.splitLines(out or '')]
+        lines = [g.toUnicode(z) for z in g.splitLines(out or '')]  # type:ignore # Don't change this!
     finally:
         os.chdir(old_dir)
     return lines
@@ -5253,7 +5253,6 @@ def doHook(tag: str, *args: Args, **kwargs: KWargs) -> Value | None:
         return None
     # Get the hook handler function.  Usually this is doPlugins.
     c = kwargs.get("c")
-    # pylint: disable=consider-using-ternary
     f = (c and c.hookFunction) or g.app.hookFunction
     if not f:
         g.app.hookFunction = f = g.app.pluginsController.doPlugins
@@ -5276,29 +5275,29 @@ def loadOnePlugin(pluginName: str, verbose: bool = False) -> ModuleType:
     return pc.loadOnePlugin(pluginName, verbose=verbose)
 
 
-def registerExclusiveHandler(tags: Tags, fn: str) -> ModuleType:
+def registerExclusiveHandler(tags: Tags, fn: Callable) -> None:
     pc = g.app.pluginsController
-    return pc.registerExclusiveHandler(tags, fn)
+    pc.registerExclusiveHandler(tags, fn)
 
 
-def registerHandler(tags: Tags, fn: Callable) -> ModuleType:
+def registerHandler(tags: Tags, fn: Callable) -> None:
     pc = g.app.pluginsController
-    return pc.registerHandler(tags, fn)
+    pc.registerHandler(tags, fn)
 
 
-def plugin_signon(module_name: str, verbose: bool = False) -> ModuleType:
+def plugin_signon(module_name: str, verbose: bool = False) -> None:
     pc = g.app.pluginsController
-    return pc.plugin_signon(module_name, verbose)
+    pc.plugin_signon(module_name, verbose)
 
 
-def unloadOnePlugin(moduleOrFileName: str, verbose: bool = False) -> ModuleType:
+def unloadOnePlugin(moduleOrFileName: str, verbose: bool = False) -> None:
     pc = g.app.pluginsController
-    return pc.unloadOnePlugin(moduleOrFileName, verbose)
+    pc.unloadOnePlugin(moduleOrFileName, verbose)
 
 
-def unregisterHandler(tags: Tags, fn: Callable) -> ModuleType:
+def unregisterHandler(tags: Tags, fn: Callable) -> None:
     pc = g.app.pluginsController
-    return pc.unregisterHandler(tags, fn)
+    pc.unregisterHandler(tags, fn)
 
 
 # @+node:ekr.20100910075900.5952: *4* g.Information

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -421,7 +421,7 @@ class NullGui(LeoGui):
     ) -> Any:
         return None
 
-    def getFullVersion(self, c: Cmdr = None) -> str:
+    def getFullVersion(self) -> str:
         return 'NullGui: dummy version'
 
     def getIconImage(self, name: str) -> None:

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -599,7 +599,7 @@ class LeoImportCommands:
         # Init ivars.
         self.encoding = c.getEncoding(parent)
         ext, s = self.init_import(ext, fileName, s)
-        if s is None:
+        if not s:
             return None
 
         # Each importer file defines `do_import` at the top level.
@@ -648,7 +648,7 @@ class LeoImportCommands:
         return p
 
     # @+node:ekr.20140724175458.18052: *5* ic.init_import
-    def init_import(self, ext: str, fileName: str, s: str) -> tuple[str, str] | tuple[None, None]:
+    def init_import(self, ext: str, fileName: str, s: str) -> tuple[str, str]:
         """
         Init ivars imports and read the file into s.
         Return ext, s.
@@ -662,7 +662,7 @@ class LeoImportCommands:
             # Set the kind for error messages in readFileIntoString.
             s, e = g.readFileIntoString(fileName, encoding=self.encoding)
             if not s:  # strict_optional
-                return None, None
+                return '', ''  # strict_optional
             if e:
                 self.encoding = e
         return ext, s

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1939,7 +1939,7 @@ class RecursiveImportController:
             c.deletePositionsInList(aList)  # Don't redraw.
 
     # @+node:ekr.20230829043849.1: *3* ric_resolve_dir_arg
-    def resolve_dir_arg(self, arg: str) -> str | None:
+    def resolve_dir_arg(self, arg: str) -> str:
         """
         arg can be None or a path (relative or absolute) to a file or
         directory.
@@ -1967,7 +1967,7 @@ class RecursiveImportController:
         elif not os.path.isabs(arg):
             arg = os.path.join(outline_dir, arg)
         if not os.path.exists(arg):
-            return None
+            return ''
 
         # Final sanity checks.
         assert arg, repr(arg1)
@@ -1995,7 +1995,7 @@ class RecursiveImportController:
         # Resolve dir_ to an absolute path.
         dir_1 = dir_
         dir_ = self.resolve_dir_arg(dir_)
-        if dir_ is None:
+        if not dir_:
             self.error(f"invalid 'dir_' argument: {dir_1!r}")
             return
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -661,7 +661,7 @@ class LeoImportCommands:
         if not s:
             # Set the kind for error messages in readFileIntoString.
             s, e = g.readFileIntoString(fileName, encoding=self.encoding)
-            if s is None:
+            if not s:  # strict_optional
                 return None, None
             if e:
                 self.encoding = e
@@ -970,7 +970,7 @@ class LeoImportCommands:
         lb = "@<" if theType == "cweb" else "<<"
         rb = "@>" if theType == "cweb" else ">>"
         s, e = g.readFileIntoString(fileName)
-        if s is None:
+        if not s:  # strict_optional
             return
         # @+<< Create a symbol table of all section names >>
         # @+node:ekr.20031218072017.3232: *6* << Create a symbol table of all section names >>
@@ -1559,7 +1559,7 @@ class MORE_Importer:
         ic.encoding = c.getEncoding(c.p)
         g.setGlobalOpenDir(fileName)
         s, _e = g.readFileIntoString(fileName)
-        if s is None:
+        if not s:
             return None
         s = s.replace('\r', '')  # Fixes bug 626101.
         lines = g.splitLines(s)

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -460,15 +460,15 @@ class LeoImportCommands:
         theFile.close()
 
     # @+node:ekr.20031218072017.3300: *4* ic.removeSentinelsCommand
-    def removeSentinelsCommand(self, paths: list[str], toString: bool = False) -> str | None:
+    def removeSentinelsCommand(self, paths: list[str]) -> None:  # #4755
         c = self.c
         self.encoding = c.getEncoding(c.p)
         for fileName in paths:
             g.setGlobalOpenDir(fileName)
             path, self.fileName = g.os_path_split(fileName)
             s, e = g.readFileIntoString(fileName, self.encoding)
-            if s is None:
-                return None
+            if not s:  # #4755
+                continue  # #4755: bug fix.
             if e:
                 self.encoding = e
             # @+<< set delims from the header line >>
@@ -483,13 +483,12 @@ class LeoImportCommands:
             line = s[i:j]
             valid, junk, start_delim, end_delim, junk = at.parseLeoSentinel(line)
             if not valid:
-                if not toString:
-                    g.es("invalid @+leo sentinel in", fileName)
-                return None
+                g.es("invalid @+leo sentinel in", fileName)
+                continue  # #4755
             if end_delim:
-                line_delim = None
+                line_delim = ''  # #4755
             else:
-                line_delim, start_delim = start_delim, None
+                line_delim, start_delim = start_delim, ''
             # @-<< set delims from the header line >>
             s = self.removeSentinelLines(s, line_delim, start_delim, end_delim)
             ext = c.config.getString('remove-sentinels-extension')
@@ -500,11 +499,6 @@ class LeoImportCommands:
             else:
                 head, ext2 = g.os_path_splitext(fileName)
                 newFileName = g.finalize_join(path, head + ext + ext2)  # 1341
-            if toString:
-                return s
-            # @+<< Write s into newFileName >>
-            # @+node:ekr.20031218072017.1149: *5* << Write s into newFileName >> (remove-sentinels)
-            # Remove sentinels command.
             try:
                 with open(newFileName, 'w') as theFile:
                     theFile.write(s)
@@ -513,8 +507,6 @@ class LeoImportCommands:
             except Exception:
                 g.es("exception creating:", newFileName)
                 g.print_exception()
-            # @-<< Write s into newFileName >>
-        return None
 
     # @+node:ekr.20031218072017.3303: *4* ic.removeSentinelLines
     # This does not handle @nonl properly, but that no longer matters.
@@ -892,7 +884,7 @@ class LeoImportCommands:
         return p
 
     # @+node:ekr.20031218072017.3227: *5* ic.findFunctionDef
-    def findFunctionDef(self, s: str, i: int) -> str | None:
+    def findFunctionDef(self, s: str, i: int) -> str:
         # Look at the next non-blank line for a function name.
         i = g.skip_ws_and_nl(s, i)
         k = g.skip_line(s, i)
@@ -908,7 +900,7 @@ class LeoImportCommands:
                 break
             else:
                 i += 1
-        return None
+        return ''
 
     # @+node:ekr.20031218072017.3228: *5* ic.scanBodyForHeadline
     # @+at This method returns the proper headline text.

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1732,7 +1732,7 @@ class RecursiveImportController:
         self,
         c: Cmdr,
         *,  # All other args are kwargs.
-        dir_: str | None,
+        dir_: str,
         ignore_pattern: re.Pattern = None,
         kind: str,
         recursive: bool = True,
@@ -1748,7 +1748,7 @@ class RecursiveImportController:
         self.recursive = recursive
         self.root: Position = None
         file_name = c.fileName()
-        self.outline_directory: str | None = os.path.dirname(file_name) if file_name else None
+        self.outline_directory: str = os.path.dirname(file_name) if file_name else ''
         self.safe_at_file = safe_at_file
         self.theTypes = theTypes
         self.verbose = verbose

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -2580,14 +2580,14 @@ class LegacyExternalFileImporter:
             print('orphan line: ', repr(line))
 
     # @+node:ekr.20200424160847.1: *3* legacy.compute_delim1
-    def compute_delim1(self, path: str) -> str | None:
+    def compute_delim1(self, path: str) -> str:
         """Return the opening comment delim for the given file."""
         junk, ext = os.path.splitext(path)
         if not ext:
-            return None
+            return ''
         language = g.app.extension_dict.get(ext[1:])
         if not language:
-            return None
+            return ''
         delim1, delim2, delim3 = g.set_delims_from_language(language)
         g.trace(language, delim1 or delim2)
         return delim1 or delim2

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -460,15 +460,15 @@ class LeoImportCommands:
         theFile.close()
 
     # @+node:ekr.20031218072017.3300: *4* ic.removeSentinelsCommand
-    def removeSentinelsCommand(self, paths: list[str]) -> None:  # #4755
+    def removeSentinelsCommand(self, paths: list[str]) -> None:  # strict_optional
         c = self.c
         self.encoding = c.getEncoding(c.p)
         for fileName in paths:
             g.setGlobalOpenDir(fileName)
             path, self.fileName = g.os_path_split(fileName)
             s, e = g.readFileIntoString(fileName, self.encoding)
-            if not s:  # #4755
-                continue  # #4755: bug fix.
+            if not s:  # strict_optional
+                continue  # strict_optional: bug fix.
             if e:
                 self.encoding = e
             # @+<< set delims from the header line >>
@@ -484,9 +484,9 @@ class LeoImportCommands:
             valid, junk, start_delim, end_delim, junk = at.parseLeoSentinel(line)
             if not valid:
                 g.es("invalid @+leo sentinel in", fileName)
-                continue  # #4755
+                continue  # strict_optional
             if end_delim:
-                line_delim = ''  # #4755
+                line_delim = ''  # strict_optional
             else:
                 line_delim, start_delim = start_delim, ''
             # @-<< set delims from the header line >>

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2275,7 +2275,7 @@ class KeyHandlerClass:
                     g.trace(f"No shortcut for {name} = {key}")
 
     # @+node:ekr.20061031131434.97: *4* k.completeAllBindings
-    def completeAllBindings(self, w: QTextMixin = None) -> None:
+    def completeAllBindings(self, w: QTextMixin | None = None) -> None:
         """
         Make an actual binding in *all* the standard places.
 
@@ -2288,7 +2288,7 @@ class KeyHandlerClass:
             k.makeMasterGuiBinding(stroke, w=w)
 
     # @+node:ekr.20061031131434.96: *4* k.completeAllBindingsForWidget
-    def completeAllBindingsForWidget(self, w: QTextMixin) -> None:
+    def completeAllBindingsForWidget(self, w: QTextMixin | None = None) -> None:
         """Make all a master gui binding for widget w."""
         k = self
         for stroke in k.bindingsDict:
@@ -2398,7 +2398,7 @@ class KeyHandlerClass:
                     k.bindKey(pane, stroke, command, commandName, tag=tag)
 
     # @+node:ekr.20061031131434.103: *4* k.makeMasterGuiBinding
-    def makeMasterGuiBinding(self, stroke: Stroke, w: QTextMixin = None) -> None:
+    def makeMasterGuiBinding(self, stroke: Stroke, w: QTextMixin | None = None) -> None:
         """Make a master gui binding for stroke in pane w, or in all the standard widgets."""
         c, k = self.c, self
         if not c.frame:
@@ -4124,7 +4124,7 @@ class KeyHandlerClass:
         k.setLabelGrey(f"@mode {modeName} is not defined (or is empty)")
 
     # @+node:ekr.20061031131434.158: *4* k.createModeBindings
-    def createModeBindings(self, modeName: str, d: dict[str, list], w: QTextMixin) -> None:
+    def createModeBindings(self, modeName: str, d: dict[str, list], w: QTextMixin | None) -> None:
         """Create mode bindings for the named mode using dictionary d for w, a text widget."""
         c, k = self.c, self
         assert d.name().endswith('-mode')

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1338,8 +1338,8 @@ class GetArg:
         self.log = c.frame.log or g.NullObject()
         self.functionTail: str = ''
         self.tabName = tabName
-        # State vars.
-        self.after_get_arg_state: tuple[str | None, int | None, Callable | None] | None = None
+        # State vars # strict_optional
+        self.after_get_arg_state: tuple[str, int, Callable | None] = ('', 0, None)
         self.arg_completion = True
         self.handler: Callable | None = None
         self.tabList: list[str] = []
@@ -1561,7 +1561,7 @@ class GetArg:
             c.minibufferWantsFocus()
         elif char in ('Up', 'Down'):  # 4685.
             finder = c.findCommands
-            handler = self.after_get_arg_state[2]  # type:ignore
+            handler = self.after_get_arg_state[2]
             if handler in (finder.find_state0, finder._start_search_escape2):
                 finder.do_arrow(char, in_minibuffer=True)
         elif k.isFKey(stroke):
@@ -1572,7 +1572,7 @@ class GetArg:
 
     # @+node:ekr.20161019060054.1: *4* ga.cancel_after_state
     def cancel_after_state(self) -> None:
-        self.after_get_arg_state = None
+        self.after_get_arg_state = ('', 0, None)  # strict_optional
 
     # @+node:ekr.20140816165728.18955: *4* ga.do_char
     def do_char(self, event: LeoKeyEvent, char: str) -> None:
@@ -1597,8 +1597,9 @@ class GetArg:
         else:
             # A hack to support the curses gui.
             k.arg = gui_arg or self.get_label()
-        kind, n, handler = self.after_get_arg_state  # type:ignore
-        n = cast(int, n)
+        kind, n, handler = self.after_get_arg_state
+        if not kind:
+            return  # strict_optional
         if kind:
             k.setState(kind, n, handler)
         self.log.deleteTab('Completion')

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -421,7 +421,7 @@ class AutoCompleterClass:
         return result
 
     # @+node:ekr.20061031131434.11: *4* ac.auto_completer_state_handler
-    def auto_completer_state_handler(self, event: LeoKeyEvent) -> str | None:
+    def auto_completer_state_handler(self, event: LeoKeyEvent) -> str:
         """Handle all keys while autocompleting."""
         c, k, tag = self.c, self.k, 'auto-complete'
         state = k.getState(tag)
@@ -477,7 +477,7 @@ class AutoCompleterClass:
         else:
             self.abort()
             return 'do-standard-keys'
-        return None
+        return ''
 
     # @+node:ekr.20061031131434.20: *4* ac.calltip & helpers
     def calltip(self) -> None:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -4205,7 +4205,7 @@ class KeyHandlerClass:
         commandName: str = None,
         func: Callable = None,
         modeName: str = None,
-        nextMode: str = None,
+        nextMode: str = 'none',  # #4755
         prompt: str = None,
     ) -> None:
         """Handle a mode defined by an @mode node in leoSettings.leo."""
@@ -4240,7 +4240,7 @@ class KeyHandlerClass:
                 func(event)
                 if g.app.quitting or not c.exists:
                     pass
-                elif nextMode in (None, 'none'):
+                elif nextMode == 'none':  # #4755
                     # Do *not* clear k.inputModeName or the focus here.
                     # func may have put us in *another* mode.
                     pass

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1344,7 +1344,7 @@ class GetArg:
         self.handler: Callable | None = None
         self.tabList: list[str] = []
         # Tab cycling ivars...
-        self.cycling_prefix: str = ''  # #4755
+        self.cycling_prefix: str = ''  # strict_optional
         self.cycling_index = -1
         self.cycling_tabList: list[str] = []
         # The following are k globals.
@@ -1495,8 +1495,8 @@ class GetArg:
     def get_arg(
         self,
         event: LeoKeyEvent,
-        returnKind: str = '',  # #4755
-        returnState: int = 0,  # #4755
+        returnKind: str = '',  # strict_optional
+        returnState: int = 0,  # strict_optional
         handler: Callable | None = None,
         tabList: list[str] | None = None,
         completion: bool = True,
@@ -1624,7 +1624,7 @@ class GetArg:
         k.getArgEscapeFlag = False
         self.after_get_arg_state = returnKind, returnState, handler
         self.arg_completion = completion
-        self.cycling_prefix = ''  # #4755
+        self.cycling_prefix = ''  # strict_optional
         self.handler = handler
         self.tabList = tabList[:] if tabList else []
         # Set the k globals...
@@ -3260,8 +3260,8 @@ class KeyHandlerClass:
         # Override entries in c.k.masterBindingsDict
         k = self
         d = k.masterBindingsDict
-        for key, d2 in d.items():  # #4755
-            for key2, bi in d2.items():  # #4755
+        for key, d2 in d.items():  # strict_optional
+            for key2, bi in d2.items():  # strict_optional
                 if bi.commandName == commandName:
                     bi.func = func
                     d2[key2] = bi
@@ -4229,7 +4229,7 @@ class KeyHandlerClass:
                 func(event)
                 if g.app.quitting or not c.exists:
                     pass
-                elif nextMode == 'none':  # #4755
+                elif nextMode == 'none':  # strict_optional
                     # Do *not* clear k.inputModeName or the focus here.
                     # func may have put us in *another* mode.
                     pass

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -617,7 +617,7 @@ class AutoCompleterClass:
             kind, aList = self.guess_class(c, varname)
         else:
             kind, aList = 'none', []
-            varname, ivar = '', ''  # #4755
+            varname, ivar = '', ''  # strict_optional
         if aList:
             if kind == 'class':
                 hits = self.lookup_methods(aList, ivar)
@@ -1467,7 +1467,7 @@ class GetArg:
     # @+node:ekr.20140819050118.18318: *4* ga.reset_tab_cycling
     def reset_tab_cycling(self) -> None:
         """Reset all tab cycling ivars."""
-        self.cycling_prefix = ''  # #4755
+        self.cycling_prefix = ''  # strict_optional
         self.cycling_index = -1
         self.cycling_tabList = []
 
@@ -2426,7 +2426,7 @@ class KeyHandlerClass:
         if commandName in h:
             h.remove(commandName)
         h.append(commandName)
-        k.commandIndex = 0  # #4755
+        k.commandIndex = 0  # strict_optional
 
     # @+node:ekr.20150402165918.1: *4* k.commandHistoryDown
     def commandHistoryFwd(self) -> None:
@@ -2478,14 +2478,14 @@ class KeyHandlerClass:
         """reset the command history index to indicate that
         we are pointing 'past' the last entry
         """
-        self.commandIndex = 0  # #4755
+        self.commandIndex = 0  # strict_optional
 
     # @+node:ekr.20150402111935.1: *4* k.sortCommandHistory
     def sortCommandHistory(self) -> None:
         """Sort the command history."""
         k = self
         k.commandHistory.sort()
-        k.commandIndex = 0  # #4755
+        k.commandIndex = 0  # strict_optional
 
     # @+node:ekr.20061031131434.104: *3* k.Dispatching
     # @+node:ekr.20061031131434.111: *4* k.fullCommand (alt-x) & helper
@@ -3035,7 +3035,7 @@ class KeyHandlerClass:
         self,
         event: LeoKeyEvent,
         handler: Callable,
-        prefix: str = '',  # #4755
+        prefix: str = '',  # strict_optional
         tabList: list[str] | None = None,
         completion: bool = True,
         oneCharacter: bool = False,
@@ -3128,7 +3128,7 @@ class KeyHandlerClass:
 
         """
         # @-<< docstring for k.get1arg >>
-        returnKind, returnState = '', 0  # #4755
+        returnKind, returnState = '', 0  # strict_optional
         assert handler is not None, g.callers()
         self.getArgInstance.get_arg(
             event,
@@ -3145,10 +3145,10 @@ class KeyHandlerClass:
     def getArg(
         self,
         event: LeoKeyEvent,
-        returnKind: str = '',  # #4755
-        returnState: int = 0,  # #4755
+        returnKind: str = '',  # strict_optional
+        returnState: int = 0,  # strict_optional
         handler: Callable | None = None,
-        prefix: str = '',  # #4755
+        prefix: str = '',  # strict_optional
         tabList: list[str] | None = None,
         completion: bool = True,
         oneCharacter: bool = False,
@@ -3839,7 +3839,7 @@ class KeyHandlerClass:
             return None
         for key, name in (
             # Order here is similar to bindtags order.
-            # #4755: Use '' instead of None here.
+            # strict_optional: Use '' instead of None here.
             ('command', ''),
             ('insert', ''),
             ('overwrite', ''),

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1432,7 +1432,7 @@ class GetArg:
         if hasattr(handler, 'tab_callback'):
             self.reset_tab_cycling()
             k.functionTail = tail  # For k.getFileName.
-            handler.tab_callback()
+            handler.tab_callback()  # type:ignore
             return True
         return False
 
@@ -1598,6 +1598,7 @@ class GetArg:
             # A hack to support the curses gui.
             k.arg = gui_arg or self.get_label()
         kind, n, handler = self.after_get_arg_state  # type:ignore
+        n = cast(int, n)
         if kind:
             k.setState(kind, n, handler)
         self.log.deleteTab('Completion')
@@ -1744,7 +1745,7 @@ class GetArg:
             d = c.commandsDict
             func = d.get(commandName)
             if hasattr(func, 'source_c'):
-                c2 = func.source_c
+                c2 = func.source_c  # type:ignore
                 fn2 = c2.shortFileName().lower()
                 if fn2.endswith('myleosettings.leo'):
                     return 'M'
@@ -2112,7 +2113,7 @@ class KeyHandlerClass:
         self,
         pane: str,
         shortcut: Any,
-        callback: Callable,
+        callback: Callable | None,
         commandName: str,
         modeFlag: bool = False,
         tag: str = '',  # #4755
@@ -2571,6 +2572,7 @@ class KeyHandlerClass:
         k.mb_tabList = []
         commandName, tail = k.getMinibufferCommandName()
         k.functionTail = tail
+        func: Any
         if commandName and commandName.isdigit():
             # The line number Easter Egg.
 
@@ -2799,10 +2801,12 @@ class KeyHandlerClass:
                 self.show_results()
 
             # @+node:ekr.20241210053936.12: *5* ShowCommands.scan_buttons_and_commands & helpers
-            def scan_buttons_and_commands(self, c: Cmdr) -> None:
+            def scan_buttons_and_commands(self, c: Cmdr | None) -> None:
                 '''Return a dict containing a representation
                 of all settings in leoSettings.leo or myLeoSettings.leo.
                 '''
+                if not c:
+                    return
                 sfn = c.shortFileName()
                 settings_node = g.findNodeAnywhere(c, '@settings', exact=False)
                 if not settings_node:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -193,7 +193,7 @@ class AutoCompleterClass:
         self.namespaces: list[dict] = []
         self.qcompleter = cast(Callable, None)
         self.qw = None  # The object that supports qcompletion methods.
-        self.tabName: str = ''  # #4755 # The name of the main completion tab.
+        self.tabName: str = ''  # The name of the main completion tab.
         self.verbose = False  # True: print all members, regardless of how many there are.
         self.w: Widget = None  # The widget that gets focus after autocomplete is done.
         self.warnings: dict[str, str] = {}  # Keys are language names.
@@ -537,7 +537,7 @@ class AutoCompleterClass:
             options = d.get(key)
             if options:
                 return key, options
-        return '', []  # #4755
+        return '', []
 
     # @+node:ekr.20061031131434.29: *4* ac.do_backspace
     def do_backspace(self) -> None:
@@ -1118,8 +1118,8 @@ class FileNameChooser:
         self.log: NullLog | LeoQtLog = c.frame.log or NullLog(frame=c.frame)
         self.callback: Callable | None = None
         self.filterExt: list[str] | None = None
-        self.prompt: str = ''  # #4755
-        self.tabName: str = ''  # #4755
+        self.prompt: str = ''
+        self.tabName: str = ''
 
     # @+node:ekr.20140813052702.18196: *3* fnc.compute_tab_list
     def compute_tab_list(self) -> tuple[str, list[str]]:
@@ -1660,7 +1660,7 @@ class GetArg:
     ) -> None:
         """Trace the vars and ivars."""
         k = self.c.k
-        handler_name = '' if self.handler is None else self.handler.__name__  # #4755
+        handler_name = '' if self.handler is None else self.handler.__name__
         g.trace(
             'state', state,
             'char', repr(char),
@@ -2116,7 +2116,7 @@ class KeyHandlerClass:
         callback: Callable | None,
         commandName: str,
         modeFlag: bool = False,
-        tag: str = '',  # #4755
+        tag: str = '',
     ) -> bool:
         """
         Bind the indicated shortcut (a Tk keystroke) to the callback.
@@ -2678,7 +2678,7 @@ class KeyHandlerClass:
                 data.remove(item)
         # Print all plain bindings.
         result.append('Plain keys...\n')
-        self.printBindingsHelper(result, data, prefix='')  # #4755
+        self.printBindingsHelper(result, data, prefix='')
         if not g.unitTesting:
             g.es_print('', ''.join(result), tabName=tabName)
         k.showStateAndMode()
@@ -3273,7 +3273,7 @@ class KeyHandlerClass:
         func: Callable,
         *,
         allowBinding: bool = False,
-        fileName: str = '',  # #4755
+        fileName: str = '',
         pane: str = 'all',
         shortcut: str = '',  # Must be '' unless allowBindings is True.
         **kwargs: Any,  # Used only to warn about deprecated kwargs.
@@ -3301,7 +3301,7 @@ class KeyHandlerClass:
         if shortcut and not allowBinding:
             g.es_print('The "shortcut" keyword arg to k.registerCommand will be ignored')
             g.es_print('Called from', g.callers())
-            shortcut = ''  # #4755
+            shortcut = ''
         for arg, val in kwargs.items():
             if val is not None:
                 g.es_print(f'The "{arg}" keyword arg to k.registerCommand is deprecated')
@@ -3596,7 +3596,7 @@ class KeyHandlerClass:
         if handler is not None:
             handler(event)
         if trace:
-            handler_name = '' if handler is None else handler.__name__  # #4755
+            handler_name = '' if handler is None else handler.__name__
             g.trace(state, 'handler:', handler_name or '<no handler>', stroke)
         return True
 
@@ -4191,11 +4191,11 @@ class KeyHandlerClass:
     def generalModeHandler(
         self,
         event: LeoKeyEvent,
-        commandName: str = '',  # #4755
+        commandName: str = '',
         func: Callable | None = None,
-        modeName: str = '',  # #4755
-        nextMode: str = 'none',  # #4755
-        prompt: str = '',  # #4755
+        modeName: str = '',
+        nextMode: str = 'none',
+        prompt: str = '',
     ) -> None:
         """Handle a mode defined by an @mode node in leoSettings.leo."""
         c, k = self.c, self

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1598,8 +1598,6 @@ class GetArg:
             # A hack to support the curses gui.
             k.arg = gui_arg or self.get_label()
         kind, n, handler = self.after_get_arg_state
-        if not kind:
-            return  # strict_optional
         if kind:
             k.setState(kind, n, handler)
         self.log.deleteTab('Completion')

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -3824,7 +3824,7 @@ class KeyHandlerClass:
         return False
 
     # @+node:ekr.20091230094319.6240: *6* k.getPaneBinding & helper
-    def getPaneBinding(self, event: LeoKeyEvent) -> g.BindingInfo:
+    def getPaneBinding(self, event: LeoKeyEvent) -> g.BindingInfo | None:
         c, k, state = self.c, self, self.unboundKeyAction
         stroke, w = event.stroke, event.w
         if not g.assert_is(stroke, g.KeyStroke):
@@ -3860,7 +3860,7 @@ class KeyHandlerClass:
         name: str,
         stroke: Stroke,
         w: QTextMixin,
-    ) -> g.BindingInfo:
+    ) -> g.BindingInfo | None:
         """Find a binding for the widget with the given name."""
         c, k = self.c, self
         trace = 'keys' in g.app.debug

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -14,7 +14,8 @@ import string
 import sys
 import textwrap
 import time
-from typing import Any, TYPE_CHECKING
+import typing
+from typing import cast, Any, TYPE_CHECKING
 from types import ModuleType
 from leo.core import leoGlobals as g
 from leo.external import codewise
@@ -190,9 +191,9 @@ class AutoCompleterClass:
         # additional namespaces to search for objects, other code
         # can append namespaces to this to extend scope of search
         self.namespaces: list[dict] = []
-        self.qcompleter: Callable = None
+        self.qcompleter = cast(Callable, None)
         self.qw = None  # The object that supports qcompletion methods.
-        self.tabName: str = None  # The name of the main completion tab.
+        self.tabName: str = ''  # #4755 # The name of the main completion tab.
         self.verbose = False  # True: print all members, regardless of how many there are.
         self.w: Widget = None  # The widget that gets focus after autocomplete is done.
         self.warnings: dict[str, str] = {}  # Keys are language names.
@@ -388,7 +389,7 @@ class AutoCompleterClass:
             log.clearTab(self.tabName)
 
     # @+node:ekr.20110509064011.14556: *4* ac.attr_matches
-    def attr_matches(self, s: str, namespace: dict) -> list[str] | None:
+    def attr_matches(self, s: str, namespace: dict) -> list[str]:
         """Compute matches when string s is of the form name.name....name.
 
         Evaluates s using eval(s,namespace)
@@ -536,7 +537,7 @@ class AutoCompleterClass:
             options = d.get(key)
             if options:
                 return key, options
-        return None, []
+        return '', []  # #4755
 
     # @+node:ekr.20061031131434.29: *4* ac.do_backspace
     def do_backspace(self) -> None:
@@ -592,7 +593,6 @@ class AutoCompleterClass:
                 )
                 d[prefix] = aList
                 return aList
-        #
         # Not jedi. Use codewise.
         # Precompute the codewise completions for '.self'.
         if not self.codewiseSelfList:
@@ -600,13 +600,10 @@ class AutoCompleterClass:
             self.codewiseSelfList = [z[5:] for z in aList]
             d['self.'] = self.codewiseSelfList
         # Use the cached list if it exists.
-        aList = d.get(prefix)
-        if aList:
+        if aList := d.get(prefix, []):
             return aList
-        aList = (
-            # Prefer the Leo completions.
-            self.get_leo_completions(prefix) or self.get_codewise_completions(prefix)
-        )
+        # Prefer the Leo completions.
+        aList = self.get_leo_completions(prefix) or self.get_codewise_completions(prefix)
         d[prefix] = aList
         return aList
 
@@ -620,7 +617,7 @@ class AutoCompleterClass:
             kind, aList = self.guess_class(c, varname)
         else:
             kind, aList = 'none', []
-            varname, ivar = None, None
+            varname, ivar = '', ''  # #4755
         if aList:
             if kind == 'class':
                 hits = self.lookup_methods(aList, ivar)
@@ -1119,10 +1116,10 @@ class FileNameChooser:
         self.k = c.k
         assert c and c.k
         self.log: NullLog | LeoQtLog = c.frame.log or NullLog(frame=c.frame)
-        self.callback: Callable = None
-        self.filterExt: list[str] = None
-        self.prompt: str = None
-        self.tabName: str = None
+        self.callback: Callable | None = None
+        self.filterExt: list[str] | None = None
+        self.prompt: str = ''  # #4755
+        self.tabName: str = ''  # #4755
 
     # @+node:ekr.20140813052702.18196: *3* fnc.compute_tab_list
     def compute_tab_list(self) -> tuple[str, list[str]]:
@@ -1221,8 +1218,8 @@ class FileNameChooser:
     def get_file_name(
         self,
         event: LeoKeyEvent,
-        callback: Callable,
-        filterExt: list[str],
+        callback: Callable | None,
+        filterExt: list[str] | None,
         prompt: str,
         tabName: str,
     ) -> None:
@@ -1268,7 +1265,7 @@ class FileNameChooser:
             self.log.deleteTab(self.tabName)
             path = self.get_label()
             k.keyboardQuit()
-            if self.callback:
+            if self.callback is not None:
                 self.callback(path)
             else:
                 g.trace('no callback')
@@ -1342,12 +1339,12 @@ class GetArg:
         self.functionTail: str = ''
         self.tabName = tabName
         # State vars.
-        self.after_get_arg_state: tuple[str, int, Callable] = None
+        self.after_get_arg_state: tuple[str | None, int | None, Callable | None] | None = None
         self.arg_completion = True
-        self.handler: Callable = None
+        self.handler: Callable | None = None
         self.tabList: list[str] = []
         # Tab cycling ivars...
-        self.cycling_prefix: str = None
+        self.cycling_prefix: str = ''  # #4755
         self.cycling_index = -1
         self.cycling_tabList: list[str] = []
         # The following are k globals.
@@ -1470,7 +1467,7 @@ class GetArg:
     # @+node:ekr.20140819050118.18318: *4* ga.reset_tab_cycling
     def reset_tab_cycling(self) -> None:
         """Reset all tab cycling ivars."""
-        self.cycling_prefix = None
+        self.cycling_prefix = ''  # #4755
         self.cycling_index = -1
         self.cycling_tabList = []
 
@@ -1498,13 +1495,13 @@ class GetArg:
     def get_arg(
         self,
         event: LeoKeyEvent,
-        returnKind: str = None,
-        returnState: int = None,
-        handler: Callable = None,
-        tabList: list[str] = None,
+        returnKind: str = '',  # #4755
+        returnState: int = 0,  # #4755
+        handler: Callable | None = None,
+        tabList: list[str] | None = None,
         completion: bool = True,
         oneCharacter: bool = False,
-        stroke: Stroke = None,
+        stroke: Stroke | None = None,
         useMinibuffer: bool = True,
     ) -> None:
         # @+<< ga.get_arg docstring >>
@@ -1518,27 +1515,20 @@ class GetArg:
 
         The arguments to ga.get_arg are as follows:
 
-        event:              The event passed to the command.
+        event:          The event passed to the command.
+        returnKind='':  A string.
+        returnState=0,  An int.
+        handler=None,   A function. When the argument is complete, ga.do_end does::
 
-        returnKind=None:    A string.
-        returnState=None,   An int.
-        handler=None,       A function.
-
-            When the argument is complete, ga.do_end does::
-
-                if kind: k.setState(kind,n,handler)
+            if kind:
+                k.setState(kind,n,handler)
 
         tabList=[]:         A list of possible completions.
-
         completion=True:    True if completions are enabled.
-
         oneCharacter=False: True if k.arg should be a single character.
-
         stroke=None:        The incoming key stroke.
-
         useMinibuffer=True: True: put focus in the minibuffer while accumulating arguments.
                             False allows sort-lines, for example, to show the selection range.
-
         """
         # @-<< ga.get_arg docstring >>
         if tabList is None:
@@ -1571,7 +1561,7 @@ class GetArg:
             c.minibufferWantsFocus()
         elif char in ('Up', 'Down'):  # 4685.
             finder = c.findCommands
-            handler = self.after_get_arg_state[2]
+            handler = self.after_get_arg_state[2]  # type:ignore
             if handler in (finder.find_state0, finder._start_search_escape2):
                 finder.do_arrow(char, in_minibuffer=True)
         elif k.isFKey(stroke):
@@ -1607,12 +1597,12 @@ class GetArg:
         else:
             # A hack to support the curses gui.
             k.arg = gui_arg or self.get_label()
-        kind, n, handler = self.after_get_arg_state
+        kind, n, handler = self.after_get_arg_state  # type:ignore
         if kind:
             k.setState(kind, n, handler)
         self.log.deleteTab('Completion')
         self.reset_tab_cycling()
-        if handler:
+        if handler is not None:
             handler(event)
 
     # @+node:ekr.20140817110228.18317: *4* ga.do_state_zero
@@ -1620,7 +1610,7 @@ class GetArg:
         self,
         completion: bool,
         event: LeoKeyEvent,
-        handler: Callable,
+        handler: Callable | None,
         oneCharacter: bool,
         returnKind: str,
         returnState: int,
@@ -1629,21 +1619,17 @@ class GetArg:
     ) -> None:
         """Do state 0 processing."""
         c, k = self.c, self.k
-        #
         # Set the ga globals...
         k.getArgEscapeFlag = False
         self.after_get_arg_state = returnKind, returnState, handler
         self.arg_completion = completion
-        self.cycling_prefix = None
+        self.cycling_prefix = ''  # #4755
         self.handler = handler
         self.tabList = tabList[:] if tabList else []
-        #
         # Set the k globals...
         k.functionTail = ''
         k.oneCharacterArg = oneCharacter
-        #
-        # Do *not* change the label here!
-        # Enter the next state.
+        # Enter the next state. Do *not* change the label!
         c.widgetWantsFocus(c.frame.body.wrapper)
         k.setState('getArg', 1, k.getArg)
         if useMinibuffer:
@@ -1673,15 +1659,15 @@ class GetArg:
     ) -> None:
         """Trace the vars and ivars."""
         k = self.c.k
+        handler_name = '' if self.handler is None else self.handler.__name__  # #4755
         g.trace(
             'state', state,
             'char', repr(char),
             'stroke', repr(stroke),
-            # 'isPlain', k.isPlainKey(stroke),
             '\n',
             'escapes', k.getArgEscapes,
             'completion', self.arg_completion,
-            'handler', self.handler and self.handler.__name__ or 'None',
+            'handler', handler_name or 'None',
         )  # fmt: skip
 
     # @+node:ekr.20140818074502.18222: *3* ga.get_command
@@ -1785,8 +1771,8 @@ class KeyHandlerClass:
         """Create a key handler for c."""
         self.c = c
         self.dispatchEvent = None
-        self.fnc: FileNameChooser = None  # A singleton defined in k.finishCreate.
-        self.getArgInstance: GetArg = None  # A singleton defined in k.finishCreate.
+        self.fnc = cast(FileNameChooser, None)  # A singleton defined in k.finishCreate.
+        self.getArgInstance = cast(GetArg, None)  # A singleton defined in k.finishCreate.
         self.inited = False  # Set at end of finishCreate.
         # A list of commands whose bindings have been set to None in the local file.
         self.killedBindings: list[str] = []
@@ -1850,7 +1836,7 @@ class KeyHandlerClass:
         self.mb_event: LeoKeyEvent = None
         self.mb_history: list[str] = []
         self.mb_help: bool = False
-        self.mb_helpHandler: Callable = None
+        self.mb_helpHandler: Callable | None = None
         # Important: these are defined in k.defineExternallyVisibleIvars...
         # self.getArgEscapes = []
         # self.getArgEscapeFlag
@@ -2129,7 +2115,7 @@ class KeyHandlerClass:
         callback: Callable,
         commandName: str,
         modeFlag: bool = False,
-        tag: str = None,
+        tag: str = '',  # #4755
     ) -> bool:
         """
         Bind the indicated shortcut (a Tk keystroke) to the callback.
@@ -2254,7 +2240,7 @@ class KeyHandlerClass:
         """Register an open-with command."""
         c, k = self.c, self
         shortcut = d.get('shortcut') or ''
-        name = d.get('name')
+        name = d.get('name', '')
         # The first parameter must be event, and it must default to None.
 
         def openWithCallback(event: LeoKeyEvent = None, c: Cmdr = c, d: dict = d) -> None:
@@ -2310,6 +2296,7 @@ class KeyHandlerClass:
             k.makeMasterGuiBinding(stroke, w=w)
 
     # @+node:ekr.20070218130238: *4* k.dumpMasterBindingsDict
+    @typing.no_type_check
     def dumpMasterBindingsDict(self) -> None:
         """Dump k.masterBindingsDict."""
         k = self
@@ -2401,7 +2388,7 @@ class KeyHandlerClass:
                     d2.add_to_list(stroke, bi)
         # Step 2: make the bindings.
         for stroke in sorted(d2.keys()):
-            aList2 = d2.get(stroke)
+            aList2 = d2.get(stroke, [])
             for bi in aList2:
                 commandName = bi.commandName
                 command = c.commandsDict.get(commandName)
@@ -2438,7 +2425,7 @@ class KeyHandlerClass:
         if commandName in h:
             h.remove(commandName)
         h.append(commandName)
-        k.commandIndex = None
+        k.commandIndex = 0  # #4755
 
     # @+node:ekr.20150402165918.1: *4* k.commandHistoryDown
     def commandHistoryFwd(self) -> None:
@@ -2452,7 +2439,7 @@ class KeyHandlerClass:
             commandName = ''
             if i == len(h) - 1:
                 # fall off the bottom
-                i = None
+                i = None  # type:ignore
             elif i is not None:
                 # move to next down in list
                 i += 1
@@ -2490,14 +2477,14 @@ class KeyHandlerClass:
         """reset the command history index to indicate that
         we are pointing 'past' the last entry
         """
-        self.commandIndex = None
+        self.commandIndex = 0  # #4755
 
     # @+node:ekr.20150402111935.1: *4* k.sortCommandHistory
     def sortCommandHistory(self) -> None:
         """Sort the command history."""
         k = self
         k.commandHistory.sort()
-        k.commandIndex = None
+        k.commandIndex = 0  # #4755
 
     # @+node:ekr.20061031131434.104: *3* k.Dispatching
     # @+node:ekr.20061031131434.111: *4* k.fullCommand (alt-x) & helper
@@ -2505,10 +2492,10 @@ class KeyHandlerClass:
     def fullCommand(
         self,
         event: LeoKeyEvent,
-        specialStroke: Stroke = None,
-        specialFunc: Callable = None,
+        specialStroke: Stroke | None = None,
+        specialFunc: Callable | None = None,
         help: bool = False,
-        helpHandler: Callable = None,
+        helpHandler: Callable | None = None,
     ) -> None:
         """Handle 'full-command' (alt-x) mode."""
         try:
@@ -2548,7 +2535,7 @@ class KeyHandlerClass:
                     commandName = s[len(helpPrompt) :].strip()
                     k.clearState()
                     k.resetLabel()
-                    if k.mb_helpHandler:
+                    if k.mb_helpHandler is not None:
                         k.mb_helpHandler(commandName)
                 else:
                     s = k.getLabel(ignorePrompt=True)
@@ -2564,8 +2551,8 @@ class KeyHandlerClass:
                 c.minibufferWantsFocus()
             elif k.ignore_unbound_non_ascii_keys and len(ch) > 1:
                 if specialStroke:
-                    g.trace(specialStroke)
-                    specialFunc()
+                    # g.trace(specialStroke)
+                    specialFunc()  # type:ignore
                 c.minibufferWantsFocus()
             else:
                 # Clear the list, any other character besides tab indicates that a new prefix is in effect.
@@ -2592,7 +2579,7 @@ class KeyHandlerClass:
 
         else:
             func = c.commandsDict.get(commandName)
-        if func:
+        if func is not None:
             # These must be done *after* getting the command.
             k.clearState()
             k.resetLabel()
@@ -2642,7 +2629,7 @@ class KeyHandlerClass:
     '''
         if not d:
             g.es('no bindings')
-            return None
+            return []
         legend = textwrap.dedent(legend)
         data = []
         # d: keys are scope names. values are interior masterBindingDicts
@@ -2689,7 +2676,7 @@ class KeyHandlerClass:
                 data.remove(item)
         # Print all plain bindings.
         result.append('Plain keys...\n')
-        self.printBindingsHelper(result, data, prefix=None)
+        self.printBindingsHelper(result, data, prefix='')  # #4755
         if not g.unitTesting:
             g.es_print('', ''.join(result), tabName=tabName)
         k.showStateAndMode()
@@ -2851,7 +2838,7 @@ class KeyHandlerClass:
 
                 # Compute the maximum length of all file names.
                 files = (self.leo_settings, self.user_settings, self.local_settings)
-                max_fn = max(len(z.shortFileName()) for z in files)
+                max_fn = max(len(z.shortFileName()) for z in files)  # type:ignore
 
                 # Compute the maximum length of all gnxs.
                 max_gnx_len = 0
@@ -3044,8 +3031,8 @@ class KeyHandlerClass:
         self,
         event: LeoKeyEvent,
         handler: Callable,
-        prefix: str = None,
-        tabList: list[str] = None,
+        prefix: str = '',  # #4755
+        tabList: list[str] | None = None,
         completion: bool = True,
         oneCharacter: bool = False,
         stroke: Stroke = None,
@@ -3137,8 +3124,8 @@ class KeyHandlerClass:
 
         """
         # @-<< docstring for k.get1arg >>
-        returnKind, returnState = None, None
-        assert handler, g.callers()
+        returnKind, returnState = '', 0  # #4755
+        assert handler is not None, g.callers()
         self.getArgInstance.get_arg(
             event,
             returnKind,
@@ -3154,14 +3141,14 @@ class KeyHandlerClass:
     def getArg(
         self,
         event: LeoKeyEvent,
-        returnKind: str = None,
-        returnState: int = None,
-        handler: Callable = None,
-        prefix: str = None,
-        tabList: list[str] = None,
+        returnKind: str = '',  # #4755
+        returnState: int = 0,  # #4755
+        handler: Callable | None = None,
+        prefix: str = '',  # #4755
+        tabList: list[str] | None = None,
         completion: bool = True,
         oneCharacter: bool = False,
-        stroke: Stroke = None,
+        stroke: Stroke | None = None,
         useMinibuffer: bool = True,
     ) -> None:
         """Convenience method mapping k.getArg to ga.get_arg."""
@@ -3269,10 +3256,8 @@ class KeyHandlerClass:
         # Override entries in c.k.masterBindingsDict
         k = self
         d = k.masterBindingsDict
-        for key in d:
-            d2 = d.get(key)
-            for key2 in d2:
-                bi = d2.get(key2)
+        for key, d2 in d.items():  # #4755
+            for key2, bi in d2.items():  # #4755
                 if bi.commandName == commandName:
                     bi.func = func
                     d2[key2] = bi
@@ -3284,9 +3269,9 @@ class KeyHandlerClass:
         func: Callable,
         *,
         allowBinding: bool = False,
-        fileName: str = None,
+        fileName: str = '',  # #4755
         pane: str = 'all',
-        shortcut: str = None,  # Must be None unless allowBindings is True.
+        shortcut: str = '',  # Must be '' unless allowBindings is True.
         **kwargs: Any,  # Used only to warn about deprecated kwargs.
     ) -> None:
         """
@@ -3301,7 +3286,7 @@ class KeyHandlerClass:
         allowBinding.
         """
         c, k = self.c, self
-        if not func:
+        if func is None:
             g.es_print('Null func passed to k.registerCommand\n', commandName)
             return
         f = c.commandsDict.get(commandName)
@@ -3312,7 +3297,7 @@ class KeyHandlerClass:
         if shortcut and not allowBinding:
             g.es_print('The "shortcut" keyword arg to k.registerCommand will be ignored')
             g.es_print('Called from', g.callers())
-            shortcut = None
+            shortcut = ''  # #4755
         for arg, val in kwargs.items():
             if val is not None:
                 g.es_print(f'The "{arg}" keyword arg to k.registerCommand is deprecated')
@@ -3393,8 +3378,8 @@ class KeyHandlerClass:
     def getFileName(
         self,
         event: LeoKeyEvent,
-        callback: Callable = None,
-        filterExt: list[str] = None,
+        callback: Callable | None = None,
+        filterExt: list[str] | None = None,
         prompt: str = 'Enter File Name: ',
         tabName: str = 'Dired',
     ) -> None:
@@ -3604,11 +3589,11 @@ class KeyHandlerClass:
             return False
         # Fourth, call the state handler.
         handler = k.getStateHandler()
-        if handler:
+        if handler is not None:
             handler(event)
         if trace:
-            handler_name = handler and handler.__name__ or '<no handler>'
-            g.trace(state, 'handler:', handler_name, stroke)
+            handler_name = '' if handler is None else handler.__name__  # #4755
+            g.trace(state, 'handler:', handler_name or '<no handler>', stroke)
         return True
 
     # @+node:ekr.20061031131434.108: *6* k.callStateFunction
@@ -3850,21 +3835,21 @@ class KeyHandlerClass:
             return None
         for key, name in (
             # Order here is similar to bindtags order.
-            ('command', None),
-            ('insert', None),
-            ('overwrite', None),
-            ('button', None),
+            # #4755: Use '' instead of None here.
+            ('command', ''),
+            ('insert', ''),
+            ('overwrite', ''),
+            ('button', ''),
             ('body', 'body'),
             ('text', 'head'),  # Important: text bindings in head before tree bindings.
             ('tree', 'head'),
             ('tree', 'canvas'),
             ('log', 'log'),
             ('text', 'log'),
-            ('text', None),
-            ('all', None),
+            ('text', ''),
+            ('all', ''),
         ):
-            bi = k.getBindingHelper(key, name, stroke, w)
-            if bi:
+            if bi := k.getBindingHelper(key, name, stroke, w):
                 return bi
         return None
 
@@ -4054,7 +4039,7 @@ class KeyHandlerClass:
                 k.setLabel(label, protect=protect)
 
     # @+node:ekr.20061031170011.11: *4* k.setLabelGrey
-    def setLabelGrey(self, label: str = None) -> None:
+    def setLabelGrey(self, label: str = '') -> None:
         k, w = self, self.w
         if not w:
             return
@@ -4065,7 +4050,7 @@ class KeyHandlerClass:
     setLabelGray = setLabelGrey
 
     # @+node:ekr.20080510153327.2: *4* k.setLabelRed
-    def setLabelRed(self, label: str = None, protect: bool = False) -> None:
+    def setLabelRed(self, label: str = '', protect: bool = False) -> None:
         k, w = self, self.w
         if not w:
             return
@@ -4175,7 +4160,7 @@ class KeyHandlerClass:
         w = g.app.gui.get_focus(c)
         if w:
             c.frame.log.deleteTab('Mode')  # Changes focus to the body pane
-        k.inputModeName = None
+        k.inputModeName = ''
         k.clearState()
         k.resetLabel()
         k.showStateAndMode()  # Restores focus.
@@ -4202,11 +4187,11 @@ class KeyHandlerClass:
     def generalModeHandler(
         self,
         event: LeoKeyEvent,
-        commandName: str = None,
-        func: Callable = None,
-        modeName: str = None,
+        commandName: str = '',  # #4755
+        func: Callable | None = None,
+        modeName: str = '',  # #4755
         nextMode: str = 'none',  # #4755
-        prompt: str = None,
+        prompt: str = '',  # #4755
     ) -> None:
         """Handle a mode defined by an @mode node in leoSettings.leo."""
         c, k = self.c, self
@@ -4225,7 +4210,7 @@ class KeyHandlerClass:
                     k.modeHelp(event)
                 else:
                     c.frame.log.hideTab('Mode')
-        elif not func:
+        elif func is None:
             g.trace('No func: improper key binding')
         else:
             if commandName == 'mode-help':
@@ -4311,8 +4296,7 @@ class KeyHandlerClass:
             if key in ('*entry-commands*', '*command-prompt*'):
                 pass
             else:
-                aList = d.get(key)
-                for bi in aList:
+                for bi in d.get(key, []):
                     stroke = bi.stroke
                     if stroke not in (None, 'None'):
                         s1 = key
@@ -4455,7 +4439,7 @@ class KeyHandlerClass:
         return self.state.kind
 
     # @+node:ekr.20061031131434.198: *4* k.inState
-    def inState(self, kind: str = None) -> bool:
+    def inState(self, kind: str = '') -> bool:
         k = self
         if kind:
             return k.state.kind == kind and k.state.n is not None
@@ -4479,7 +4463,7 @@ class KeyHandlerClass:
         k.unboundKeyAction = state
 
     # @+node:ekr.20061031131434.199: *4* k.setState
-    def setState(self, kind: str, n: int, handler: Callable = None) -> None:
+    def setState(self, kind: str, n: int, handler: Callable | None = None) -> None:
         k = self
         if kind and n is not None:
             k.state.kind = kind
@@ -4491,7 +4475,7 @@ class KeyHandlerClass:
         # k.showStateAndMode()
 
     # @+node:ekr.20061031131434.192: *4* k.showStateAndMode
-    def showStateAndMode(self, *, prompt: str = None, setFocus: bool = True) -> None:
+    def showStateAndMode(self, *, prompt: str = '', setFocus: bool = True) -> None:
         """Show the state and mode at the start of the minibuffer."""
         c, k = self.c, self
         state = k.unboundKeyAction

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -342,7 +342,7 @@ class MarkupCommands:
     # @+node:ekr.20190515084219.1: *4* markup.filename
     adoc_pattern = re.compile(r'^@(adoc|asciidoctor)')
 
-    def filename(self, p: Position) -> str | None:
+    def filename(self, p: Position) -> str:
         """Return the filename of the @adoc, @pandoc or @sphinx node, or None."""
         kind = self.kind
         h = p.h.rstrip()
@@ -350,14 +350,14 @@ class MarkupCommands:
             if m := self.adoc_pattern.match(h):
                 prefix = m.group(1)
                 return h[1 + len(prefix) :].strip()
-            return None
+            return ''
         if kind in ('pandoc', 'sphinx'):
             prefix = f"@{kind}"
             if g.match_word(h, 0, prefix):
                 return h[len(prefix) :].strip()
-            return None
+            return ''
         g.trace('BAD KIND', kind)
-        return None
+        return ''
 
     # @+node:ekr.20191007053522.1: *4* markup.compute_opath
     def compute_opath(self, i_path: str) -> str:

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -30,23 +30,23 @@ if TYPE_CHECKING:  # pragma: no cover
 
 # PR #4615: Defer calls to `which` until needed.
 @functools.cache
-def _asciidoctor_exec() -> str | None:
-    return which('asciidoctor')
+def _asciidoctor_exec() -> str:
+    return which('asciidoctor') or ''
 
 
 @functools.cache
-def _asciidoc3_exec() -> str | None:
-    return which('asciidoc3')
+def _asciidoc3_exec() -> str:
+    return which('asciidoc3') or ''
 
 
 @functools.cache
-def _pandoc_exec() -> str | None:
-    return which('pandoc')
+def _pandoc_exec() -> str:
+    return which('pandoc') or ''
 
 
 @functools.cache
-def _sphinx_build() -> str | None:
-    return which('sphinx-build')
+def _sphinx_build() -> str:
+    return which('sphinx-build') or ''
 
 
 # @-<< leoMarkup: cached functions >>

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2660,7 +2660,7 @@ class VNode:
     def contentModified(self) -> None:
         g.contentModifiedSet.add(self)
 
-    # @+node:ekr.20260622103203.1: *4* v.findAllAncetorAtFileNodes
+    # @+node:ekr.20260622103203.1: *4* v.findAllAncestorAtFileNodes
     def findAllAncestorAtFileNodes(self, *, to_do_set: set[VNode] | None = None) -> list[VNode]:
         """
         Return a list of all @<file> nodes containing this VNode.

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -857,7 +857,7 @@ class Position:
     def getNext(self) -> Position:
         return self.copy().moveToNext()
 
-    def getNodeAfterTree(self) -> Position:
+    def getNodeAfterTree(self) -> Position | None:
         return self.copy().moveToNodeAfterTree()
 
     def getNthChild(self, n: int) -> Position:
@@ -1002,7 +1002,7 @@ class Position:
     simpleLevel = level
 
     # @+node:ekr.20111005152227.15566: *4* p.positionAfterDeletedTree
-    def positionAfterDeletedTree(self) -> Position:  # pragma: no cover
+    def positionAfterDeletedTree(self) -> Position | None:  # pragma: no cover
         """Return the position corresponding to p.nodeAfterTree() after this node is
         deleted. This will be p.nodeAfterTree() unless p.next() exists.
 
@@ -1433,7 +1433,7 @@ class Position:
         return p
 
     # @+node:ekr.20080416161551.205: *4* p.moveToNodeAfterTree
-    def moveToNodeAfterTree(self) -> Position:
+    def moveToNodeAfterTree(self) -> Position | None:
         """Move a position to the node after the position's tree."""
         p = self
         while p:
@@ -1512,7 +1512,7 @@ class Position:
                 p.moveToParent()  # Same as p.moveToThreadBack()
             if p:
                 if limit:
-                    done, val = self.checkVisBackLimit(limit, limitIsVisible, p)
+                    done, val = self.checkVisBackLimit(limit, limitIsVisible, p)  # type:ignore
                     if done:
                         return val  # A position or None
                 if p.isVisible(c):

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2212,10 +2212,10 @@ class VNode:
     __str__ = __repr__
 
     # @+node:ekr.20040312145256: *4* v.dump
-    def dumpLink(self, link: str | None) -> str:  # pragma: no cover
+    def dumpLink(self, link: str) -> str:  # pragma: no cover
         return link if link else "<none>"
 
-    def dump(self, label: str = "") -> None:  # pragma: no cover
+    def dump(self, label: str = '') -> None:  # pragma: no cover
         v = self
         print('')
         print(f"dump of vnode: {label} {v}")
@@ -2962,7 +2962,7 @@ class VNode:
     u = property(__get_u, __set_u, doc="VNode u property")
 
     # @+node:ekr.20090215165030.1: *4* v.gnx Property
-    def __get_gnx(self) -> str | None:
+    def __get_gnx(self) -> str:
         v = self
         return v.fileIndex
 

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -11,7 +11,7 @@ import os
 import re
 import time
 import uuid
-from typing import Any, Generator, Iterable, TYPE_CHECKING
+from typing import cast, Any, Generator, Iterable, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import signal_manager
 
@@ -351,9 +351,9 @@ class Position:
             if p.v not in all_unique_vnodes:
                 all_unique_vnodes.append(p.v)
 
-        def ref(v: VNode) -> str | None:
+        def ref(v: VNode) -> str:
             if v == c.hiddenRootNode:
-                return None
+                return ''
             if v.gnx not in all_unique_vnodes:
                 all_unique_vnodes.append(v.gnx)
             return v.gnx
@@ -404,10 +404,10 @@ class Position:
         return aList
 
     # @+node:ekr.20040310153624: *4* p.dump
-    def dumpLink(self, link: str | None) -> str:  # pragma: no cover
-        return link if link else "<none>"
+    def dumpLink(self, link: str) -> str:  # pragma: no cover
+        return link if link else '<none>'
 
-    def dump(self, label: str = "") -> None:  # pragma: no cover
+    def dump(self, label: str = '') -> None:  # pragma: no cover
         p = self
         if p.v:
             p.v.dump()  # Don't print a label
@@ -1896,7 +1896,7 @@ class Position:
     h = property(__get_h, __set_h, doc="position property returning the headline string")
 
     # @+node:ekr.20090215165030.3: *4* p.gnx property
-    def __get_gnx(self) -> str | None:
+    def __get_gnx(self) -> str:
         p = self
         return p.v.fileIndex
 
@@ -2174,7 +2174,7 @@ class VNode:
         self.children: list[VNode] = []  # Ordered list of all children of this node.
         self.parents: list[VNode] = []  # Unordered list of all parents of this node.
         # The immutable fileIndex (gnx) for this node. Set below.
-        self.fileIndex: str | None = None
+        self.fileIndex = cast(str, None)  # strict_optional
         self.iconVal = 0  # The present value of the node's icon.
         self.statusBits = 0  # status bits
 

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -212,7 +212,7 @@ class NodeIndices:
         """Update ni.lastIndex if the gnx affects it."""
         id_, t, n = self.scanGnx(gnx)
         # Don't you dare touch this code to keep pylint happy.
-        if not id_ or n in (None, ''):  # #4755
+        if not id_ or n in (None, ''):  # strict_optional
             return  # the gnx is not well formed.
         if id_ == self.userId and t == self.timeString:
             try:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -153,7 +153,7 @@ class NodeIndices:
             v.fileIndex = ni.getNewIndex(v)
 
     # @+node:ekr.20031218072017.1997: *3* ni.scanGnx
-    def scanGnx(self, s: str) -> tuple[str, str, str]:
+    def scanGnx(self, s: str) -> tuple:
         """Create a gnx from its string representation."""
         if not isinstance(s, str):  # pragma: no cover
             g.error("scanGnx: unexpected index type:", type(s), '', s)
@@ -190,11 +190,7 @@ class NodeIndices:
         theId, t, n = aTuple
         # This logic must match the existing logic so that
         # previously written gnx's can be found.
-        if n in (
-            None,
-            0,
-            '',
-        ):
+        if n in (None, 0, ''):
             s = f"{theId}.{t}"
         else:
             s = f"{theId}.{t}.{n}"
@@ -216,9 +212,8 @@ class NodeIndices:
         """Update ni.lastIndex if the gnx affects it."""
         id_, t, n = self.scanGnx(gnx)
         # Don't you dare touch this code to keep pylint happy.
-        # pylint: disable=literal-comparison
-        if not id_ or (n != 0 and not n):
-            return  # the gnx is not well formed or n in ('',None)
+        if not id_ or n in (None, ''):
+            return  # the gnx is not well formed.
         if id_ == self.userId and t == self.timeString:
             try:
                 n2 = int(n)
@@ -560,7 +555,9 @@ class Position:
                 p.moveToThreadNext()
 
     # @+node:ekr.20161120163203.1: *4* p.nearest_unique_roots (aka p.nearest)
-    def nearest_unique_roots(self, copy: bool = True, predicate: Callable = None) -> Generator:
+    def nearest_unique_roots(
+        self, copy: bool = True, predicate: Callable | None = None
+    ) -> Generator:
         """
         A generator yielding all unique root positions "near" p1 = self that
         satisfy the given predicate. p.isAnyAtFileNode is the default
@@ -578,7 +575,7 @@ class Position:
         def default_predicate(p: Position) -> bool:
             return p.isAnyAtFileNode()
 
-        the_predicate = predicate or default_predicate
+        the_predicate = predicate or default_predicate  # type:ignore # Trust the callable.
 
         # First, look up the tree.
         for p in p1.copy().self_and_parents(copy=False):
@@ -618,7 +615,7 @@ class Position:
     def parents(self, copy: bool = True) -> Generator:
         """Yield all parent positions of p."""
         p = self
-        p = p.parent()
+        p = p.parent()  # type:ignore # We are about to test p.
         while p:
             yield p.copy() if copy else p
             p.moveToParent()
@@ -866,21 +863,21 @@ class Position:
     def getNthChild(self, n: int) -> Position:
         return self.copy().moveToNthChild(n)
 
-    def getParent(self) -> Position:
+    def getParent(self) -> Position | None:
         return self.copy().moveToParent()
 
-    def getThreadBack(self) -> Position:
+    def getThreadBack(self) -> Position | None:
         return self.copy().moveToThreadBack()
 
-    def getThreadNext(self) -> Position:
+    def getThreadNext(self) -> Position | None:
         return self.copy().moveToThreadNext()
 
     # New in Leo 4.4.3 b2: add c args.
 
-    def getVisBack(self, c: Cmdr) -> Position:
+    def getVisBack(self, c: Cmdr) -> Position | None:
         return self.copy().moveToVisBack(c)
 
-    def getVisNext(self, c: Cmdr) -> Position:
+    def getVisNext(self, c: Cmdr) -> Position | None:
         return self.copy().moveToVisNext(c)
 
     # These are efficient enough now that iterators are the normal way to traverse the tree!
@@ -914,7 +911,7 @@ class Position:
         except Exception:  # pragma: no cover
             g.trace('*** Unexpected exception')
             g.es_exception()
-            return None
+            return False
 
     def hasParent(self) -> bool:
         p = self
@@ -1298,7 +1295,7 @@ class Position:
                 v, junk = data
                 return v
             return p.v.context.hiddenRootNode
-        return None  # pragma: no cover
+        return None  # type:ignore  # mypy is not wrong to complain, but this is correct.
 
     # @+node:ekr.20131219220412.16582: *4* p._relinkAsCloneOf
     def _relinkAsCloneOf(self, p2: Position) -> None:
@@ -1381,7 +1378,7 @@ class Position:
             p._childIndex -= 1
             p.v = parent_v.children[n - 1]
         else:
-            p.v = None
+            p.v = None  # type:ignore  # mypy is not wrong to complain, but this is correct.
         return p
 
     # @+node:ekr.20080416161551.201: *4* p.moveToFirstChild
@@ -1393,7 +1390,7 @@ class Position:
             p.v = p.v.children[0]
             p._childIndex = 0
         else:
-            p.v = None
+            p.v = None  # type:ignore  # mypy is not wrong to complain, but this is correct.
         return p
 
     # @+node:ekr.20080416161551.202: *4* p.moveToLastChild
@@ -1406,7 +1403,7 @@ class Position:
             p.v = p.v.children[n - 1]
             p._childIndex = n - 1
         else:
-            p.v = None  # pragma: no cover
+            p.v = None  # type:ignore  # mypy is not wrong to complain, but this is correct.
         return p
 
     # @+node:ekr.20080416161551.203: *4* p.moveToLastNode
@@ -1432,7 +1429,7 @@ class Position:
             p._childIndex = n + 1
             p.v = parent_v.children[n + 1]
         else:
-            p.v = None
+            p.v = None  # type:ignore  # mypy is not wrong to complain, but this is correct.
         return p
 
     # @+node:ekr.20080416161551.205: *4* p.moveToNodeAfterTree
@@ -1455,7 +1452,7 @@ class Position:
             p._childIndex = n
         else:
             # Leo's code must use the test `if p:` as appropriate.
-            p.v = None
+            p.v = None  # type:ignore  # mypy is not wrong to complain, but this is correct.
         return p
 
     # @+node:ekr.20080416161551.207: *4* p.moveToParent
@@ -1466,7 +1463,7 @@ class Position:
             p.v, p._childIndex = p.stack.pop()
         else:
             # Leo's code must use the test `if p:` as appropriate.
-            p.v = None
+            p.v = None  # type:ignore  # mypy is not wrong to complain, but this is correct.
         return p
 
     # @+node:ekr.20080416161551.208: *4* p.moveToThreadBack
@@ -1500,7 +1497,7 @@ class Position:
         return p
 
     # @+node:ekr.20080416161551.210: *4* p.moveToVisBack & helper
-    def moveToVisBack(self, c: Cmdr) -> Position:
+    def moveToVisBack(self, c: Cmdr) -> Position | None:
         """Move a position to the position of the previous visible node."""
         p = self
         limit, limitIsVisible = c.visLimit()
@@ -1540,7 +1537,7 @@ class Position:
         return True, None
 
     # @+node:ekr.20080416161551.211: *4* p.moveToVisNext & helper
-    def moveToVisNext(self, c: Cmdr) -> Position:
+    def moveToVisNext(self, c: Cmdr) -> Position | None:
         """Move a position to the position of the next visible node."""
         p = self
         limit, limitIsVisible = c.visLimit()
@@ -1900,7 +1897,7 @@ class Position:
     h = property(__get_h, __set_h, doc="position property returning the headline string")
 
     # @+node:ekr.20090215165030.3: *4* p.gnx property
-    def __get_gnx(self) -> str:
+    def __get_gnx(self) -> str | None:
         p = self
         return p.v.fileIndex
 
@@ -2664,7 +2661,7 @@ class VNode:
         g.contentModifiedSet.add(self)
 
     # @+node:ekr.20260622103203.1: *4* v.findAllAncetorAtFileNodes
-    def findAllAncestorAtFileNodes(self, *, to_do_set: set[VNode] = None) -> list[VNode]:
+    def findAllAncestorAtFileNodes(self, *, to_do_set: set[VNode] | None = None) -> list[VNode]:
         """
         Return a list of all @<file> nodes containing this VNode.
 
@@ -2739,14 +2736,14 @@ class VNode:
             pass
 
     # @+node:ekr.20191213161023.1: *4* v.setAllAncestorAtFileNodesDirty
-    def setAllAncestorAtFileNodesDirty(self, *, to_do_set: set[VNode] = None) -> None:
+    def setAllAncestorAtFileNodesDirty(self, *, to_do_set: set[VNode] | None = None) -> None:
         """Set all ancestor @<file> nodes dirty."""
         v = self
         for v2 in v.findAllAncestorAtFileNodes():
             v2.setDirty()
 
     # @+node:ekr.20040315032144: *4* v.setBodyString & v.setHeadString
-    def setBodyString(self, s: object) -> None:
+    def setBodyString(self, s: bytes | str) -> None:
         v = self
         if isinstance(s, str):
             v._bodyString = s
@@ -2756,7 +2753,7 @@ class VNode:
             signal_manager.emit(self.context, 'body_changed', self)
         v.updateIcon()
 
-    def setHeadString(self, s: object) -> None:
+    def setHeadString(self, s: bytes | str) -> None:
         v = self
         if isinstance(s, str):
             v._headString = s.replace('\n', '')
@@ -2966,7 +2963,7 @@ class VNode:
     u = property(__get_u, __set_u, doc="VNode u property")
 
     # @+node:ekr.20090215165030.1: *4* v.gnx Property
-    def __get_gnx(self) -> str:
+    def __get_gnx(self) -> str | None:
         v = self
         return v.fileIndex
 

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1293,8 +1293,7 @@ class Position:
             if data:
                 v, junk = data
                 return v
-            return p.v.context.hiddenRootNode
-        return None  # type:ignore  # mypy is not wrong to complain, but this is correct.
+        return p.v.context.hiddenRootNode  # strict_optional # Bug fix! 2026/06/29.
 
     # @+node:ekr.20131219220412.16582: *4* p._relinkAsCloneOf
     def _relinkAsCloneOf(self, p2: Position) -> None:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -267,7 +267,7 @@ class Position:
         return not self.__eq__(p2)
 
     # @+node:ekr.20080416161551.190: *4*  p.__init__
-    def __init__(self, v: VNode, childIndex: int = 0, stack: list = None) -> None:
+    def __init__(self, v: VNode, childIndex: int = 0, stack: list | None = None) -> None:
         """Create a new position with the given childIndex and parent stack."""
         self._childIndex = childIndex
         self.v = v
@@ -1283,7 +1283,7 @@ class Position:
         return p
 
     # @+node:ekr.20080416161551.212: *4* p._parentVnode
-    def _parentVnode(self) -> VNode | None:
+    def _parentVnode(self) -> VNode:
         """
         Return the parent VNode.
         Return the hiddenRootNode if there is no other parent.

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -614,8 +614,7 @@ class Position:
     # @+node:ekr.20091001141621.6058: *4* p.parents
     def parents(self, copy: bool = True) -> Generator:
         """Yield all parent positions of p."""
-        p = self
-        p = p.parent()  # type:ignore # We are about to test p.
+        p = self.parent()
         while p:
             yield p.copy() if copy else p
             p.moveToParent()
@@ -2163,7 +2162,7 @@ class VNode:
     # @+others
     # @+node:ekr.20031218072017.3342: *3* v.Birth & death
     # @+node:ekr.20031218072017.3344: *4* v.__init__
-    def __init__(self, context: Cmdr, gnx: str | None = None):
+    def __init__(self, context: Cmdr, gnx: str = ''):
         """
         Ctor for the VNode class.
         To support ZODB, the code must set v._p_changed = True whenever
@@ -2417,7 +2416,7 @@ class VNode:
         """
         v = self
         # Allocate a new vnode and gnx with empty children & parents.
-        v2 = VNode(context=v.context, gnx=None)
+        v2 = VNode(context=v.context)  # strict_optional
         assert v2.parents == [], v2.parents  # pylint: disable=use-implicit-booleaness-not-comparison
         assert v2.gnx
         assert v.gnx != v2.gnx

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2232,7 +2232,7 @@ class VNode:
 
     # @+node:ekr.20031218072017.3346: *3* v.Comparisons
     # @+node:ekr.20040705201018: *4* v.findAtFileName
-    def findAtFileName(self, names: Iterable, h: str | None = None) -> str:
+    def findAtFileName(self, names: Iterable, h: str = '') -> str:
         """Return the name following one of the names in nameList or"""
         # Allow h argument for unit testing.
         if not h:
@@ -2260,14 +2260,14 @@ class VNode:
     # These return the filename following @xxx, in v.headString.
     # Return the the empty string if v is not an @xxx node.
 
-    def atAutoNodeName(self, h: str | None = None) -> str:
+    def atAutoNodeName(self, h: str = '') -> str:
         return self.findAtFileName(g.app.atAutoNames, h=h)
 
     # Retain this special case as part of the "escape hatch".
     # That is, we fall back on code in leoRst.py if no
     # importer or writer for reStructuredText exists.
 
-    def atAutoRstNodeName(self, h: str | None = None) -> str:
+    def atAutoRstNodeName(self, h: str = '') -> str:
         names = ("@auto-rst",)
         return self.findAtFileName(names, h=h)
 

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -212,7 +212,7 @@ class NodeIndices:
         """Update ni.lastIndex if the gnx affects it."""
         id_, t, n = self.scanGnx(gnx)
         # Don't you dare touch this code to keep pylint happy.
-        if not id_ or n in (None, ''):
+        if not id_ or n in (None, ''):  # #4755
             return  # the gnx is not well formed.
         if id_ == self.userId and t == self.timeString:
             try:

--- a/leo/core/leoPersistence.py
+++ b/leo/core/leoPersistence.py
@@ -424,13 +424,13 @@ class PersistenceDataController:
         g.trace('no representative node for:', target, 'parent:', target.parent())
         return None
 
-    # @+node:ekr.20140712105818.16751: *4* pd.foreign_file_name
-    def foreign_file_name(self, p: Position) -> str | None:
+    # @+node:ekr.20140712105818.16751: *4* pd.foreign_file_name (not used)
+    def foreign_file_name(self, p: Position) -> str:
         """Return the file name for p, a foreign file node."""
         for tag in ('@auto', '@org-mode', '@vim-outline'):
             if g.match_word(p.h, 0, tag):
                 return p.h[len(tag) :].strip()
-        return None
+        return ''
 
     # @+node:ekr.20140711111623.17864: *4* pd.has...
     # The has commands return None if the node does not exist.

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -150,14 +150,7 @@ class BaseLeoPlugin:
 
     - setCommand::
 
-            def setCommand(
-        self,
-        commandName: str,
-        handler: Callable,
-        shortcut: Any=None,
-        pane: str='all',
-        verbose: bool=True,
-    ) -> None:
+        def setCommand(self, commandName: str, handler: Callable, pane: str='all') -> None:
 
     - setMenuItem::
 
@@ -172,8 +165,6 @@ class BaseLeoPlugin:
     :commandName:  the string typed into minibuffer to execute the ``handler``
 
     :handler:  the method in the class which actually does the work
-
-    :shortcut:  the key combination to activate the command
 
     :menu:  a string designating on of the menus ('File', Edit', 'Outline', ...)
 
@@ -195,9 +186,6 @@ class BaseLeoPlugin:
                 self.setCommand('Hello', self.hello)
                 self.setButton()
                 self.setMenuItem('Cmds')
-
-                # create a command with a shortcut
-                self.setCommand('Hola', self.hola, 'Alt-Ctrl-H')
 
                 # create a button using different text than commandName
                 self.setButton('Hello in Spanish')
@@ -237,19 +225,16 @@ class BaseLeoPlugin:
         self,
         commandName: str,
         handler: Callable,
-        shortcut: str = '',
+        *,  # #4755
         pane: str = 'all',
-        verbose: bool = True,
+        shortcut: str = '',  # No longer used
+        verbose: bool = True,  # No longer used
     ) -> None:
-        """Associate a command name with handler code,
-        optionally defining a keystroke shortcut
-        """
+        """Associate a command name with handler code."""
         self.commandNames.append(commandName)
         self.commandName = commandName
-        self.shortcut = shortcut
         self.handler = handler
-        # #4087: k.registerCommand no longer supports the 'shortcut' kwarg.
-        self.c.k.registerCommand(commandName, handler, pane=pane, verbose=verbose)
+        self.c.k.registerCommand(commandName, handler, pane=pane)
 
     # @+node:ekr.20100908125007.6014: *3* BaseLeoPlugin.setMenuItem
     def setMenuItem(

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -225,7 +225,7 @@ class BaseLeoPlugin:
         self,
         commandName: str,
         handler: Callable,
-        *,  # #4755
+        *,  # strict_optional
         pane: str = 'all',
         shortcut: str = '',  # No longer used
         verbose: bool = True,  # No longer used

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -477,12 +477,12 @@ class RstCommands:
         return changed
 
     # @+node:ekr.20090502071837.65: *5* rst.writeToDocutils & helper
-    def writeToDocutils(self, s: str, ext: str) -> str | None:
+    def writeToDocutils(self, s: str, ext: str) -> str:
         """Send s to docutils using the writer implied by ext and return the result."""
         c = self.c
         if not docutils:
             g.error('writeToDocutils: docutils not present')
-            return None
+            return ''
         join = g.finalize_join
         openDirectory = g.os_path_dirname(c.fileName())
         overrides = {'output_encoding': self.encoding}
@@ -492,7 +492,7 @@ class RstCommands:
         if ext == '.pdf':
             module = g.import_module('leo.plugins.leo_pdf')
             if not module:
-                return None
+                return ''
             writer = module.Writer()  # Get an instance.
             writer_name = None
         else:
@@ -539,7 +539,6 @@ class RstCommands:
             if rel_stylesheet_path:
                 g.es_print('relative path:', rel_stylesheet_path)
         try:
-            result = None
             result = docutils.core.publish_string(
                 source=s,
                 reader_name='standalone',

--- a/leo/core/leoSessions.py
+++ b/leo/core/leoSessions.py
@@ -52,13 +52,13 @@ class SessionManager:
                 result.append(unl)
         return result
 
-    # @+node:ekr.20120420054855.14416: *3* SessionManager.get_session_path
-    def get_session_path(self) -> str | None:
+    # @+node:ekr.20120420054855.14416: *3* SessionManager.get_session_path (not used)
+    def get_session_path(self) -> str:
         """Return the path to the session file."""
         for path in (g.app.homeLeoDir, g.app.homeDir):
             if g.os_path_exists(path):
                 return g.finalize_join(path, 'leo.session')
-        return None
+        return ''
 
     # @+node:ekr.20120420054855.14247: *3* SessionManager.load_session
     def load_session(self, c: Cmdr = None, unls: list[str] = None) -> None:

--- a/leo/core/leoShadow.py
+++ b/leo/core/leoShadow.py
@@ -148,7 +148,7 @@ class ShadowController:
         if exists:
             # Read the file.  Return if it is the same.
             s2, e = g.readFileIntoString(fileName)
-            if s2 is None:
+            if not s2:  # strict_optional
                 return False
             if s == s2:
                 report = c.config.getBool('report-unchanged-files', default=True)

--- a/leo/core/leoShadow.py
+++ b/leo/core/leoShadow.py
@@ -97,14 +97,14 @@ class ShadowController:
 
     # @+node:ekr.20080711063656.1: *3* x.File utils
     # @+node:ekr.20080711063656.7: *4* x.baseDirName
-    def baseDirName(self) -> str | None:
+    def baseDirName(self) -> str:
         c = self.c
         filename = c.fileName()
         if filename:
             return g.os_path_dirname(g.finalize(filename))
         print('')
         self.error('Can not compute shadow path: .leo file has not been saved')
-        return None
+        return ''
 
     # @+node:ekr.20080711063656.4: *4* x.dirName and pathName
     def dirName(self, filename: str) -> str:

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -1760,7 +1760,7 @@ class LeoServer:
                 fileName = param.get("name")
                 if fileName:
                     s, e = g.readFileIntoString(fileName)
-                    if s is None:
+                    if not s:  # strict_optional
                         return None
                     g.chdir(fileName)
                     s = '@nocolor\n' + s

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -963,7 +963,7 @@ class LeoServer:
         # Init ivars first.
         self.c: Cmdr = None  # Currently Selected Commander.
         self.dummy_c: Cmdr = None  # Set below, after we set g.
-        self.action: str = None
+        self.action: str = ''  # strict_optional
         self.bad_commands_list: list[str] = []  # Set below.
         self.idle_tasks: list[tuple[Callable, int | float]] = []
         #
@@ -5069,14 +5069,13 @@ class LeoServer:
         tag = '_do_message'
         trace, verbose = 'request' in traces, 'verbose' in traces
         func: Callable
-        action: str | None
 
         # Require "id" and "action" keys
         id_: int | None = d.get("id")
         if id_ is None:  # pragma: no cover
             raise ServerError(f"{tag}: no id")
-        action = d.get("action")
-        if action is None:  # pragma: no cover
+        action = d.get("action", '')  # strict_optional
+        if not action:  # pragma: no cover
             raise ServerError(f"{tag}: no action")
 
         param: dict | None = d.get('param', {})

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -5907,7 +5907,7 @@ def main() -> None:  # pragma: no cover (tested in client)
             wsLimit = 1
 
     # @+node:felix.20260523224253.1: *3* function: get_ssl_context
-    def get_ssl_context(cert_path: str | None, key_path: str | None) -> ssl.SSLContext | None:
+    def get_ssl_context(cert_path: str, key_path: str) -> ssl.SSLContext | None:
         """Returns an SSLContext if paths are valid, otherwise returns None."""
         # Ensure both arguments were provided
         if not cert_path or not key_path:

--- a/leo/plugins/backlink.py
+++ b/leo/plugins/backlink.py
@@ -422,7 +422,7 @@ class backlinkController:
             "Enter URL / UNL to link to from this node",
             default=g.app.gui.getTextFromClipboard(),
         )
-        if url is None or not url.strip():
+        if not url.strip():
             return
         if '://' not in url:
             url = 'unl://' + url

--- a/leo/plugins/bookmarks.py
+++ b/leo/plugins/bookmarks.py
@@ -423,7 +423,7 @@ def cmd_bookmark_find_flat(event):
     if bm is None:
         return
     ans = g.app.gui.runAskOkCancelStringDialog(c, "Search for", "Target:")
-    if ans is None or not ans.strip():
+    if not ans.strip():
         return
 
     nodes = []

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -285,14 +285,14 @@ class Python_Importer(Importer):
                     child.h = f"function: {child.h[4:].strip()}"
 
     # @+node:ekr.20230825164231.1: *4* python_i.find_docstring
-    def find_docstring(self, p: Position) -> str | None:
+    def find_docstring(self, p: Position) -> str:
         """Creating a regex that returns a docstring is too tricky."""
         delims = ('"""', "'''")
         s_strip = p.b.strip()
         if not s_strip:
-            return None
+            return ''
         if not s_strip.startswith(delims):
-            return None
+            return ''
         delim = delims[0] if s_strip.startswith(delims[0]) else delims[1]
         lines = g.splitLines(p.b)
         if lines[0].count(delim) == 2:
@@ -306,7 +306,7 @@ class Python_Importer(Importer):
                     i += 1
                 return ''.join(lines[:i])
             i += 1
-        return None
+        return ''
 
     # @+node:ekr.20230825164234.1: *4* python_i.move_class_docstring
     def move_class_docstring(self, docstring: str, child_p: Position, class_p: Position) -> None:

--- a/leo/plugins/leoscreen.py
+++ b/leo/plugins/leoscreen.py
@@ -397,7 +397,7 @@ class leoscreen_Controller:
             self.c, 'Prefix for text loading', 'Prefix for text loading'
         )
 
-        if x is not None:
+        if x:
             self.get_line_prefix = x
 
     # @+node:tbrown.20150805094115.1: *3* select_screen

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -665,7 +665,7 @@ class ScriptingController:
         buttonText: str,
         p: Position,
         script: str,
-        script_gnx: str = None,
+        script_gnx: str = '',
     ) -> Value:
         """Execute an @button script in p.b or script."""
         c = self.c

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -663,7 +663,7 @@ class ScriptingController:
         self,
         b: QtWidgets.QButton,
         buttonText: str,
-        p: Position,
+        p: Position | None,
         script: str,
         script_gnx: str = '',
     ) -> Value:
@@ -689,7 +689,7 @@ class ScriptingController:
         return result
 
     # @+node:ekr.20130912061655.11294: *3* sc.open_gnx
-    def open_gnx(self, c: Cmdr, gnx: str) -> tuple[Cmdr, Position]:
+    def open_gnx(self, c: Cmdr, gnx: str) -> tuple[Cmdr | None, Position | None]:
         """
         Find the node with the given gnx in c, myLeoSettings.leo and leoSettings.leo.
         If found, open the tab/outline and return c,p of the found node.
@@ -1045,7 +1045,7 @@ class ScriptingController:
             self.c.bodyWantsFocus()
 
     # @+node:ekr.20080813064908.4: *4* sc.getArgs
-    def getArgs(self, p: Position) -> list[str]:
+    def getArgs(self, p: Position | None) -> list[str]:
         """Return the list of @args field of p.h."""
         args: list[str] = []
         if not p:
@@ -1130,7 +1130,7 @@ class ScriptingController:
         return shortcut
 
     # @+node:ekr.20150402042350.1: *4* sc.getScript
-    def getScript(self, p: Position) -> str:
+    def getScript(self, p: Position | None) -> str:
         """Return the script composed from p and its descendants."""
         return g.getScript(
             self.c,
@@ -1147,7 +1147,7 @@ class ScriptingController:
         func: Callable,
         h: str,
         pane: str,
-        source_c: Cmdr = None,
+        source_c: Cmdr | None = None,
         tag: str = '',  # Not used.
     ) -> None:
         """Register @button <name> and @rclick <name> and <name>"""
@@ -1167,7 +1167,7 @@ class ScriptingController:
             func=func,
             pane=pane,
             shortcut=shortcut,
-            fileName=fileName,
+            fileName=fileName or '',
         )
 
         # 2013/11/13 Jake Peck:
@@ -1194,7 +1194,7 @@ class ScriptingController:
                     k.registerCommand(
                         allowBinding=True,
                         commandName=commandName2,
-                        fileName=fileName,
+                        fileName=fileName or '',
                         func=registerAllCommandsCallback,
                         pane=pane,
                         shortcut=shortcut,

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -170,7 +170,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # @+node:ekr.20180328085010.1: ** Top level (mod_scripting)
 # @+node:tbrown.20140819100840.37719: *3* mod_scripting.build_rclick_tree
 def build_rclick_tree(
-    command_p: Position, rclicks: RClicks = None, top_level: bool = False
+    command_p: Position, rclicks: RClicks | None = None, top_level: bool = False
 ) -> list:
     """
     Return a list of top level RClicks for the button at command_p, which can be
@@ -532,8 +532,8 @@ class ScriptingController:
             else:
                 self.seen.add(gnx)
                 if m := pattern.match(p.h):
-                    func = d.get(m.group(1))
-                    func(p)
+                    if func := d.get(m.group(1)):
+                        func(p)  # strict_optional
                 p.moveToThreadNext()
 
     # @+node:ekr.20060328125248.24: *3* sc.createLocalAtButtonHelper
@@ -572,7 +572,7 @@ class ScriptingController:
             buttonText=buttonText,
             docstring=docstring,
             gnx=p.v.gnx,
-            script=None,
+            script='',
         )
         self.iconBar.setCommandForButton(
             button=b,
@@ -580,7 +580,7 @@ class ScriptingController:
             command_p=p and p.copy(),  # This does exist.
             controller=self,
             gnx=p and p.gnx,
-            script=None,
+            script='',
         )
         # At last we can define the command and use the shortcut.
         # registerAllCommands recomputes the shortcut.
@@ -599,10 +599,10 @@ class ScriptingController:
         self,
         args: Args,
         text: str,
-        command: Callable,
+        command: Callable | None,
         statusLine: str,
-        bg: str = None,
-        kind: str = None,
+        bg: str = '',
+        kind: str = '',
     ) -> QtWidgets.QButton:
         """
         Create one icon button.
@@ -732,7 +732,7 @@ class ScriptingController:
                 self.createCommonButton(p, script, rclicks)
 
     # @+node:ekr.20070926084600: *4* sc.createCommonButton (common @button)
-    def createCommonButton(self, p: Position, script: str, rclicks: RClicks = None) -> None:
+    def createCommonButton(self, p: Position, script: str, rclicks: RClicks | None = None) -> None:
         """
         Create a button in the icon area for a common @button node in an
         @buttons node in an @setting tree. Binds button presses to a callback
@@ -824,7 +824,7 @@ class ScriptingController:
         args = self.getArgs(p)
         commonCommandCallback = AtButtonCallback(
             b=None,
-            buttonText=None,
+            buttonText='',
             c=c,
             controller=self,
             docstring=g.getDocString(p.b).strip(),
@@ -939,7 +939,7 @@ class ScriptingController:
         g.app.config.atLocalCommandsList.append(p.copy())
 
     # @+node:vitalije.20180224113123.1: *4* sc.handleRclicks
-    def handleRclicks(self, rclicks: RClicks) -> None:
+    def handleRclicks(self, rclicks: RClicks | None) -> None:
         def handlerc(rc: RClick) -> None:
             if rc.children:
                 for i in rc.children:
@@ -947,7 +947,7 @@ class ScriptingController:
             else:
                 self.handleAtRclickNode(rc.position)
 
-        for rc in rclicks:
+        for rc in rclicks or []:  # strict_optional
             handlerc(rc)
 
     # @+node:ekr.20060328125248.14: *4* sc.handleAtScriptNode @script
@@ -1095,7 +1095,7 @@ class ScriptingController:
     # @+node:peckj.20140103101946.10404: *4* sc.getColor
     def getColor(self, h: str) -> str:
         """Returns the background color from the given headline string"""
-        color = None
+        color = ''
         tag = '@color'
         i = h.find(tag)
         if i > -1:
@@ -1111,7 +1111,7 @@ class ScriptingController:
     # @+node:ekr.20060328125248.16: *4* sc.getShortcut
     def getShortcut(self, h: str) -> str:
         """Return the keyboard shortcut from the given headline string"""
-        shortcut = None
+        shortcut = ''
         i = h.find('@key')
         if i > -1:
             j = g.skip_ws(h, i + len('@key'))
@@ -1148,7 +1148,7 @@ class ScriptingController:
         h: str,
         pane: str,
         source_c: Cmdr = None,
-        tag: str = None,
+        tag: str = '',  # Not used.
     ) -> None:
         """Register @button <name> and @rclick <name> and <name>"""
         c, k = self.c, self.c.k

--- a/leo/plugins/qt_commands.py
+++ b/leo/plugins/qt_commands.py
@@ -3,7 +3,7 @@
 """Leo's Qt-related commands defined by @g.command."""
 
 from __future__ import annotations
-from typing import Any, TYPE_CHECKING
+from typing import Any, TypeAlias, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoColor
 from leo.core import leoConfig
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
 
-    QWidget = QtWidgets.QWidget
+    QWidget: TypeAlias = QtWidgets.QWidget
 
 
 # @+others

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -320,7 +320,7 @@ class LeoQtEventFilter(QtCore.QObject):
             }
             if ch.lower() in mac_d:
                 # Ignore the case.
-                actual_ch = ch = g.checkUnicode(mac_d.get(ch.lower()))
+                actual_ch = ch = g.checkUnicode(mac_d.get(ch.lower()))  # type:ignore # ch is a str.
                 mods = []
         return actual_ch, ch, mods
 

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -3787,7 +3787,7 @@ class QtIconBarClass:
         if not self.w:
             return None
         command: Callable = keys.get('command')
-        text: str = keys.get('text')
+        text: str = keys.get('text', '')
         # able to specify low-level QAction directly (QPushButton not forced)
         qaction: QAction = keys.get('qaction')
         if not text and not qaction:
@@ -3831,7 +3831,7 @@ class QtIconBarClass:
         b.leo_removeAction = rb = QAction('Remove Button', b)
         b.addAction(rb)
         rb.triggered.connect(delete_callback)
-        if command:
+        if command is not None:
 
             def button_callback(event: QEvent, c: Cmdr = c, command: Callable = command) -> None:
                 val = command()
@@ -3864,7 +3864,7 @@ class QtIconBarClass:
         self.actions = []
 
     # @+node:ekr.20110605121601.18269: *3* QtIconBar.createChaptersIcon
-    def createChaptersIcon(self) -> "LeoQtTreeTab":
+    def createChaptersIcon(self) -> LeoQtTreeTab | None:
         c = self.c
         f = c.frame
         if f.use_chapters and f.use_chapter_tabs:

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -13,7 +13,7 @@ import string
 import sys
 import time
 import urllib
-from typing import Any, TYPE_CHECKING
+from typing import cast, Any, TYPE_CHECKING
 from leo.commands import gotoCommands
 from leo.core.leoAPI import StringTextWrapper
 from leo.core import (
@@ -145,8 +145,8 @@ class DynamicWindow(QtWidgets.QMainWindow):
         self.leo_master: LeoTabbedTopLevel = None  # Set in construct.
         self.leo_menubar: QWidget = None  # Set in createMenuBar.
         self.leo_statusBar: QtWidgets.QStatusBar = None
-        self.layout_name: str = None
-        self.old_layout_name: str = None
+        self.layout_name: str = ''
+        self.old_layout_name: str = ''
         self.verticalLayout: QBoxLayout = None
         self.vr_parent_frame: QWidget = None
         c._style_deltas = defaultdict(lambda: 0)  # for adjusting styles dynamically
@@ -1618,7 +1618,7 @@ class LeoBaseTabWidget(QtWidgets.QTabWidget):
                     self.setTabText(i, title)
 
     # @+node:ekr.20131115120119.17396: *3* qt_base_tab.setTabName
-    def setTabName(self, c: Cmdr, fileName: str, tooltip: str = None) -> None:
+    def setTabName(self, c: Cmdr, fileName: str, tooltip: str = '') -> None:
         """Set the tab name and optional tooltip for c's tab to fileName."""
         # Find the tab corresponding to c.
         dw = c.frame.top  # A DynamicWindow
@@ -2431,10 +2431,10 @@ class LeoQtLog(leoFrame.LeoLog):
     def put(
         self,
         s: str,
-        color: str = None,
+        color: str = '',
         tabName: str = 'Log',
         from_redirect: bool = False,
-        nodeLink: str = None,
+        nodeLink: str = '',
     ) -> None:
         """
         Put s to the Qt Log widget, converting to html.
@@ -2624,7 +2624,7 @@ class LeoQtLog(leoFrame.LeoLog):
         self.selectTab('Log')
 
     # @+node:ekr.20111122080923.10185: *4* LeoQtLog.orderedTabNames
-    def orderedTabNames(self, LeoLog: str = None) -> list[str]:  # Unused: LeoLog
+    def orderedTabNames(self, LeoLog: str = '') -> list[str]:  # Unused: LeoLog
         """Return a list of tab names in the order in which they appear in the QTabbedWidget."""
         w = self.tabWidget
         return [w.tabText(i) for i in range(w.count())]
@@ -2737,9 +2737,9 @@ class LeoQtMenu(leoMenu.LeoMenu):
         self,
         menu: QMenu,
         accelerator: str = '',
-        command: Callable = None,
-        commandName: str = None,
-        label: str = None,
+        command: Callable | None = None,
+        commandName: str = '',
+        label: str = '',
         underline: int = 0,
     ) -> None:
         """Wrapper for the Tkinter add_command menu method."""
@@ -3557,7 +3557,7 @@ class LeoQtSpellTab:
         self.c.frame.log.selectTab('Spell')
 
     # @+node:ekr.20110605121601.18399: *4* LeoQtSpellTab.fillbox
-    def fillbox(self, alts: list[str], word: str = None) -> None:
+    def fillbox(self, alts: list[str], word: str = '') -> None:
         """Update the suggestions listBox in the Check Spelling dialog."""
         self.suggestions = alts
         if not word:
@@ -3946,8 +3946,8 @@ class QtIconBarClass:
         rclicks: RClicks,
         controller: ScriptingController,
         top_level: bool = True,
-        button: QWidget = None,
-        script: str = None,
+        button: QWidget | None = None,
+        script: str = '',
     ) -> None:
         c = controller.c
         top_offset = -2  # insert before the remove button and goto script items
@@ -4128,11 +4128,11 @@ class QtStatusLineClass:
     def get(self) -> str:
         return self.textWidget2.text()
 
-    def put(self, s: str, bg: str = None, fg: str = None) -> None:
+    def put(self, s: str, bg: str = '', fg: str = '') -> None:
         """Put the UNL area."""
         self.put_helper(s, self.textWidget2, bg, fg)
 
-    def put1(self, s: str, bg: str = None, fg: str = None) -> None:
+    def put1(self, s: str, bg: str = '', fg: str = '') -> None:
         """Put the status area"""
         self.put_helper(s, self.textWidget1, bg, fg)
 
@@ -4140,7 +4140,7 @@ class QtStatusLineClass:
     # Keys are widgets, values are stylesheets.
     styleSheetCache: dict[QWidget, str] = {}
 
-    def put_helper(self, s: str, w: QWidget, bg: str = None, fg: str = None) -> None:
+    def put_helper(self, s: str, w: QWidget, bg: str = '', fg: str = '') -> None:
         """Put string s in the indicated widget, with proper colors."""
         c = self.c
         bg = bg or c.config.getColor('status-bg') or 'white'
@@ -4226,7 +4226,7 @@ class QtStatusLineClass:
         fcol_offset = 0
         s2 = line[0:col]
         col = g.computeWidth(s2, c.tab_width)
-        #
+
         # #195: fcol when using @first directive is inaccurate
         i = line.find('<<')
         j = line.find('>>')
@@ -4237,9 +4237,9 @@ class QtStatusLineClass:
                 if line.startswith(tag):
                     fcol_offset = len(tag)
                     break
-        #
+
         # fcol is '' if there is no ancestor @<file> node.
-        fcol = None if offset is None else max(0, col + offset - fcol_offset)
+        fcol = 0 if offset is None else max(0, col + offset - fcol_offset)
         return col, fcol
 
     # @+node:chris.20180320072817.2: *4* qstatus.file_line (not used)
@@ -4267,7 +4267,7 @@ class QtStatusLineClass:
             self.put1(f"fline: {fline:2} line: {row:2d} col: {col:2} fcol: {fcol:2}")
 
     # @+node:ekr.20220911120019.1: *3* QtStatusLineClass: do-nothings
-    def disable(self, background: str = None) -> None:
+    def disable(self, background: str = '') -> None:
         pass
 
     def enable(self, background: str = "white") -> None:
@@ -4317,7 +4317,7 @@ class TabbedFrameFactory:
         # Workaround a problem setting the window title when tabs are shown.
         self.alwaysShowTabs = True
         self.leoFrames: dict[QWidget, QWidget] = {}
-        self.masterFrame: LeoTabbedTopLevel = None
+        self.masterFrame = cast(LeoTabbedTopLevel, None)
         self.createTabCommands()
 
     # @+node:ekr.20110605121601.18466: *3* TabbedFrameFactory.createFrame

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -72,26 +72,27 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.plugins.mod_scripting import ScriptingController
     from leo.plugins.qt_text import LeoQTextBrowser, QScintillaWrapper
 
-    QBoxLayout = QtWidgets.QBoxLayout
-    QComboBox = QtWidgets.QComboBox
-    QCursor = QtGui.QCursor
+    QBoxLayout: TypeAlias = QtWidgets.QBoxLayout
+    QComboBox: TypeAlias = QtWidgets.QComboBox
+    QCursor: TypeAlias = QtGui.QCursor
     QEvent: TypeAlias = QtCore.QEvent
     QFocusEvent: TypeAlias = QtGui.QFocusEvent
-    QFrame = QtWidgets.QFrame
-    QGridLayout = QtWidgets.QGridLayout
-    QLayout = QtWidgets.QWidget
-    QMenu = QtWidgets.QMenu
-    QMenuBar = QtWidgets.QMenuBar
+    QFrame: TypeAlias = QtWidgets.QFrame
+    QGridLayout: TypeAlias = QtWidgets.QGridLayout
+    QLayout: TypeAlias = QtWidgets.QWidget
+    QMenu: TypeAlias = QtWidgets.QMenu
+    QMenuBar: TypeAlias = QtWidgets.QMenuBar
     QMouseEvent: TypeAlias = QtGui.QMouseEvent
-    QObject = QtCore.QObject
-    QPoint = QtCore.QPoint
-    QPushButton = QtWidgets.QPushButton
-    QRect = QtGui.QRect
-    QSplitter = QtWidgets.QSplitter
-    QTabWidget = QtWidgets.QTabWidget
-    QTextBlock = QtGui.QTextBlock
-    QTextCursor = QtGui.QTextCursor
-    QWidget = QtWidgets.QWidget
+    QObject: TypeAlias = QtCore.QObject
+    QPoint: TypeAlias = QtCore.QPoint
+    QPushButton: TypeAlias = QtWidgets.QPushButton
+    QRect: TypeAlias = QtGui.QRect
+    QSplitter: TypeAlias = QtWidgets.QSplitter
+    QTabWidget: TypeAlias = QtWidgets.QTabWidget
+    QTextBlock: TypeAlias = QtGui.QTextBlock
+    QTextCursor: TypeAlias = QtGui.QTextCursor
+    QWidget: TypeAlias = QtWidgets.QWidget
+
     RClick = tuple
     RClicks = list[RClick]
 

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -3255,7 +3255,7 @@ class LeoQTreeWidget(QtWidgets.QTreeWidget):
             parent = p
         else:
             p2 = p.insertAfter()
-            parent = p.parent()
+            parent = p.parent() or p  # type:ignore # Bug fix!
         # #60: create relative paths & urls when dragging files.
         path = c.getPath(parent)
         if path:

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -96,7 +96,7 @@ if TYPE_CHECKING:  # pragma: no cover
     RClick = tuple
     RClicks = list[RClick]
 
-    QtWrapper = QScintillaWrapper | QTextEditWrapper
+    QtWrapper: TypeAlias = QScintillaWrapper | QTextEditWrapper
 
 
 # @-<< qt_frame annotations >>
@@ -190,7 +190,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
                 self.iconBar.hide()
 
     # @+node:ekr.20110605121601.18139: *3* dw.construct & helpers
-    def construct(self, master: LeoTabbedTopLevel = None) -> None:
+    def construct(self, master: LeoTabbedTopLevel) -> None:
         """Factor 'heavy duty' code out from the DynamicWindow ctor"""
         c = self.leo_c
         self.leo_master = master
@@ -492,7 +492,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         class EventWrapper:
             """A class to handle key presses in the Find tab."""
 
-            def __init__(self, c: Cmdr, w: QWidget, next_w: QWidget, func: Callable) -> None:
+            def __init__(self, c: Cmdr, w: QWidget, next_w: QWidget, func: Callable | None) -> None:
                 self.c = c
                 self.d = self.create_d()  # Keys: stroke.s; values: command-names.
                 self.w = w
@@ -551,7 +551,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
                         else:
                             # Do the normal processing.
                             return self.oldEvent(event)
-                    elif self.func:
+                    elif self.func is not None:
                         self.func()
                     return True
 
@@ -1084,7 +1084,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         self.findScrollArea.setWidget(self.findTab)
 
     # @+node:ekr.20110605121601.18212: *4* dw.packLabel
-    def packLabel(self, w: QWidget, n: int = None) -> None:
+    def packLabel(self, w: QWidget, n: int = 0) -> None:
         """
         Pack w into the body frame's QVGridLayout.
 
@@ -1099,7 +1099,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         label = QtWidgets.QLineEdit(None)
         label.setObjectName('editorLabel')
         label.setText(c.p.h)
-        if n is None:
+        if n == 0:  # strict_optional
             n = c.frame.body.numberOfEditors
         n = max(0, n - 1)
         # mypy error: grid is a QGridLayout, not a QLayout.
@@ -1317,18 +1317,18 @@ class FindTabManager:
             ('search_headline', self.check_box_search_headline),
             ('whole_word',      self.check_box_whole_word),
         )  # fmt: skip
-        for setting_name, w in check_box_table:
+        for setting_name, box_w in check_box_table:
             val = c.config.getBool(setting_name, default=False)
             # The setting name is also the name of the LeoFind ivar.
             assert hasattr(find, setting_name), setting_name
             setattr(find, setting_name, val)
             if val:
-                w.toggle()
+                box_w.toggle()
 
-            def check_box_callback(n: int, setting_name: str = setting_name, w: str = w) -> None:
+            def check_box_callback(n: int, setting_name: str = setting_name, w=box_w) -> None:
                 # The focus has already change when this gets called.
                 # focus_w = QtWidgets.QApplication.focusWidget()
-                val = w.isChecked()
+                val = box_w.isChecked()
                 assert hasattr(find, setting_name), setting_name
                 setattr(find, setting_name, val)
                 # Too kludgy: we must use an accurate setting.
@@ -1336,7 +1336,7 @@ class FindTabManager:
                 # Put focus in minibuffer if minibuffer find is in effect.
                 c.bodyWantsFocusNow()
 
-            w.stateChanged.connect(check_box_callback)
+            box_w.stateChanged.connect(check_box_callback)
 
         # Radio buttons
         radio_buttons_table = (
@@ -1345,27 +1345,27 @@ class FindTabManager:
             ('suboutline_only', 'suboutline_only', self.radio_button_suboutline_only),
             ('file_only',       'file_only',       self.radio_button_file_only),
         )  # fmt: skip
-        for setting_name, ivar, w in radio_buttons_table:
+        for setting_name, ivar, radio_w in radio_buttons_table:
             val = c.config.getBool(setting_name, default=False)
             # The setting name is also the name of the LeoFind ivar.
             if ivar is not None:
                 assert hasattr(find, setting_name), setting_name
                 setattr(find, setting_name, val)
-                w.toggle()
+                radio_w.toggle()
 
             def radio_button_callback(
-                n: int, ivar: str = ivar, setting_name: str = setting_name, w: str = w
+                n: int, ivar: str = ivar, setting_name: str = setting_name, w=radio_w
             ) -> None:
-                val = w.isChecked()
+                val = radio_w.isChecked()
                 if ivar:
                     assert hasattr(find, ivar), ivar
                     setattr(find, ivar, val)
 
-            w.toggled.connect(radio_button_callback)
+            radio_w.toggled.connect(radio_button_callback)
         # Ensure one radio button is set.
         if not find.node_only and not find.suboutline_only and not find.file_only:
-            w = self.radio_button_entire_outline
-            w.toggle()
+            entire_w = self.radio_button_entire_outline
+            entire_w.toggle()
 
     # @+node:ekr.20210923060904.1: *3* FindTabManager.set_widgets_from_dict
     def set_widgets_from_dict(self, d: g.Bunch) -> None:
@@ -1571,7 +1571,8 @@ class LeoBaseTabWidget(QtWidgets.QTabWidget):
         w = self.widget(index)
         name = self.tabText(index)
         self.detached.append((name, w))
-        self.factory.detachTab(w)
+        if self.factory:  # strict_optional # possible bug fix.
+            self.factory.detachTab(w)
         icon = g.app.gui.getImageFinder("application-x-leo-outline.png")
         icon = QtGui.QIcon(icon)
         if icon:
@@ -1589,7 +1590,7 @@ class LeoBaseTabWidget(QtWidgets.QTabWidget):
         """reattach all detached tabs"""
         for name, w in self.detached:
             self.addTab(w, name)
-            self.factory.leoFrames[w] = w.leo_c.frame
+            self.factory.leoFrames[w] = w.leo_c.frame  # type:ignore # I don't understand this.
         self.detached = []
 
     # @+node:ekr.20131115120119.17394: *3* qt_base_tab.delete
@@ -1657,9 +1658,9 @@ class LeoQtBody(leoFrame.LeoBody):
         super().__init__(frame)
         c = self.c
         assert c.frame == frame and frame.c == c
-        self.colorizer: BaseColorizer = None
-        self.wrapper: QtWrapper = None
-        self.widget: QWidget = None
+        self.colorizer: BaseColorizer | None = None
+        self.wrapper: QtWrapper | None = None
+        self.widget: QWidget | None = None
         self.reloadSettings()
         self.set_widget()  # Sets self.widget and self.wrapper.
         self.setWrap(c.p)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1790,15 +1790,15 @@ class LeoQtFrame(leoFrame.LeoFrame):
         leoFrame.LeoFrame.instances += 1  # Increment the class var.
 
         # Official ivars for objects.
-        self.bar1: LeoQtFrame = None
-        self.bar2: LeoQtFrame = None
-        self.body: LeoQtBody = None
-        self.iconBar: QtIconBarClass = None
-        self.iconFrame: QtIconBarClass = None
-        self.log: LeoQtLog = None
-        self.statusLine: QtStatusLineClass = None
-        self.tree: LeoQtTree = None
-        self.top: DynamicWindow = None
+        self.bar1 = cast(LeoQtFrame, None)
+        self.bar2 = cast(LeoQtFrame, None)
+        self.body = cast(LeoQtBody, None)
+        self.iconBar = cast(QtIconBarClass, None)
+        self.iconFrame = cast(QtIconBarClass, None)
+        self.log = cast(LeoQtLog, None)
+        self.statusLine = cast(QtStatusLineClass, None)
+        self.tree = cast(LeoQtTree, None)
+        self.top = cast(DynamicWindow, None)
 
         # Status ivars...
         self.title = title
@@ -1961,10 +1961,10 @@ class LeoQtFrame(leoFrame.LeoFrame):
         pass
 
     # @+node:ekr.20110605121601.18280: *4* LeoQtFrame.forceWrap & setWrap
-    def forceWrap(self, p: Position = None) -> None:
+    def forceWrap(self, p: Position | None = None) -> None:
         self.c.frame.body.forceWrap(p)
 
-    def setWrap(self, p: Position = None) -> None:
+    def setWrap(self, p: Position | None = None) -> None:
         self.c.frame.body.setWrap(p)
 
     # @+node:ekr.20110605121601.18281: *4* LeoQtFrame.reconfigurePanes
@@ -2666,7 +2666,7 @@ class LeoQtLog(leoFrame.LeoLog):
         i = self.findTabIndex(tabName)
         if i is None:
             g.trace('can not happen', tabName)
-            self.tabName = None
+            self.tabName = ''
             return
         w.setCurrentIndex(i)
         self.tabName = tabName
@@ -2800,7 +2800,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
         position: int,
         label: str,
         command: Callable,
-        underline: int = None,
+        underline: int = 0,
     ) -> None:
         menu = self.getMenu(menuName)
         if menu and label:
@@ -2808,7 +2808,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
             if -1 > n > len(label):
                 label = label[:n] + '&' + label[n:]
             action = menu.addAction(label)
-            if command:
+            if command is not None:
 
                 def insert_callback(
                     checked: str, label: str = label, command: Callable = command
@@ -3749,7 +3749,7 @@ class QtIconBarClass:
 
     # @+others
     # @+node:ekr.20110605121601.18263: *3*  QtIconBar.ctor & reloadSettings
-    def __init__(self, c: Cmdr, parentFrame: LeoQtFrame) -> None:
+    def __init__(self, c: Cmdr, parentFrame: LeoQtFrame | None) -> None:
         """Ctor for QtIconBarClass."""
         # Copy ivars
         self.c = c
@@ -4088,7 +4088,7 @@ class QtStatusLineClass:
 
     # @+others
     # @+node:ekr.20110605121601.18258: *3* QtStatusLineClass.ctor
-    def __init__(self, c: Cmdr, parentFrame: LeoQtFrame) -> None:
+    def __init__(self, c: Cmdr, parentFrame: LeoQtFrame | None) -> None:
         """Ctor for LeoQtFrame class."""
         self.c = c
         self.statusBar = c.frame.top.leo_statusBar

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -63,7 +63,7 @@ from leo.plugins.qt_layout import LayoutCacheWidget
 # @+<< qt_frame annotations >>
 # @+node:ekr.20220415080427.1: ** << qt_frame annotations >>
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import TypeAlias  # Requires Python 3.12+
+    from typing import TypeAlias  # Requires Python 3.12+, but works with Python 3.10+.
     from leo.core.leoColorizer import BaseColorizer
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoGui, LeoKeyEvent, NullFrame

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -3887,7 +3887,7 @@ class QtIconBarClass:
         # Fix bug 74: command_p may be in another outline.
         c = self.c
         c2, p = controller.open_gnx(c, gnx)
-        if p:
+        if c2 and p:  # strict_optional
             assert c2.positionExists(p)
             if c == c2:
                 c2.selectPosition(p)
@@ -3905,7 +3905,7 @@ class QtIconBarClass:
     def setCommandForButton(
         self,
         button: QPushButton,
-        command: Callable,
+        command: Callable | None,
         command_p: Position,
         controller: ScriptingController,
         gnx: str,
@@ -3921,7 +3921,7 @@ class QtIconBarClass:
         gnx is the gnx of the @button node.
         script is a static script for common @button nodes.
         """
-        if not command:
+        if command is None:
             return
         b = button.button
         b.clicked.connect(command)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2259,7 +2259,7 @@ class LeoQtLog(leoFrame.LeoLog):
         self.logCtrl: Any = None  # A Union.
         self.logDict: dict[str, LeoQTextBrowser] = {}  # Keys: tab names.
         self.logWidget: LeoLog = None
-        self.menu: qt_text.LeoQTextBrowser = None
+        self.menu = cast(qt_text.LeoQTextBrowser, None)
         self.tabWidget: QWidget = c.frame.top.tabWidget
         tw = self.tabWidget
 

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -142,7 +142,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         super().__init__(parent)
         self.leo_c = c
         self.leo_body_frame: QWidget = None
-        self.leo_master: LeoTabbedTopLevel = None  # Set in construct.
+        self.leo_master: LeoTabbedTopLevel = None  # type:ignore # cast won't work. Set in construct.
         self.leo_menubar: QWidget = None  # Set in createMenuBar.
         self.leo_statusBar: QtWidgets.QStatusBar = None
         self.layout_name: str = ''
@@ -1341,14 +1341,14 @@ class FindTabManager:
         # Radio buttons
         radio_buttons_table = (
             ('node_only',       'node_only',       self.radio_button_node_only),
-            ('entire_outline',  None,              self.radio_button_entire_outline),
+            ('entire_outline',  ''  ,              self.radio_button_entire_outline),
             ('suboutline_only', 'suboutline_only', self.radio_button_suboutline_only),
             ('file_only',       'file_only',       self.radio_button_file_only),
         )  # fmt: skip
         for setting_name, ivar, radio_w in radio_buttons_table:
             val = c.config.getBool(setting_name, default=False)
             # The setting name is also the name of the LeoFind ivar.
-            if ivar is not None:
+            if ivar:  # strict_optional
                 assert hasattr(find, setting_name), setting_name
                 setattr(find, setting_name, val)
                 radio_w.toggle()

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -3341,6 +3341,8 @@ class LeoQTreeWidget(QtWidgets.QTreeWidget):
         dummy_p = p.insertAsNthChild(0)
         c.selectPosition(dummy_p)
         c2 = g.openWithFileName(fn, old_c=c, gui=g.app.nullGui)
+        if not c2:  # strict_optional # Bug fix!
+            return
         for p2 in c2.rootPosition().self_and_siblings():
             c2.selectPosition(p2)
             s = c2.fileCommands.outline_to_clipboard_string()
@@ -3768,7 +3770,7 @@ class QtIconBarClass:
     # @+node:ekr.20110605121601.18264: *3*  QtIconBar.do-nothings
     # These *are* called from Leo's core.
 
-    def addRow(self, height: int = None) -> None:
+    def addRow(self, height: int = 0) -> None:
         pass
 
     def getNewFrame(self) -> None:
@@ -3786,7 +3788,7 @@ class QtIconBarClass:
         c = self.c
         if not self.w:
             return None
-        command: Callable = keys.get('command')
+        command: Callable | None = keys.get('command')
         text: str = keys.get('text', '')
         # able to specify low-level QAction directly (QPushButton not forced)
         qaction: QAction = keys.get('qaction')

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -61,24 +61,24 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position
 
-    QDialog = QtWidgets.QDialog
+    QDialog: TypeAlias = QtWidgets.QDialog
     QEvent: TypeAlias = QtCore.QEvent
-    QFont = QtGui.QFont
-    QFrame = QtWidgets.QFrame
-    QGridLayout = QtWidgets.QGridLayout
-    QHBoxLayout = QtWidgets.QHBoxLayout
-    QIcon = QtGui.QIcon
-    QLabel = QtWidgets.QLabel
-    QLayout = QtWidgets.QLayout
-    QMainWindow = QtWidgets.QMainWindow
-    QObject = QtCore.QObject
-    QPixmap = QtGui.QPixmap
-    QPoint = QtCore.QPoint
-    QPushButton = QtWidgets.QPushButton
-    QSplitter = QtWidgets.QSplitter
-    QTabWidget = QtWidgets.QTabWidget
-    QVBoxLayout = QtWidgets.QVBoxLayout
-    QWidget = QtWidgets.QWidget
+    QFont: TypeAlias = QtGui.QFont
+    QFrame: TypeAlias = QtWidgets.QFrame
+    QGridLayout: TypeAlias = QtWidgets.QGridLayout
+    QHBoxLayout: TypeAlias = QtWidgets.QHBoxLayout
+    QIcon: TypeAlias = QtGui.QIcon
+    QLabel: TypeAlias = QtWidgets.QLabel
+    QLayout: TypeAlias = QtWidgets.QLayout
+    QMainWindow: TypeAlias = QtWidgets.QMainWindow
+    QObject: TypeAlias = QtCore.QObject
+    QPixmap: TypeAlias = QtGui.QPixmap
+    QPoint: TypeAlias = QtCore.QPoint
+    QPushButton: TypeAlias = QtWidgets.QPushButton
+    QSplitter: TypeAlias = QtWidgets.QSplitter
+    QTabWidget: TypeAlias = QtWidgets.QTabWidget
+    QVBoxLayout: TypeAlias = QtWidgets.QVBoxLayout
+    QWidget: TypeAlias = QtWidgets.QWidget
 
 
 # @-<< qt_gui annotations >>

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -302,10 +302,10 @@ class LeoQtGui(leoGui.LeoGui):
         c: Cmdr,
         args: Any = None,
         p: Position = None,  # A node containing the script.
-        script: str = None,  # The script itself.
-        buttonText: str = None,
+        script: str = '',  # The script itself.
+        buttonText: str = '',
         balloonText: str = 'Script Button',
-        shortcut: str = None,
+        shortcut: str = '',
         bg: str = 'LightSteelBlue1',
         define_g: bool = True,
         define_name: str = '__main__',

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -879,13 +879,13 @@ class LeoQtGui(leoGui.LeoGui):
         okButtonText: str = None,
         default: str = "",
         wide: bool = False,
-    ) -> str | None:  ###
+    ) -> str:
         """Create and run askOkCancelString dialog.
 
         wide - edit a long string
         """
         if g.unitTesting:
-            return None
+            return ''
         dialog = QtWidgets.QInputDialog()
         ssm = g.app.gui.styleSheetManagerClass(c)
         w = ssm.get_master_widget()
@@ -907,7 +907,7 @@ class LeoQtGui(leoGui.LeoGui):
         self.attachLeoIcon(dialog)
         dialog.raise_()
         ok = dialog.exec()
-        return str(dialog.textValue()) if ok else None
+        return str(dialog.textValue()) if ok else ''
 
     # @+node:ekr.20110605121601.18495: *4* LeoQtGui.runAskOkDialog
     def runAskOkDialog(self, c: Cmdr, title: str, message: str = None, text: str = "Ok") -> None:

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -879,7 +879,7 @@ class LeoQtGui(leoGui.LeoGui):
         okButtonText: str = None,
         default: str = "",
         wide: bool = False,
-    ) -> str | None:
+    ) -> str | None:  ###
         """Create and run askOkCancelString dialog.
 
         wide - edit a long string
@@ -1067,10 +1067,10 @@ class LeoQtGui(leoGui.LeoGui):
         return button.objectName() or 'cancel'
 
     # @+node:ekr.20110605121601.18499: *4* LeoQtGui.runOpenDirectoryDialog
-    def runOpenDirectoryDialog(self, title: str, startdir: str) -> str | None:
+    def runOpenDirectoryDialog(self, title: str, startdir: str) -> str:
         """Create and run an Qt open directory dialog ."""
         if g.unitTesting:
-            return None
+            return ''
         dialog = QtWidgets.QFileDialog()
         self.attachLeoIcon(dialog)
         return dialog.getExistingDirectory(None, title, startdir)
@@ -1493,7 +1493,7 @@ class LeoQtGui(leoGui.LeoGui):
     dump_given = False
 
     @functools.lru_cache(maxsize=128)
-    def getImageFinder(self, name: str) -> str | None:
+    def getImageFinder(self, name: str) -> str:
         """Theme aware image (icon) path searching."""
         trace = 'themes' in g.app.debug
         exists = g.os_path_exists
@@ -1538,7 +1538,7 @@ class LeoQtGui(leoGui.LeoGui):
             # if trace: g.trace(name, 'not in', base_dir)
         if trace:
             g.trace('not found:', name)
-        return None
+        return ''
 
     # @+node:ekr.20110605121601.18518: *4* LeoQtGui.getTreeImage
     @functools.lru_cache(maxsize=128)

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -338,13 +338,13 @@ class LeoQtGui(leoGui.LeoGui):
             b: QPushButton = b,
             c: Cmdr = c,
             buttonText: str = buttonText,
-            p: Position = p and p.copy(),
+            p: Position | None = p.copy() if p else None,
             script: str = script,
         ) -> None:
             if c.disableCommandsMessage:
                 g.blue('', c.disableCommandsMessage)
             else:
-                g.app.scriptDict = {'script_gnx': p.gnx}
+                g.app.scriptDict = {'script_gnx': p.gnx if p else ''}  # strict_optional # Bug fix.
                 c.executeScript(
                     args=args,
                     p=p,
@@ -617,6 +617,8 @@ class LeoQtGui(leoGui.LeoGui):
         dialog = self.globalFindDialog
         if not dialog:
             dialog = self.createFindDialog(c)
+            if not dialog:
+                return  # strict_optional # Bug fix.
             self.globalFindDialog = dialog
             # Fix #516: Do the following only once...
             if c:
@@ -683,7 +685,7 @@ class LeoQtGui(leoGui.LeoGui):
 
     def createSpellTab(
         self, c: Cmdr, spellHandler: Callable, tabName: str
-    ) -> qt_frame.LeoQtSpellTab:
+    ) -> qt_frame.LeoQtSpellTab | None:
         if g.unitTesting:
             return None
         return qt_frame.LeoQtSpellTab(c, spellHandler, tabName)
@@ -954,7 +956,7 @@ class LeoQtGui(leoGui.LeoGui):
 
         """
         if g.unitTesting:
-            return None
+            return ''
 
         # Create the dialog.
         top_frame: QWidget | None = c.frame.top if c else None
@@ -1017,7 +1019,7 @@ class LeoQtGui(leoGui.LeoGui):
         - `no_all`: bool - show NoToAll button
         """
         if g.unitTesting:
-            return None
+            return ''
 
         # Create the dialog.
         top_frame: QWidget | None = c.frame.top if c else None
@@ -1225,80 +1227,6 @@ class LeoQtGui(leoGui.LeoGui):
         if c and s:
             c.last_dir = g.os_path_dirname(s)
         return s
-
-    # @+node:ekr.20110605121601.18503: *4* LeoQtGui.runScrolledMessageDialog
-    def runScrolledMessageDialog(
-        self,
-        short_title: str = '',
-        title: str = 'Message',
-        label: str = '',
-        msg: str = '',
-        c: Cmdr | None = None,
-        **keys: Any,
-    ) -> None:
-        if g.unitTesting:
-            return None
-
-        def send() -> Any:
-            return g.doHook(
-                'scrolledMessage',
-                short_title=short_title,
-                title=title,
-                label=label,
-                msg=msg,
-                c=c,
-                **keys,
-            )
-
-        if not c or not c.exists:
-            # @+<< no c error>>
-            # @+node:ekr.20110605121601.18504: *5* << no c error>>
-            g.es_print_error(
-                '%s\n%s\n\t%s'
-                % (
-                    "The qt plugin requires calls to g.app.gui.scrolledMessageDialog to include 'c'",
-                    "as a keyword argument",
-                    g.callers(),
-                )
-            )
-            # @-<< no c error>>
-        else:
-            retval = send()
-            if retval:
-                return retval
-            # @+<< load viewrendered plugin >>
-            # @+node:ekr.20110605121601.18505: *5* << load viewrendered plugin >>
-            pc = g.app.pluginsController
-            # Load viewrendered (and call vr.onCreate) *only* if not already loaded.
-            if not pc.isLoaded('viewrendered.py') and not pc.isLoaded('viewrendered3.py'):
-                vr = pc.loadOnePlugin('viewrendered.py')
-                if vr:
-                    g.blue('viewrendered plugin loaded.')
-                    vr.onCreate('tag', {'c': c})
-            # @-<< load viewrendered plugin >>
-            retval = send()
-            if retval:
-                return retval
-            # @+<< no dialog error >>
-            # @+node:ekr.20110605121601.18506: *5* << no dialog error >>
-            g.es_print_error(f'No handler for the "scrolledMessage" hook.\n\t{g.callers()}')
-            # @-<< no dialog error >>
-        # @+<< emergency fallback >>
-        # @+node:ekr.20110605121601.18507: *5* << emergency fallback >>
-        dialog = QtWidgets.QMessageBox(None)
-        # That is, not a fixed size dialog.
-        dialog.setWindowFlags(WindowType.Dialog)
-        dialog.setWindowTitle(title)
-        if msg:
-            dialog.setText(msg)
-        dialog.setIcon(Icon.Information)
-        dialog.addButton('Ok', ButtonRole.YesRole)
-        try:
-            c.in_qt_dialog = True
-            dialog.exec()
-        finally:
-            c.in_qt_dialog = False
-        # @-<< emergency fallback >>
 
     # @+node:ekr.20110607182447.16456: *3* LeoQtGui: Event handlers
     # @+node:ekr.20190824094650.1: *4* LeoQtGui.close_event
@@ -1542,11 +1470,11 @@ class LeoQtGui(leoGui.LeoGui):
 
     # @+node:ekr.20110605121601.18518: *4* LeoQtGui.getTreeImage
     @functools.lru_cache(maxsize=128)
-    def getTreeImage(self, c: Cmdr, path: str) -> tuple[QPixmap, int]:
+    def getTreeImage(self, c: Cmdr, path: str) -> tuple[QPixmap | None, int]:
         image = QtGui.QPixmap(path)
         if image.height() > 0 and image.width() > 0:
             return image, image.height()
-        return None, None
+        return None, 0
 
     # @+node:ekr.20111215193352.10220: *3* LeoQtGui: Splash Screen
     # @+node:ekr.20110605121601.18479: *4* LeoQtGui.createSplashScreen
@@ -1626,7 +1554,7 @@ class LeoQtGui(leoGui.LeoGui):
     import PyQt6.QtTest as QtTest
 
     QSignalSpy = QtTest.QSignalSpy
-    assert QSignalSpy
+    assert QSignalSpy is not None
 
     # @+node:ekr.20240521171848.1: *4* LeoQtGui.equalize_splitter
     def equalize_splitter(self, splitter):
@@ -1821,7 +1749,7 @@ class StyleClassManager:
     def has_sclass(self, w: QTextMixin, prop: str) -> bool:
         """Check for style class or list of classes prop on QWidget w"""
         if not prop:
-            return None
+            return False
         props = self.sclasses(w)
         if isinstance(prop, str):
             ans = [prop in props]
@@ -2297,7 +2225,7 @@ class StyleSheetManager:
                 scaled = max(float(sz) * factor, 1)
             except Exception as e:
                 g.es('ssm.rescale_fonts:', e)
-                return None
+                return ''
             return f'{prefix} {scaled:.1f}{units}'
 
         newsheet = re.sub(RE, scale, sheet)

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -301,7 +301,7 @@ class LeoQtGui(leoGui.LeoGui):
         self,
         c: Cmdr,
         args: Any = None,
-        p: Position = None,  # A node containing the script.
+        p: Position | None = None,  # A node containing the script.
         script: str = '',  # The script itself.
         buttonText: str = '',
         balloonText: str = 'Script Button',
@@ -730,8 +730,8 @@ class LeoQtGui(leoGui.LeoGui):
         c: Cmdr,
         title: str,
         message: str = 'Select Date/Time',
-        init: datetime.datetime = None,
-        step_min: dict = None,
+        init: datetime.datetime | None = None,
+        step_min: dict | None = None,
     ) -> datetime.datetime | None:
         """Create and run a qt date/time selection dialog.
 
@@ -760,9 +760,9 @@ class LeoQtGui(leoGui.LeoGui):
 
             def __init__(
                 self,
-                parent: QWidget = None,
-                init: datetime.datetime = None,
-                step_min: dict = None,
+                parent: QWidget | None = None,
+                init: datetime.datetime | None = None,
+                step_min: dict | None = None,
             ) -> None:
                 if step_min is None:
                     step_min = {}
@@ -781,10 +781,10 @@ class LeoQtGui(leoGui.LeoGui):
         class Calendar(QtWidgets.QDialog):
             def __init__(
                 self,
-                parent: QWidget = None,
+                parent: QWidget | None = None,
                 message: str = 'Select Date/Time',
-                init: datetime.datetime = None,
-                step_min: dict = None,
+                init: datetime.datetime | None = None,
+                step_min: dict | None = None,
             ) -> None:
                 if step_min is None:
                     step_min = {}
@@ -1173,8 +1173,8 @@ class LeoQtGui(leoGui.LeoGui):
         self,
         title: str = 'Properties',
         data: Any = None,
-        callback: Callable = None,
-        buttons: list[str] = None,
+        callback: Callable | None = None,
+        buttons: list[str] | None = None,
     ) -> tuple[str, dict]:
         """Display a modal TkPropertiesDialog"""
         if not g.unitTesting:
@@ -1187,7 +1187,7 @@ class LeoQtGui(leoGui.LeoGui):
         c: Cmdr,
         title: str = 'Save',
         *,
-        filetypes: list[tuple[str, str]] = None,
+        filetypes: list[tuple[str, str]] | None = None,
         defaultextension: str = '',  # Not used.
     ) -> str:
         """Create and run an Qt save file dialog ."""
@@ -1233,7 +1233,7 @@ class LeoQtGui(leoGui.LeoGui):
         title: str = 'Message',
         label: str = '',
         msg: str = '',
-        c: Cmdr = None,
+        c: Cmdr | None = None,
         **keys: Any,
     ) -> None:
         if g.unitTesting:
@@ -1417,7 +1417,7 @@ class LeoQtGui(leoGui.LeoGui):
                 c.bodyWantsFocusNow()
 
     # @+node:ekr.20190601054958.1: *4* LeoQtGui.get_focus
-    def get_focus(self, c: Cmdr = None, raw: bool = False, at_idle: bool = False) -> QWidget:
+    def get_focus(self, c: Cmdr | None = None, raw: bool = False, at_idle: bool = False) -> QWidget:
         """Returns the widget that has focus."""
         trace = 'focus' in g.app.debug and not at_idle
         w = QtWidgets.QApplication.focusWidget()
@@ -2033,7 +2033,7 @@ class StyleSheetManager:
     # @+node:ekr.20140915062551.19510: *4* StyleSheetManager.expand_css_constants & helpers
     css_warning_given = False  # For do_pass.
 
-    def expand_css_constants(self, sheet: str, settingsDict: g.SettingsDict = None) -> str:
+    def expand_css_constants(self, sheet: str, settingsDict: g.SettingsDict | None = None) -> str:
         """Expand @ settings into their corresponding constants."""
         c = self.c
         trace = 'zoom' in g.app.debug

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -1928,18 +1928,18 @@ class StyleSheetManager:
         return table
 
     # @+node:ekr.20170307083738.1: *4* StyleSheetManager.find_icon_path
-    def find_icon_path(self, setting: str) -> str | None:
+    def find_icon_path(self, setting: str) -> str:
         """Return the path to the open/close indicator icon."""
         c = self.c
         s = c.config.getString(setting)
         if not s:
-            return None  # Not an error.
+            return ''  # Not an error.
         for directory in self.compute_icon_directories():
             path = g.finalize_join(directory, s)
             if g.os_path_exists(path):
                 return path
         g.es_print('no icon found for:', setting)
-        return None
+        return ''
 
     # @+node:ekr.20180316091920.1: *3* StyleSheetManager: Settings
     # @+node:ekr.20110605121601.18176: *4* StyleSheetManager.default_style_sheet

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -287,7 +287,7 @@ class LeoQtGui(leoGui.LeoGui):
             return None
 
     # @+node:ekr.20110605121601.18511: *3* LeoQtGui.getFullVersion
-    def getFullVersion(self, c: Cmdr = None) -> str:
+    def getFullVersion(self) -> str:
         """Return the PyQt version (for signon)"""
         try:
             qtLevel = f"version {QtCore.qVersion()}"
@@ -837,8 +837,8 @@ class LeoQtGui(leoGui.LeoGui):
         c: Cmdr,
         title: str,
         message: str,
-        cancelButtonText: str = None,
-        okButtonText: str = None,
+        cancelButtonText: str = '',
+        okButtonText: str = '',
     ) -> int | None:
         """Create and run askOkCancelNumber dialog ."""
         if g.unitTesting:
@@ -875,8 +875,8 @@ class LeoQtGui(leoGui.LeoGui):
         c: Cmdr,
         title: str,
         message: str,
-        cancelButtonText: str = None,
-        okButtonText: str = None,
+        cancelButtonText: str = '',
+        okButtonText: str = '',
         default: str = "",
         wide: bool = False,
     ) -> str:
@@ -910,7 +910,7 @@ class LeoQtGui(leoGui.LeoGui):
         return str(dialog.textValue()) if ok else ''
 
     # @+node:ekr.20110605121601.18495: *4* LeoQtGui.runAskOkDialog
-    def runAskOkDialog(self, c: Cmdr, title: str, message: str = None, text: str = "Ok") -> None:
+    def runAskOkDialog(self, c: Cmdr, title: str, message: str = '', text: str = "Ok") -> None:
         """Create and run a qt askOK dialog ."""
         if g.unitTesting:
             return
@@ -940,12 +940,12 @@ class LeoQtGui(leoGui.LeoGui):
         self,
         c: Cmdr,
         title: str,
-        message: str = None,
+        message: str = '',
         yesMessage: str = "&Yes",
         noMessage: str = "&No",
-        yesToAllMessage: str = None,
+        yesToAllMessage: str = '',
         defaultButton: str = "Yes",
-        cancelMessage: str = None,
+        cancelMessage: str = '',
     ) -> str:
         """
         Create and run an askYesNo dialog.
@@ -1001,7 +1001,7 @@ class LeoQtGui(leoGui.LeoGui):
         self,
         c: Cmdr,
         title: str,
-        message: str = None,
+        message: str = '',
         yes_all: bool = False,
         no_all: bool = False,
     ) -> str:
@@ -1083,7 +1083,7 @@ class LeoQtGui(leoGui.LeoGui):
         *,
         filetypes: list[tuple[str, str]],
         defaultextension: str = '',  # Not used
-        startpath: str = None,
+        startpath: str = '',
     ) -> str:
         """
         Create and run an Qt open file dialog.
@@ -1129,7 +1129,7 @@ class LeoQtGui(leoGui.LeoGui):
         *,
         filetypes: list[tuple[str, str]],
         defaultextension: str = '',  # Not used.
-        startpath: str = None,
+        startpath: str = '',
     ) -> list[str]:
         """
         Create and run an Qt open file dialog.
@@ -1874,7 +1874,7 @@ class StyleSheetManager:
         # g.es("https://leo-editor.github.io/leo-editor/tutorial-basics.html#configuring-leo")
 
     # @+node:ekr.20170222051716.1: *3*  StyleSheetManager.reload_settings
-    def reload_settings(self, sheet: str = None) -> None:
+    def reload_settings(self, sheet: str = '') -> None:
         """
         Recompute and apply the stylesheet.
         Called automatically by the reload-settings commands.

--- a/leo/plugins/qt_idle_time.py
+++ b/leo/plugins/qt_idle_time.py
@@ -52,12 +52,12 @@ class IdleTime:
 
     # @+others
     # @+node:ekr.20140825042850.18406: *3* IdleTime.__init__
-    def __init__(self, handler: Callable, delay: int = 500, tag: str = None) -> None:
+    def __init__(self, handler: Callable, delay: int = 500, tag: str = '') -> None:
         """ctor for IdleTime class."""
         # For use by handlers...
         self.count = 0  # The number of times handler has been called.
-        self.starting_time: float = None  # Time that the timer started.
-        self.time: float = None  # Time that the handle is called.
+        self.starting_time: float = 0.0  # Time that the timer started.
+        self.time: float = 0.0  # Time that the handle is called.
         self.tag: str = tag  # For debugging.
 
         # For the IdleTime class...

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -107,7 +107,7 @@ def big_tree(event: LeoKeyEvent) -> None:
     ss = cache.find_widget('secondary_splitter')
     vs = cache.find_widget('vrx_splitter')
     if vs is None:
-        vs = QSplitter(cache)
+        vs = QtWidgets.QSplitter(cache)
         vs.setObjectName('vrx_splitter')
     of = cache.find_widget('outlineFrame')
     lf = cache.find_widget('logFrame')

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -8,17 +8,18 @@ from __future__ import annotations
 
 import textwrap
 from collections import OrderedDict
-from typing import Dict, TYPE_CHECKING
+from typing import cast, Any, Dict, TYPE_CHECKING
 
 from leo.core.leoQt import QtWidgets, Orientation
 from leo.core import leoGlobals as g
 
-QSplitter = QtWidgets.QSplitter
-QWidget = QtWidgets.QWidget
-
 if TYPE_CHECKING:  # pragma: no cover
+    from typing import TypeAlias  # Requires Python 3.12+, but works with Python 3.10+.
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
+
+    QSplitter: TypeAlias = QtWidgets.QSplitter
+    QWidget: TypeAlias = QtWidgets.QWidget
 # @-<< qt_layout: imports & annotations >>
 # @+<< qt_layout: declarations >>
 # @+node:tom.20241009141008.1: ** << qt_layout: declarations >>
@@ -464,7 +465,7 @@ VERTICAL_THIRDS_LAYOUT = {
 
 
 # @+node:tom.20240930095459.1: ** class LayoutCacheWidget
-class LayoutCacheWidget(QWidget):
+class LayoutCacheWidget(QtWidgets.QWidget):
     """
     Manage layouts, which may be defined by methods or by
     a layout data structure such as the following::
@@ -486,7 +487,7 @@ class LayoutCacheWidget(QWidget):
         super().__init__(parent)
         self.c = c
         self.setObjectName('leo-layout-cache')
-        self.layout_dict: Dict = None
+        self.layout_dict = cast(Dict, None)
 
         # maps splitter objectNames to their splitter object.
         self.created_splitter_dict: Dict[str, QWidget] = {}
@@ -584,8 +585,8 @@ class LayoutCacheWidget(QWidget):
     def find_splitter_by_name(self, name: str) -> QSplitter | None:
         """Return the splitter with the given objectName."""
 
-        def is_splitter(obj: object) -> bool:
-            return obj is not None and isinstance(obj, QSplitter)
+        def is_splitter(obj: Any) -> bool:
+            return isinstance(obj, QtWidgets.QSplitter)
 
         splitter = self.find_widget(name)
         if is_splitter(splitter):
@@ -606,11 +607,10 @@ class LayoutCacheWidget(QWidget):
     # @+node:tom.20240923194438.4: *4* LCW.find_widget_in_children
     def find_widget_in_children(self, name: str) -> QWidget | None:
         """Return a child widget with the given objectName."""
-        w: QWidget = None
         for kid in self.children():
             if kid.objectName() == name:
-                w = kid  # type: ignore [assignment]
-        return w
+                return kid  # type: ignore [assignment]
+        return None
 
     # @+node:ekr.20241027181931.1: *4* LCW.resize_pane
     def resize_pane(self, widget: QWidget, delta: int) -> None:
@@ -657,10 +657,8 @@ class LayoutCacheWidget(QWidget):
                 return
 
     # @+node:tom.20240923194438.6: *4* LCW.restoreFromLayout
-    def restoreFromLayout(self, layout: Dict = None) -> None:
-        self.layout_dict = layout
-        if layout is None:
-            layout = FALLBACK_LAYOUT
+    def restoreFromLayout(self, layout: Dict | None = None) -> None:
+        self.layout_dict = layout = layout or FALLBACK_LAYOUT  # strict_optional
         # @+<< initialize data structures >>
         # @+node:tom.20240923194438.7: *5* << initialize data structures >> restoreFromLayout
         ORIENTATIONS = layout['ORIENTATIONS']
@@ -689,7 +687,7 @@ class LayoutCacheWidget(QWidget):
         for _, name in SPLITTERS.items():
             splitter: QWidget = self.find_splitter_by_name(name)
             if splitter is None:
-                splitter = QSplitter(self)
+                splitter = QtWidgets.QSplitter(self)
                 splitter.setObjectName(name)
                 self.created_splitter_dict[name] = splitter
 

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -14,21 +14,22 @@ from leo.core.leoQt import MouseButton, MoveMode, MoveOperation
 from leo.core.leoQt import Shadow, Shape, SliderAction, SolidLine, WindowType, WrapMode
 
 if TYPE_CHECKING:  # pragma: no cover
+    from typing import TypeAlias
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
 
-    QEvent = QtCore.QEvent
-    QFrame = QtWidgets.QFrame
-    QKeyEvent = QtGui.QKeyEvent
-    QLineEdit = QtWidgets.QLineEdit
-    QObject = QtCore.QObject
-    QMouseEvent = QtGui.QMouseEvent
-    QPainter = QtGui.QPainter
-    QPaintEvent = QtGui.QPaintEvent
-    QPoint = QtCore.QPoint
-    QTreeWidgetItem = QtWidgets.QTreeWidgetItem
-    QWheelEvent = QtGui.QWheelEvent
-    QWidget = QtWidgets.QWidget
+    QEvent: TypeAlias = QtCore.QEvent
+    QFrame: TypeAlias = QtWidgets.QFrame
+    QKeyEvent: TypeAlias = QtGui.QKeyEvent
+    QLineEdit: TypeAlias = QtWidgets.QLineEdit
+    QObject: TypeAlias = QtCore.QObject
+    QMouseEvent: TypeAlias = QtGui.QMouseEvent
+    QPainter: TypeAlias = QtGui.QPainter
+    QPaintEvent: TypeAlias = QtGui.QPaintEvent
+    QPoint: TypeAlias = QtCore.QPoint
+    QTreeWidgetItem: TypeAlias = QtWidgets.QTreeWidgetItem
+    QWheelEvent: TypeAlias = QtGui.QWheelEvent
+    QWidget: TypeAlias = QtWidgets.QWidget
 
 FullWidthSelection = 0x06000
 QColor = QtGui.QColor
@@ -154,14 +155,14 @@ class QTextMixin:
 
     # @+others
     # @+node:ekr.20140901062324.18732: *3* QTextMixin.ctor & helper
-    def __init__(self, c: Cmdr = None) -> None:
+    def __init__(self, c: Cmdr) -> None:
         """Ctor for QTextMixin class"""
         self.c = c
         self.enabled = True
         self.tags: dict[str, str] = {}
         self.permanent = True  # False if selecting the minibuffer will make the widget go away.
         self.useScintilla = False  # This is used!
-        self.virtualInsertPoint: int = None
+        self.virtualInsertPoint: int | None = None
         self.widget: Any = None  # 'Any' is correct for the QTextMixin class.
         if c:
             self.injectIvars(c)
@@ -234,7 +235,7 @@ class QTextMixin:
         self.setInsertPoint(len(s2))
 
     # @+node:ekr.20140901141402.18706: *5* QTextMixin.delete
-    def delete(self, i: int, j: int = None) -> None:
+    def delete(self, i: int, j: int | None = None) -> None:
         if j is None:
             j = i + 1
         # This allows subclasses to use this base class method.
@@ -251,7 +252,7 @@ class QTextMixin:
         self.delete(i, j)
 
     # @+node:ekr.20110605121601.18102: *5* QTextMixin.get
-    def get(self, i: int, j: int = None) -> str:
+    def get(self, i: int, j: int | None = None) -> str:
         # 2012/04/12: fix the following two bugs by using the vanilla code:
         # https://bugs.launchpad.net/leo-editor/+bug/979142
         # https://bugs.launchpad.net/leo-editor/+bug/971166
@@ -323,7 +324,7 @@ class QLineEditWrapper(QTextMixin):
 
     # @+others
     # @+node:ekr.20110605121601.18060: *3* QLineEditWrapper.__init__ & __repr__
-    def __init__(self, widget: QLineEdit, name: str, c: Cmdr = None) -> None:
+    def __init__(self, widget: QLineEdit, name: str, c: Cmdr) -> None:
         """Ctor for QLineEditWrapper class."""
         super().__init__(c)
         self.widget = widget
@@ -418,7 +419,7 @@ class QLineEditWrapper(QTextMixin):
             g.app.gui.set_focus(self.c, self.widget)
 
     # @+node:ekr.20110605121601.18129: *4* QLineEditWrapper.setInsertPoint
-    def setInsertPoint(self, i: int, s: str = None) -> None:
+    def setInsertPoint(self, i: int, s: str = '') -> None:
         """QHeadlineWrapper."""
         if not self.check():
             return
@@ -429,7 +430,7 @@ class QLineEditWrapper(QTextMixin):
         w.setCursorPosition(i)
 
     # @+node:ekr.20110605121601.18130: *4* QLineEditWrapper.setSelectionRange
-    def setSelectionRange(self, i: int, j: int, insert: int | None = None, s: str = None) -> None:
+    def setSelectionRange(self, i: int, j: int, insert: int | None = None, s: str = '') -> None:
         """QHeadlineWrapper."""
         if not self.check():
             return
@@ -771,7 +772,7 @@ if QtWidgets:
         # @+node:tom.20210827225119.4: *4* LeoQTextBrowser.assign_bg
         # @@language python
         @staticmethod
-        def assign_bg(fg: str) -> QColor:
+        def assign_bg(fg: str) -> QtGui.QColor:
             """If fg or bg colors are missing, assign
             reasonable values.  Can happen with incorrectly
             constructed themes, or no-theme color schemes.
@@ -798,7 +799,7 @@ if QtWidgets:
         # @+node:tom.20210827225119.5: *4* LeoQTextBrowser.calc_hl
         # @@language python
         @staticmethod
-        def calc_hl(palette: QtGui.QPalette) -> QColor:
+        def calc_hl(palette: QtGui.QPalette) -> QtGui.QColor:
             """Return the line highlight color.
 
             ARGUMENT
@@ -975,7 +976,7 @@ if QtWidgets:
         # @+node:ekr.20201204172235.1: *3* LeoQTextBrowser.paintEvent
         leo_cursor_width = 0
 
-        leo_vim_mode: bool = None
+        leo_vim_mode: bool = False
 
         def paintEvent(self, event: QPaintEvent) -> None:
             """
@@ -1318,7 +1319,7 @@ class QMinibufferWrapper(QLineEditWrapper):
         # level sheet will get pushed down quite frequently.
         self.widget.setStyleSheet(self.c.frame.top.styleSheet())
 
-    def setSelectionRange(self, i: int, j: int, insert: int = None, s: str = None) -> None:
+    def setSelectionRange(self, i: int, j: int, insert: int | None = None, s: str = '') -> None:
         QLineEditWrapper.setSelectionRange(self, i, j, insert, s)
         insert = j if insert is None else insert
         if self.widget:
@@ -1338,7 +1339,7 @@ class QScintillaWrapper(QTextMixin):
 
     # @+others
     # @+node:ekr.20110605121601.18105: *3* QScintillaWrapper.ctor
-    def __init__(self, widget: QWidget, c: Cmdr, name: str = None) -> None:
+    def __init__(self, widget: QWidget, c: Cmdr, name: str = '') -> None:
         """Ctor for the QScintillaWrapper class."""
         super().__init__(c)
         self.baseClassName = 'QScintillaWrapper'
@@ -1369,7 +1370,7 @@ class QScintillaWrapper(QTextMixin):
 
     # @+node:ekr.20110605121601.18107: *3* QScintillaWrapper.WidgetAPI
     # @+node:ekr.20140901062324.18593: *4* QScintillaWrapper.delete
-    def delete(self, i: int, j: int = None) -> None:
+    def delete(self, i: int, j: int | None = None) -> None:
         """Delete s[i:j]"""
         w = self.widget
         if j is None:
@@ -1438,7 +1439,7 @@ class QScintillaWrapper(QTextMixin):
             addFlashCallback()
 
     # @+node:ekr.20140901062324.18595: *4* QScintillaWrapper.get
-    def get(self, i: int, j: int = None) -> str:
+    def get(self, i: int, j: int | None = None) -> str:
         # Fix the following two bugs by using vanilla code:
         # https://bugs.launchpad.net/leo-editor/+bug/979142
         # https://bugs.launchpad.net/leo-editor/+bug/971166
@@ -1551,7 +1552,7 @@ class QScintillaWrapper(QTextMixin):
         # w.update()
 
     # @+node:ekr.20110605121601.18114: *4* QScintillaWrapper.setInsertPoint
-    def setInsertPoint(self, i: int, s: str = None) -> None:
+    def setInsertPoint(self, i: int, s: str = '') -> None:
         """Set the insertion point in a QsciScintilla widget."""
         w = self.widget
         # w.SendScintilla(w.SCI_SETCURRENTPOS,i)
@@ -1559,7 +1560,7 @@ class QScintillaWrapper(QTextMixin):
         w.SendScintilla(w.SCI_SETSEL, i, i)
 
     # @+node:ekr.20110605121601.18115: *4* QScintillaWrapper.setSelectionRange
-    def setSelectionRange(self, i: int, j: int, insert: int = None, s: str = None) -> None:
+    def setSelectionRange(self, i: int, j: int, insert: int | None = None, s: str = '') -> None:
         """Set the selection range in a QsciScintilla widget."""
         w = self.widget
         if insert is None:
@@ -1655,7 +1656,7 @@ class QTextEditWrapper(QTextMixin):
     # @+node:ekr.20110605121601.18078: *3* QTextEditWrapper: High-level interface
     # These are all widget-dependent
     # @+node:ekr.20110605121601.18079: *4* QTextEditWrapper.delete (avoid call to setAllText)
-    def delete(self, i: int, j: int = None) -> None:
+    def delete(self, i: int, j: int | None = None) -> None:
         """QTextEditWrapper."""
         w = self.widget
         if j is None:
@@ -1779,13 +1780,14 @@ class QTextEditWrapper(QTextMixin):
         return self.widget.textCursor().hasSelection()
 
     # @+node:ekr.20110605121601.18089: *4* QTextEditWrapper.insert (avoid call to setAllText)
-    def insert(self, i: int, s: str) -> None:
+    def insert(self, i: int, s: str) -> int:
         """QTextEditWrapper."""
         w = self.widget
         cursor = w.textCursor()
         cursor.setPosition(i)
         cursor.insertText(s)
         w.setTextCursor(cursor)  # Bug fix: 2010/01/27
+        return i
 
     # @+node:ekr.20110605121601.18077: *4* QTextEditWrapper.leoMoveCursorHelper & helper
     def leoMoveCursorHelper(self, kind: str, extend: bool = False, linesPerPage: int = 15) -> None:
@@ -1952,7 +1954,7 @@ class QTextEditWrapper(QTextMixin):
         self.setSelectionRange(i=i, j=i, insert=i)
 
     # @+node:ekr.20110605121601.18096: *4* QTextEditWrapper.setSelectionRange
-    def setSelectionRange(self, i: int, j: int, insert: int = None) -> None:
+    def setSelectionRange(self, i: int, j: int, insert: int | None = None) -> None:
         """Set the selection range and the insert point."""
         c = self.c
         # Part 1

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -419,7 +419,11 @@ class QLineEditWrapper(QTextMixin):
             g.app.gui.set_focus(self.c, self.widget)
 
     # @+node:ekr.20110605121601.18129: *4* QLineEditWrapper.setInsertPoint
-    def setInsertPoint(self, i: int, s: str = '') -> None:
+    def setInsertPoint(
+        self,
+        i: int,
+        s: str | None = None,  # None is the correct default!
+    ) -> None:
         """QHeadlineWrapper."""
         if not self.check():
             return
@@ -430,7 +434,13 @@ class QLineEditWrapper(QTextMixin):
         w.setCursorPosition(i)
 
     # @+node:ekr.20110605121601.18130: *4* QLineEditWrapper.setSelectionRange
-    def setSelectionRange(self, i: int, j: int, insert: int | None = None, s: str = '') -> None:
+    def setSelectionRange(
+        self,
+        i: int,
+        j: int,
+        insert: int | None = None,  # None is the correct default!
+        s: str | None = None,  # None is the correct default!
+    ) -> None:
         """QHeadlineWrapper."""
         if not self.check():
             return
@@ -1319,7 +1329,13 @@ class QMinibufferWrapper(QLineEditWrapper):
         # level sheet will get pushed down quite frequently.
         self.widget.setStyleSheet(self.c.frame.top.styleSheet())
 
-    def setSelectionRange(self, i: int, j: int, insert: int | None = None, s: str = '') -> None:
+    def setSelectionRange(
+        self,
+        i: int,
+        j: int,
+        insert: int | None = None,  # None is the correct default!
+        s: str | None = None,  # None is the correct default!
+    ) -> None:
         QLineEditWrapper.setSelectionRange(self, i, j, insert, s)
         insert = j if insert is None else insert
         if self.widget:
@@ -1552,7 +1568,11 @@ class QScintillaWrapper(QTextMixin):
         # w.update()
 
     # @+node:ekr.20110605121601.18114: *4* QScintillaWrapper.setInsertPoint
-    def setInsertPoint(self, i: int, s: str = '') -> None:
+    def setInsertPoint(
+        self,
+        i: int,
+        s: str | None = '',  # None is the correct default!
+    ) -> None:
         """Set the insertion point in a QsciScintilla widget."""
         w = self.widget
         # w.SendScintilla(w.SCI_SETCURRENTPOS,i)
@@ -1560,7 +1580,13 @@ class QScintillaWrapper(QTextMixin):
         w.SendScintilla(w.SCI_SETSEL, i, i)
 
     # @+node:ekr.20110605121601.18115: *4* QScintillaWrapper.setSelectionRange
-    def setSelectionRange(self, i: int, j: int, insert: int | None = None, s: str = '') -> None:
+    def setSelectionRange(
+        self,
+        i: int,
+        j: int,
+        insert: int | None = None,  # None is the correct default!
+        s: str | None = None,  # None is the correct default!
+    ) -> None:
         """Set the selection range in a QsciScintilla widget."""
         w = self.widget
         if insert is None:

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -8,11 +8,12 @@ from __future__ import annotations
 from collections.abc import Callable
 import re
 import time
-from typing import Any, TYPE_CHECKING
+from typing import cast, Any, TYPE_CHECKING
 from leo.core.leoQt import QtCore, QtGui, QtWidgets
 from leo.core.leoQt import EndEditHint, Format, ItemFlag, KeyboardModifier
 from leo.core import leoGlobals as g
 from leo.core import leoFrame
+from leo.core.leoNodes import VNode
 from leo.core import leoPlugins  # Uses leoPlugins.TryNext.
 from leo.plugins import qt_text
 
@@ -24,15 +25,15 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoFrame import LeoQTreeWidget
     from leo.core.leoGui import LeoKeyEvent
-    from leo.core.leoNodes import Position, VNode
+    from leo.core.leoNodes import Position
     from leo.plugins.qt_frame import LeoQtFrame
     from leo.plugins.qt_text import QHeadlineWrapper
 
-    QLineEdit = QtWidgets.QLineEdit
-    QIcon = QtGui.QIcon
-    QPoint = QtCore.QPoint
+    QLineEdit: TypeAlias = QtWidgets.QLineEdit
+    QIcon: TypeAlias = QtGui.QIcon
+    QPoint: TypeAlias = QtCore.QPoint
     QTreeWidgetItem: TypeAlias = QtWidgets.QTreeWidgetItem
-    QWidget = QtWidgets.QWidget
+    QWidget: TypeAlias = QtWidgets.QWidget
 
 
 # @-<< qt_tree annotations >>
@@ -48,7 +49,7 @@ class LeoQtTree(leoFrame.LeoTree):
         super().__init__(frame)
         self.c = c
         # Widget independent status ivars...
-        self.prev_v = None
+        self.prev_v = cast(VNode, None)
         self.redrawCount = 0  # Count for debugging.
         self.revertHeadline = None  # Previous headline text for abortEditLabel.
         self.busy = False
@@ -69,7 +70,7 @@ class LeoQtTree(leoFrame.LeoTree):
         w = self.treeWidget
         # Declutter data...
         # list of pairs of patterns for decluttering
-        self.declutter_patterns: list[tuple[Any, Any]] = None
+        self.declutter_patterns: list[tuple[Any, Any]] | None = None
         self.declutter_data: dict[Any, Any] = {}
         self.loaded_images: dict[str, QIcon] = {}
 
@@ -164,7 +165,7 @@ class LeoQtTree(leoFrame.LeoTree):
         w.clear()
 
     # @+node:ekr.20110605121601.17873: *4* LeoQtTree.redraw_tree & helpers
-    def redraw_tree(self, p: Position = None) -> Position:
+    def redraw_tree(self, p: Position | None = None) -> Position | None:
         """
         Redraw all visible nodes of the tree.
         Preserve the vertical scrolling unless scroll is True.
@@ -238,7 +239,7 @@ class LeoQtTree(leoFrame.LeoTree):
             If cmd is not a replacement command returns (None, None)
             """
             # 's' is string when 'cmd' is recognized and is None otherwise
-            s: str = None
+            s: str = ''
             if cmd == 'REPLACE':
                 try:
                     s = pattern.sub(arg, text)
@@ -267,7 +268,7 @@ class LeoQtTree(leoFrame.LeoTree):
             return None, s
 
         # @+node:ekr.20171122055719.1: *6* declutter_style
-        def declutter_style(arg: str, cmd: Callable) -> tuple[Callable, str]:
+        def declutter_style(arg: str, cmd: Callable) -> tuple[Callable | None, str]:
             """
             Handles style options and returns pair '(commander, param)',
             where 'commander' is the applied style-modifying operation,
@@ -275,7 +276,7 @@ class LeoQtTree(leoFrame.LeoTree):
             Returns (None, param) if 'cmd' is not a style option.
             """
             param = c.styleSheetManager.expand_css_constants(arg).split()[0]
-            modifier: Callable = None
+            modifier: Callable | None = None
 
             if cmd == 'ICON':
 
@@ -346,7 +347,7 @@ class LeoQtTree(leoFrame.LeoTree):
                 modifier = pt_modifier
 
             # Apply the style update
-            if modifier:
+            if modifier is not None:
                 modifier(item, param)
             return modifier, param
 
@@ -361,9 +362,9 @@ class LeoQtTree(leoFrame.LeoTree):
             modifiers = []
             for cmd, arg in cmds:
                 modifier, param = declutter_replace(arg, cmd, pattern)
-                if not modifier:
+                if modifier is None:
                     modifier, param = declutter_style(arg, cmd)
-                if modifier:
+                if modifier is not None:
                     modifiers.append((modifier, param))
             return modifiers
 
@@ -558,7 +559,7 @@ class LeoQtTree(leoFrame.LeoTree):
     # @+node:ekr.20110605121601.17885: *3* LeoQtTree: Event handlers
     # @+node:ekr.20110605121601.17887: *4*  LeoQtTree: Click box event handlers
     # @+node:ekr.20110605121601.17888: *5* LeoQtTree.onClickBoxClick
-    def onClickBoxClick(self, event: LeoKeyEvent, p: Position = None) -> None:
+    def onClickBoxClick(self, event: LeoKeyEvent, p: Position | None = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -567,7 +568,7 @@ class LeoQtTree(leoFrame.LeoTree):
         c.outerUpdate()
 
     # @+node:ekr.20110605121601.17889: *5* LeoQtTree.onClickBoxRightClick
-    def onClickBoxRightClick(self, event: LeoKeyEvent, p: Position = None) -> None:
+    def onClickBoxRightClick(self, event: LeoKeyEvent, p: Position | None = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -576,7 +577,7 @@ class LeoQtTree(leoFrame.LeoTree):
         c.outerUpdate()
 
     # @+node:ekr.20110605121601.17890: *5* LeoQtTree.onPlusBoxRightClick
-    def onPlusBoxRightClick(self, event: LeoKeyEvent, p: Position = None) -> None:
+    def onPlusBoxRightClick(self, event: LeoKeyEvent, p: Position | None = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -586,7 +587,7 @@ class LeoQtTree(leoFrame.LeoTree):
     # @+node:ekr.20110605121601.17891: *4*  LeoQtTree: Icon box event handlers
     # For Qt, there seems to be no way to trigger these events.
     # @+node:ekr.20110605121601.17892: *5* LeoQtTree.onIconBoxClick
-    def onIconBoxClick(self, event: LeoKeyEvent, p: Position = None) -> None:
+    def onIconBoxClick(self, event: LeoKeyEvent, p: Position | None = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -595,7 +596,7 @@ class LeoQtTree(leoFrame.LeoTree):
         c.outerUpdate()
 
     # @+node:ekr.20110605121601.17893: *5* LeoQtTree.onIconBoxRightClick
-    def onIconBoxRightClick(self, event: LeoKeyEvent, p: Position = None) -> None:
+    def onIconBoxRightClick(self, event: LeoKeyEvent, p: Position | None = None) -> None:
         """Handle a right click in any outline widget."""
         if self.busy:
             return
@@ -605,7 +606,7 @@ class LeoQtTree(leoFrame.LeoTree):
         c.outerUpdate()
 
     # @+node:ekr.20110605121601.17894: *5* LeoQtTree.onIconBoxDoubleClick
-    def onIconBoxDoubleClick(self, event: LeoKeyEvent, p: Position = None) -> None:
+    def onIconBoxDoubleClick(self, event: LeoKeyEvent, p: Position | None = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -633,8 +634,7 @@ class LeoQtTree(leoFrame.LeoTree):
         c = self.c
         try:
             self.busy = True
-            p = self.item2position(item)
-            if p:
+            if p := self.item2position(item):  # strict_optional
                 auto_edit = self.prev_v == p.v  # #1049.
                 self.prev_v = p.v
                 event = None
@@ -850,12 +850,12 @@ class LeoQtTree(leoFrame.LeoTree):
     def itemHash(self, item: QTreeWidgetItem) -> str:
         return f"{repr(item)} at {str(id(item))}"
 
-    def item2position(self, item: QTreeWidgetItem) -> Position:
+    def item2position(self, item: QTreeWidgetItem) -> Position | None:
         itemHash = self.itemHash(item)
         p = self.item2positionDict.get(itemHash)  # was item
         return p
 
-    def item2vnode(self, item: QTreeWidgetItem) -> VNode:
+    def item2vnode(self, item: QTreeWidgetItem) -> VNode | None:
         itemHash = self.itemHash(item)
         return self.item2vnodeDict.get(itemHash)  # was item
 
@@ -896,7 +896,7 @@ class LeoQtTree(leoFrame.LeoTree):
         return items
 
     # @+node:ekr.20110605121601.18418: *4* LeoQtTree.connectEditorWidget & callback
-    def connectEditorWidget(self, w: QLineEdit, item: QTreeWidgetItem) -> QHeadlineWrapper:
+    def connectEditorWidget(self, w: QLineEdit, item: QTreeWidgetItem) -> QHeadlineWrapper | None:
         """
         Connect QLineEdit w to QTreeItem item.
 
@@ -1005,7 +1005,7 @@ class LeoQtTree(leoFrame.LeoTree):
         return e
 
     # @+node:ekr.20110605121601.18428: *4* LeoQtTree.getWrapper
-    def getWrapper(self, e: QLineEdit, item: QTreeWidgetItem) -> QHeadlineWrapper:
+    def getWrapper(self, e: QLineEdit, item: QTreeWidgetItem) -> QHeadlineWrapper | None:
         """Return the QHeadlineWrapper that wraps e (a QLineEdit)."""
         c = self.c
         if not e:
@@ -1128,7 +1128,7 @@ class LeoQtTree(leoFrame.LeoTree):
 
     # @+node:ekr.20110605121601.17905: *3* LeoQtTree: Selecting & editing
     # @+node:ekr.20110605121601.17908: *4* LeoQtTree.headline_wrapper
-    def headline_wrapper(self, p: Position) -> QHeadlineWrapper:
+    def headline_wrapper(self, p: Position) -> QHeadlineWrapper | None:
         """Returns the edit widget (A QLineEdit) for position p."""
         item = self.position2item(p)
         if item:
@@ -1149,11 +1149,11 @@ class LeoQtTree(leoFrame.LeoTree):
         self,
         p: Position,
         selectAll: bool = False,
-        selection: tuple = None,
-    ) -> tuple[QLineEdit, QHeadlineWrapper]:
+        selection: tuple | None = None,
+    ) -> tuple[QLineEdit | None, QHeadlineWrapper | None]:
         """Start editing p's headline."""
         if self.busy:
-            return None
+            return None, None
         c = self.c
         # Do any scheduled redraw.
         # This won't do anything in the new redraw scheme.
@@ -1177,8 +1177,8 @@ class LeoQtTree(leoFrame.LeoTree):
         self,
         item: QTreeWidgetItem,
         selectAll: bool = False,
-        selection: tuple = None,
-    ) -> tuple[QLineEdit, QHeadlineWrapper]:
+        selection: tuple | None = None,
+    ) -> tuple[QLineEdit, QHeadlineWrapper | None]:
         """Helper for qtree.editLabel."""
         c, vc = self.c, self.c.vimCommands
         w = self.treeWidget
@@ -1242,7 +1242,8 @@ class LeoQtTree(leoFrame.LeoTree):
 
     # @+node:ekr.20110605121601.17915: *4* LeoQtTree.getSelectedPositions
     def getSelectedPositions(self) -> list[Position]:
-        return [self.item2position(z) for z in self.getSelectedItems()]
+        positions = [self.item2position(z) for z in self.getSelectedItems()]
+        return [z for z in positions if z]  # strict_optional: Bug fix.
 
     # @+node:ekr.20110605121601.17914: *4* LeoQtTree.setHeadline
     def setHeadline(self, p: Position, s: str) -> None:

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -203,7 +203,7 @@ from pathlib import Path
 import shutil
 import sys
 import textwrap
-from typing import Any, TYPE_CHECKING
+from typing import cast, Any, TypeAlias, TYPE_CHECKING
 from urllib.request import urlopen
 from leo.core import leoGlobals as g
 from leo.core.leoQt import QtCore, QtWidgets
@@ -232,7 +232,7 @@ try:
     import docutils
     import docutils.core
 except ImportError:
-    docutils = None
+    docutils = None  # type:ignore
 if docutils:
     try:
         from docutils.core import publish_string
@@ -284,12 +284,13 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position, VNode
     from leo.core.leoQt import QtGui
+
     from QtMultimedia import QMediaPlayer
 
-    QCloseEvent = QtGui.QCloseEvent
-    QGraphicsScene = QtWidgets.QGraphicsScene
-    QGraphicsView = QtWidgets.QGraphicsView
-    QWidget = QtWidgets.QWidget
+    QCloseEvent: TypeAlias = QtGui.QCloseEvent
+    QGraphicsScene: TypeAlias = QtWidgets.QGraphicsScene
+    QGraphicsView: TypeAlias = QtWidgets.QGraphicsView
+    QWidget: TypeAlias = QtWidgets.QWidget
 # @-<< vr: annotations >>
 trace = False  # This global trace is convenient.
 asciidoctor_exec = shutil.which('asciidoctor')
@@ -352,12 +353,12 @@ def onCreate(tag: str, keys: dict) -> None:
     c = keys.get('c')
     if not c:
         return
-    vr = getVr(c=c)
-    g.registerHandler('select2', vr.update_vr)
-    g.registerHandler('idle', vr.update_vr)
-    vr.active = True
-    vr.is_visible = False
-    vr.hide()
+    if vr := getVr(c=c):
+        g.registerHandler('select2', vr.update_vr)
+        g.registerHandler('idle', vr.update_vr)
+        vr.active = True
+        vr.is_visible = False
+        vr.hide()
 
 
 # @+node:vitalije.20170712174157.1: *3* vr function: onClose
@@ -397,8 +398,8 @@ def show_scrolled_message(tag: str, kw: Any) -> None:
     vr.gnx = p.v.gnx
     vr.length = len(p.v.b)
     # Render!
-    f = vr.dispatch_dict.get('rest')
-    f(s, kw)
+    if f := vr.dispatch_dict.get('rest'):
+        f(s, kw)
     c.bodyWantsFocusNow()
 
 
@@ -653,23 +654,23 @@ class ViewRenderedController(QtWidgets.QWidget):
         super().__init__(parent)
         self.create_pane(parent)
         # Ivars set by reloadSettings.
-        self.auto_create: bool = None
-        self.background_color: str = None
-        self.keep_open: bool = None
-        self.katex_template: str = None
-        self.latex_template: str = None
-        self.mathjax_template: str = None
-        self.typst_template: str = None
-        self.pdf_zoom: int = None
+        self.auto_create: bool = False
+        self.background_color: str = ''
+        self.keep_open: bool = False
+        self.katex_template: str = ''
+        self.latex_template: str = ''
+        self.mathjax_template: str = ''
+        self.typst_template: str = ''
+        self.pdf_zoom: int = 0
         # Widgets managed by destroy_widgets.
-        self.browser: QWidget = None
-        self.gs: QGraphicsScene = None
-        self.gv: QGraphicsView = None
-        self.vp: QMediaPlayer = None
+        self.browser = cast(QtWidgets.QWidget, None)
+        self.gs = cast(QtWidgets.QGraphicsScene, None)
+        self.gv = cast(QtWidgets.QGraphicsView, None)
+        self.vp: QMediaPlayer | None = None
         self.w: QWidget = None  # The present widget in the rendering pane.
         # Set the ivars.
         self.active = True
-        self.gnx: str = None
+        self.gnx: str = ''
         self.keep_open = False  # True: keep the VR pane open even when showing text.
         self.is_visible = False
         self.length = 0  # The length of previous p.b.
@@ -860,7 +861,7 @@ class ViewRenderedController(QtWidgets.QWidget):
         if not self.must_update(keywords):
             return
         # Suppress updates until we change nodes.
-        f: Callable = None
+        f: Callable | None = None
         self.node_changed = self.gnx != p.v.gnx
         self.gnx = p.v.gnx
         self.length = len(p.b)  # not s
@@ -876,7 +877,7 @@ class ViewRenderedController(QtWidgets.QWidget):
             # Do *not* try to render plain text.
             w = self.get_base_text_widget()
             w.setPlainText(s)
-        if f:
+        if f is not None:
             f(s, keywords)
             self.show()
         elif self.keep_open:
@@ -1488,18 +1489,18 @@ class ViewRenderedController(QtWidgets.QWidget):
         if not h.startswith('@jinja'):
             return
 
-        def find_root(p: Position) -> tuple[Position, Position] | None:
+        def find_root(p: Position) -> tuple[Position | None, Position | None]:
             for newp in p.parents():
                 if newp.h.strip() == '@jinja':
                     oldp, p = p, newp
                     return oldp, p
             return None, None
 
-        def find_inputs(p: Position) -> tuple[Position, Position] | None:
+        def find_inputs(p: Position) -> tuple[Position | None, Position | None]:
             for newp in p.parents():
                 if newp.h.strip() == '@jinja inputs':
                     oldp, p = p, newp
-                    _, p = find_root(p)
+                    _, p = find_root(p)  # type:ignore
                     return oldp, p
             return None, None
 
@@ -1728,7 +1729,7 @@ class ViewRenderedController(QtWidgets.QWidget):
                 language = m.group(1)
                 if g.isValidLanguage(language):
                     return language
-            return None
+            return ''
 
         # #1287: Honor both kind of directives node by node.
         for p1 in p.self_and_parents():

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -267,12 +267,12 @@ try:
     import nbformat
     from nbconvert import HTMLExporter
 except ImportError:
-    nbformat = None
+    nbformat = None  # type:ignore
 
 try:
     import pyperclip
 except Exception:
-    pyperclip = None
+    pyperclip = None  # type:ignore
 
 # Fail fast, right after all imports.
 g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -1696,7 +1696,7 @@ class ViewRenderedController(QtWidgets.QWidget):
         return w
 
     # @+node:ekr.20110320120020.14483: *4* vr.get_kind
-    def get_kind(self, p: Position) -> str | None:
+    def get_kind(self, p: Position) -> str:
         """Return the proper rendering kind for node p."""
 
         p0 = p  # Special case selected position.
@@ -1735,12 +1735,12 @@ class ViewRenderedController(QtWidgets.QWidget):
             language = get_language(p1)
             if language:
                 if language in ('md', 'markdown'):
-                    return language if got_markdown else None
+                    return language if got_markdown else ''
                 if language in ('rest', 'rst'):
-                    return language if got_docutils else None
+                    return language if got_docutils else ''
                 if language in self.dispatch_dict:
                     return language
-        return None
+        return ''
 
     # @+node:ekr.20110320233639.5776: *4* vr.get_fn
     def get_fn(self, s: str, tag: str) -> tuple[bool, str]:

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1099,7 +1099,7 @@ try:
     import docutils
     import docutils.core
 except ImportError:
-    docutils = None
+    docutils = None  # type:ignore
 if docutils:
     try:
         from docutils.core import publish_string
@@ -1127,13 +1127,13 @@ try:
     import matplotlib.pyplot as plt
     from matplotlib import animation
 except ImportError:
-    matplotlib = None
+    matplotlib = None  # type:ignore
     print('VR3: *** No matplotlib')
 try:
     import numpy as np
 except ImportError:
     print('VR3: *** No numpy')
-    np = None
+    np = None  # type:ignore
 
 try:
     from pygments import cmdline
@@ -1528,11 +1528,11 @@ def configure_asciidoc():
     if asciidoc_ok:
         # These locations are needed by our custom config file html5.conf
         d_ = {}
-        file_ = sys.modules['asciidoc.asciidoc'].__file__
-        asciidoc_dir = os.path.dirname(file_)
-        d_['stylesheets'] = find_dir('stylesheets', asciidoc_dir)
-        d_['javascripts'] = find_dir('javascripts', asciidoc_dir)
-        asciidoc_dirs['asciidoc'] = d_
+        if file_ := sys.modules['asciidoc.asciidoc'].__file__:  # strict_optional
+            asciidoc_dir = os.path.dirname(file_)
+            d_['stylesheets'] = find_dir('stylesheets', asciidoc_dir)
+            d_['javascripts'] = find_dir('javascripts', asciidoc_dir)
+            asciidoc_dirs['asciidoc'] = d_
     # @-<< get asciidoc >>
     # @+<< get asciidoc3 >>
     # @+node:tom.20211125003406.4: *3* << get asciidoc3 >>
@@ -2803,7 +2803,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             # @+<< check existence >>
             # @+node:tom.20211117161734.1: *5* << check existence >>
             # Check for style file's existence
-            style_path = None
+            style_path = ''
             if os.path.isabs(stylefile):
                 style_path = stylefile
             else:
@@ -3312,10 +3312,10 @@ class ViewRenderedController3(QtWidgets.QWidget):
     # @+node:tom.20240724084623.1: *4* vr3.show_literal
     def show_literal(self, s):
         h = f'<pre>{s}</pre>'
-        w = self.w
-        self.set_html(h, w)
-        self.rst_html = h
-        w.show()
+        if w := self.w:  # strict_optional
+            self.set_html(h, w)
+            self.rst_html = h
+            w.show()
 
     # @+node:tom.20240724083001.1: *4* vr3.compute_kind
     def compute_kind(self, p, keywords):
@@ -3743,7 +3743,8 @@ class ViewRenderedController3(QtWidgets.QWidget):
 
             def delete_callback():
                 for w in (self.gs, self.gv):
-                    w.deleteLater()
+                    if w:  # strict_optional
+                        w.deleteLater()
                 self.gs = self.gv = None
 
             self.embed_widget(w, delete_callback=delete_callback)
@@ -3970,7 +3971,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
         # @+node:TomP.20200209115750.1: *6* generate HTML
 
         try:
-            _html = self.Markdown.reset().convert(result)
+            _html = self.Markdown.reset().convert(result)  # type:ignore
             self.last_markup = result
 
         except SystemMessage as sm:
@@ -4017,8 +4018,8 @@ class ViewRenderedController3(QtWidgets.QWidget):
 
         self.embed_widget(vp, delete_callback=delete_callback)
         self.show()
-        vp = self.vp
-        vp.play()
+        if vp := self.vp:  # strict_optional
+            vp.play()
 
     # @+node:TomP.20191215195433.68: *4* vr3.update_networkx
     def update_networkx(self, s, keywords):

--- a/leo/plugins/vim.py
+++ b/leo/plugins/vim.py
@@ -248,11 +248,10 @@ class VimCommander:
         return contextMenu
 
     # @+node:ekr.20150326180515.1: *4* vim.find_path_for_node
-    def find_path_for_node(self, p):
+    def find_path_for_node(self, p) -> str:
         """Search the open-files list for a file corresponding to p."""
         efc = g.app.externalFilesController
-        path = efc.find_path_for_node(p)
-        return path
+        return efc.find_path_for_node(p)
 
     # @+node:ekr.20150326173414.1: *4* vim.find_root
     def find_root(self, p):

--- a/leo/plugins/writers/markdown.py
+++ b/leo/plugins/writers/markdown.py
@@ -19,9 +19,7 @@ class MarkdownWriter(basewriter.BaseWriter):
         """Write all the *descendants* of an @auto-markdown node."""
         self.root = root
         self.write_root(root)
-        count = 0
         for p in root.subtree():
-            count += 1
             if g.app.force_at_auto_sentinels:  # pragma: no cover
                 self.put_node_sentinel(p, '<!--', delim2='-->')
             if self.placeholder_regex.match(p.h):

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -42,7 +42,7 @@ else:  # Test only specific files.
         'leo/plugins/qt_frame.py',
         'leo/plugins/qt_gui.py',
         'leo/plugins/qt_idle_time.py',
-        # 'leo/plugins/qt_layout.py',
+        'leo/plugins/qt_layout.py',
         # 'leo/plugins/qt_text.py',
         # 'leo/plugins/qt_tree.py',
         # 'leo/plugins/viewrendered.py',

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -46,7 +46,7 @@ else:  # Test only specific files.
         'leo/plugins/qt_text.py',
         'leo/plugins/qt_tree.py',
         'leo/plugins/viewrendered.py',
-        # 'leo/plugins/viewrendered3.py',
+        'leo/plugins/viewrendered3.py',
     ]
 # Apparently 'strict-optional' doesn't work.
 incremental = True

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -25,20 +25,24 @@ os.chdir(leo_editor_dir)
 
 # args = ' '.join(sys.argv[1:])
 python = sys.executable
+passed = (
+    'leoAtFile.py',
+    'leoCommands.py',
+    'leoGlobals.py',
+    'leoKeys.py',
+    'leoNodes.py',
+)
 if 0:
     # Test all files
-    args = ''
-    files = 'leo'
+    args = '--follow-imports=skip'
+    files = 'leo'  # 2742 errors.
+elif 1:  # Test all passed files.
+    args = '--follow-imports=skip'
+    files = ' '.join(f"leo/core/{z}" for z in passed)
 else:
-    files = 'leo/core/leoColorizer.py'
-    # fail
-    # files = 'leo/core'  # 3000 errors
-
-    # pass
-    # files = 'leo/core/leoGlobals.py'
-    # files = 'leo/core/leoNodes.py'
-    # files = 'leo/core/leoAtFile.py'
-
+    # Fails
+    files = 'leo/core/leoCommands.py'
+    # files = 'leo/core/leoColorizer.py' # 36 errors
     if 1:  # For testing one file.
         args = '--follow-imports=skip'
     else:  # Safe.

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -25,28 +25,20 @@ os.chdir(leo_editor_dir)
 
 # args = ' '.join(sys.argv[1:])
 python = sys.executable
-passed = (
-    'leoAtFile.py',
-    'leoCommands.py',
-    'leoGlobals.py',
-    'leoKeys.py',
-    'leoNodes.py',
-)
-if 1:
-    # Test all files
-    args = '--follow-imports=skip'  # Apparently 'strict-optional' doesn't work.
-    files = 'leo/core'
-elif 1:  # Test all passed files.
-    args = '--follow-imports=skip'
-    files = ' '.join(f"leo/core/{z}" for z in passed)
-else:
-    # Fails
-    files = 'leo/core/leoCommands.py'
-    # files = 'leo/core/leoColorizer.py' # 36 errors
-    if 1:  # For testing one file.
-        args = '--follow-imports=skip'
-    else:  # Safe.
-        args = '--no-incremental'
+files = [
+    'leo/core/leoGlobals.py',
+    'leo/core/leoNodes.py',
+    'leo/core/leoCommands.py',
+    'leo/core/leoAtFile.py',
+    'leo/core/leoKeys.py',
+    'leo/core/leoApp.py',
+    # 'leo/core', # 1400+ errors.
+]
+# Apparently 'strict-optional' doesn't work.
+incremental = False
+incremental_arg = '' if incremental else '--no-incremental'
+args = f"--follow-imports=skip {incremental_arg}"
+files = ' '.join(files)
 command = rf"{python} -m mypy {args} {files}"
 subprocess.Popen(command, shell=True).communicate()
 # @-leo

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -30,7 +30,7 @@ if 0:  # Test all files.
 else:  # Test only specific files.
     files = [
         # The six files to be checked.
-        'leo/core/leoApp.py',  # More complaints.
+        'leo/core/leoApp.py',
         'leo/core/leoAtFile.py',
         'leo/core/leoCommands.py',
         'leo/core/leoKeys.py',  # More complaints.

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -30,15 +30,15 @@ if 0:  # Test all files.
 else:  # Test only specific files.
     files = [
         # The six files to be checked.
-        # 'leo/core/leoApp.py',
-        # 'leo/core/leoAtFile.py',
-        # 'leo/core/leoCommands.py',
-        # 'leo/core/leoKeys.py',
-        # 'leo/core/leoGlobals.py',
-        # 'leo/core/leoNodes.py',
+        'leo/core/leoApp.py',
+        'leo/core/leoAtFile.py',
+        'leo/core/leoCommands.py',
+        'leo/core/leoKeys.py',
+        'leo/core/leoGlobals.py',
+        'leo/core/leoNodes.py',
         # Additional files containing complaints when following imports.
         'leo/plugins/mod_scripting.py',
-        # 'leo/plugins/qt_commands.py',
+        'leo/plugins/qt_commands.py',
         # 'leo/plugins/qt_frame.py',
         # 'leo/plugins/qt_gui.py',
         # 'leo/plugins/qt_idle_time.py',

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -30,12 +30,15 @@ if 0:
     args = ''
     files = 'leo'
 else:
-    files = 'leo/core/leoAtFile.py'  # 64 errors.
+    files = 'leo/core/leoColorizer.py'
     # fail
-    # files = 'leo/core'  # 1363 errors
+    # files = 'leo/core'  # 3000 errors
+
     # pass
-    # 'leo/core/leoNodes.py'
-    #'leo/core/leoGlobals.py'
+    # files = 'leo/core/leoGlobals.py'
+    # files = 'leo/core/leoNodes.py'
+    # files = 'leo/core/leoAtFile.py'
+
     if 1:  # For testing one file.
         args = '--follow-imports=skip'
     else:  # Safe.

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -30,27 +30,27 @@ if 0:  # Test all files.
 else:  # Test only specific files.
     files = [
         # The six files to be checked.
-        'leo/core/leoApp.py',
-        'leo/core/leoAtFile.py',
-        'leo/core/leoCommands.py',
-        'leo/core/leoKeys.py',  # More complaints.
-        'leo/core/leoGlobals.py',
-        'leo/core/leoNodes.py',
+        # 'leo/core/leoApp.py',
+        # 'leo/core/leoAtFile.py',
+        # 'leo/core/leoCommands.py',
+        # 'leo/core/leoKeys.py',
+        # 'leo/core/leoGlobals.py',
+        # 'leo/core/leoNodes.py',
         # Additional files containing complaints when following imports.
         'leo/plugins/mod_scripting.py',
-        'leo/plugins/qt_commands.py',
-        'leo/plugins/qt_frame.py',
-        'leo/plugins/qt_gui.py',
-        'leo/plugins/qt_idle_time.py',
-        'leo/plugins/qt_layout.py',
-        'leo/plugins/qt_text.py',
-        'leo/plugins/qt_tree.py',
-        'leo/plugins/viewrendered.py',
-        'leo/plugins/viewrendered3.py',
+        # 'leo/plugins/qt_commands.py',
+        # 'leo/plugins/qt_frame.py',
+        # 'leo/plugins/qt_gui.py',
+        # 'leo/plugins/qt_idle_time.py',
+        # 'leo/plugins/qt_layout.py',
+        # 'leo/plugins/qt_text.py',
+        # 'leo/plugins/qt_tree.py',
+        # 'leo/plugins/viewrendered.py',
+        # 'leo/plugins/viewrendered3.py',
     ]
 # Apparently 'strict-optional' doesn't work.
 incremental = True
-follow = True  # False: 436 errors. True: 443 errors.
+follow = False  # False: 436 errors. True: 443 errors.
 incremental_arg = '' if incremental else '--no-incremental'
 follow_kind = 'normal' if follow else 'skip'
 args = f"--follow-imports={follow_kind} {incremental_arg}"

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -39,7 +39,7 @@ else:  # Test only specific files.
         # Additional files containing complaints when following imports.
         'leo/plugins/mod_scripting.py',
         'leo/plugins/qt_commands.py',
-        # 'leo/plugins/qt_frame.py',
+        'leo/plugins/qt_frame.py',
         # 'leo/plugins/qt_gui.py',
         # 'leo/plugins/qt_idle_time.py',
         # 'leo/plugins/qt_layout.py',

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -23,11 +23,14 @@ print(os.path.basename(__file__))
 leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
 os.chdir(leo_editor_dir)
 
-args = ' '.join(sys.argv[1:])
+# args = ' '.join(sys.argv[1:])
 python = sys.executable
+files = 'leo/core/leoGlobals.py'
+
 if 1:  # Quick.
-    command = rf"{python} -m mypy leo"
+    args = '--follow-imports=skip'
 else:  # Safe.
-    command = rf"{python} -m mypy --no-incremental leo"
+    args = '--no-incremental'
+command = rf"{python} -m mypy {args} {files}"
 subprocess.Popen(command, shell=True).communicate()
 # @-leo

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -29,16 +29,28 @@ if 0:  # Test all files.
     files = ['leo/core']  # 1054 errors.
 else:  # Test only specific files.
     files = [
-        'leo/core/leoApp.py',
+        # The six files to be checked.
+        'leo/core/leoApp.py',  # More complaints.
         'leo/core/leoAtFile.py',
         'leo/core/leoCommands.py',
-        'leo/core/leoKeys.py',
+        'leo/core/leoKeys.py',  # More complaints.
         'leo/core/leoGlobals.py',
         'leo/core/leoNodes.py',
+        # Additional files containing complaints when following imports.
+        'leo/plugins/mod_scripting.py',
+        'leo/plugins/qt_commands.py',
+        'leo/plugins/qt_frame.py',
+        'leo/plugins/qt_gui.py',
+        'leo/plugins/qt_idle_time.py',
+        'leo/plugins/qt_layout.py',
+        'leo/plugins/qt_text.py',
+        'leo/plugins/qt_tree.py',
+        'leo/plugins/viewrendered.py',
+        'leo/plugins/viewrendered3.py',
     ]
 # Apparently 'strict-optional' doesn't work.
-incremental = False
-follow = False
+incremental = True
+follow = True  # False: 436 errors. True: 443 errors.
 incremental_arg = '' if incremental else '--no-incremental'
 follow_kind = 'normal' if follow else 'skip'
 args = f"--follow-imports={follow_kind} {incremental_arg}"

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -30,12 +30,12 @@ if 0:  # Test all files.
 else:  # Test only specific files.
     # 112 errors.
     files = [
+        'leo/core/leoApp.py',
         'leo/core/leoGlobals.py',
         'leo/core/leoNodes.py',
         'leo/core/leoCommands.py',
         'leo/core/leoAtFile.py',
         'leo/core/leoKeys.py',
-        'leo/core/leoApp.py',
     ]
 # Apparently 'strict-optional' doesn't work.
 incremental = False

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -44,7 +44,7 @@ else:  # Test only specific files.
         'leo/plugins/qt_idle_time.py',
         'leo/plugins/qt_layout.py',
         'leo/plugins/qt_text.py',
-        # 'leo/plugins/qt_tree.py',
+        'leo/plugins/qt_tree.py',
         'leo/plugins/viewrendered.py',
         # 'leo/plugins/viewrendered3.py',
     ]

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -40,7 +40,7 @@ else:  # Test only specific files.
         'leo/plugins/mod_scripting.py',
         'leo/plugins/qt_commands.py',
         'leo/plugins/qt_frame.py',
-        # 'leo/plugins/qt_gui.py',
+        'leo/plugins/qt_gui.py',
         # 'leo/plugins/qt_idle_time.py',
         # 'leo/plugins/qt_layout.py',
         # 'leo/plugins/qt_text.py',

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -41,7 +41,7 @@ else:  # Test only specific files.
         'leo/plugins/qt_commands.py',
         'leo/plugins/qt_frame.py',
         'leo/plugins/qt_gui.py',
-        # 'leo/plugins/qt_idle_time.py',
+        'leo/plugins/qt_idle_time.py',
         # 'leo/plugins/qt_layout.py',
         # 'leo/plugins/qt_text.py',
         # 'leo/plugins/qt_tree.py',

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -50,7 +50,7 @@ else:  # Test only specific files.
     ]
 # Apparently 'strict-optional' doesn't work.
 incremental = True
-follow = False  # False: 436 errors. True: 443 errors.
+follow = True
 incremental_arg = '' if incremental else '--no-incremental'
 follow_kind = 'normal' if follow else 'skip'
 args = f"--follow-imports={follow_kind} {incremental_arg}"

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -43,7 +43,7 @@ else:  # Test only specific files.
         'leo/plugins/qt_gui.py',
         'leo/plugins/qt_idle_time.py',
         'leo/plugins/qt_layout.py',
-        # 'leo/plugins/qt_text.py',
+        'leo/plugins/qt_text.py',
         # 'leo/plugins/qt_tree.py',
         'leo/plugins/viewrendered.py',
         # 'leo/plugins/viewrendered3.py',

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -33,7 +33,7 @@ else:  # Test only specific files.
         'leo/core/leoApp.py',
         'leo/core/leoGlobals.py',
         'leo/core/leoNodes.py',
-        # 'leo/core/leoCommands.py',
+        'leo/core/leoCommands.py',
         # 'leo/core/leoAtFile.py',
         # 'leo/core/leoKeys.py',
     ]

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -25,15 +25,18 @@ os.chdir(leo_editor_dir)
 
 # args = ' '.join(sys.argv[1:])
 python = sys.executable
-files = [
-    'leo/core/leoGlobals.py',
-    'leo/core/leoNodes.py',
-    'leo/core/leoCommands.py',
-    'leo/core/leoAtFile.py',
-    'leo/core/leoKeys.py',
-    'leo/core/leoApp.py',
-    # 'leo/core', # 1400+ errors.
-]
+if 0:  # Test all files.
+    files = ['leo/core']  # 1054 errors.
+else:  # Test only specific files.
+    # 112 errors.
+    files = [
+        'leo/core/leoGlobals.py',
+        'leo/core/leoNodes.py',
+        'leo/core/leoCommands.py',
+        'leo/core/leoAtFile.py',
+        'leo/core/leoKeys.py',
+        'leo/core/leoApp.py',
+    ]
 # Apparently 'strict-optional' doesn't work.
 incremental = False
 incremental_arg = '' if incremental else '--no-incremental'

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -45,7 +45,7 @@ else:  # Test only specific files.
         'leo/plugins/qt_layout.py',
         # 'leo/plugins/qt_text.py',
         # 'leo/plugins/qt_tree.py',
-        # 'leo/plugins/viewrendered.py',
+        'leo/plugins/viewrendered.py',
         # 'leo/plugins/viewrendered3.py',
     ]
 # Apparently 'strict-optional' doesn't work.

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -32,7 +32,7 @@ else:  # Test only specific files.
     files = [
         'leo/core/leoApp.py',
         'leo/core/leoGlobals.py',
-        # 'leo/core/leoNodes.py',
+        'leo/core/leoNodes.py',
         # 'leo/core/leoCommands.py',
         # 'leo/core/leoAtFile.py',
         # 'leo/core/leoKeys.py',

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -32,10 +32,10 @@ passed = (
     'leoKeys.py',
     'leoNodes.py',
 )
-if 0:
+if 1:
     # Test all files
-    args = '--follow-imports=skip'
-    files = 'leo'  # 2742 errors.
+    args = '--follow-imports=skip'  # Apparently 'strict-optional' doesn't work.
+    files = 'leo/core'
 elif 1:  # Test all passed files.
     args = '--follow-imports=skip'
     files = ' '.join(f"leo/core/{z}" for z in passed)

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -28,12 +28,11 @@ python = sys.executable
 if 0:  # Test all files.
     files = ['leo/core']  # 1054 errors.
 else:  # Test only specific files.
-    # 112 errors.
     files = [
         'leo/core/leoApp.py',
+        'leo/core/leoCommands.py',
         'leo/core/leoGlobals.py',
         'leo/core/leoNodes.py',
-        'leo/core/leoCommands.py',
         # 'leo/core/leoAtFile.py',
         # 'leo/core/leoKeys.py',
     ]

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -30,16 +30,18 @@ if 0:  # Test all files.
 else:  # Test only specific files.
     files = [
         'leo/core/leoApp.py',
+        'leo/core/leoAtFile.py',
         'leo/core/leoCommands.py',
+        'leo/core/leoKeys.py',
         'leo/core/leoGlobals.py',
         'leo/core/leoNodes.py',
-        # 'leo/core/leoAtFile.py',
-        # 'leo/core/leoKeys.py',
     ]
 # Apparently 'strict-optional' doesn't work.
 incremental = False
+follow = False
 incremental_arg = '' if incremental else '--no-incremental'
-args = f"--follow-imports=skip {incremental_arg}"
+follow_kind = 'normal' if follow else 'skip'
+args = f"--follow-imports={follow_kind} {incremental_arg}"
 files = ' '.join(files)
 command = rf"{python} -m mypy {args} {files}"
 subprocess.Popen(command, shell=True).communicate()

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -32,10 +32,10 @@ else:  # Test only specific files.
     files = [
         'leo/core/leoApp.py',
         'leo/core/leoGlobals.py',
-        'leo/core/leoNodes.py',
-        'leo/core/leoCommands.py',
-        'leo/core/leoAtFile.py',
-        'leo/core/leoKeys.py',
+        # 'leo/core/leoNodes.py',
+        # 'leo/core/leoCommands.py',
+        # 'leo/core/leoAtFile.py',
+        # 'leo/core/leoKeys.py',
     ]
 # Apparently 'strict-optional' doesn't work.
 incremental = False

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -25,12 +25,21 @@ os.chdir(leo_editor_dir)
 
 # args = ' '.join(sys.argv[1:])
 python = sys.executable
-files = 'leo/core/leoGlobals.py'
-
-if 1:  # Quick.
-    args = '--follow-imports=skip'
-else:  # Safe.
-    args = '--no-incremental'
+if 0:
+    # Test all files
+    args = ''
+    files = 'leo'
+else:
+    files = 'leo/core/leoAtFile.py'  # 64 errors.
+    # fail
+    # files = 'leo/core'  # 1363 errors
+    # pass
+    # 'leo/core/leoNodes.py'
+    #'leo/core/leoGlobals.py'
+    if 1:  # For testing one file.
+        args = '--follow-imports=skip'
+    else:  # Safe.
+        args = '--no-incremental'
 command = rf"{python} -m mypy {args} {files}"
 subprocess.Popen(command, shell=True).communicate()
 # @-leo

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -1019,8 +1019,8 @@ class TestFind(LeoUnitTest):
     def test_switch_style(self):
         x = self.x
         table = (
-            ('', None),
-            ('TestClass', None),
+            ('', ''),  # #4755
+            ('TestClass', ''),  # #4755
             ('camelCase', 'camel_case'),
             ('under_score', 'underScore'),
         )


### PR DESCRIPTION
This PR enforces mypy's strict_optional setting on Leo's core files.
Future PRs will do the same for leo/commands and Leo's Qt gui.

- [x] Remove g.execute_shell_command_with_options. It was a total mess.
- [x] Fix all mypy complaints in the following six core files:
    - [x] `leoApp.py`.
    - [x] `leoAtFile.py`.
    - [x] `leoCommands.py`.
    - [x] `leoGlobals.py`.
    - [x] `leoKeys.py`.
    - [x] `leoNodes.py`.
- [x] Fix all mypy complaints found with `--follow-imports`:
    - [x] 'leo/plugins/mod_scripting.py',
    - [x] 'leo/plugins/qt_commands.py',
    - [x] 'leo/plugins/qt_frame.py',
    - [x] 'leo/plugins/qt_gui.py',
    - [x] 'leo/plugins/qt_idle_time.py',
    - [x] 'leo/plugins/qt_layout.py',
    - [x]  'leo/plugins/qt_text.py',
    - [x] 'leo/plugins/qt_tree.py',
    - [x] 'leo/plugins/viewrendered.py',
    - [x] 'leo/plugins/viewrendered3.py',
- [x] Rev 5b17fa6 revises `c.currentPosition()` and `c.rootPosition` so they always return Positions.
       These methods may return a position `p` with `p.v == None`, but that's no worse than returning `None`!
- [x] Fix mypy complaints in other files as necessary, but without following imports.
- [x] Use the empty string instead of None as the default return for (almost) all methods in the files above.
    Exception: `s: str | None = None` is *essential* for some text-related methods!
    Rev ad72009 adds important comments.
- [x] Resolve all of Thomas's suggestions.
- [ ] Search for `x is None:` everywhere, changing them to `not x:` if necessary.
- [ ] Search for `x is not None:` everywhere, changing them to `x:` if necessary.
- [ ] Revert code that handles command history, tab completion, and find completion.

**Testing**

 - [x]  Check all callers of methods that now return only `str` (instead of `str | None`).
- [x] Fix Control-clicking on URLs.
- [x] Check that find-string completion works as before.
- [x] Rev f6a5745c4: Fix the find commands! The culprit: rev 45b17a3e39.
- [x] Rev 164af56: Fix an improbable bug  `p._parentVnode`. It must *always* return a `Position`!
- [x] Rev ad72009: Fix a devastating text bug! The culprit: rev 4e5d2306c.
- [ ] (For EKR): Review all diffs with git-diff-pr.