### PR TITLE
Fix macOS tabbed outline shortcut dispatch

### DIFF
--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -2,6 +2,8 @@
 # @+node:ekr.20140907103315.18766: * @file ../plugins/qt_events.py
 """Leo's Qt event handling code."""
 
+from __future__ import annotations
+
 # @+<< about internal bindings >>
 # @+node:ekr.20110605121601.18538: ** << about internal bindings >>
 # @@language rest
@@ -35,10 +37,14 @@
 # rules.
 # @-<< about internal bindings >>
 import sys
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoGui
 from leo.core.leoQt import QtCore, QtGui, QtWidgets
 from leo.core.leoQt import Key, KeyboardModifier, Type
+
+if TYPE_CHECKING:
+    from leo.core.leoCommands import Commands as Cmdr
 
 
 # @+others
@@ -98,7 +104,7 @@ class LeoQtEventFilter(QtCore.QObject):
     # @+node:ekr.20110605121601.18540: *3* LeoQtEventFilter.eventFilter & helpers
     def eventFilter(self, obj, event):
         """Return False if Qt should handle the event."""
-        c, k = self.c, self.c.k
+        c = self.c
         # Handle non-key events first.
         if not g.app:
             return False  # For unit tests, but g.unitTesting may be False!
@@ -127,6 +133,8 @@ class LeoQtEventFilter(QtCore.QObject):
             binding, ch, lossage = self.toBinding(event)
             if not binding:
                 return False  # Let Qt handle the key.
+            c = self.currentCommander()
+            k = c.k
             # Pass the KeyStroke to masterKeyHandler.
             key_event = self.createKeyEvent(event, c, self.w, ch, binding)
             # #1933: Update the g.app.lossage
@@ -142,9 +150,11 @@ class LeoQtEventFilter(QtCore.QObject):
         return True  # Whatever happens, suppress all other Qt key handling.
 
     # @+node:ekr.20110605195119.16937: *4* LeoQtEventFilter.createKeyEvent
-    def createKeyEvent(self, event, c, w, ch, binding):
+    def createKeyEvent(
+        self, event: Any, c: Cmdr, w: Any, ch: str, binding: str
+    ) -> leoGui.LeoKeyEvent:
         return leoGui.LeoKeyEvent(
-            c=self.c,
+            c=c,
             # char = None doesn't work at present.
             # But really, the binding should suffice.
             char=ch,
@@ -155,6 +165,18 @@ class LeoQtEventFilter(QtCore.QObject):
             x_root=getattr(event, 'x_root', None) or 0,
             y_root=getattr(event, 'y_root', None) or 0,
         )
+
+    def currentCommander(self) -> Cmdr:
+        """Return the current tab's commander on macOS."""
+        c = self.c
+        if sys.platform != 'darwin':
+            return c
+        try:
+            master = getattr(c.frame.top, 'leo_master', None)
+            current = master.currentWidget()
+            return getattr(current, 'leo_c', None) or c
+        except Exception:
+            return c
 
     # @+node:ekr.20180413180751.2: *4* LeoQtEventFilter.doNonKeyEvent
     def doNonKeyEvent(self, event, obj):


### PR DESCRIPTION
TL;DR; Changing tabs for macOS wouldn't update commander, so under some circumstances (usually after 1-2 minutes after starting) one outline was stuck. Even if the file was closed, commander would still dispatch to it.

## Summary

Fixes macOS shortcut dispatch when multiple outlines are open in Leo's tabbed UI.

Previously, `LeoQtEventFilter` could dispatch a key event through the commander captured when the event filter was created, even if another tab was currently active. This could make shortcuts such as `save-file` act on the wrong outline.

This PR resolves the current tab's commander at key-dispatch time on macOS and uses that commander for both `masterKeyHandler` and `LeoKeyEvent` creation.

## Notes

This is a Mac-specific bug/fix. It was developed and checked on macOS.

Change itself has more type annotation changes than the code itself, though I was advised to try and add them. 

LLM contribution: Codex helped investigate the dispatch path, draft the patch, add annotations, and run local verification. Contribution took: ~2h in total (includes patch grooming).

## Checks

All tests green. `py_compile`, `flake8`, `mypy`, `pylint` ran OK.