### PR TITLE
PR one for #4766: require strict_optional in leoNodes.py

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -39,6 +39,12 @@ exclude =
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 
+# #4766: more specific descriptions override less specific.
+[mypy-leo.core.leoNodes]
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+strict_optional = True
+
 # The default leo.commands: full annotation.
 [mypy-leo.commands.*]
 disallow_untyped_defs = True

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1589,7 +1589,6 @@ class Commands:
         As a result, c.p.copy() is never necessary.
         """
         c = self
-        # strict_optional
         return c._currentPosition.copy() if c._currentPosition else c.rootPosition()
 
     # For compatibility with old scripts...
@@ -2025,9 +2024,12 @@ class Commands:
     _rootCount = 0
 
     def rootPosition(self) -> Position:
-        """Return a new *copy* of the root position."""
+        """
+        Return a new *copy* of the root position.
+
+        This may return an empty Position (with p.v == None) during startup.
+        """
         c = self
-        # strict_optional
         v = c.hiddenRootNode.children[0] if c.hiddenRootNode.children else cast(VNode, None)
         return Position(v=v, childIndex=0, stack=None)
 

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2055,7 +2055,7 @@ class Commands:
         return False
 
     # @+node:ekr.20070609122713: *5* c.visLimit
-    def visLimit(self) -> tuple[None, None] | tuple[Position, bool]:
+    def visLimit(self) -> tuple[Position | None, bool]:
         """
         Return the topmost visible node.
         This is affected by chapters and hoists.
@@ -2067,7 +2067,7 @@ class Commands:
             p = bunch.p
             limitIsVisible = not cc or not p.h.startswith('@chapter')
             return p, limitIsVisible
-        return None, None
+        return None, False
 
     # @+node:tbrown.20091206142842.10296: *5* c.vnode2allPositions
     def vnode2allPositions(self, v: VNode) -> list[Position]:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2027,7 +2027,12 @@ class Commands:
         """
         Return a new *copy* of the root position.
 
-        This may return an empty Position (with p.v == None) during startup.
+        New in Leo 6.8.10: Return an empty Position (p.v == None) instead of None.
+
+        No valid existing code will break because the only valid tests for Positions are:
+
+            if p:
+            if not p:
         """
         c = self
         v = c.hiddenRootNode.children[0] if c.hiddenRootNode.children else cast(VNode, None)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -5445,7 +5445,7 @@ class Commands:
                 op, p, n = z
                 ok = (
                     op in ('insert', 'delete')
-                    and isinstance(p, Position)  # #4744: bug fix.
+                    and isinstance(p, Position)  # PR #4767: bug fix.
                     and isinstance(n, int)
                 )
                 if ok:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -15,14 +15,15 @@ import tabnanny
 import tempfile
 import time
 import tokenize
-from typing import Any, Generator, Iterable, Sequence, TYPE_CHECKING
+from typing import cast, Any, Generator, Iterable, Sequence, TYPE_CHECKING
 import xml.etree.ElementTree as ElementTree
 
 from leo.core import leoGlobals as g
 
 # The leoCommands ctor now does most leo.core.leo* imports,
 # thereby breaking circular dependencies.
-from leo.core import leoNodes
+### from leo.core import leoNodes
+from leo.core.leoNodes import Position, VNode
 
 # @-<< leoCommands imports >>
 # @+<< leoCommands annotations >>
@@ -31,7 +32,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoApp import PreviousSettings
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoConfig import LocalConfigManager
-    from leo.core.leoNodes import Position, VNode
 
     # 11 subcommanders...
     from leo.core.leoAtFile import AtFile
@@ -287,7 +287,7 @@ class Commands:
     # @+node:ekr.20120217070122.10470: *5* c.initObjects
     def initObjects(self, gui: LeoGui) -> None:
         c = self
-        self.hiddenRootNode = leoNodes.VNode(context=c, gnx='hidden-root-vnode-gnx')
+        self.hiddenRootNode = VNode(context=c, gnx='hidden-root-vnode-gnx')
         self.hiddenRootNode.h = '<hidden root vnode>'
         # Create the gui frame.
         title = c.computeTabTitle()
@@ -1479,7 +1479,7 @@ class Commands:
         if stack is None:
             stack = []
 
-        if not isinstance(v, leoNodes.VNode):
+        if not isinstance(v, VNode):
             g.es_print(f"not a VNode: {v!r}")
             return  # Stop the generator.
 
@@ -1492,7 +1492,7 @@ class Commands:
         def stack2pos(stack: list[tuple]) -> Position:
             """Convert the stack to a position."""
             v, i = stack[-1]
-            return leoNodes.Position(v, i, stack[:-1])
+            return Position(v, i, stack[:-1])
 
         for v2 in set(v.parents):
             for i in allinds(v2, v):
@@ -1586,14 +1586,11 @@ class Commands:
     def currentPosition(self) -> Position:
         """
         Return a copy of the presently selected position or None.
-        So c.p.copy() is never necessary.
+        As a result, c.p.copy() is never necessary.
         """
         c = self
-        if getattr(c, '_currentPosition', None):
-            # *Always* return a copy.
-            return c._currentPosition.copy()
-        # Returns a new copy of the root position or None
-        return c.rootPosition()
+        # strict_optional
+        return c._currentPosition.copy() if c._currentPosition else c.rootPosition()
 
     # For compatibility with old scripts...
 
@@ -2027,13 +2024,12 @@ class Commands:
     # @+node:ekr.20040803140033.2: *5* c.rootPosition
     _rootCount = 0
 
-    def rootPosition(self) -> Position | None:
-        """Return a new *copy* of the root position or None."""
+    def rootPosition(self) -> Position:
+        """Return a new *copy* of the root position."""
         c = self
-        if c.hiddenRootNode.children:
-            v = c.hiddenRootNode.children[0]
-            return leoNodes.Position(v, childIndex=0, stack=None)
-        return None
+        # strict_optional
+        v = c.hiddenRootNode.children[0] if c.hiddenRootNode.children else cast(VNode, None)
+        return Position(v=v, childIndex=0, stack=None)
 
     # For compatibility with old scripts...
 
@@ -2100,7 +2096,7 @@ class Commands:
                 immediate = parent
             else:
                 v, n = stack.pop()
-                p = leoNodes.Position(v, n, stack)
+                p = Position(v, n, stack)
                 positions.append(p)
         return positions
 
@@ -2126,7 +2122,7 @@ class Commands:
             # a VNode not in the tree
             return None
         v, n = stack.pop()
-        p = leoNodes.Position(v, n, stack)
+        p = Position(v, n, stack)
         return p
 
     # @+node:ekr.20090130135126.1: *4* c.Properties
@@ -5449,7 +5445,7 @@ class Commands:
                 op, p, n = z
                 ok = (
                     op in ('insert', 'delete')
-                    and isinstance(p, leoNodes.position)
+                    and isinstance(p, Position)  # #4744: bug fix.
                     and isinstance(n, int)
                 )
                 if ok:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -563,7 +563,9 @@ class Position:
 
     # @+node:ekr.20161120163203.1: *4* p.nearest_unique_roots (aka p.nearest)
     def nearest_unique_roots(
-        self, copy: bool = True, predicate: Callable | None = None
+        self,
+        copy: bool = True,
+        predicate: Callable | None = None,
     ) -> Generator:
         """
         A generator yielding all unique root positions "near" p1 = self that

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -159,7 +159,7 @@ class NodeIndices:
             g.error("scanGnx: unexpected index type:", type(s), '', s)
             return None, None, None
         s = s.strip()
-        theId, t, n = None, None, None
+        theId, t, n = '', '', ''  # PR #4767
         i, theId = g.skip_to_char(s, 0, '.')
         if g.match(s, i, '.'):
             i, t = g.skip_to_char(s, i + 1, '.')
@@ -221,7 +221,7 @@ class NodeIndices:
             return  # the gnx is not well formed or n in ('',None)
         if id_ == self.userId and t == self.timeString:
             try:
-                n2 = int(n)
+                n2 = int(n)  # type:ignore
                 if n2 > self.lastIndex:
                     self.lastIndex = n2
                     if not g.unitTesting:
@@ -348,6 +348,8 @@ class Position:
     def archive(self) -> dict[str, Value] | None:
         """Return a json-like archival dictionary for p/v.unarchive."""
         p = self
+        if not p.v:
+            return None  # PR #4767
         c = p.v.context
 
         # Create an *initial* list of all vnodes in p.self_and_subtree.
@@ -723,7 +725,8 @@ class Position:
 
     # @+node:ekr.20040323160302: *5* p.directParents
     def directParents(self) -> list[VNode]:
-        return self.v.directParents()
+        p = self
+        return p.v.directParents() if p.v else []
 
     # @+node:ekr.20040306214240.3: *5* p.hasChildren & p.numberOfChildren
     def hasChildren(self) -> bool:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1292,7 +1292,7 @@ class Position:
         """
         Return the parent VNode or p.v.hiddenRootNode.
         """
-        trace = True and not g.unitTesting
+        trace = True  ### and not g.unitTesting
         tag = 'p._parentVnode'
         p = self
         c = p.v.context
@@ -1303,9 +1303,11 @@ class Position:
                 if trace and v == p.v.context.hiddenRootNode:
                     g.print_unique_message(f"{tag} {'Hidden':9} {c.shortFileName()} {g.callers(2)}")
                 return v
+            return c.hiddenRootNode
         if trace:
             g.print_unique_message(f"{tag} {'Not found':9} {c.shortFileName()} {g.callers(2)}")
-        return c.hiddenRootNode  # PR 4767 # Bug fix! 2026/07/01
+        return None  ### Legacy.
+        # return c.hiddenRootNode  # PR 4767 #### Experimental!!!
 
     # @+node:ekr.20131219220412.16582: *4* p._relinkAsCloneOf
     def _relinkAsCloneOf(self, p2: Position) -> None:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1686,9 +1686,10 @@ class Position:
 
     def copyTreeFromSelfTo(self, p2: Position, copyGnxs: bool = False) -> None:
         p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p2.v  # Silence mypy warning that p2.v may be None.
         p2.v._headString = g.toUnicode(p.h, reportErrors=True)  # 2017/01/24
         p2.v._bodyString = g.toUnicode(p.b, reportErrors=True)  # 2017/01/24
-        #
         # #1019794: p.copyTreeFromSelfTo, should deepcopy p.v.u.
         p2.v.u = copy.deepcopy(p.v.u)
         if copyGnxs:
@@ -1705,6 +1706,7 @@ class Position:
         The new vnode is complete copy of v and all its descendants.
         """
         p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
         return Position(v=p.v.copyTree(copyMarked))
 
     # @+node:peckj.20131023115434.10115: *4* p.createNodeHierarchy
