### PR TITLE
Boltex/issue4758

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -429,7 +429,9 @@ def refreshFromDisk(
     at.changed_roots = []
     c.fileCommands.handleNodeConflicts()
     c.setChanged()
-    c.redraw()
+    # We may be coming from idle_check_commander and not already have p selected, 
+    # if the selected position was inside the expanded & refreshed outline, it may not be valid.
+    c.redraw(update_p)  # Select a valid update_p position or p
     c.undoer.clearAndWarn('refresh-from-disk')
 
 

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -186,6 +186,7 @@ class ExternalFilesController:
         # #1134: Nested @<file> nodes are no longer valid, but this will do no harm.
         changed = False
         state = 'no'
+        changed_roots: set[str] = set()
         for p in c.all_unique_positions():
             if not p.isAnyAtFileNode():
                 continue
@@ -215,6 +216,7 @@ class ExternalFilesController:
                         p2.v.setDirty()
                 # #4565: set all ancestor file nodes dirty and redraw.
                 p.v.setDirty()
+                changed_roots.add(p.h)
                 to_do_set: set[VNode] = set()
                 for p2 in c.all_positions():
                     if p2.v.isDirty():
@@ -224,10 +226,6 @@ class ExternalFilesController:
             return
         # #4570: Write all update messages here, and only here.
         if not g.unitTesting:
-            changed_roots: set[str] = set()
-            for p2 in c.all_positions():
-                if p2.isAnyAtFileNode() and p2.isDirty():
-                    changed_roots.add(p2.h)
             for s in sorted(list(changed_roots)):
                 g.es_print('update:', s, color='blue')
         c.redraw()

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2663,7 +2663,7 @@ class VNode:
     def contentModified(self) -> None:
         g.contentModifiedSet.add(self)
 
-    # @+node:ekr.20260622103203.1: *4* v.findAllAncetorAtFileNodes
+    # @+node:ekr.20260622103203.1: *4* v.findAllAncestorAtFileNodes
     def findAllAncestorAtFileNodes(self, *, to_do_set: set[VNode] = None) -> list[VNode]:
         """
         Return a list of all @<file> nodes containing this VNode.

--- a/leo/plugins/writers/markdown.py
+++ b/leo/plugins/writers/markdown.py
@@ -19,9 +19,7 @@ class MarkdownWriter(basewriter.BaseWriter):
         """Write all the *descendants* of an @auto-markdown node."""
         self.root = root
         self.write_root(root)
-        count = 0
         for p in root.subtree():
-            count += 1
             if g.app.force_at_auto_sentinels:  # pragma: no cover
                 self.put_node_sentinel(p, '<!--', delim2='-->')
             if self.placeholder_regex.match(p.h):


### PR DESCRIPTION
Fixed possible external files outline refreshing errors when selected node was inside an @file or @auto outline. (Caused by leaving c.p to be a non-existent node after refreshing from disk)

Also fixed changed nodes reporting so that they do not print out headlines of external files that just hapened to be dirty when that refreshed occured (from a prior refresh or user editing, etc. )