### PR TITLE
Add macOS setting to preserve Qt Control/Command key roles

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -200,6 +200,7 @@
 <v t="ekr.20210914081311.1"><vh>@bool highlight-body-line = False</vh></v>
 <v t="ekr.20210914081428.1"><vh>@string line-highlight-color = None</vh></v>
 <v t="ekr.20240726065425.1"><vh>@string qt-layout-name = legacy</vh></v>
+<v t="codex.20260701120000.1"><vh>@bool qt-mac-dont-swap-ctrl-and-meta = False</vh></v>
 <v t="ekr.20140915194122.23431"><vh>Colors</vh>
 <v t="ekr.20140912075503.19318"><vh>Body pane colors</vh>
 <v t="ekr.20140912075503.19319"><vh>@color body-bg = white</vh></v>
@@ -10853,6 +10854,10 @@ Use different names instead.</t>
 False: Legacy operation.
 True:  Replace the Meta key with the Alt Key.
        This allows Windows Keyboards to be used without changing key bindings.
+</t>
+<t tx="codex.20260701120000.1">The setting only has effect on MacOS.
+False: Legacy operation: Qt swaps Command and Control into cross-platform roles.
+True:  Tell Qt not to swap Command and Control before QApplication is created.
 </t>
 <t tx="ekr.20180525053145.1">True: use jedi for autocompletion if available.
 See https://jedi.readthedocs.io/en/latest/index.html

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -114,6 +114,10 @@ class LeoQtGui(leoGui.LeoGui):
         self.mGuiName = 'qt'
         self.show_tips_flag = False  # #2390: Can't be inited in reload_settings.
         self.styleSheetManagerClass = StyleSheetManager
+        if g.isMac and g.app.config.getBool('qt-mac-dont-swap-ctrl-and-meta', default=False):
+            attr = getattr(Qt.ApplicationAttribute, 'AA_MacDontSwapCtrlAndMeta', None)
+            if attr is not None:
+                QtWidgets.QApplication.setAttribute(attr, True)
         # Be aware of the systems native colors, fonts, etc.
         QtWidgets.QApplication.setDesktopSettingsAware(True)
         # Create objects...


### PR DESCRIPTION
## Summary

Adds a new macOS-only Qt setting:

`@bool qt-mac-dont-swap-ctrl-and-meta = False`

When enabled, Leo calls Qt's `AA_MacDontSwapCtrlAndMeta` application attribute before creating `QApplication`. This lets users opt out of Qt's default Command/Control role swapping while preserving the existing default behavior.

## Notes

I'm probably the only one who uses Caps Lock mapped to Control on macOS, and having to use `Cmd+...` binding made me annoyed pretty quick. This PR fixes it:

- Default remains `False`, so existing behavior is unchanged.
- The setting only has effect on macOS.
- The attribute is applied during Qt GUI startup, before `QApplication` is created.

LLM Disclosure
This PR was prepared with assistance from OpenAI Codex. Codex helped identify the Qt startup location, add the setting, and run verification checks. Contribution took ~1h in total.