@@ -1723,7 +1725,9 @@ class Position:
                       If True, will create nodes regardless of existing nodes
         returns the final position ('baz' in the above example)
         """
-        c = self.v.context
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        c = p.v.context
         return c.createNodeHierarchy(heads, parent=self, forcecreate=forcecreate)
 
     # @+node:ekr.20131230090121.16552: *4* p.deleteAllChildren
@@ -1764,6 +1768,7 @@ class Position:
         Returns the newly created position.
         """
         p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
         context = p.v.context
         p2 = self.copy()
         p2.v = VNode(context=context)
@@ -1801,6 +1806,7 @@ class Position:
         Returns the newly created position.
         """
         p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
         context = p.v.context
         p2 = self.copy()
         p2.v = VNode(context=context)

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -759,7 +759,7 @@ class Position:
     # @+node:ekr.20060920203352: *4* p.findRootPosition
     def findRootPosition(self) -> Position:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         c = p.v.context
         return c.rootPosition()
 
@@ -774,7 +774,7 @@ class Position:
         Not used in Leo's core or official plugins.
         """
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         c = p.v.context
         file_part = c.fileName()
         return 'unl:gnx:' + f"//{file_part}#{self.gnx}"
@@ -787,7 +787,7 @@ class Position:
         Not used in Leo's core or official plugins.
         """
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         c = p.v.context
         path_part = '-->'.join(list(reversed([z.h for z in self.self_and_parents(copy=False)])))
         return 'unl:' + f"//{c.fileName()}#{path_part}"
@@ -802,7 +802,7 @@ class Position:
         LeoTree.set_status_line will call this method if legacy unls are in effect.
         """
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         c = p.v.context
         path_part = '-->'.join(list(reversed([z.h for z in self.self_and_parents()])))
         full = c.config.getBool('full-unl-paths', default=False)
@@ -817,7 +817,7 @@ class Position:
         Not used in Leo's core or official plugins.
         """
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         c = p.v.context
         file_part = os.path.basename(c.fileName())
         return 'unl:gnx:' + f"//{file_part}#{self.gnx}"
@@ -830,7 +830,7 @@ class Position:
         Not used in Leo's core or official plugins.
         """
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         c = p.v.context
         file_part = os.path.basename(c.fileName())
         path_part = '-->'.join(list(reversed([z.h for z in self.self_and_parents(copy=False)])))
@@ -848,7 +848,7 @@ class Position:
         LeoTree.set_status_line calls this method if gnx-based unls are in effect.
         """
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         c = p.v.context
         full = c.config.getBool('full-unl-paths', default=False)
         file_part = c.fileName() if full else os.path.basename(c.fileName())
@@ -953,7 +953,7 @@ class Position:
     def isAncestorOf(self, p2: Position) -> bool:
         """Return True if p is one of the direct ancestors of p2."""
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         c = p.v.context
         if not c.positionExists(p2):
             return False
@@ -968,7 +968,7 @@ class Position:
     # @+node:ekr.20040306215056: *4* p.isCloned
     def isCloned(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         return p.v.isCloned()
 
     # @+node:ekr.20040307104131.2: *4* p.isRoot
@@ -1076,54 +1076,56 @@ class Position:
 
     # @+node:ekr.20040306210951: *4* p.VNode proxies
     # @+node:ekr.20040306211032: *5* p.Comparisons
+    # PR #4767: the asserts below suppress mypy warnings.
+
     def anyAtFileNodeName(self) -> str:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.anyAtFileNodeName()
 
     def atAutoNodeName(self) -> str:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.atAutoNodeName()
 
     def atCleanNodeName(self) -> str:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.atCleanNodeName()
 
     def atEditNodeName(self) -> str:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.atEditNodeName()
 
     def atFileNodeName(self) -> str:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.atFileNodeName()
 
     def atLeoNodeName(self) -> str:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.atLeoNodeName()
 
     def atNoSentinelsFileNodeName(self) -> str:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.atNoSentinelsFileNodeName()
 
     def atShadowFileNodeName(self) -> str:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.atShadowFileNodeName()
 
     def atSilentFileNodeName(self) -> str:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.atSilentFileNodeName()
 
     def atThinFileNodeName(self) -> str:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.atThinFileNodeName()
 
     # New names, less confusing
@@ -1132,82 +1134,82 @@ class Position:
 
     def isAnyAtFileNode(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isAnyAtFileNode()
 
     def isAtAllNode(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isAtAllNode()
 
     def isAtAutoNode(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isAtAutoNode()
 
     def isAtAutoRstNode(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isAtAutoRstNode()
 
     def isAtCleanNode(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isAtCleanNode()
 
     def isAtEditNode(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isAtEditNode()
 
     def isAtFileNode(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isAtFileNode()
 
     def isAtJupytextNode(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isAtJupytextNode()
 
     def isAtIgnoreNode(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isAtIgnoreNode()
 
     def isAtLeoNode(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isAtLeoNode()
 
     def isAtNoSentinelsFileNode(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isAtNoSentinelsFileNode()
 
     def isAtOthersNode(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isAtOthersNode()
 
     def isAtRstFileNode(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isAtRstFileNode()
 
     def isAtSilentFileNode(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isAtSilentFileNode()
 
     def isAtShadowFileNode(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isAtShadowFileNode()
 
     def isAtThinFileNode(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isAtThinFileNode()
 
     # New names, less confusing:
@@ -1218,49 +1220,51 @@ class Position:
 
     def matchHeadline(self, pattern: str) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         return p.v.matchHeadline(pattern)
 
     # @+node:ekr.20040306220230: *5* p.Headline & body strings
     def bodyString(self) -> str:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         return p.v.bodyString()
 
     def headString(self) -> str:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         return p.v.headString()
 
     # @+node:ekr.20040306214401: *5* p.Status bits
+    # PR #4767: the asserts below suppress mypy warnings.
+
     def isDirty(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isDirty()
 
     def isMarked(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isMarked()
 
     def isOrphan(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isOrphan()
 
     def isSelected(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isSelected()
 
     def isVisited(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.isVisited()
 
     def status(self) -> int:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         return p.v.status()
 
     # @+node:ekr.20080423062035.1: *3* p.Low level methods
@@ -1308,7 +1312,7 @@ class Position:
         p.stack = p_after.stack[:]
         p._childIndex = p_after._childIndex + 1
         child = p.v
-        assert child  # Silence mypy warning that p.v may be None.
+        assert child  # PR #4767: suppress mypy warning.
         n = p_after._childIndex + 1
         child._addLink(n, parent_v)
 
@@ -1320,7 +1324,7 @@ class Position:
         p.stack = p_after.stack[:]
         p._childIndex = p_after._childIndex + 1
         child = p.v
-        assert child  # Silence mypy warning that p.v may be None.
+        assert child  # PR #4767: suppress mypy warning.
         n = p_after._childIndex + 1
         child._addCopiedLink(n, parent_v)
 
@@ -1329,12 +1333,12 @@ class Position:
         """Link self as the n'th child of the parent."""
         p = self
         parent_v = parent.v
-        assert parent_v  # Silence mypy warning that parent_v may be None.
+        assert parent_v  # PR #4767: suppress mypy warning.
         p.stack = parent.stack[:]
         p.stack.append((parent_v, parent._childIndex))
         p._childIndex = n
         child = p.v
-        assert child  # Silence mypy warning that p.v may be None.
+        assert child  # PR #4767: suppress mypy warning.
         child._addLink(n, parent_v)
 
     # @+node:ekr.20180709180140.1: *4* p._linkCopiedAsNthChild
@@ -1342,12 +1346,12 @@ class Position:
         """Link a copied self as the n'th child of the parent."""
         p = self
         parent_v = parent.v
-        assert parent_v  # Silence mypy warning that parent_v may be None.
+        assert parent_v  # PR #4767: suppress mypy warning.
         p.stack = parent.stack[:]
         p.stack.append((parent_v, parent._childIndex))
         p._childIndex = n
         child = p.v
-        assert child  # Silence mypy warning that p.v may be None.
+        assert child  # PR #4767: suppress mypy warning.
         child._addCopiedLink(n, parent_v)
 
     # @+node:ekr.20080416161551.216: *4* p._linkAsRoot
@@ -1395,7 +1399,7 @@ class Position:
         v, v2 = p.v, p2.v
         tag = 'p._relinkAsCloneOf'
         parent_v = p._parentVnode()
-        # Silence mypy warnings...
+        # PR #4767: suppress mypy warnings...
         assert v2, f"{tag} no v2: {p2!r} callers: {g.callers()}"
         assert parent_v, f"{tag} no parent_v: {parent_v!r} callers: {g.callers()}"
         assert parent_v.children, f"{tag} no children: {parent_v!r} callers: {g.callers()}"
@@ -1410,7 +1414,7 @@ class Position:
         n = p._childIndex
         parent_v = p._parentVnode()  # PR #4767 # May throw ValueError
         child = p.v
-        # Silence mypy warnings...
+        # PR #4767: suppress mypy warnings...
         assert p.v
         assert parent_v
         assert child
@@ -1597,7 +1601,7 @@ class Position:
             else:
                 p.moveToParent()  # Same as p.moveToThreadBack()
             if p:
-                assert p  # Silence mypy warning that p.v may be None.
+                assert p  # PR #4767: suppress mypy warning.
                 if limit:
                     done, val = self.checkVisBackLimit(limit, limitIsVisible, p)
                     if done:
@@ -1614,7 +1618,7 @@ class Position:
         p: Position,
     ) -> tuple[bool, Position | None]:
         """Return done, p or None"""
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         c = p.v.context
         if limit == p:
             if limitIsVisible and p.isVisible(c):
@@ -1666,7 +1670,7 @@ class Position:
     def copy(self) -> Position:
         """ "Return an independent copy of a position."""
         p = self
-        assert p.v, g.callers()  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         return Position(p.v, p._childIndex, p.stack)
 
     # @+node:ekr.20040303175026.9: *4* p.copyTreeAfter, copyTreeTo
@@ -1684,8 +1688,9 @@ class Position:
 
     def copyTreeFromSelfTo(self, p2: Position, copyGnxs: bool = False) -> None:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
-        assert p2.v  # Silence mypy warning that p2.v may be None.
+        # PR #4767: suppress mypy warnings.
+        assert p.v
+        assert p2.v
         p2.v._headString = g.toUnicode(p.h, reportErrors=True)  # 2017/01/24
         p2.v._bodyString = g.toUnicode(p.b, reportErrors=True)  # 2017/01/24
         # #1019794: p.copyTreeFromSelfTo, should deepcopy p.v.u.
@@ -1704,7 +1709,7 @@ class Position:
         The new vnode is complete copy of v and all its descendants.
         """
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         return Position(v=p.v.copyTree(copyMarked))
 
     # @+node:peckj.20131023115434.10115: *4* p.createNodeHierarchy
@@ -1724,7 +1729,7 @@ class Position:
         returns the final position ('baz' in the above example)
         """
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         c = p.v.context
         return c.createNodeHierarchy(heads, parent=self, forcecreate=forcecreate)
 
@@ -1766,7 +1771,7 @@ class Position:
         Returns the newly created position.
         """
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         context = p.v.context
         p2 = self.copy()
         p2.v = VNode(context=context)
@@ -1804,7 +1809,7 @@ class Position:
         Returns the newly created position.
         """
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         context = p.v.context
         p2 = self.copy()
         p2.v = VNode(context=context)
@@ -1834,7 +1839,7 @@ class Position:
     # @+node:ekr.20040310062332.1: *4* p.invalidOutline
     def invalidOutline(self, message: str) -> None:  # pragma: no cover
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         if p.hasParent():
             node = p.parent()
         else:
@@ -1887,7 +1892,7 @@ class Position:
     def promote(self) -> None:
         """A low-level promote helper."""
         p = self  # Do NOT copy the position.
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         parent_v = p._parentVnode()  # PR #4767 # May throw ValueError
         children = p.v.children
         # Add the children to parent_v's children.
@@ -1997,7 +2002,7 @@ class Position:
     # @+node:ekr.20090215165030.3: *4* p.gnx property
     def __get_gnx(self) -> str:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         return p.v.fileIndex
 
     gnx = property(
@@ -2008,7 +2013,7 @@ class Position:
     # @+node:ekr.20140203082618.15486: *4* p.script property
     def __get_script(self) -> str:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         return g.getScript(
             p.v.context,
             p,
@@ -2035,12 +2040,12 @@ class Position:
     # @+node:ekr.20160129073222.1: *4* p.u Property
     def __get_u(self) -> Value:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         return p.v.u
 
     def __set_u(self, val: Value) -> None:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         p.v.u = val
 
     u = property(__get_u, __set_u, doc="p.u property")
@@ -2051,14 +2056,14 @@ class Position:
     def contract(self) -> None:
         """Contract p.v and clear p.v.expandedPositions list."""
         p, v = self, self.v
-        assert v  # Silence mypy warning that p.v may be None.
+        assert v  # PR #4767: suppress mypy warning.
         v.expandedPositions = [z for z in v.expandedPositions if z != p]
         v.contract()
 
     def expand(self) -> None:
         p = self
         v = self.v
-        assert v  # Silence mypy warning that p.v may be None.
+        assert v  # PR #4767: suppress mypy warning.
         v.expandedPositions = [z for z in v.expandedPositions if z != p]
         for p2 in v.expandedPositions:
             if p == p2:
@@ -2069,7 +2074,7 @@ class Position:
 
     def isExpanded(self) -> bool:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         if p.isCloned():
             c = p.v.context
             return c.shouldBeExpanded(p)
@@ -2079,60 +2084,62 @@ class Position:
     # Clone bits are no longer used.
     # Dirty bits are handled carefully by the position class.
 
+    # PR #4767: the asserts below suppress mypy warnings.
+
     def clearMarked(self) -> None:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         p.v.clearMarked()
 
     def clearOrphan(self) -> None:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         p.v.clearOrphan()
 
     def clearVisited(self) -> None:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         p.v.clearVisited()
 
     def initExpandedBit(self) -> None:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         p.v.initExpandedBit()
 
     def initMarkedBit(self) -> None:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         p.v.initMarkedBit()
 
     def initStatus(self, status: int) -> None:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         p.v.initStatus(status)
 
     def setMarked(self) -> None:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         p.v.setMarked()
 
     def setOrphan(self) -> None:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         p.v.setOrphan()
 
     def setSelected(self) -> None:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         p.v.setSelected()
 
     def setVisited(self) -> None:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v
         p.v.setVisited()
 
     # @+node:ekr.20040306220634.8: *5* p.computeIcon & p.setIcon
     def computeIcon(self) -> int:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         return p.v.computeIcon()
 
     def setIcon(self) -> None:
@@ -2141,24 +2148,24 @@ class Position:
     # @+node:ekr.20040306220634.29: *5* p.setSelection
     def setSelection(self, start: int, length: int) -> None:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         p.v.setSelection(start, length)
 
     # @+node:ekr.20100303074003.5637: *5* p.restore/saveCursorAndScroll
     def restoreCursorAndScroll(self) -> None:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         p.v.restoreCursorAndScroll()
 
     def saveCursorAndScroll(self) -> None:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         p.v.saveCursorAndScroll()
 
     # @+node:ekr.20040315034158: *4* p.setBodyString & setHeadString
     def setBodyString(self, s: bytes | str) -> None:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         p.v.setBodyString(s)
 
     initBodyString = setBodyString
@@ -2167,12 +2174,12 @@ class Position:
 
     def initHeadString(self, s: bytes | str) -> None:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         p.v.initHeadString(s)
 
     def setHeadString(self, s: bytes | str) -> None:
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         p.v.initHeadString(s)
         p.setDirty()
 
@@ -2195,7 +2202,7 @@ class Position:
     def clearDirty(self) -> None:
         """(p) Set p.v dirty."""
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         p.v.clearDirty()
 
     # @+node:ekr.20040702104823: *5* p.inAtIgnoreRange
@@ -2213,7 +2220,7 @@ class Position:
         Set all ancestor @<file> nodes dirty, including ancestors of all clones of p.
         """
         p = self
-        assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # PR #4767: suppress mypy warning.
         p.v.setAllAncestorAtFileNodesDirty()
 
     # @+node:ekr.20040303163330: *5* p.setDirty

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -774,9 +774,11 @@ class Position:
         Not used in Leo's core or official plugins.
         """
         p = self
-        c = p.v.context
-        file_part = c.fileName()
-        return 'unl:gnx:' + f"//{file_part}#{self.gnx}"
+        if v := p.v:
+            c = v.context
+            file_part = c.fileName()
+            return 'unl:gnx:' + f"//{file_part}#{self.gnx}"
+        raise ValueError(f"findRootPosition: empty p. {g.callers()}")
 
     # @+node:tbrown.20111010104549.26758: *5* p.get_full_legacy_UNL
     def get_full_legacy_UNL(self) -> str:
@@ -786,9 +788,12 @@ class Position:
         Not used in Leo's core or official plugins.
         """
         p = self
-        c = p.v.context
-        path_part = '-->'.join(list(reversed([z.h for z in self.self_and_parents(copy=False)])))
-        return 'unl:' + f"//{c.fileName()}#{path_part}"
+        if v := p.v:
+            c = v.context
+            path_part = '-->'.join(list(reversed([z.h for z in self.self_and_parents(copy=False)])))
+            return 'unl:' + f"//{c.fileName()}#{path_part}"
+
+        raise ValueError(f"findRootPosition: empty p. {g.callers()}")
 
     # @+node:ekr.20230628173542.1: *5* p.get_legacy_UNL
     def get_legacy_UNL(self) -> str:
@@ -800,11 +805,13 @@ class Position:
         LeoTree.set_status_line will call this method if legacy unls are in effect.
         """
         p = self
-        c = p.v.context
-        path_part = '-->'.join(list(reversed([z.h for z in self.self_and_parents()])))
-        full = c.config.getBool('full-unl-paths', default=False)
-        file_part = c.fileName() if full else os.path.basename(c.fileName())
-        return 'unl:' + f"//{file_part}#{path_part}"
+        if v := p.v:
+            c = v.context
+            path_part = '-->'.join(list(reversed([z.h for z in self.self_and_parents()])))
+            full = c.config.getBool('full-unl-paths', default=False)
+            file_part = c.fileName() if full else os.path.basename(c.fileName())
+            return 'unl:' + f"//{file_part}#{path_part}"
+        raise ValueError(f"findRootPosition: empty p. {g.callers()}")
 
     # @+node:ekr.20230628175148.1: *5* p.get_short_gnx_UNL
     def get_short_gnx_UNL(self) -> str:
@@ -814,9 +821,11 @@ class Position:
         Not used in Leo's core or official plugins.
         """
         p = self
-        c = p.v.context
-        file_part = os.path.basename(c.fileName())
-        return 'unl:gnx:' + f"//{file_part}#{self.gnx}"
+        if v := p.v:
+            c = v.context
+            file_part = os.path.basename(c.fileName())
+            return 'unl:gnx:' + f"//{file_part}#{self.gnx}"
+        raise ValueError(f"findRootPosition: empty p. {g.callers()}")
 
     # @+node:ekr.20230628174804.1: *5* p.get_short_legacy_UNL
     def get_short_legacy_UNL(self) -> str:
@@ -826,10 +835,12 @@ class Position:
         Not used in Leo's core or official plugins.
         """
         p = self
-        c = p.v.context
-        file_part = os.path.basename(c.fileName())
-        path_part = '-->'.join(list(reversed([z.h for z in self.self_and_parents(copy=False)])))
-        return 'unl:' + f"//{file_part}#{path_part}"
+        if v := p.v:
+            c = v.context
+            file_part = os.path.basename(c.fileName())
+            path_part = '-->'.join(list(reversed([z.h for z in self.self_and_parents(copy=False)])))
+            return 'unl:' + f"//{file_part}#{path_part}"
+        raise ValueError(f"findRootPosition: empty p. {g.callers()}")
 
     # @+node:ekr.20230624171452.1: *5* p.get_UNL
     def get_UNL(self) -> str:
@@ -843,10 +854,12 @@ class Position:
         LeoTree.set_status_line calls this method if gnx-based unls are in effect.
         """
         p = self
-        c = p.v.context
-        full = c.config.getBool('full-unl-paths', default=False)
-        file_part = c.fileName() if full else os.path.basename(c.fileName())
-        return 'unl:gnx:' + f"//{file_part}#{self.gnx}"
+        if v := p.v:
+            c = v.context
+            full = c.config.getBool('full-unl-paths', default=False)
+            file_part = c.fileName() if full else os.path.basename(c.fileName())
+            return 'unl:gnx:' + f"//{file_part}#{self.gnx}"
+        raise ValueError(f"findRootPosition: empty p. {g.callers()}")
 
     # @+node:ekr.20031218072017.915: *4* p.getX & VNode compatibility traversal routines
     # These methods are useful abbreviations.

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -11,7 +11,7 @@ import os
 import re
 import time
 import uuid
-from typing import Any, Generator, Iterable, TYPE_CHECKING
+from typing import cast, Any, Generator, Iterable, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import signal_manager
 
@@ -272,7 +272,7 @@ class Position:
         return not self.__eq__(p2)
 
     # @+node:ekr.20080416161551.190: *4*  p.__init__
-    def __init__(self, v: VNode, childIndex: int = 0, stack: list = None) -> None:
+    def __init__(self, v: VNode, childIndex: int = 0, stack: list | None = None) -> None:
         """Create a new position with the given childIndex and parent stack."""
         self._childIndex = childIndex
         self.v = v
@@ -560,7 +560,9 @@ class Position:
                 p.moveToThreadNext()
 
     # @+node:ekr.20161120163203.1: *4* p.nearest_unique_roots (aka p.nearest)
-    def nearest_unique_roots(self, copy: bool = True, predicate: Callable = None) -> Generator:
+    def nearest_unique_roots(
+        self, copy: bool = True, predicate: Callable | None = None
+    ) -> Generator:
         """
         A generator yielding all unique root positions "near" p1 = self that
         satisfy the given predicate. p.isAnyAtFileNode is the default
@@ -1286,10 +1288,9 @@ class Position:
         return p
 
     # @+node:ekr.20080416161551.212: *4* p._parentVnode
-    def _parentVnode(self) -> VNode | None:
+    def _parentVnode(self) -> VNode:
         """
-        Return the parent VNode.
-        Return the hiddenRootNode if there is no other parent.
+        Return the parent VNode or p.v.hiddenRootNode.
         """
         p = self
         if p.v:
@@ -1297,8 +1298,7 @@ class Position:
             if data:
                 v, junk = data
                 return v
-            return p.v.context.hiddenRootNode
-        return None  # pragma: no cover
+        return p.v.context.hiddenRootNode  # PR 4767 # Bug fix! 2026/07/01
 
     # @+node:ekr.20131219220412.16582: *4* p._relinkAsCloneOf
     def _relinkAsCloneOf(self, p2: Position) -> None:
@@ -2178,7 +2178,7 @@ class VNode:
         self.children: list[VNode] = []  # Ordered list of all children of this node.
         self.parents: list[VNode] = []  # Unordered list of all parents of this node.
         # The immutable fileIndex (gnx) for this node. Set below.
-        self.fileIndex: str | None = None
+        self.fileIndex = cast(str, None)
         self.iconVal = 0  # The present value of the node's icon.
         self.statusBits = 0  # status bits
 
@@ -2664,7 +2664,7 @@ class VNode:
         g.contentModifiedSet.add(self)
 
     # @+node:ekr.20260622103203.1: *4* v.findAllAncestorAtFileNodes
-    def findAllAncestorAtFileNodes(self, *, to_do_set: set[VNode] = None) -> list[VNode]:
+    def findAllAncestorAtFileNodes(self, *, to_do_set: set[VNode] | None = None) -> list[VNode]:
         """
         Return a list of all @<file> nodes containing this VNode.
 
@@ -2739,7 +2739,7 @@ class VNode:
             pass
 
     # @+node:ekr.20191213161023.1: *4* v.setAllAncestorAtFileNodesDirty
-    def setAllAncestorAtFileNodesDirty(self, *, to_do_set: set[VNode] = None) -> None:
+    def setAllAncestorAtFileNodesDirty(self, *, to_do_set: set[VNode] | None = None) -> None:
         """Set all ancestor @<file> nodes dirty."""
         v = self
         for v2 in v.findAllAncestorAtFileNodes(to_do_set=to_do_set):

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1223,29 +1223,45 @@ class Position:
 
     # @+node:ekr.20040306220230: *5* p.Headline & body strings
     def bodyString(self) -> str:
-        return self.v.bodyString()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.bodyString()
 
     def headString(self) -> str:
-        return self.v.headString()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.headString()
 
     # @+node:ekr.20040306214401: *5* p.Status bits
     def isDirty(self) -> bool:
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
         return self.v.isDirty()
 
     def isMarked(self) -> bool:
-        return self.v.isMarked()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isMarked()
 
     def isOrphan(self) -> bool:
-        return self.v.isOrphan()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isOrphan()
 
     def isSelected(self) -> bool:
-        return self.v.isSelected()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isSelected()
 
     def isVisited(self) -> bool:
-        return self.v.isVisited()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isVisited()
 
     def status(self) -> int:
-        return self.v.status()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.status()
 
     # @+node:ekr.20080423062035.1: *3* p.Low level methods
     # These methods are only for the use of low-level code

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1668,7 +1668,7 @@ class Position:
     def copy(self) -> Position:
         """ "Return an independent copy of a position."""
         p = self
-        # Don't assert p.v here.
+        assert p.v, g.callers()  # Silence mypy warning that p.v may be None.
         return Position(p.v, p._childIndex, p.stack)
 
     # @+node:ekr.20040303175026.9: *4* p.copyTreeAfter, copyTreeTo

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1412,8 +1412,10 @@ class Position:
         n = p._childIndex
         parent_v = p._parentVnode()  # PR #4767 # May throw ValueError
         child = p.v
+        # Silence mypy warnings...
         assert p.v
         assert parent_v
+        assert child
         # Delete the child.
         if 0 <= n < len(parent_v.children) and parent_v.children[n] == child:
             # This is the only call to v._cutlink.
@@ -1597,6 +1599,7 @@ class Position:
             else:
                 p.moveToParent()  # Same as p.moveToThreadBack()
             if p:
+                assert p  # Silence mypy warning that p.v may be None.
                 if limit:
                     done, val = self.checkVisBackLimit(limit, limitIsVisible, p)
                     if done:
@@ -1613,6 +1616,7 @@ class Position:
         p: Position,
     ) -> tuple[bool, Position | None]:
         """Return done, p or None"""
+        assert p.v  # Silence mypy warning that p.v may be None.
         c = p.v.context
         if limit == p:
             if limitIsVisible and p.isVisible(c):

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -856,7 +856,7 @@ class Position:
 
     # @+node:ekr.20031218072017.915: *4* p.getX & VNode compatibility traversal routines
     # These methods are useful abbreviations.
-    # Warning: they make copies of positions, so they should be used _sparingly_
+    # They are efficient enough now that iterators are the normal way to traverse the tree!
 
     def getBack(self) -> Position:
         return self.copy().moveToBack()
@@ -888,20 +888,17 @@ class Position:
     def getThreadNext(self) -> Position:
         return self.copy().moveToThreadNext()
 
-    # New in Leo 4.4.3 b2: add c args.
-
-    def getVisBack(self, c: Cmdr) -> Position:
+    def getVisBack(self, c: Cmdr) -> Position | None:  # PR #4767
         return self.copy().moveToVisBack(c)
 
-    def getVisNext(self, c: Cmdr) -> Position:
+    def getVisNext(self, c: Cmdr) -> Position | None:  # PR #4767
         return self.copy().moveToVisNext(c)
 
-    # These are efficient enough now that iterators are the normal way to traverse the tree!
     back = getBack
     firstChild = getFirstChild
+    hasVisBack = getVisBack
     lastChild = getLastChild
     lastNode = getLastNode
-    # lastVisible   = getLastVisible # New in 4.2 (was in tk tree code).
     next = getNext
     nodeAfterTree = getNodeAfterTree
     nthChild = getNthChild
@@ -910,8 +907,6 @@ class Position:
     threadNext = getThreadNext
     visBack = getVisBack
     visNext = getVisNext
-    # New in Leo 4.4.3:
-    hasVisBack = visBack
     hasVisNext = visNext
 
     # @+node:ekr.20080416161551.192: *4* p.hasBack/Next/Parent/ThreadBack
@@ -1506,7 +1501,7 @@ class Position:
         return p
 
     # @+node:ekr.20080416161551.210: *4* p.moveToVisBack & helper
-    def moveToVisBack(self, c: Cmdr) -> Position:
+    def moveToVisBack(self, c: Cmdr) -> Position | None:  # PR #4767
         """Move a position to the position of the previous visible node."""
         p = self
         limit, limitIsVisible = c.visLimit()

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2231,9 +2231,9 @@ class Position:
         p.setDirty() is no longer expensive.
         """
         p = self
-        if v := p.v:
-            v.setAllAncestorAtFileNodesDirty()
-            v.setDirty()
+        assert p.v
+        p.v.setAllAncestorAtFileNodesDirty()
+        p.v.setDirty()
 
     # @+node:ekr.20160225153333.1: *3* p.Predicates
     # @+node:ekr.20160225153414.1: *4* p.is_at_all & is_at_all_tree

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -792,7 +792,6 @@ class Position:
             c = v.context
             path_part = '-->'.join(list(reversed([z.h for z in self.self_and_parents(copy=False)])))
             return 'unl:' + f"//{c.fileName()}#{path_part}"
-
         raise ValueError(f"findRootPosition: empty p. {g.callers()}")
 
     # @+node:ekr.20230628173542.1: *5* p.get_legacy_UNL
@@ -928,13 +927,8 @@ class Position:
 
     def hasNext(self) -> bool:
         p = self
-        try:
-            parent_v = p._parentVnode()  # PR #4767 # May throw ValueError
-            return bool(p.v and parent_v and p._childIndex + 1 < len(parent_v.children))
-        except Exception:  # pragma: no cover
-            g.trace('*** Unexpected exception')
-            g.es_exception()
-            return False
+        parent_v = p._parentVnode()  # PR #4767 # May throw ValueError
+        return bool(p.v and parent_v and p._childIndex + 1 < len(parent_v.children))
 
     def hasParent(self) -> bool:
         p = self
@@ -943,7 +937,7 @@ class Position:
     def hasThreadBack(self) -> bool:
         p = self
         # Much cheaper than computing the actual value.
-        return bool(p.hasParent() or p.hasBack())
+        return p.hasParent() or p.hasBack()
 
     # @+node:ekr.20080416161551.193: *5* p.hasThreadNext (the only complex hasX method)
     def hasThreadNext(self) -> bool:
@@ -1336,16 +1330,8 @@ class Position:
         if parent_v.children[p._childIndex] == v:
             parent_v.children[p._childIndex] = v2
             v2.parents.append(parent_v)
-            # p.v no longer truly exists.
-            # p.v = p2.v
-        else:  # pragma: no cover
-            g.internalError(
-                'parent_v.children[childIndex] != v',
-                p,
-                parent_v.children,
-                p._childIndex,
-                v,
-            )
+            return
+        raise ValueError(f"_relinkAsCloneOf parent_v: {parent_v!r} callers: {g.callers()}")
 
     # @+node:ekr.20080416161551.217: *4* p._unlink
     def _unlink(self) -> None:
@@ -2052,7 +2038,10 @@ class Position:
     # @+node:ekr.20040315034158: *4* p.setBodyString & setHeadString
     def setBodyString(self, s: bytes | str) -> None:
         p = self
-        return p.v.setBodyString(s)
+        if v := p.v:
+            v.setBodyString(s)
+            return
+        raise ValueError(f"p.setBodyString: empty p. {g.callers()}")
 
     initBodyString = setBodyString
     setTnodeText = setBodyString

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -733,13 +733,15 @@ class Position:
     # @+node:ekr.20040306214240.3: *5* p.hasChildren & p.numberOfChildren
     def hasChildren(self) -> bool:
         p = self
-        return bool(p.v and len(p.v.children) > 0)
+        assert p.v
+        return len(p.v.children) > 0
 
     hasFirstChild = hasChildren
 
     def numberOfChildren(self) -> int:
         p = self
-        return len(p.v.children) if p.v else 0  # PR #4767
+        assert p.v
+        return len(p.v.children)  # PR #4767
 
     # @+node:ekr.20250405080955.1: *4* p.findDirective
     at_directive_pattern = re.compile(r'@([\w]+)', re.MULTILINE)

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -635,7 +635,7 @@ class Position:
     def self_and_parents(self, copy: bool = True) -> Generator:
         """Yield p and all parent positions of p."""
         p = self
-        if not p:  # PR #4767 # p.v may be None.
+        if not p:  # Don't use assert p here.
             return
         p = p.copy()
         while p:
@@ -728,7 +728,8 @@ class Position:
     # @+node:ekr.20040323160302: *5* p.directParents
     def directParents(self) -> list[VNode]:
         p = self
-        return p.v.directParents() if p.v else []
+        assert p.v
+        return p.v.directParents()
 
     # @+node:ekr.20040306214240.3: *5* p.hasChildren & p.numberOfChildren
     def hasChildren(self) -> bool:
@@ -2569,9 +2570,9 @@ class VNode:
         v = self
         # Allocate a new vnode and gnx with empty children & parents.
         v2 = VNode(context=v.context, gnx=None)
-        assert v2.parents == [], v2.parents  # pylint: disable=use-implicit-booleaness-not-comparison
-        assert v2.gnx
-        assert v.gnx != v2.gnx
+        assert v2.parents, v2
+        assert v2.gnx, v2
+        assert v.gnx != v2.gnx, v2
         # Copy vnode fields. Do **not** set v2.parents.
         v2._headString = g.toUnicode(v._headString, reportErrors=True)
         v2._bodyString = g.toUnicode(v._bodyString, reportErrors=True)

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2103,7 +2103,8 @@ class Position:
         Set all ancestor @<file> nodes dirty, including ancestors of all clones of p.
         """
         p = self
-        p.v.setAllAncestorAtFileNodesDirty()
+        if v := p.v:
+            v.setAllAncestorAtFileNodesDirty()
 
     # @+node:ekr.20040303163330: *5* p.setDirty
     def setDirty(self) -> None:
@@ -2113,8 +2114,9 @@ class Position:
         p.setDirty() is no longer expensive.
         """
         p = self
-        p.v.setAllAncestorAtFileNodesDirty()
-        p.v.setDirty()
+        if v := p.v:
+            v.setAllAncestorAtFileNodesDirty()
+            v.setDirty()
 
     # @+node:ekr.20160225153333.1: *3* p.Predicates
     # @+node:ekr.20160225153414.1: *4* p.is_at_all & is_at_all_tree

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -275,7 +275,7 @@ class Position:
     def __init__(self, v: VNode, childIndex: int = 0, stack: list | None = None) -> None:
         """Create a new position with the given childIndex and parent stack."""
         self._childIndex = childIndex
-        self.v = v
+        self.v: VNode | None = v  # PR #4767: Yes, p.v may be None.
         # Stack entries are tuples (v, childIndex).
         if stack:
             self.stack = stack[:]  # Creating a copy here is safest and best.
@@ -911,7 +911,7 @@ class Position:
     def hasNext(self) -> bool:
         p = self
         try:
-            parent_v = p._parentVnode()  # Returns None if p.v is None.
+            parent_v = p._parentVnode()  # PR #4767 # May throw ValueError
             return bool(p.v and parent_v and p._childIndex + 1 < len(parent_v.children))
         except Exception:  # pragma: no cover
             g.trace('*** Unexpected exception')
@@ -1314,10 +1314,7 @@ class Position:
         """A low-level method to replace p.v by a p2.v."""
         p = self
         v, v2 = p.v, p2.v
-        parent_v = p._parentVnode()
-        if not parent_v:  # pragma: no cover
-            g.internalError('no parent_v', p)
-            return
+        parent_v = p._parentVnode()  # PR #4767 # May throw ValueError
         if parent_v.children[p._childIndex] == v:
             parent_v.children[p._childIndex] = v2
             v2.parents.append(parent_v)
@@ -1337,7 +1334,7 @@ class Position:
         """Unlink the receiver p from the tree."""
         p = self
         n = p._childIndex
-        parent_v = p._parentVnode()  # returns None if p.v is None
+        parent_v = p._parentVnode()  # PR #4767 # May throw ValueError
         child = p.v
         assert p.v
         assert parent_v
@@ -1384,7 +1381,7 @@ class Position:
         """Move self to its previous sibling."""
         p = self
         n = p._childIndex
-        parent_v = p._parentVnode()  # Returns None if p.v is None.
+        parent_v = p._parentVnode()  # PR #4767 # May throw ValueError
         # Do not assume n is in range: this is used by positionExists.
         if parent_v and p.v and 0 < n <= len(parent_v.children):
             p._childIndex -= 1
@@ -1434,7 +1431,7 @@ class Position:
         """Move a position to its next sibling."""
         p = self
         n = p._childIndex
-        parent_v = p._parentVnode()  # Returns None if p.v is None.
+        parent_v = p._parentVnode()  # PR #4767 # May throw ValueError
         if p and not p.v:
             g.trace('no p.v:', p, g.callers())  # pragma: no cover
         if p.v and parent_v and len(parent_v.children) > n + 1:
@@ -1802,7 +1799,7 @@ class Position:
     def promote(self) -> None:
         """A low-level promote helper."""
         p = self  # Do NOT copy the position.
-        parent_v = p._parentVnode()
+        parent_v = p._parentVnode()  # PR #4767 # May throw ValueError
         children = p.v.children
         # Add the children to parent_v's children.
         n = p.childIndex() + 1

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1836,6 +1836,7 @@ class Position:
     # @+node:ekr.20040310062332.1: *4* p.invalidOutline
     def invalidOutline(self, message: str) -> None:  # pragma: no cover
         p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
         if p.hasParent():
             node = p.parent()
         else:
@@ -1888,6 +1889,7 @@ class Position:
     def promote(self) -> None:
         """A low-level promote helper."""
         p = self  # Do NOT copy the position.
+        assert p.v  # Silence mypy warning that p.v may be None.
         parent_v = p._parentVnode()  # PR #4767 # May throw ValueError
         children = p.v.children
         # Add the children to parent_v's children.

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1290,24 +1290,24 @@ class Position:
     # @+node:ekr.20080416161551.212: *4* p._parentVnode
     def _parentVnode(self) -> VNode:
         """
-        Return the parent VNode or p.v.hiddenRootNode.
+        Return the parent VNode or the hidden root VNode.
+
+        Raise ValueError if p is empty or already refers to the hidden root VNode.
         """
-        trace = True  ### and not g.unitTesting
-        tag = 'p._parentVnode'
         p = self
+        tag = 'p._parentVnode'
+        if not p:
+            raise ValueError(f"{tag} Empty p: {p!r} callers: {g.callers()}")
         c = p.v.context
-        if p.v:
-            data = p.stack and p.stack[-1]
-            if data:
-                v, junk = data
-                if trace and v == p.v.context.hiddenRootNode:
-                    g.print_unique_message(f"{tag} {'Hidden':9} {c.shortFileName()} {g.callers(2)}")
-                return v
-            return c.hiddenRootNode
-        if trace:
-            g.print_unique_message(f"{tag} {'Not found':9} {c.shortFileName()} {g.callers(2)}")
-        return None  ### Legacy.
-        # return c.hiddenRootNode  # PR 4767 #### Experimental!!!
+        if not c:
+            raise ValueError(f"{tag} Empty context: {p!r} callers: {g.callers()}")
+        if p.v == c.hiddenRootNode:
+            raise ValueError(f"{tag} hiddenRootNode has no parent: {p!r} callers: {g.callers()}")
+        data = p.stack and p.stack[-1]
+        if data:
+            v, junk = data
+            return v
+        return c.hiddenRootNode
 
     # @+node:ekr.20131219220412.16582: *4* p._relinkAsCloneOf
     def _relinkAsCloneOf(self, p2: Position) -> None:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -758,8 +758,10 @@ class Position:
     def findRootPosition(self) -> Position:
         # 2011/02/25: always use c.rootPosition
         p = self
-        c = p.v.context
-        return c.rootPosition()
+        if v := p.v:
+            c = v.context
+            return c.rootPosition()
+        raise ValueError(f"findRootPosition: empty p. {g.callers()}")
 
     # @+node:ekr.20230628173526.1: *4* p.get_UNL and related methods
     # All unls must contain a file part: f"//{file-name}#"

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -953,7 +953,7 @@ class Position:
     def isAncestorOf(self, p2: Position) -> bool:
         """Return True if p is one of the direct ancestors of p2."""
         p = self
-        ### assert p.v  # Silence mypy warning that p.v may be None.
+        assert p.v  # Silence mypy warning that p.v may be None.
         c = p.v.context
         if not c.positionExists(p2):
             return False
@@ -968,6 +968,7 @@ class Position:
     # @+node:ekr.20040306215056: *4* p.isCloned
     def isCloned(self) -> bool:
         p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
         return p.v.isCloned()
 
     # @+node:ekr.20040307104131.2: *4* p.isRoot
@@ -1076,86 +1077,138 @@ class Position:
     # @+node:ekr.20040306210951: *4* p.VNode proxies
     # @+node:ekr.20040306211032: *5* p.Comparisons
     def anyAtFileNodeName(self) -> str:
-        return self.v.anyAtFileNodeName()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.anyAtFileNodeName()
 
     def atAutoNodeName(self) -> str:
-        return self.v.atAutoNodeName()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.atAutoNodeName()
 
     def atCleanNodeName(self) -> str:
-        return self.v.atCleanNodeName()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.atCleanNodeName()
 
     def atEditNodeName(self) -> str:
-        return self.v.atEditNodeName()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.atEditNodeName()
 
     def atFileNodeName(self) -> str:
-        return self.v.atFileNodeName()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.atFileNodeName()
 
     def atLeoNodeName(self) -> str:
-        return self.v.atLeoNodeName()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.atLeoNodeName()
 
     def atNoSentinelsFileNodeName(self) -> str:
-        return self.v.atNoSentinelsFileNodeName()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.atNoSentinelsFileNodeName()
 
     def atShadowFileNodeName(self) -> str:
-        return self.v.atShadowFileNodeName()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.atShadowFileNodeName()
 
     def atSilentFileNodeName(self) -> str:
-        return self.v.atSilentFileNodeName()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.atSilentFileNodeName()
 
     def atThinFileNodeName(self) -> str:
-        return self.v.atThinFileNodeName()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.atThinFileNodeName()
 
     # New names, less confusing
     atNoSentFileNodeName = atNoSentinelsFileNodeName
     atAsisFileNodeName = atSilentFileNodeName
 
     def isAnyAtFileNode(self) -> bool:
-        return self.v.isAnyAtFileNode()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isAnyAtFileNode()
 
     def isAtAllNode(self) -> bool:
-        return self.v.isAtAllNode()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isAtAllNode()
 
     def isAtAutoNode(self) -> bool:
-        return self.v.isAtAutoNode()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isAtAutoNode()
 
     def isAtAutoRstNode(self) -> bool:
-        return self.v.isAtAutoRstNode()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isAtAutoRstNode()
 
     def isAtCleanNode(self) -> bool:
-        return self.v.isAtCleanNode()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isAtCleanNode()
 
     def isAtEditNode(self) -> bool:
-        return self.v.isAtEditNode()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isAtEditNode()
 
     def isAtFileNode(self) -> bool:
-        return self.v.isAtFileNode()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isAtFileNode()
 
     def isAtJupytextNode(self) -> bool:
-        return self.v.isAtJupytextNode()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isAtJupytextNode()
 
     def isAtIgnoreNode(self) -> bool:
-        return self.v.isAtIgnoreNode()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isAtIgnoreNode()
 
     def isAtLeoNode(self) -> bool:
-        return self.v.isAtLeoNode()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isAtLeoNode()
 
     def isAtNoSentinelsFileNode(self) -> bool:
-        return self.v.isAtNoSentinelsFileNode()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isAtNoSentinelsFileNode()
 
     def isAtOthersNode(self) -> bool:
-        return self.v.isAtOthersNode()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isAtOthersNode()
 
     def isAtRstFileNode(self) -> bool:
-        return self.v.isAtRstFileNode()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isAtRstFileNode()
 
     def isAtSilentFileNode(self) -> bool:
-        return self.v.isAtSilentFileNode()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isAtSilentFileNode()
 
     def isAtShadowFileNode(self) -> bool:
-        return self.v.isAtShadowFileNode()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isAtShadowFileNode()
 
     def isAtThinFileNode(self) -> bool:
-        return self.v.isAtThinFileNode()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.isAtThinFileNode()
 
     # New names, less confusing:
     isAtNoSentFileNode = isAtNoSentinelsFileNode
@@ -1164,7 +1217,9 @@ class Position:
     # Utilities.
 
     def matchHeadline(self, pattern: str) -> bool:
-        return self.v.matchHeadline(pattern)
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.matchHeadline(pattern)
 
     # @+node:ekr.20040306220230: *5* p.Headline & body strings
     def bodyString(self) -> str:
@@ -1582,8 +1637,7 @@ class Position:
     def copy(self) -> Position:
         """ "Return an independent copy of a position."""
         p = self
-        ### Something weird is happening.
-        ### assert p.v  # Silence mypy warning that p.v may be None.
+        # Don't assert p.v here.
         return Position(p.v, p._childIndex, p.stack)
 
     # @+node:ekr.20040303175026.9: *4* p.copyTreeAfter, copyTreeTo

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1292,12 +1292,17 @@ class Position:
         """
         Return the parent VNode or p.v.hiddenRootNode.
         """
+        trace = True and not g.unitTesting
         p = self
         if p.v:
             data = p.stack and p.stack[-1]
             if data:
                 v, junk = data
+                if trace:
+                    g.print_unique_message(f"    FOUND: p._parentVnode: {g.callers(2)}")
                 return v
+        if trace:
+            g.print_unique_message(f"NOT FOUND: p._parentVnode: {g.callers(2)}")
         return p.v.context.hiddenRootNode  # PR 4767 # Bug fix! 2026/07/01
 
     # @+node:ekr.20131219220412.16582: *4* p._relinkAsCloneOf

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1236,7 +1236,7 @@ class Position:
     def isDirty(self) -> bool:
         p = self
         assert p.v  # Silence mypy warning that p.v may be None.
-        return self.v.isDirty()
+        return p.v.isDirty()
 
     def isMarked(self) -> bool:
         p = self
@@ -1308,6 +1308,7 @@ class Position:
         p.stack = p_after.stack[:]
         p._childIndex = p_after._childIndex + 1
         child = p.v
+        assert child  # Silence mypy warning that p.v may be None.
         n = p_after._childIndex + 1
         child._addLink(n, parent_v)
 
@@ -1319,6 +1320,7 @@ class Position:
         p.stack = p_after.stack[:]
         p._childIndex = p_after._childIndex + 1
         child = p.v
+        assert child  # Silence mypy warning that p.v may be None.
         n = p_after._childIndex + 1
         child._addCopiedLink(n, parent_v)
 
@@ -1327,10 +1329,12 @@ class Position:
         """Link self as the n'th child of the parent."""
         p = self
         parent_v = parent.v
+        assert parent_v  # Silence mypy warning that parent_v may be None.
         p.stack = parent.stack[:]
         p.stack.append((parent_v, parent._childIndex))
         p._childIndex = n
         child = p.v
+        assert child  # Silence mypy warning that p.v may be None.
         child._addLink(n, parent_v)
 
     # @+node:ekr.20180709180140.1: *4* p._linkCopiedAsNthChild
@@ -1338,10 +1342,12 @@ class Position:
         """Link a copied self as the n'th child of the parent."""
         p = self
         parent_v = parent.v
+        assert parent_v  # Silence mypy warning that parent_v may be None.
         p.stack = parent.stack[:]
         p.stack.append((parent_v, parent._childIndex))
         p._childIndex = n
         child = p.v
+        assert child  # Silence mypy warning that p.v may be None.
         child._addCopiedLink(n, parent_v)
 
     # @+node:ekr.20080416161551.216: *4* p._linkAsRoot
@@ -1371,6 +1377,8 @@ class Position:
         tag = 'p._parentVnode'
         if not p:
             raise ValueError(f"{tag} Empty p: {p!r} callers: {g.callers()}")
+        if not p.v:
+            raise ValueError(f"{tag} Empty p: {p!r} callers: {g.callers()}")
         c = p.v.context
         if not c:
             raise ValueError(f"{tag} Empty context: {p!r} callers: {g.callers()}")
@@ -1387,12 +1395,15 @@ class Position:
         """A low-level method to replace p.v by a p2.v."""
         p = self
         v, v2 = p.v, p2.v
-        parent_v = p._parentVnode()  # PR #4767 # May throw ValueError
+        tag = 'p._relinkAsCloneOf'
+        parent_v = p._parentVnode()
+        # Silence mypy warnings...
+        assert v2, f"{tag} no v2: {p2!r} callers: {g.callers()}"
+        assert parent_v, f"{tag} no parent_v: {parent_v!r} callers: {g.callers()}"
+        assert parent_v.children, f"{tag} no children: {parent_v!r} callers: {g.callers()}"
         if parent_v.children[p._childIndex] == v:
             parent_v.children[p._childIndex] = v2
             v2.parents.append(parent_v)
-            return
-        raise ValueError(f"_relinkAsCloneOf parent_v: {parent_v!r} callers: {g.callers()}")
 
     # @+node:ekr.20080416161551.217: *4* p._unlink
     def _unlink(self) -> None:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -137,7 +137,7 @@ class NodeIndices:
         return gnx
 
     # @+node:ekr.20150322134954.1: *3* ni.new_vnode_helper
-    def new_vnode_helper(self, c: Cmdr, gnx: str, v: VNode) -> None:
+    def new_vnode_helper(self, c: Cmdr, gnx: str | None, v: VNode) -> None:
         """Handle all gnx-related tasks for VNode.__init__."""
         ni = self
         # Special case for the c.hiddenRootNode. This eliminates a hack in c.initObjects.
@@ -2341,6 +2341,7 @@ class VNode:
         #   def allocate_vnode(c,gnx):
         #       v = VNode(c)
         #       g.app.nodeIndices.new_vnode_helper(c,gnx,v)
+        assert g.app.nodeIndices  # Silence mypy warning that g.app may be None.
         g.app.nodeIndices.new_vnode_helper(context, gnx, self)
         assert self.fileIndex, g.callers()
 

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -731,13 +731,13 @@ class Position:
     # @+node:ekr.20040306214240.3: *5* p.hasChildren & p.numberOfChildren
     def hasChildren(self) -> bool:
         p = self
-        return len(p.v.children) > 0
+        return bool(p.v and len(p.v.children) > 0)
 
     hasFirstChild = hasChildren
 
     def numberOfChildren(self) -> int:
         p = self
-        return len(p.v.children)
+        return len(p.v.children) if p.v else 0  # PR #4767
 
     # @+node:ekr.20250405080955.1: *4* p.findDirective
     at_directive_pattern = re.compile(r'@([\w]+)', re.MULTILINE)

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2339,9 +2339,11 @@ class VNode:
         #   def allocate_vnode(c,gnx):
         #       v = VNode(c)
         #       g.app.nodeIndices.new_vnode_helper(c,gnx,v)
-        assert g.app.nodeIndices  # Silence mypy warning that g.app may be None.
-        g.app.nodeIndices.new_vnode_helper(context, gnx, self)
-        assert self.fileIndex, g.callers()
+        if g.app and g.app.nodeIndices:
+            g.app.nodeIndices.new_vnode_helper(context, gnx, self)
+            assert self.fileIndex, g.callers()
+            return
+        raise ValueError(f"VNode.__init__: not initialized: {g.callers()}")
 
     # @+node:ekr.20031218072017.3345: *4* v.__repr__ & v.__str__
     def __repr__(self) -> str:  # pragma: no cover

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1991,6 +1991,7 @@ class Position:
     # @+node:ekr.20090215165030.3: *4* p.gnx property
     def __get_gnx(self) -> str:
         p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
         return p.v.fileIndex
 
     gnx = property(
@@ -2001,6 +2002,7 @@ class Position:
     # @+node:ekr.20140203082618.15486: *4* p.script property
     def __get_script(self) -> str:
         p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
         return g.getScript(
             p.v.context,
             p,
@@ -2027,10 +2029,12 @@ class Position:
     # @+node:ekr.20160129073222.1: *4* p.u Property
     def __get_u(self) -> Value:
         p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
         return p.v.u
 
     def __set_u(self, val: Value) -> None:
         p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
         p.v.u = val
 
     u = property(__get_u, __set_u, doc="p.u property")
@@ -2041,12 +2045,14 @@ class Position:
     def contract(self) -> None:
         """Contract p.v and clear p.v.expandedPositions list."""
         p, v = self, self.v
+        assert v  # Silence mypy warning that p.v may be None.
         v.expandedPositions = [z for z in v.expandedPositions if z != p]
         v.contract()
 
     def expand(self) -> None:
         p = self
         v = self.v
+        assert v  # Silence mypy warning that p.v may be None.
         v.expandedPositions = [z for z in v.expandedPositions if z != p]
         for p2 in v.expandedPositions:
             if p == p2:
@@ -2057,6 +2063,7 @@ class Position:
 
     def isExpanded(self) -> bool:
         p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
         if p.isCloned():
             c = p.v.context
             return c.shouldBeExpanded(p)
@@ -2067,52 +2074,80 @@ class Position:
     # Dirty bits are handled carefully by the position class.
 
     def clearMarked(self) -> None:
-        self.v.clearMarked()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        p.v.clearMarked()
 
     def clearOrphan(self) -> None:
-        self.v.clearOrphan()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        p.v.clearOrphan()
 
     def clearVisited(self) -> None:
-        self.v.clearVisited()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        p.v.clearVisited()
 
     def initExpandedBit(self) -> None:
-        self.v.initExpandedBit()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        p.v.initExpandedBit()
 
     def initMarkedBit(self) -> None:
-        self.v.initMarkedBit()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        p.v.initMarkedBit()
 
     def initStatus(self, status: int) -> None:
-        self.v.initStatus(status)
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        p.v.initStatus(status)
 
     def setMarked(self) -> None:
-        self.v.setMarked()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        p.v.setMarked()
 
     def setOrphan(self) -> None:
-        self.v.setOrphan()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        p.v.setOrphan()
 
     def setSelected(self) -> None:
-        self.v.setSelected()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        p.v.setSelected()
 
     def setVisited(self) -> None:
-        self.v.setVisited()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        p.v.setVisited()
 
     # @+node:ekr.20040306220634.8: *5* p.computeIcon & p.setIcon
     def computeIcon(self) -> int:
-        return self.v.computeIcon()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        return p.v.computeIcon()
 
     def setIcon(self) -> None:
         pass  # Compatibility routine for old scripts
 
     # @+node:ekr.20040306220634.29: *5* p.setSelection
     def setSelection(self, start: int, length: int) -> None:
-        self.v.setSelection(start, length)
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        p.v.setSelection(start, length)
 
     # @+node:ekr.20100303074003.5637: *5* p.restore/saveCursorAndScroll
     def restoreCursorAndScroll(self) -> None:
-        self.v.restoreCursorAndScroll()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        p.v.restoreCursorAndScroll()
 
     def saveCursorAndScroll(self) -> None:
-        self.v.saveCursorAndScroll()
+        p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
+        p.v.saveCursorAndScroll()
 
     # @+node:ekr.20040315034158: *4* p.setBodyString & setHeadString
     def setBodyString(self, s: bytes | str) -> None:
@@ -2126,10 +2161,12 @@ class Position:
 
     def initHeadString(self, s: bytes | str) -> None:
         p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
         p.v.initHeadString(s)
 
     def setHeadString(self, s: bytes | str) -> None:
         p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
         p.v.initHeadString(s)
         p.setDirty()
 
@@ -2152,6 +2189,7 @@ class Position:
     def clearDirty(self) -> None:
         """(p) Set p.v dirty."""
         p = self
+        assert p.v  # Silence mypy warning that p.v may be None.
         p.v.clearDirty()
 
     # @+node:ekr.20040702104823: *5* p.inAtIgnoreRange
@@ -2169,8 +2207,8 @@ class Position:
         Set all ancestor @<file> nodes dirty, including ancestors of all clones of p.
         """
         p = self
-        if v := p.v:
-            v.setAllAncestorAtFileNodesDirty()
+        assert p.v  # Silence mypy warning that p.v may be None.
+        p.v.setAllAncestorAtFileNodesDirty()
 
     # @+node:ekr.20040303163330: *5* p.setDirty
     def setDirty(self) -> None:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1293,17 +1293,19 @@ class Position:
         Return the parent VNode or p.v.hiddenRootNode.
         """
         trace = True and not g.unitTesting
+        tag = 'p._parentVnode'
         p = self
+        c = p.v.context
         if p.v:
             data = p.stack and p.stack[-1]
             if data:
                 v, junk = data
-                if trace:
-                    g.print_unique_message(f"    FOUND: p._parentVnode: {g.callers(2)}")
+                if trace and v == p.v.context.hiddenRootNode:
+                    g.print_unique_message(f"{tag} {'Hidden':9} {c.shortFileName()} {g.callers(2)}")
                 return v
         if trace:
-            g.print_unique_message(f"NOT FOUND: p._parentVnode: {g.callers(2)}")
-        return p.v.context.hiddenRootNode  # PR 4767 # Bug fix! 2026/07/01
+            g.print_unique_message(f"{tag} {'Not found':9} {c.shortFileName()} {g.callers(2)}")
+        return c.hiddenRootNode  # PR 4767 # Bug fix! 2026/07/01
 
     # @+node:ekr.20131219220412.16582: *4* p._relinkAsCloneOf
     def _relinkAsCloneOf(self, p2: Position) -> None:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -635,6 +635,8 @@ class Position:
     def self_and_parents(self, copy: bool = True) -> Generator:
         """Yield p and all parent positions of p."""
         p = self
+        if not p:  # PR #4767 # p.v may be None.
+            return
         p = p.copy()
         while p:
             yield p.copy() if copy else p
@@ -756,12 +758,10 @@ class Position:
 
     # @+node:ekr.20060920203352: *4* p.findRootPosition
     def findRootPosition(self) -> Position:
-        # 2011/02/25: always use c.rootPosition
         p = self
-        if v := p.v:
-            c = v.context
-            return c.rootPosition()
-        raise ValueError(f"findRootPosition: empty p. {g.callers()}")
+        assert p.v  # Silence mypy warning that p.v may be None.
+        c = p.v.context
+        return c.rootPosition()
 
     # @+node:ekr.20230628173526.1: *4* p.get_UNL and related methods
     # All unls must contain a file part: f"//{file-name}#"
@@ -774,11 +774,10 @@ class Position:
         Not used in Leo's core or official plugins.
         """
         p = self
-        if v := p.v:
-            c = v.context
-            file_part = c.fileName()
-            return 'unl:gnx:' + f"//{file_part}#{self.gnx}"
-        raise ValueError(f"findRootPosition: empty p. {g.callers()}")
+        assert p.v  # Silence mypy warning that p.v may be None.
+        c = p.v.context
+        file_part = c.fileName()
+        return 'unl:gnx:' + f"//{file_part}#{self.gnx}"
 
     # @+node:tbrown.20111010104549.26758: *5* p.get_full_legacy_UNL
     def get_full_legacy_UNL(self) -> str:
@@ -788,11 +787,10 @@ class Position:
         Not used in Leo's core or official plugins.
         """
         p = self
-        if v := p.v:
-            c = v.context
-            path_part = '-->'.join(list(reversed([z.h for z in self.self_and_parents(copy=False)])))
-            return 'unl:' + f"//{c.fileName()}#{path_part}"
-        raise ValueError(f"findRootPosition: empty p. {g.callers()}")
+        assert p.v  # Silence mypy warning that p.v may be None.
+        c = p.v.context
+        path_part = '-->'.join(list(reversed([z.h for z in self.self_and_parents(copy=False)])))
+        return 'unl:' + f"//{c.fileName()}#{path_part}"
 
     # @+node:ekr.20230628173542.1: *5* p.get_legacy_UNL
     def get_legacy_UNL(self) -> str:
@@ -804,13 +802,12 @@ class Position:
         LeoTree.set_status_line will call this method if legacy unls are in effect.
         """
         p = self
-        if v := p.v:
-            c = v.context
-            path_part = '-->'.join(list(reversed([z.h for z in self.self_and_parents()])))
-            full = c.config.getBool('full-unl-paths', default=False)
-            file_part = c.fileName() if full else os.path.basename(c.fileName())
-            return 'unl:' + f"//{file_part}#{path_part}"
-        raise ValueError(f"findRootPosition: empty p. {g.callers()}")
+        assert p.v  # Silence mypy warning that p.v may be None.
+        c = p.v.context
+        path_part = '-->'.join(list(reversed([z.h for z in self.self_and_parents()])))
+        full = c.config.getBool('full-unl-paths', default=False)
+        file_part = c.fileName() if full else os.path.basename(c.fileName())
+        return 'unl:' + f"//{file_part}#{path_part}"
 
     # @+node:ekr.20230628175148.1: *5* p.get_short_gnx_UNL
     def get_short_gnx_UNL(self) -> str:
@@ -820,11 +817,10 @@ class Position:
         Not used in Leo's core or official plugins.
         """
         p = self
-        if v := p.v:
-            c = v.context
-            file_part = os.path.basename(c.fileName())
-            return 'unl:gnx:' + f"//{file_part}#{self.gnx}"
-        raise ValueError(f"findRootPosition: empty p. {g.callers()}")
+        assert p.v  # Silence mypy warning that p.v may be None.
+        c = p.v.context
+        file_part = os.path.basename(c.fileName())
+        return 'unl:gnx:' + f"//{file_part}#{self.gnx}"
 
     # @+node:ekr.20230628174804.1: *5* p.get_short_legacy_UNL
     def get_short_legacy_UNL(self) -> str:
@@ -834,12 +830,11 @@ class Position:
         Not used in Leo's core or official plugins.
         """
         p = self
-        if v := p.v:
-            c = v.context
-            file_part = os.path.basename(c.fileName())
-            path_part = '-->'.join(list(reversed([z.h for z in self.self_and_parents(copy=False)])))
-            return 'unl:' + f"//{file_part}#{path_part}"
-        raise ValueError(f"findRootPosition: empty p. {g.callers()}")
+        assert p.v  # Silence mypy warning that p.v may be None.
+        c = p.v.context
+        file_part = os.path.basename(c.fileName())
+        path_part = '-->'.join(list(reversed([z.h for z in self.self_and_parents(copy=False)])))
+        return 'unl:' + f"//{file_part}#{path_part}"
 
     # @+node:ekr.20230624171452.1: *5* p.get_UNL
     def get_UNL(self) -> str:
@@ -853,12 +848,11 @@ class Position:
         LeoTree.set_status_line calls this method if gnx-based unls are in effect.
         """
         p = self
-        if v := p.v:
-            c = v.context
-            full = c.config.getBool('full-unl-paths', default=False)
-            file_part = c.fileName() if full else os.path.basename(c.fileName())
-            return 'unl:gnx:' + f"//{file_part}#{self.gnx}"
-        raise ValueError(f"findRootPosition: empty p. {g.callers()}")
+        assert p.v  # Silence mypy warning that p.v may be None.
+        c = p.v.context
+        full = c.config.getBool('full-unl-paths', default=False)
+        file_part = c.fileName() if full else os.path.basename(c.fileName())
+        return 'unl:gnx:' + f"//{file_part}#{self.gnx}"
 
     # @+node:ekr.20031218072017.915: *4* p.getX & VNode compatibility traversal routines
     # These methods are useful abbreviations.
@@ -964,6 +958,7 @@ class Position:
     def isAncestorOf(self, p2: Position) -> bool:
         """Return True if p is one of the direct ancestors of p2."""
         p = self
+        ### assert p.v  # Silence mypy warning that p.v may be None.
         c = p.v.context
         if not c.positionExists(p2):
             return False
@@ -1386,6 +1381,7 @@ class Position:
         p = self
         n = p._childIndex
         parent_v = p._parentVnode()  # PR #4767 # May throw ValueError
+
         # Do not assume n is in range: this is used by positionExists.
         if parent_v and p.v and 0 < n <= len(parent_v.children):
             p._childIndex -= 1
@@ -1590,7 +1586,10 @@ class Position:
     # @+node:ekr.20040117171654: *4* p.copy
     def copy(self) -> Position:
         """ "Return an independent copy of a position."""
-        return Position(self.v, self._childIndex, self.stack)
+        p = self
+        ### Something weird is happening.
+        ### assert p.v  # Silence mypy warning that p.v may be None.
+        return Position(p.v, p._childIndex, p.stack)
 
     # @+node:ekr.20040303175026.9: *4* p.copyTreeAfter, copyTreeTo
     # These used by unit tests, by the group_operations plugin,
@@ -2038,10 +2037,8 @@ class Position:
     # @+node:ekr.20040315034158: *4* p.setBodyString & setHeadString
     def setBodyString(self, s: bytes | str) -> None:
         p = self
-        if v := p.v:
-            v.setBodyString(s)
-            return
-        raise ValueError(f"p.setBodyString: empty p. {g.callers()}")
+        assert p.v  # Silence mypy warning that p.v may be None.
+        p.v.setBodyString(s)
 
     initBodyString = setBodyString
     setTnodeText = setBodyString

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1375,9 +1375,7 @@ class Position:
         """
         p = self
         tag = 'p._parentVnode'
-        if not p:
-            raise ValueError(f"{tag} Empty p: {p!r} callers: {g.callers()}")
-        if not p.v:
+        if not p or not p.v:
             raise ValueError(f"{tag} Empty p: {p!r} callers: {g.callers()}")
         c = p.v.context
         if not c:

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -26,9 +26,9 @@ os.chdir(leo_editor_dir)
 # args = ' '.join(sys.argv[1:])
 python = sys.executable
 files = [
-    # PR #4766. Require strict optional only for leoNodes.py.
-    'leo/core/leoCommands.py',  # strict_optional = False
-    'leo/core/leoNodes.py',     # strict_optional = True: 25 errors.
+    # PR #4766. Require strict optional for leoNodes.py.
+    'leo/core/leoCommands.py',
+    'leo/core/leoNodes.py',
     # To be checked in other PRs...
     #   'leo/core/leoApp.py',
     #   'leo/core/leoAtFile.py',

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -47,8 +47,8 @@ files = [
 ]  # fmt: skip
 
 # The only way to enable strict_optional is within .mypy.ini.
-incremental = False
-follow = False
+incremental = True
+follow = True
 incremental_arg = '' if incremental else '--no-incremental'
 follow_kind = 'normal' if follow else 'skip'
 args = f"--follow-imports={follow_kind} {incremental_arg}"

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -23,11 +23,36 @@ print(os.path.basename(__file__))
 leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
 os.chdir(leo_editor_dir)
 
-args = ' '.join(sys.argv[1:])
+# args = ' '.join(sys.argv[1:])
 python = sys.executable
-if 1:  # Quick.
-    command = rf"{python} -m mypy leo"
-else:  # Safe.
-    command = rf"{python} -m mypy --no-incremental leo"
+files = [
+    # PR #4766. Require strict optional only for leoNodes.py.
+    'leo/core/leoCommands.py',  # strict_optional = False
+    'leo/core/leoNodes.py',     # strict_optional = True: 25 errors.
+    # To be checked in other PRs...
+    #   'leo/core/leoApp.py',
+    #   'leo/core/leoAtFile.py',
+    #   'leo/core/leoKeys.py',
+    #   'leo/core/leoGlobals.py',
+    #   'leo/plugins/mod_scripting.py',
+    #   'leo/plugins/qt_commands.py',
+    #   'leo/plugins/qt_frame.py',
+    #   'leo/plugins/qt_gui.py',
+    #   'leo/plugins/qt_idle_time.py',
+    #   'leo/plugins/qt_layout.py',
+    #   'leo/plugins/qt_text.py',
+    #   'leo/plugins/qt_tree.py',
+    #   'leo/plugins/viewrendered.py',
+    #   'leo/plugins/viewrendered3.py',
+]  # fmt: skip
+
+# The only way to enable strict_optional is within .mypy.ini.
+incremental = False
+follow = False
+incremental_arg = '' if incremental else '--no-incremental'
+follow_kind = 'normal' if follow else 'skip'
+args = f"--follow-imports={follow_kind} {incremental_arg}"
+files = ' '.join(files)
+command = rf"{python} -m mypy {args} {files}"
 subprocess.Popen(command, shell=True).communicate()
 # @-leo

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -47,8 +47,8 @@ files = [
 ]  # fmt: skip
 
 # The only way to enable strict_optional is within .mypy.ini.
-incremental = True
-follow = True
+incremental = False
+follow = False
 incremental_arg = '' if incremental else '--no-incremental'
 follow_kind = 'normal' if follow else 'skip'
 args = f"--follow-imports={follow_kind} {incremental_arg}"

--- a/leo/unittests/core/test_leoNodes.py
+++ b/leo/unittests/core/test_leoNodes.py
@@ -194,7 +194,7 @@ class TestNodes(LeoUnitTest):
             ('self_and_parents',     root.firstChild().self_and_parents),
             ('self_and_subtree',     root.self_and_subtree),
             ('following_siblings',   root.following_siblings),
-            ('parents',              root.firstChild().firstChild().parents),
+            ('parents',              root.parents),
             ('unique_subtree',       root.unique_subtree),
         )  # fmt: skip
         for kind, generator in table:

--- a/leo/unittests/core/test_leoNodes.py
+++ b/leo/unittests/core/test_leoNodes.py
@@ -1139,7 +1139,7 @@ class TestNodeIndices(LeoUnitTest):
     # @+node:ekr.20220306055506.1: *3* TestNodeIndices.test_scanGnx
     def test_scanGnx(self):
         ni = g.app.nodeIndices
-        for s, id1, t1, n1 in (
+        for s, id1, t1, n1 in (  # PR #4767
             ('ekr.123', 'ekr', '123', ''),
             ('ekr.456.2', 'ekr', '456', '2'),
             ('', g.app.leoID, '', ''),

--- a/leo/unittests/core/test_leoNodes.py
+++ b/leo/unittests/core/test_leoNodes.py
@@ -1140,9 +1140,9 @@ class TestNodeIndices(LeoUnitTest):
     def test_scanGnx(self):
         ni = g.app.nodeIndices
         for s, id1, t1, n1 in (
-            ('ekr.123', 'ekr', '123', None),
+            ('ekr.123', 'ekr', '123', ''),
             ('ekr.456.2', 'ekr', '456', '2'),
-            ('', g.app.leoID, None, None),
+            ('', g.app.leoID, '', ''),
         ):
             id2, t2, n2 = ni.scanGnx(s)
             self.assertEqual(id1, id2)


### PR DESCRIPTION
See #4766.

**Summary**

- [x] .mypy.ini: require strict_optional only in leoNodes.py.
- [x] Improve leo/scripts/mypy_leo.py.
- [x] Clean up all annotations. See below.
- [x] Add asserts as needed. See below.
- [x] Fix all mypy complaints.

**Significant code changes**

- [x] c.currentPosition and c.rootPosition always return a Position, *never* None.
  However, the returned Position may *empty* (p.v == None).
  This change *not* change any previously valid code because `if p:` and `if not p:` are the *only* valid tests on positions.
- [x] Raise ValueError in p._parentVnode and v.__init__.
    Doing so prevents data loss by aborting whatever was going on before it can cause damage.
   - p._parentVnode raises ValueError when `p` has no valid parent VNode, per [this ENB](https://groups.google.com/g/leo-editor/c/iH4Rh5YifqM/m/1BlSGbLvAAAJ).
   - v.__init__ raises `ValueError` if `g.app.nodeIndices` does not exist.
- [x] Add asserts, typically `assert p.v` to guard against empty Positions.
   These asserts help mypy without risk. They simply replace imminent AttributeErrors with AssertionErrors.
- [x] Modify imports and related code as needed. These have only local effects.
 
**Significant annotation changes**

- [x] Annotate the `p.v` *ivar* as `v: VNode | None`.  This implies many new `assert p.v` statements.
- [x] p.getVisBack and p.getVisNext are annotated to return `Position | None`.
- [x] For arguments only: change `x: whatever = None` to `x: whatever | None = None`.