### PR TITLE
PR2 fixes #4766: Require strict_optional for leoGlobals.py

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -3,7 +3,7 @@
 # Note: Do not put comments after settings.
 
 [mypy]
-python_version = 3.13
+python_version = 3.14
 ignore_missing_imports  = True
 incremental = True
 # cache_dir=nul
@@ -40,7 +40,7 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 
 # #4766: more specific descriptions override less specific.
-[mypy-leo.core.leoNodes]
+[mypy-leo.core.leoNodes,leo.core.leoGlobals]
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 strict_optional = True

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3983,9 +3983,9 @@ def openUrl(event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20150514125218.6: *3* open-url-under-cursor
 @g.command('open-url-under-cursor')
-def openUrlUnderCursor(event: LeoKeyEvent = None) -> str | None:
+def openUrlUnderCursor(event: LeoKeyEvent = None) -> None:
     """Open the url under the cursor."""
-    return g.openUrlOnClick(event)
+    g.openUrlOnClick(event)
 
 
 # @-others

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3112,8 +3112,6 @@ class AtFile:
             return False  # No change to original file.
 
         old_contents = g.readFileIntoUnicodeString(fileName, encoding=at.encoding, silent=True)
-        if not old_contents:
-            old_contents = ''
 
         unchanged = (
             contents == old_contents

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3588,9 +3588,11 @@ class Commands:
 
     # @+node:ekr.20171124101444.1: *3* c.File
     # @+node:ekr.20200305104646.1: *4* c.archivedPositionToPosition
-    def archivedPositionToPosition(self, s: str) -> Position:
+    def archivedPositionToPosition(self, s: str) -> Position | None:
         """Convert an archived position (a string) to a position."""
         c = self
+        if not s:  # PR #4772
+            return None
         s = g.toUnicode(s)
         aList: list[int]
         aList_s = s.split(',')

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1809,7 +1809,7 @@ class SettingsDict(dict):
 
     # @+others
     # @+node:ekr.20120223062418.10422: *4* SettingsDict.copy
-    def copy(self, name: str | None = None) -> Value:
+    def copy(self, name: str = '') -> Value:
         """Return a new dict with the same contents."""
         # The result is a g.SettingsDict.
         return copy.deepcopy(self)
@@ -2474,7 +2474,7 @@ def oldDump(s: str) -> str:
 
 
 # @+node:ekr.20210904114446.1: *4* g.dump_tree & g.tree_to_string
-def dump_tree(c: Cmdr, dump_body: bool = False, msg: str | None = None) -> None:
+def dump_tree(c: Cmdr, dump_body: bool = False, msg: str = '') -> None:
     if msg:
         print(msg.rstrip())
     else:
@@ -2486,7 +2486,7 @@ def dump_tree(c: Cmdr, dump_body: bool = False, msg: str | None = None) -> None:
                 print(z.rstrip())
 
 
-def tree_to_string(c: Cmdr, dump_body: bool = False, msg: str | None = None) -> str:
+def tree_to_string(c: Cmdr, dump_body: bool = False, msg: str = '') -> str:
     result = ['\n']
     if msg:
         result.append(msg)
@@ -2632,7 +2632,7 @@ def objToString(
     obj: object,
     *,
     indent: int = 0,
-    tag: str | None = None,
+    tag: str = '',
     width: int = 120,
     offset: int = 0,  # Offset into array-like objects.
 ) -> str:
@@ -2689,7 +2689,7 @@ def sleep(n: float) -> None:
 
 
 # @+node:ekr.20171023140544.1: *4* g.printObj & aliases
-def printObj(obj: object, *, tag: str | None = None, indent: int = 0, offset: int = 0) -> None:
+def printObj(obj: object, *, tag: str = '', indent: int = 0, offset: int = 0) -> None:
     """Pretty print any Python object using g.pr."""
     g.pr(objToString(obj, indent=indent, tag=tag, offset=offset))
 
@@ -3082,7 +3082,7 @@ def getLanguageAtPosition(c: Cmdr, p: Position) -> str:
 
 
 # @+node:ekr.20031218072017.1386: *3* g.getOutputNewline
-def getOutputNewline(c: Cmdr | None = None, name: str | None = None) -> str:
+def getOutputNewline(c: Cmdr | None = None, name: str = '') -> str:
     """Convert the name of a line ending to the line ending itself.
 
     Priority:
@@ -3841,7 +3841,7 @@ def readFileIntoUnicodeString(fn: str, encoding: str = '', silent: bool = False)
 # @@c
 
 
-def readlineForceUnixNewline(f: IO, fileName: str | None = None) -> str:
+def readlineForceUnixNewline(f: IO, fileName: str = '') -> str:
     try:
         s = f.readline()
     except UnicodeDecodeError:
@@ -4623,7 +4623,7 @@ def skip_c_id(s: str, i: int) -> int:
 
 
 # @+node:ekr.20040705195048: *4* g.skip_id
-def skip_id(s: str, i: int, chars: str | None = None) -> int:
+def skip_id(s: str, i: int, chars: str = '') -> int:
     chars = g.toUnicode(chars) if chars else ''
     n = len(s)
     while i < n and (g.isWordChar(s[i]) or s[i] in chars):
@@ -4868,11 +4868,11 @@ class GitIssueController:
         c: Cmdr,
         label_list: list[str],
         root: Position,
-        state: str | None = None,
+        state: str = '',
     ) -> None:
         self.base_url = base_url
         self.root = root
-        self.milestone = None
+        self.milestone = ''
         if label_list:
             for state in ('closed', 'open'):
                 for label in label_list:
@@ -5131,7 +5131,7 @@ def gitDescribe(path: str = '') -> tuple[str, str, str]:
 
 
 # @+node:ekr.20170414034616.6: *3* g.gitHeadPath
-def gitHeadPath(path_s: str) -> str | None:
+def gitHeadPath(path_s: str) -> str:
     """
     Compute the path to .git/HEAD given the path.
     """
@@ -5144,11 +5144,11 @@ def gitHeadPath(path_s: str) -> str | None:
         if path == path.parent:
             break
         path = path.parent
-    return None
+    return ''
 
 
 # @+node:ekr.20170414034616.3: *3* g.gitInfo
-def gitInfo(path: str | None = None) -> tuple[str, str]:
+def gitInfo(path: str = '') -> tuple[str, str]:
     """
     Path may be a directory or file.
 
@@ -5342,7 +5342,7 @@ def enableIdleTimeHook(*args: Args, **kwargs: KWargs) -> None:
 
 
 # @+node:ekr.20140825042850.18410: *3* g.IdleTime
-def IdleTime(handler: Callable, delay: int = 500, tag: str | None = None) -> QtIdleTime | None:
+def IdleTime(handler: Callable, delay: int = 500, tag: str = '') -> QtIdleTime | None:
     """
     A thin wrapper for the LeoQtGui.IdleTime class.
 
@@ -5398,7 +5398,7 @@ def idleTimeHookHandler(timer: Callable) -> None:
 
 # @+node:ekr.20041219095213: ** g.Importing
 # @+node:ekr.20040917061619: *3* g.cantImport
-def cantImport(moduleName: str, pluginName: str | None = None, verbose: bool = True) -> None:
+def cantImport(moduleName: str, pluginName: str = '', verbose: bool = True) -> None:
     """Print a "Can't Import" message and return None."""
     s = f"Can not import {moduleName}"
     if pluginName:
@@ -5412,7 +5412,7 @@ def cantImport(moduleName: str, pluginName: str | None = None, verbose: bool = T
 
 
 # @+node:ekr.20191220044128.1: *3* g.import_module
-def import_module(name: str, package: str | None = None) -> ModuleType | None:
+def import_module(name: str, package: str = '') -> ModuleType | None:
     """
     A thin wrapper over importlib.import_module.
     """
@@ -5673,7 +5673,7 @@ def bytesToStr(b: bytes, reportErrors: bool = False) -> str:
 
 
 # @+node:ekr.20190505052756.1: *4* g.checkUnicode
-def checkUnicode(s: str, encoding: str | None = None) -> str:
+def checkUnicode(s: str, encoding: str = '') -> str:
     """
     Warn when converting bytes. Report *all* errors.
 
@@ -6244,7 +6244,7 @@ log = es
 
 
 # @+node:ekr.20060917120951: *3* g.es_dump
-def es_dump(s: str, n: int = 30, title: str | None = None) -> None:
+def es_dump(s: str, n: int = 30, title: str = '') -> None:
     if title:
         g.es_print('', title)
     i = 0
@@ -6429,7 +6429,7 @@ is_unique_class = isUniqueClass
 
 
 # @+node:ekr.20150127060254.5: *3* g.log_to_file
-def log_to_file(s: str, fn: str | None = None) -> None:
+def log_to_file(s: str, fn: str = '') -> None:
     """Write a message to ~/test/leo_log.txt."""
     if fn is None:
         fn = g.finalize('~/test/leo_log.txt')
@@ -6541,7 +6541,7 @@ def printEntireTree(c: Cmdr, tag: str = '') -> None:
 
 
 # @+node:ekr.20031218072017.3114: *3* g.printGlobals
-def printGlobals(message: str | None = None) -> None:
+def printGlobals(message: str = '') -> None:
     # Get the list of globals.
     globs = list(globals())
     globs.sort()
@@ -6554,7 +6554,7 @@ def printGlobals(message: str | None = None) -> None:
 
 
 # @+node:ekr.20031218072017.3115: *3* g.printLeoModules
-def printLeoModules(message: str | None = None) -> None:
+def printLeoModules(message: str = '') -> None:
     # Create the list.
     mods = []
     for name in sys.modules:
@@ -6829,7 +6829,7 @@ def cls(event: LeoKeyEvent | None = None) -> None:
 
 
 # @+node:ekr.20131114124839.16665: *3* g.createScratchCommander
-def createScratchCommander(fileName: str | None = None) -> None:
+def createScratchCommander(fileName: str = '') -> None:
     c = g.app.newCommander(fileName)
     frame = c.frame
     frame.createFirstTreeNode()
@@ -6850,7 +6850,7 @@ def deprecated() -> None:
 
 
 # @+node:ekr.20031218072017.3126: *3* g.funcToMethod (Python Cookbook)
-def funcToMethod(f: Callable, theClass: object, name: str | None = None) -> None:
+def funcToMethod(f: Callable, theClass: object, name: str = '') -> None:
     """
     From the Python Cookbook...
 
@@ -7433,7 +7433,7 @@ def python_tokenize(s: str) -> list:
 
 # @+node:ekr.20040327103735.2: ** g.Scripting
 # @+node:ekr.20161223090721.1: *3* g.exec_file
-def exec_file(path: str, d: dict[str, Value], script: str | None = None) -> None:
+def exec_file(path: str, d: dict[str, Value], script: str = '') -> None:
     """Simulate python's execfile statement for python 3."""
     if script is None:
         with open(path) as f:
@@ -7791,7 +7791,7 @@ def run_coverage_tests(module: str = '', filename: str = '') -> None:
 
 
 # @+node:ekr.20210901065224.1: *3* g.run_unit_tests
-def run_unit_tests(tests: str | None = None, verbose: bool = False) -> None:
+def run_unit_tests(tests: str = '', verbose: bool = False) -> None:
     """
     Run the unit tests given by the "tests" string.
 
@@ -8371,7 +8371,7 @@ def openUrl(p: Position) -> None:  # pragma: no cover
 
 
 # @+node:ekr.20110605121601.18135: *3* g.openUrlOnClick (open-url-under-cursor)
-def openUrlOnClick(event: QMouseEvent, url: str | None = None) -> str | None:  # pragma: no cover
+def openUrlOnClick(event: QMouseEvent, url: str = '') -> str | None:  # pragma: no cover
     """Open the URL under the cursor.  Return it for unit testing."""
     from leo.core.leoGui import LeoKeyEvent
     from leo.plugins.qt_text import QTextEditWrapper
@@ -8390,7 +8390,7 @@ def openUrlOnClick(event: QMouseEvent, url: str | None = None) -> str | None:  #
 
 
 # @+node:ekr.20170216091704.1: *4* g.openUrlHelper
-def openUrlHelper(event: LeoKeyEvent, url: str | None = None) -> str | None:
+def openUrlHelper(event: LeoKeyEvent, url: str = '') -> str | None:
     """Open the unl, url or gnx under the cursor.  Return it for unit testing."""
     if not event:
         return None

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1386,7 +1386,7 @@ class MatchBrackets:
                         return True
                     i -= 1
             return False
-        return self.start_comment and self.end_comment and g.match(s, i, self.end_comment)
+        return bool(self.start_comment and self.end_comment and g.match(s, i, self.end_comment))
 
     # @+node:ekr.20160119230141.1: *4* mb.scan_back & helpers
     def scan_back(self, ch1: str, target: str, s: str, i: int) -> int | None:
@@ -7378,26 +7378,26 @@ def getDocStringForFunction(func: Callable) -> str:
 
     def get_defaults(func: Callable, i: int) -> Value:
         defaults = inspect.getfullargspec(func)[3]
-        return defaults[i]
+        return defaults[i] if defaults else None
 
     # Fix bug 1251252: https://bugs.launchpad.net/leo-editor/+bug/1251252
     # Minibuffer commands created by mod_scripting.py have no docstrings.
     # Do special cases first.
 
-    s = ''
     if name(func) == 'minibufferCallback':
         func = get_defaults(func, 0)
-        if hasattr(func, '__doc__') and func.__doc__.strip():
-            s = func.__doc__
-    if not s and name(func) == 'commonCommandCallback':
+        if s := getattr(func, '__doc__', '').strip():
+            return s
+    if name(func) == 'commonCommandCallback':
         script = get_defaults(func, 1)
-        s = g.getDocString(script)  # Do a text scan for the function.
+        if s := g.getDocString(script):  # Do a text scan for the function.
+            return s
     # Now the general cases.  Prefer __doc__ to docstring()
-    if not s and hasattr(func, '__doc__'):
-        s = func.__doc__
-    if not s and hasattr(func, 'docstring'):
-        s = func.docstring
-    return s
+    if s := getattr(func, '__doc__', '').strip():
+        return s
+    if s := getattr(func, 'docstring', '').strip():
+        return s
+    return ''
 
 
 # @+node:ekr.20111115155710.9814: *3* g.python_tokenize (not used)
@@ -7471,89 +7471,6 @@ def execute_shell_commands(
         proc = subprocess.Popen(command, shell=shell)
         if wait:
             proc.communicate()
-
-
-# @+node:ekr.20180217113719.1: *3* g.execute_shell_commands_with_options & helpers
-def execute_shell_commands_with_options(
-    base_dir: str | None = None,
-    c: Cmdr | None = None,
-    command_setting: str | None = None,
-    commands: list | None = None,
-    path_setting: str | None = None,
-    trace: bool = False,
-    warning: str | None = None,
-) -> None:
-    """
-    A helper for prototype commands or any other code that
-    runs programs in a separate process.
-
-    base_dir:           Base directory to use if no config path given.
-    commands:           A list of commands, for g.execute_shell_commands.
-    commands_setting:   Name of @data setting for commands.
-    path_setting:       Name of @string setting for the base directory.
-    warning:            A warning to be printed before executing the commands.
-    """
-    base_dir = g.computeBaseDir(c, base_dir, path_setting)
-    if not base_dir:
-        return
-    commands = g.computeCommands(c, commands, command_setting)
-    if not commands:
-        return
-    if warning:
-        g.es_print(warning)
-    os.chdir(base_dir)  # Can't do this in the commands list.
-    g.execute_shell_commands(commands, trace=trace)
-
-
-# @+node:ekr.20180217152624.1: *4* g.computeBaseDir
-def computeBaseDir(c: Cmdr, base_dir: str, path_setting: str) -> str | None:
-    """
-    Compute a base_directory.
-    If given, @string path_setting takes precedence.
-    """
-    # Prefer the path setting to the base_dir argument.
-    if path_setting:
-        if not c:
-            g.es_print('@string path_setting requires valid c arg')
-            return None
-        # It's not an error for the setting to be empty.
-        base_dir2 = c.config.getString(path_setting)
-        if base_dir2:
-            base_dir2 = base_dir2.replace('\\', '/')
-            if g.os_path_exists(base_dir2):
-                return base_dir2
-            g.es_print(f"@string {path_setting} not found: {base_dir2!r}")
-            return None
-    # Fall back to given base_dir.
-    if base_dir:
-        base_dir = base_dir.replace('\\', '/')
-        if g.os_path_exists(base_dir):
-            return base_dir
-        g.es_print(f"base_dir not found: {base_dir!r}")
-        return None
-    g.es_print(f"Please use @string {path_setting}")
-    return None
-
-
-# @+node:ekr.20180217153459.1: *4* g.computeCommands
-def computeCommands(c: Cmdr, commands: list[str], command_setting: str) -> list[str]:
-    """
-    Get the list of commands.
-    If given, @data command_setting takes precedence.
-    """
-    if not commands and not command_setting:
-        g.es_print('Please use commands, command_setting or both')
-        return []
-    # Prefer the setting to the static commands.
-    if command_setting:
-        if c:
-            aList = c.config.getData(command_setting)
-            # It's not an error for the setting to be empty.
-            # Fall back to the commands.
-            return aList or commands
-        g.es_print('@data command_setting requires valid c arg')
-        return []
-    return commands
 
 
 # @+node:ekr.20050503112513.7: *3* g.executeFile
@@ -7760,16 +7677,13 @@ def extractExecutableString(c: Cmdr, p: Position, s: str) -> str:
 
 
 # @+node:ekr.20060624085200: *3* g.handleScriptException
-def handleScriptException(
-    c: Cmdr,
-    p: Position,
-    script: str | None = None,  # No longer used.
-    script1: str | None = None,  # No longer used.
-) -> None:
+def handleScriptException(c: Cmdr, p: Position, script: str = '') -> None:
+    # PR #4772 Minor change to signature.
     g.warning("exception executing script")
     g.es_exception()
 
     # Careful: this test is no longer guaranteed.
+    assert p.v
     if p.v.context != c:
         return
     fileName, n = g.getLastTracebackFileAndLineNumber()
@@ -7970,7 +7884,7 @@ def run_unit_tests(tests: str | None = None, verbose: bool = False) -> None:
 #    For example, Leo's forum: https://leo-editor.github.io/leo-editor/
 # @-<< About clickable links >>
 # @+node:ekr.20120320053907.9776: *3* g.computeFileUrl
-def computeFileUrl(fn: str, c: Cmdr | None = None, p: Position | None = None) -> str:
+def computeFileUrl(fn: str, c: Cmdr, p: Position) -> str:
     """
     Compute finalized url for filename fn.
     """
@@ -8235,6 +8149,7 @@ def getUrlFromNode(p: Position) -> str | None:
     """
     if not p:
         return None
+    assert p.v
     c = p.v.context
     assert c
     table = [p.h, g.splitLines(p.b)[0] if p.b else '']
@@ -8279,6 +8194,7 @@ def handleUnl(unl_s: str, c: Cmdr) -> Cmdr | None:
         print(f"Not found: {unl!r}")
         return None
     # Do not assume that p is in c.
+    assert p.v
     c2 = p.v.context
     if c2 != c:
         g.app.selectLeoWindow(c2)  # Switch outlines.
@@ -8331,11 +8247,9 @@ def handleUrl(url: str, c: Cmdr, p: Position | None = None) -> None:  ### str | 
         return
     try:
         g.handleUrlHelper(url, c, p)
-        ### return urll  # For unit tests.
     except Exception:
         g.es_print("g.handleUrl: exception opening", repr(url))
         g.es_exception()
-        ### return None
 
 
 # @+node:ekr.20170226054459.1: *4* g.handleUrlHelper

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1503,10 +1503,10 @@ class MatchBrackets:
         With selected range: the first time, move cursor back to other end of
         range. The second time, select enclosing range.
         """
-        #
+
         # A partial fix for bug 127: Bracket matching is buggy.
         w = self.c.frame.body.wrapper
-        s = cast(str, w.getAllText())
+        s = w.getAllText() or ''
         _mb = self.c.user_dict['_match_brackets']
         sel_range = w.getSelectionRange()
         if not w.hasSelection():
@@ -7869,7 +7869,7 @@ def run_unit_tests(tests: str = '', verbose: bool = False) -> None:
 #    For example, Leo's forum: https://leo-editor.github.io/leo-editor/
 # @-<< About clickable links >>
 # @+node:ekr.20120320053907.9776: *3* g.computeFileUrl
-def computeFileUrl(fn: str, c: Cmdr, p: Position) -> str:
+def computeFileUrl(fn: str, c: Cmdr | None = None, p: Position | None = None) -> str:
     """
     Compute finalized url for filename fn.
     """
@@ -7892,7 +7892,7 @@ def computeFileUrl(fn: str, c: Cmdr, p: Position) -> str:
         else:
             path = url
         # Handle ancestor @path directives.
-        if c and c.fileName():
+        if c and p and c.fileName():
             base = c.getPath(p)
             path = g.finalize_join(g.os_path_dirname(c.fileName()), base, path)
         else:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -38,24 +38,23 @@ import time
 import traceback
 import types
 from types import ModuleType
-from typing import Any, IO, Iterable, Sequence, TYPE_CHECKING
+from typing import cast, Any, IO, Iterable, Sequence, TYPE_CHECKING
 import unittest
 import urllib
 import urllib.parse as urlparse
 
-# Leo never imports any other Leo module.
-
 # Third-party tools.
 import webbrowser
 
-# PR #4772
+# Leo never imports any other Leo module.
+# PR #4772: add this import statement.
 from leo.core import leoGlobals as g  # pylint: disable=import-self
 
 try:
     import tkinter as Tk
 except Exception:
-    Tk = None
-#
+    Tk = None  # type:ignore
+
 # Abbreviations...
 StringIO = io.StringIO
 # @-<< leoGlobals: imports >>
@@ -153,7 +152,7 @@ directives_pat = None  # Set below.
 
 global_commands_dict: dict[str, Callable] = {}
 
-cmd_instance_dict = {
+cmd_instance_dict: dict[str, list[str]] = {
     # Keys are class names, values are attribute chains.
     'AbbrevCommandsClass':      ['c', 'abbrevCommands'],
     'AtFile':                   ['c', 'atFileCommands'],
@@ -290,7 +289,8 @@ class CommanderCommand:
         def commander_command_wrapper(event: LeoKeyEvent) -> Any:
             c = event.get('c')
             method = getattr(c, func.__name__, None)
-            return method(event=event)  # Return value to caller (for doCommand, doCommandByName...)
+            # Return value to caller (for doCommand, doCommandByName...)
+            return method(event=event) if method else None
 
         # Inject ivars for plugins_menu.py.
         commander_command_wrapper.__func_name__ = func.__name__  # For leoInteg.
@@ -313,7 +313,7 @@ commander_command = CommanderCommand
 
 
 # @+node:ekr.20150508164812.1: *3* g.ivars2instance
-def ivars2instance(c: Cmdr, g: LeoGlobals, ivars: list[str]) -> Any | None:
+def ivars2instance(c: Cmdr, g: LeoGlobals, ivars: list[str] | None) -> Any | None:
     """
     Return the instance of c given by ivars.
     ivars is a list of strings.
@@ -346,12 +346,13 @@ def new_cmd_decorator(name: str, ivars: list[str]) -> Callable:
     """
 
     def _decorator(func: Callable) -> Callable:
+
         def new_cmd_wrapper(event: LeoKeyEvent) -> None:
             if isinstance(event, dict):
                 c = event.get('c')
             else:
                 c = event.c
-            self = g.ivars2instance(c, g, ivars)
+            self = g.ivars2instance(c, g, ivars)  # type:ignore
             try:
                 # Don't use a keyword for self.
                 # This allows the VimCommands class to use vc instead.
@@ -735,11 +736,8 @@ class KeyStroke:
     # @+others
     # @+node:ekr.20180414195401.2: *4*  ks.__init__
     def __init__(self, binding: str) -> None:
-        self.s: str
-        if binding:
-            self.s = self.finalize_binding(binding)
-        else:
-            self.s = None
+
+        self.s = self.finalize_binding(binding)  # PR #4772: self.s is always a string.
 
     # @+node:ekr.20120203053243.10117: *4* ks.__eq__, etc
     # All these must be defined in order to say, for example:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -48,6 +48,9 @@ import urllib.parse as urlparse
 # Third-party tools.
 import webbrowser
 
+# PR #4772
+from leo.core import leoGlobals as g  # pylint: disable=import-self
+
 try:
     import tkinter as Tk
 except Exception:
@@ -2165,7 +2168,7 @@ class TestLeoGlobals(unittest.TestCase):
     # @+others
     # @+node:ekr.20200219071958.1: *4* TestLeoGlobals.test_comment_delims_from_extension
     def test_comment_delims_from_extension(self) -> None:
-        from leo.core import leoGlobals as leo_g  # pylint: disable=import-self
+        from leo.core import leoGlobals as leo_g  # pylint: disable=import-self,reimported
         from leo.core import leoApp
 
         leo_g.app = leoApp.LeoApp()
@@ -2175,7 +2178,7 @@ class TestLeoGlobals(unittest.TestCase):
 
     # @+node:ekr.20200219072957.1: *4* TestLeoGlobals.test_is_sentinel
     def test_is_sentinel(self) -> None:
-        from leo.core import leoGlobals as leo_g  # pylint: disable=import-self
+        from leo.core import leoGlobals as leo_g  # pylint: disable=import-self,reimported
 
         # Python. Test regular and blackened sentinels.
         py_delims = leo_g.comment_delims_from_extension('.py')
@@ -8732,9 +8735,7 @@ def parsePathData(c: Cmdr) -> dict[str, str]:
 
 
 # @-others
-# set g when the import is about to complete.
-g = sys.modules.get('leo.core.leoGlobals')
-assert g, sorted(sys.modules.keys())
+
 if __name__ == '__main__':
     unittest.main()  # pragma: no cover
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -472,9 +472,10 @@ class BindingInfo:
         self,
         kind: str,
         commandName: str = '',
+        *,
         func: Callable | None = None,
-        nextMode: str | None = None,
-        pane: str | None = None,
+        nextMode: str = '',
+        pane: str = '',
         stroke: KeyStroke | None = None,
     ) -> None:
         if not g.isStrokeOrNone(stroke):

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3162,7 +3162,7 @@ def scanAtCommentAndAtLanguageDirectives(aList: list) -> dict[str, str] | None:
 
 
 # @+node:ekr.20080827175609.32: *4* g.scanAtEncodingDirectives (deprecated)
-def scanAtEncodingDirectives(aList: list) -> str | None:
+def scanAtEncodingDirectives(aList: list) -> str:
     """Scan aList for @encoding directives."""
     g.deprecated()
     for d in aList:
@@ -3171,7 +3171,7 @@ def scanAtEncodingDirectives(aList: list) -> str | None:
             return encoding
         if encoding and not g.unitTesting:
             g.error("invalid @encoding:", encoding)
-    return None
+    return ''
 
 
 # @+node:ekr.20080827175609.53: *4* g.scanAtHeaderDirectives (deprecated)
@@ -3582,7 +3582,7 @@ def getBaseDirectory(c: Cmdr) -> str:
 
 
 # @+node:ekr.20170223093758.1: *3* g.getEncodingAt (deprecated)
-def getEncodingAt(p: Position, b: bytes | None = None) -> str:
+def getEncodingAt(p: Position, b: bytes) -> str:
     """
     Return the encoding in effect at p and/or for string s.
 
@@ -3638,8 +3638,8 @@ def init_dialog_folder(c: Cmdr, p: Position, use_at_path: bool = True) -> str:
             dir_ = g.os_path_dirname(path)
             if dir_ and g.os_path_exists(dir_):
                 return dir_
-    table = (
-        c and c.last_dir,
+    table: tuple = (
+        c.last_dir if c else None,
         g.os_path_abspath(os.curdir),
     )
     for dir_ in table:
@@ -3657,7 +3657,7 @@ def is_binary_external_file(fileName: str) -> bool:
     try:
         with open(fileName, 'rb') as f:
             s = f.read(1024)
-        return g.is_binary_string(s)
+        return g.is_binary_string(g.toUnicode(s))
     except IOError:
         return False
     except Exception:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6298,10 +6298,11 @@ def es_exception(*args: Sequence, **kwargs: Sequence) -> None:
 
 
 # @+node:ekr.20061015090538: *3* g.es_exception_type
-def es_exception_type(c: Cmdr | None = None, color: str = "red") -> None:
+def es_exception_type(color: str = "red") -> None:  # PR #4772: remove unused c arg.
     # exctype is a Exception class object; value is the error message.
     exctype, value = sys.exc_info()[:2]
-    g.es_print('', f"{exctype.__name__}, {value}", color=color)
+    if exctype:
+        g.es_print('', f"{exctype.__name__}, {value}", color=color)
 
 
 # @+node:ekr.20050707064040: *3* g.es_print
@@ -6362,8 +6363,7 @@ def getLastTracebackFileAndLineNumber() -> tuple[str, int]:
     typ, val, tb = sys.exc_info()
     if typ is SyntaxError:
         # IndentationError is a subclass of SyntaxError.
-        return val.filename, val.lineno
-    #
+        return val.filename, val.lineno  # type:ignore
     # Data is a list of tuples, one per stack entry.
     # Tuples have the form (filename,lineNumber,functionName,text).
     data = traceback.extract_tb(tb)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2945,18 +2945,18 @@ def findTabWidthDirectives(c: Cmdr, p: Position) -> int | None:
 
 
 # @+node:ekr.20170127142001.5: *3* g.findFirstAtLanguageDirective
-def findFirstValidAtLanguageDirective(s: str) -> str | None:
+def findFirstValidAtLanguageDirective(s: str) -> str:
     """
     Return the first language for which there is a valid @language
     directive in s.
     """
     if not s.strip():
-        return None
+        return ''
     for m in g.g_language_pat.finditer(s):
         language = m.group(1)
         if g.isValidLanguage(language):
             return language
-    return None
+    return ''
 
 
 # @+node:ekr.20090214075058.6: *3* g.findLanguageDirectives (must be fast)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -402,7 +402,7 @@ url_regex = re.compile(rf"""\b{url_kinds}://[^\s'"]+""")
 # @-<< define regexes >>
 tree_popup_handlers: list[Callable] = []  # Set later.
 user_dict: dict[str, Value] = {}  # Non-persistent dictionary for scripts and plugins.
-app: LeoApp = None  # The singleton app object. Set by runLeo.py.
+app: LeoApp | None = None  # The singleton app object. Set by runLeo.py.
 # Global status vars.
 inScript = False  # A synonym for app.inScript
 unitTesting = False  # A synonym for app.unitTesting.
@@ -468,10 +468,10 @@ class BindingInfo:
         self,
         kind: str,
         commandName: str = '',
-        func: Callable = None,
-        nextMode: str = None,
-        pane: str = None,
-        stroke: KeyStroke = None,
+        func: Callable | None = None,
+        nextMode: str | None = None,
+        pane: str | None = None,
+        stroke: KeyStroke | None = None,
     ) -> None:
         if not g.isStrokeOrNone(stroke):
             g.trace('***** (BindingInfo) oops', repr(stroke))
@@ -573,7 +573,7 @@ class Bunch:
         """Support aBunch[key]"""
         return operator.getitem(self.__dict__, key)
 
-    def get(self, key: str, theDefault: Value = None) -> Value:
+    def get(self, key: str, theDefault: Value | None = None) -> Value:
         return self.__dict__.get(key, theDefault)
 
     def __contains__(self, key: str) -> bool:
@@ -691,13 +691,13 @@ class GeneralSetting:
     def __init__(
         self,
         kind: str,
-        encoding: str = None,
-        ivar: str = None,
-        source: str = None,
-        val: Value = None,
-        path: str = None,
+        encoding: str | None = None,
+        ivar: str | None = None,
+        source: str | None = None,
+        val: Value | None = None,
+        path: str | None = None,
         tag: str = 'setting',
-        unl: str = None,
+        unl: str | None = None,
     ) -> None:
         self.encoding = encoding
         self.ivar = ivar
@@ -1569,7 +1569,7 @@ class OptionsUtils:
     This class *calculates* valid options from the usage message.
     """
 
-    def __init__(self, usage: str, obsolete_options: list[str] = None) -> None:
+    def __init__(self, usage: str, obsolete_options: list[str] | None = None) -> None:
         # This class is essentially stateless because these ivars never change.
         self.usage = usage
         self.obsolete_options = obsolete_options
@@ -1803,7 +1803,7 @@ class SettingsDict(dict):
 
     # @+others
     # @+node:ekr.20120223062418.10422: *4* SettingsDict.copy
-    def copy(self, name: str = None) -> Value:
+    def copy(self, name: str | None = None) -> Value:
         """Return a new dict with the same contents."""
         # The result is a g.SettingsDict.
         return copy.deepcopy(self)
@@ -2031,7 +2031,7 @@ tracing_tags: dict[int, str] = {}  # Keys are id's, values are tags.
 class NullObject:
     """An object that does nothing, and does it very well."""
 
-    def __init__(self, ivars: list[str] = None, *args: Args, **kwargs: KWargs) -> None:
+    def __init__(self, ivars: list[str] | None = None, *args: Args, **kwargs: KWargs) -> None:
         pass
 
     def __call__(self, *args: Args, **kwargs: KWargs) -> "NullObject":
@@ -2080,7 +2080,9 @@ class NullObject:
 class TracingNullObject:
     """Tracing NullObject."""
 
-    def __init__(self, tag: str, ivars: list[str] = None, *args: Args, **kwargs: KWargs) -> None:
+    def __init__(
+        self, tag: str, ivars: list[str] | None = None, *args: Args, **kwargs: KWargs
+    ) -> None:
         tracing_tags[id(self)] = tag  # noqa  # conflict between flake8 and black.
 
     def __call__(self, *args: Args, **kwargs: KWargs) -> "TracingNullObject":
@@ -2363,7 +2365,7 @@ qt_text_classes = [
 ]
 
 
-def checkQtTextWidget(obj: Any, *, other_classes: list[str] = None) -> None:
+def checkQtTextWidget(obj: Any, *, other_classes: list[str] | None = None) -> None:
     """
     Check that an object has the appropriate class.
     """
@@ -2465,7 +2467,7 @@ def oldDump(s: str) -> str:
 
 
 # @+node:ekr.20210904114446.1: *4* g.dump_tree & g.tree_to_string
-def dump_tree(c: Cmdr, dump_body: bool = False, msg: str = None) -> None:
+def dump_tree(c: Cmdr, dump_body: bool = False, msg: str | None = None) -> None:
     if msg:
         print(msg.rstrip())
     else:
@@ -2477,7 +2479,7 @@ def dump_tree(c: Cmdr, dump_body: bool = False, msg: str = None) -> None:
                 print(z.rstrip())
 
 
-def tree_to_string(c: Cmdr, dump_body: bool = False, msg: str = None) -> str:
+def tree_to_string(c: Cmdr, dump_body: bool = False, msg: str | None = None) -> str:
     result = ['\n']
     if msg:
         result.append(msg)
@@ -2507,19 +2509,19 @@ def dump_encoded_string(encoding: str, s: str) -> None:
 
 
 # @+node:ekr.20031218072017.1317: *4* g.file/module/plugin_date
-def module_date(mod: ModuleType, format: str = None) -> str:
+def module_date(mod: ModuleType, format: str | None = None) -> str:
     theFile = g.os_path_join(app.loadDir, mod.__file__)
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=format)
 
 
-def plugin_date(plugin_mod: ModuleType, format: str = None) -> str:
+def plugin_date(plugin_mod: ModuleType, format: str | None = None) -> str:
     theFile = g.os_path_join(app.loadDir, "..", "plugins", plugin_mod.__file__)
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=str)
 
 
-def file_date(theFile: IO, format: str = None) -> str:
+def file_date(theFile: IO, format: str | None = None) -> str:
     if theFile and g.os_path_exists(theFile):
         try:
             n = g.os_path_getmtime(theFile)
@@ -2577,7 +2579,7 @@ def getIvarsDict(obj: object) -> dict[str, Value]:
 def checkUnchangedIvars(
     obj: object,
     d: dict[str, Value],
-    exceptions: Sequence[str] = None,
+    exceptions: Sequence[str] | None = None,
 ) -> bool:
     if not exceptions:
         exceptions = []
@@ -2623,7 +2625,7 @@ def objToString(
     obj: object,
     *,
     indent: int = 0,
-    tag: str = None,
+    tag: str | None = None,
     width: int = 120,
     offset: int = 0,  # Offset into array-like objects.
 ) -> str:
@@ -2680,7 +2682,7 @@ def sleep(n: float) -> None:
 
 
 # @+node:ekr.20171023140544.1: *4* g.printObj & aliases
-def printObj(obj: object, *, tag: str = None, indent: int = 0, offset: int = 0) -> None:
+def printObj(obj: object, *, tag: str | None = None, indent: int = 0, offset: int = 0) -> None:
     """Pretty print any Python object using g.pr."""
     g.pr(objToString(obj, indent=indent, tag=tag, offset=offset))
 
@@ -2793,7 +2795,7 @@ def clearStats() -> None:
 
 # @+node:ekr.20031218072017.3135: *4* g.printStats
 @command('show-stats')
-def printStats(event: LeoKeyEvent = None) -> None:
+def printStats(event: LeoKeyEvent | None = None) -> None:
     """
     Print all stats created by g.stat(), counts first.
     """
@@ -2822,7 +2824,7 @@ def printStats(event: LeoKeyEvent = None) -> None:
 _int_stat_prefix = 'stat_count: '
 
 
-def stat(obj: Any = None) -> None:
+def stat(obj: Any | None = None) -> None:
     """
     Add another count stat to g.app.statsDict.
     g.printStats() prints all such stats.
@@ -3071,7 +3073,7 @@ def getLanguageAtPosition(c: Cmdr, p: Position) -> str:
 
 
 # @+node:ekr.20031218072017.1386: *3* g.getOutputNewline
-def getOutputNewline(c: Cmdr = None, name: str = None) -> str:
+def getOutputNewline(c: Cmdr | None = None, name: str | None = None) -> str:
     """Convert the name of a line ending to the line ending itself.
 
     Priority:
@@ -3504,7 +3506,7 @@ def createHiddenCommander(fn: str) -> Cmdr | None:
 
 
 # @+node:vitalije.20170714085545.1: *3* g.defaultLeoFileExtension
-def defaultLeoFileExtension(c: Cmdr = None) -> str:
+def defaultLeoFileExtension(c: Cmdr | None = None) -> str:
     conf = c.config if c else g.app.config
     return conf.getString('default-leo-extension') or '.leo'
 
@@ -3535,7 +3537,9 @@ def fullPath(c: Cmdr, p: Position) -> str:
 
 
 # @+node:ekr.20190327192721.1: *3* g.get_files_in_directory
-def get_files_in_directory(directory: str, kinds: list = None, recursive: bool = True) -> list[str]:
+def get_files_in_directory(
+    directory: str, kinds: list | None = None, recursive: bool = True
+) -> list[str]:
     """
     Return a list of all files of the given file extensions in the directory.
     Default kinds: ['*.py'].
@@ -3577,7 +3581,7 @@ def getBaseDirectory(c: Cmdr) -> str:
 
 
 # @+node:ekr.20170223093758.1: *3* g.getEncodingAt (deprecated)
-def getEncodingAt(p: Position, b: bytes = None) -> str:
+def getEncodingAt(p: Position, b: bytes | None = None) -> str:
     """
     Return the encoding in effect at p and/or for string s.
 
@@ -3598,7 +3602,7 @@ def getEncodingAt(p: Position, b: bytes = None) -> str:
 
 
 # @+node:ville.20090701144325.14942: *3* g.guessExternalEditor
-def guessExternalEditor(c: Cmdr = None) -> str | None:
+def guessExternalEditor(c: Cmdr | None = None) -> str | None:
     """Return a 'sensible' external editor"""
     editor = (
         c
@@ -3700,7 +3704,9 @@ def makePathRelativeTo(fullPath: str, basePath: str) -> str:
 
 
 # @+node:ekr.20090520055433.5945: *3* g.openWithFileName
-def openWithFileName(fileName: str, old_c: Cmdr = None, gui: LeoGui = None) -> Cmdr | None:
+def openWithFileName(
+    fileName: str, old_c: Cmdr | None = None, gui: LeoGui | None = None
+) -> Cmdr | None:
     """
     Load any kind of file in the appropriate way:
 
@@ -3748,7 +3754,7 @@ def readFileIntoEncodedString(fn: str, silent: bool = False) -> bytes:
 def readFileIntoString(
     fileName: str,
     encoding: str = 'utf-8',  # BOM may override this.
-    kind: str = None,  # @file, @edit, ...
+    kind: str | None = None,  # @file, @edit, ...
     verbose: bool = True,
 ) -> tuple[str, str] | tuple[None, None]:
     """
@@ -3914,7 +3920,7 @@ def setGlobalOpenDir(fileName: str) -> None:
 
 
 # @+node:ekr.20031218072017.3125: *3* g.shortFileName & shortFilename
-def shortFileName(fileName: str, n: int = None) -> str:
+def shortFileName(fileName: str, n: int | None = None) -> str:
     """Return the base name of a path."""
     if n is not None:
         g.trace('"n" keyword argument is no longer used')
@@ -4040,7 +4046,9 @@ def findAncestorVnodeByPredicate(p: Position, v_predicate: Callable | None) -> V
 
 
 # @+node:ekr.20170220103251.1: *3* g.findRootsWithPredicate
-def findRootsWithPredicate(c: Cmdr, root: Position, predicate: Callable = None) -> list[Position]:
+def findRootsWithPredicate(
+    c: Cmdr, root: Position, predicate: Callable | None = None
+) -> list[Position]:
     """
     Commands often want to find one or more **roots**, given a position p.
     A root is the position of any node matching a predicate.
@@ -4609,7 +4617,7 @@ def skip_c_id(s: str, i: int) -> int:
 
 
 # @+node:ekr.20040705195048: *4* g.skip_id
-def skip_id(s: str, i: int, chars: str = None) -> int:
+def skip_id(s: str, i: int, chars: str | None = None) -> int:
     chars = g.toUnicode(chars) if chars else ''
     n = len(s)
     while i < n and (g.isWordChar(s[i]) or s[i] in chars):
@@ -4770,7 +4778,7 @@ def skip_ws_and_nl(s: str, i: int) -> int:
 
 # @+node:ekr.20170414034616.1: ** g.Git
 # @+node:ekr.20180325025502.1: *3* g.backupGitIssues
-def backupGitIssues(c: Cmdr, base_url: str = None) -> None:
+def backupGitIssues(c: Cmdr, base_url: str | None = None) -> None:
     """Get a list of issues from Leo's GitHub site."""
     if base_url is None:
         base_url = 'https://api.github.com/repos/leo-editor/leo-editor/issues'
@@ -4818,10 +4826,10 @@ def execGitCommand(command: str, directory: str) -> list[str]:
 # @+node:ekr.20180126043905.1: *3* g.getGitIssues
 def getGitIssues(
     c: Cmdr,
-    base_url: str = None,
-    label_list: list = None,
-    milestone: str = None,
-    state: str = None,  # in (None, 'closed', 'open')
+    base_url: str | None = None,
+    label_list: list | None = None,
+    milestone: str | None = None,
+    state: str | None = None,  # in (None, 'closed', 'open')
 ) -> None:
     """Get a list of issues from Leo's GitHub site."""
     if base_url is None:
@@ -4854,7 +4862,7 @@ class GitIssueController:
         c: Cmdr,
         label_list: list[str],
         root: Position,
-        state: str = None,
+        state: str | None = None,
     ) -> None:
         self.base_url = base_url
         self.root = root
@@ -5010,7 +5018,7 @@ class GitIssueController:
 
 
 # @+node:ekr.20190428173354.1: *3* g.getGitVersion
-def getGitVersion(directory: str = None) -> tuple[str, str, str]:
+def getGitVersion(directory: str | None = None) -> tuple[str, str, str]:
     """Return a tuple (author, build, date) from the git log, or None."""
 
     # -n: Get only the last log.
@@ -5074,7 +5082,7 @@ def getModifiedFiles(repo_path: str) -> list[str]:
 
 
 # @+node:ekr.20170414034616.2: *3* g.gitBranchName
-def gitBranchName(path: str = None) -> str:
+def gitBranchName(path: str | None = None) -> str:
     """
     Return the git branch name associated with path/.git, or the empty
     string if path/.git does not exist. If path is None, use the leo-editor
@@ -5085,7 +5093,7 @@ def gitBranchName(path: str = None) -> str:
 
 
 # @+node:ekr.20170414034616.4: *3* g.gitCommitNumber
-def gitCommitNumber(path: str = None) -> str:
+def gitCommitNumber(path: str | None = None) -> str:
     """
     Return the git commit number associated with path/.git, or the empty
     string if path/.git does not exist. If path is None, use the leo-editor
@@ -5096,7 +5104,7 @@ def gitCommitNumber(path: str = None) -> str:
 
 
 # @+node:maphew.20171112205129.1: *3* g.gitDescribe
-def gitDescribe(path: str = None) -> tuple[str, str, str]:
+def gitDescribe(path: str | None = None) -> tuple[str, str, str]:
     """
     Return the Git tag, distance-from-tag, and commit hash for the
     associated path. If path is None, use the leo-editor directory.
@@ -5132,7 +5140,7 @@ def gitHeadPath(path_s: str) -> str | None:
 
 
 # @+node:ekr.20170414034616.3: *3* g.gitInfo
-def gitInfo(path: str = None) -> tuple[str, str]:
+def gitInfo(path: str | None = None) -> tuple[str, str]:
     """
     Path may be a directory or file.
 
@@ -5326,7 +5334,7 @@ def enableIdleTimeHook(*args: Args, **kwargs: KWargs) -> None:
 
 
 # @+node:ekr.20140825042850.18410: *3* g.IdleTime
-def IdleTime(handler: Callable, delay: int = 500, tag: str = None) -> QtIdleTime | None:
+def IdleTime(handler: Callable, delay: int = 500, tag: str | None = None) -> QtIdleTime | None:
     """
     A thin wrapper for the LeoQtGui.IdleTime class.
 
@@ -5382,7 +5390,7 @@ def idleTimeHookHandler(timer: Callable) -> None:
 
 # @+node:ekr.20041219095213: ** g.Importing
 # @+node:ekr.20040917061619: *3* g.cantImport
-def cantImport(moduleName: str, pluginName: str = None, verbose: bool = True) -> None:
+def cantImport(moduleName: str, pluginName: str | None = None, verbose: bool = True) -> None:
     """Print a "Can't Import" message and return None."""
     s = f"Can not import {moduleName}"
     if pluginName:
@@ -5396,7 +5404,7 @@ def cantImport(moduleName: str, pluginName: str = None, verbose: bool = True) ->
 
 
 # @+node:ekr.20191220044128.1: *3* g.import_module
-def import_module(name: str, package: str = None) -> ModuleType | None:
+def import_module(name: str, package: str | None = None) -> ModuleType | None:
     """
     A thin wrapper over importlib.import_module.
     """
@@ -5431,7 +5439,7 @@ def convertPythonIndexToRowCol(s: str, i: int) -> tuple[int, int]:
 
 
 # @+node:ekr.20050315071727: *4* g.convertRowColToPythonIndex
-def convertRowColToPythonIndex(s: str, row: int, col: int, lines: list[str] = None) -> int:
+def convertRowColToPythonIndex(s: str, row: int, col: int, lines: list[str] | None = None) -> int:
     """Convert zero-based row/col indices into a python index into string s."""
     if row < 0:
         return 0
@@ -5657,7 +5665,7 @@ def bytesToStr(b: bytes, reportErrors: bool = False) -> str:
 
 
 # @+node:ekr.20190505052756.1: *4* g.checkUnicode
-def checkUnicode(s: str, encoding: str = None) -> str:
+def checkUnicode(s: str, encoding: str | None = None) -> str:
     """
     Warn when converting bytes. Report *all* errors.
 
@@ -5814,7 +5822,7 @@ def toEncodedString(s: bytes | str, encoding: str = 'utf-8', reportErrors: bool 
 
 
 # @+node:ekr.20050208093800.1: *4* g.toUnicode
-def toUnicode(s: bytes | str, encoding: str = None, reportErrors: bool = False) -> str:
+def toUnicode(s: bytes | str, encoding: str | None = None, reportErrors: bool = False) -> str:
     """Convert bytes to unicode if necessary."""
     if isinstance(s, str):
         return s
@@ -5910,7 +5918,7 @@ def computeWidth(s: str, tab_width: int) -> int:
 # @@language python
 
 
-def wrap_lines(lines: list[str], pageWidth: int, firstLineWidth: int = None) -> list[str]:
+def wrap_lines(lines: list[str], pageWidth: int, firstLineWidth: int | None = None) -> list[str]:
     """Returns a list of lines, consisting of the input lines wrapped to the given pageWidth."""
     if pageWidth < 10:
         pageWidth = 10
@@ -6126,7 +6134,7 @@ def stripBlankLines(s: str) -> str:
 # g.pr prints to the console.
 # g.es_print and related print to both the Log window and the console.
 # @+node:ekr.20080821073134.2: *3* g.doKeywordArgs
-def doKeywordArgs(keys: dict, d: dict = None) -> dict:
+def doKeywordArgs(keys: dict, d: dict | None = None) -> dict:
     """
     Return a result dict that is a copy of the keys dict
     with missing items replaced by defaults in d dict.
@@ -6240,7 +6248,7 @@ log = es
 
 
 # @+node:ekr.20060917120951: *3* g.es_dump
-def es_dump(s: str, n: int = 30, title: str = None) -> None:
+def es_dump(s: str, n: int = 30, title: str | None = None) -> None:
     if title:
         g.es_print('', title)
     i = 0
@@ -6289,7 +6297,7 @@ def es_exception(*args: Sequence, **kwargs: Sequence) -> None:
 
 
 # @+node:ekr.20061015090538: *3* g.es_exception_type
-def es_exception_type(c: Cmdr = None, color: str = "red") -> None:
+def es_exception_type(c: Cmdr | None = None, color: str = "red") -> None:
     # exctype is a Exception class object; value is the error message.
     exctype, value = sys.exc_info()[:2]
     g.es_print('', f"{exctype.__name__}, {value}", color=color)
@@ -6425,7 +6433,7 @@ is_unique_class = isUniqueClass
 
 
 # @+node:ekr.20150127060254.5: *3* g.log_to_file
-def log_to_file(s: str, fn: str = None) -> None:
+def log_to_file(s: str, fn: str | None = None) -> None:
     """Write a message to ~/test/leo_log.txt."""
     if fn is None:
         fn = g.finalize('~/test/leo_log.txt')
@@ -6501,7 +6509,7 @@ def prettyPrintType(obj: object) -> str:
 # @+node:ekr.20111107181638.9741: *3* g.print_exception
 def print_exception(
     full: bool = True,
-    c: Cmdr = None,
+    c: Cmdr | None = None,
     flush: bool = False,
     color: str = "red",
 ) -> tuple[str, int]:
@@ -6537,7 +6545,7 @@ def printEntireTree(c: Cmdr, tag: str = '') -> None:
 
 
 # @+node:ekr.20031218072017.3114: *3* g.printGlobals
-def printGlobals(message: str = None) -> None:
+def printGlobals(message: str | None = None) -> None:
     # Get the list of globals.
     globs = list(globals())
     globs.sort()
@@ -6550,7 +6558,7 @@ def printGlobals(message: str = None) -> None:
 
 
 # @+node:ekr.20031218072017.3115: *3* g.printLeoModules
-def printLeoModules(message: str = None) -> None:
+def printLeoModules(message: str | None = None) -> None:
     # Create the list.
     mods = []
     for name in sys.modules:
@@ -6762,7 +6770,7 @@ def CheckVersion(
     s1: str,
     s2: str,
     condition: str = ">=",
-    stringCompare: bool = None,
+    stringCompare: bool | None = None,
     delimiter: str = '.',
     trace: bool = False,
 ) -> bool:
@@ -6814,7 +6822,7 @@ def CheckVersionToInt(s: str) -> int:
 
 # @+node:ekr.20111103205308.9657: *3* g.cls
 @command('cls')
-def cls(event: LeoKeyEvent = None) -> None:
+def cls(event: LeoKeyEvent | None = None) -> None:
     """Clear the screen."""
     if g.isWindows:
         # Leo 6.7.5: Two calls seem to be required!
@@ -6825,7 +6833,7 @@ def cls(event: LeoKeyEvent = None) -> None:
 
 
 # @+node:ekr.20131114124839.16665: *3* g.createScratchCommander
-def createScratchCommander(fileName: str = None) -> None:
+def createScratchCommander(fileName: str | None = None) -> None:
     c = g.app.newCommander(fileName)
     frame = c.frame
     frame.createFirstTreeNode()
@@ -6846,7 +6854,7 @@ def deprecated() -> None:
 
 
 # @+node:ekr.20031218072017.3126: *3* g.funcToMethod (Python Cookbook)
-def funcToMethod(f: Callable, theClass: object, name: str = None) -> None:
+def funcToMethod(f: Callable, theClass: object, name: str | None = None) -> None:
     """
     From the Python Cookbook...
 
@@ -6906,7 +6914,7 @@ def init_zodb(pathToZodbStorage: str, verbose: bool = True) -> Value | None:
 
 
 # @+node:ekr.20170206080908.1: *3* g.input_
-def input_(message: str = '', c: Cmdr = None) -> str:
+def input_(message: str = '', c: Cmdr | None = None) -> str:
     """
     Safely execute python's input statement.
 
@@ -7323,7 +7331,7 @@ def os_startfile(fname: str) -> None:
 
 # @+node:ekr.20111115155710.9859: ** g.Parsing & Tokenizing
 # @+node:ekr.20031218072017.822: *3* g.createTopologyList
-def createTopologyList(c: Cmdr, root: Position = None, useHeadlines: bool = False) -> list:
+def createTopologyList(c: Cmdr, root: Position | None = None, useHeadlines: bool = False) -> list:
     """Creates a list describing a node and all its descendants"""
     if not root:
         root = c.rootPosition()
@@ -7429,7 +7437,7 @@ def python_tokenize(s: str) -> list:
 
 # @+node:ekr.20040327103735.2: ** g.Scripting
 # @+node:ekr.20161223090721.1: *3* g.exec_file
-def exec_file(path: str, d: dict[str, Value], script: str = None) -> None:
+def exec_file(path: str, d: dict[str, Value], script: str | None = None) -> None:
     """Simulate python's execfile statement for python 3."""
     if script is None:
         with open(path) as f:
@@ -7466,13 +7474,13 @@ def execute_shell_commands(
 
 # @+node:ekr.20180217113719.1: *3* g.execute_shell_commands_with_options & helpers
 def execute_shell_commands_with_options(
-    base_dir: str = None,
-    c: Cmdr = None,
-    command_setting: str = None,
-    commands: list = None,
-    path_setting: str = None,
+    base_dir: str | None = None,
+    c: Cmdr | None = None,
+    command_setting: str | None = None,
+    commands: list | None = None,
+    path_setting: str | None = None,
     trace: bool = False,
-    warning: str = None,
+    warning: str | None = None,
 ) -> None:
     """
     A helper for prototype commands or any other code that
@@ -7754,8 +7762,8 @@ def extractExecutableString(c: Cmdr, p: Position, s: str) -> str:
 def handleScriptException(
     c: Cmdr,
     p: Position,
-    script: str = None,  # No longer used.
-    script1: str = None,  # No longer used.
+    script: str | None = None,  # No longer used.
+    script1: str | None = None,  # No longer used.
 ) -> None:
     g.warning("exception executing script")
     g.es_exception()
@@ -7873,7 +7881,7 @@ def run_coverage_tests(module: str = '', filename: str = '') -> None:
 
 
 # @+node:ekr.20210901065224.1: *3* g.run_unit_tests
-def run_unit_tests(tests: str = None, verbose: bool = False) -> None:
+def run_unit_tests(tests: str | None = None, verbose: bool = False) -> None:
     """
     Run the unit tests given by the "tests" string.
 
@@ -7961,7 +7969,7 @@ def run_unit_tests(tests: str = None, verbose: bool = False) -> None:
 #    For example, Leo's forum: https://leo-editor.github.io/leo-editor/
 # @-<< About clickable links >>
 # @+node:ekr.20120320053907.9776: *3* g.computeFileUrl
-def computeFileUrl(fn: str, c: Cmdr = None, p: Position = None) -> str:
+def computeFileUrl(fn: str, c: Cmdr | None = None, p: Position | None = None) -> str:
     """
     Compute finalized url for filename fn.
     """
@@ -8300,7 +8308,7 @@ def handleUnl(unl_s: str, c: Cmdr) -> Cmdr | None:
 
 
 # @+node:tbrown.20090219095555.63: *3* g.handleUrl & helpers
-def handleUrl(url: str, c: Cmdr = None, p: Position = None) -> str | None:
+def handleUrl(url: str, c: Cmdr | None = None, p: Position | None = None) -> str | None:
     """Open a url or a unl."""
     if c and not p:
         p = c.p
@@ -8449,7 +8457,7 @@ def openUrl(p: Position) -> None:  # pragma: no cover
 
 
 # @+node:ekr.20110605121601.18135: *3* g.openUrlOnClick (open-url-under-cursor)
-def openUrlOnClick(event: QMouseEvent, url: str = None) -> str | None:  # pragma: no cover
+def openUrlOnClick(event: QMouseEvent, url: str | None = None) -> str | None:  # pragma: no cover
     """Open the URL under the cursor.  Return it for unit testing."""
     from leo.core.leoGui import LeoKeyEvent
     from leo.plugins.qt_text import QTextEditWrapper
@@ -8468,7 +8476,7 @@ def openUrlOnClick(event: QMouseEvent, url: str = None) -> str | None:  # pragma
 
 
 # @+node:ekr.20170216091704.1: *4* g.openUrlHelper
-def openUrlHelper(event: LeoKeyEvent, url: str = None) -> str | None:
+def openUrlHelper(event: LeoKeyEvent, url: str | None = None) -> str | None:
     """Open the unl, url or gnx under the cursor.  Return it for unit testing."""
     if not event:
         return None

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -38,7 +38,7 @@ import time
 import traceback
 import types
 from types import ModuleType
-from typing import Any, IO, Iterable, Sequence, TYPE_CHECKING
+from typing import cast, Any, IO, Iterable, Sequence, TYPE_CHECKING
 import unittest
 import urllib
 import urllib.parse as urlparse
@@ -1312,7 +1312,7 @@ class MatchBrackets:
                 # Scan to the end/beginning of the string.
                 i = self.scan_string(s, i)
             elif self.starts_comment(s, i):
-                i = self.scan_comment(s, i)
+                i = self.scan_comment(s, i)  # type:ignore # i can't be None.
             elif ch == '/' and self.is_regex(s, i):
                 i = self.scan_regex(s, i)
             elif ch == ch1:
@@ -1376,7 +1376,9 @@ class MatchBrackets:
         if self.forward:
             if self.single_comment and g.match(s, i, self.single_comment):
                 return True
-            return self.start_comment and self.end_comment and g.match(s, i, self.start_comment)
+            return bool(
+                self.start_comment and self.end_comment and g.match(s, i, self.start_comment)
+            )
         if s[i] == '\n':
             if self.single_comment:
                 # Scan backward for any single-comment delim.
@@ -1483,7 +1485,7 @@ class MatchBrackets:
                         i -= 1
                     assert progress > i
             return False
-        return self.start_comment and self.end_comment and g.match(s, i, self.end_comment)
+        return bool(self.start_comment and self.end_comment and g.match(s, i, self.end_comment))
 
     # @+node:ekr.20160119104148.1: *4* mb.oops
     def oops(self, s: str) -> None:
@@ -1503,7 +1505,7 @@ class MatchBrackets:
         #
         # A partial fix for bug 127: Bracket matching is buggy.
         w = self.c.frame.body.wrapper
-        s = w.getAllText()
+        s = cast(str, w.getAllText())
         _mb = self.c.user_dict['_match_brackets']
         sel_range = w.getSelectionRange()
         if not w.hasSelection():
@@ -1523,7 +1525,9 @@ class MatchBrackets:
         if left is None:
             g.es("Bracket not found")
             return
-        index2 = self.find_matching_bracket(ch, s, index)
+        ch = cast(str, ch)
+        index = cast(int, index)
+        index2 = cast(int, self.find_matching_bracket(ch, s, index))
         if index2 is None:
             g.es("No matching bracket.")  # #1447.
             return
@@ -1544,6 +1548,7 @@ class MatchBrackets:
                 s, max(minmax[0], 0), min(minmax[1], max_right), max_right, expand=True
             )
             if index3 is not None:  # found nearest bracket outside range
+                ch = cast(str, ch)
                 index4 = self.find_matching_bracket(ch, s, index3)
                 if index4 is not None:  # found matching bracket, expand range
                     index, index2 = index3, index4
@@ -1570,7 +1575,7 @@ class OptionsUtils:
     This class *calculates* valid options from the usage message.
     """
 
-    def __init__(self, usage: str, obsolete_options: list[str] | None = None) -> None:
+    def __init__(self, usage: str, obsolete_options: list[str]) -> None:
         # This class is essentially stateless because these ivars never change.
         self.usage = usage
         self.obsolete_options = obsolete_options
@@ -1953,11 +1958,12 @@ class Tracer:
         g.pr('\ncallDict...')
         for key in sorted(self.callDict):
             # Print the calling function.
-            g.pr(f"{self.calledDict.get(key, 0):d}", key)  # noqa  # conflict between flake8 and black.
+            g.pr(f"{self.calledDict.get(key, 0):d}", key)
             # Print the called functions.
             d = self.callDict.get(key)
-            for key2 in sorted(d):
-                g.pr(f"{d.get(key2):8d}", key2)
+            if isinstance(d, dict):
+                for key2 in sorted(d):
+                    g.pr(f"{d.get(key2):8d} {key2}")
 
     # @+node:ekr.20080531075119.5: *4* stop
     def stop(self) -> None:
@@ -2019,7 +2025,7 @@ class Tracer:
     # @-others
 
 
-def startTracer(limit: int = 0, trace: bool = False, verbose: bool = False) -> Callable:
+def startTracer(limit: int = 0, trace: bool = False, verbose: bool = False) -> g.Tracer:
     t = g.Tracer(limit=limit, trace=trace, verbose=verbose)
     sys.settrace(t.tracer)
     return t

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2968,7 +2968,7 @@ def findLanguageDirectives(c: Cmdr, p: Position) -> str:
     v0 = p.v
     assert v0
 
-    def find_language(p_or_v: Position | VNode) -> str | None:
+    def find_language(p_or_v: Position | VNode) -> str:
         for s in p_or_v.h, p_or_v.b:
             for m in g_language_pat.finditer(s):
                 language = m.group(1)
@@ -3063,7 +3063,7 @@ def get_directives_dict_list(p: Position) -> list[dict]:
 
 
 # @+node:ekr.20111010082822.15545: *3* g.getLanguageFromAncestorAtFileNode (deprecated)
-def getLanguageFromAncestorAtFileNode(p: Position) -> str | None:
+def getLanguageFromAncestorAtFileNode(p: Position) -> str:
     """Return the language in effect at node p."""
     g.deprecated()
     assert p.v
@@ -3192,7 +3192,7 @@ def scanAtHeaderDirectives(aList: list) -> None:
 
 
 # @+node:ekr.20080827175609.33: *4* g.scanAtLineendingDirectives (deprecated)
-def scanAtLineendingDirectives(aList: list) -> str | None:
+def scanAtLineendingDirectives(aList: list) -> str:
     """Scan aList for @lineending directives."""
     g.deprecated()
     for d in aList:
@@ -3202,7 +3202,7 @@ def scanAtLineendingDirectives(aList: list) -> str | None:
             return lineending
         # else:
         # g.error("invalid @lineending directive:",e)
-    return None
+    return ''
 
 
 # @+node:ekr.20080827175609.34: *4* g.scanAtPagewidthDirectives (deprecated)
@@ -3610,7 +3610,7 @@ def getEncodingAt(p: Position, b: bytes) -> str:
 
 
 # @+node:ville.20090701144325.14942: *3* g.guessExternalEditor
-def guessExternalEditor(c: Cmdr | None = None) -> str | None:
+def guessExternalEditor(c: Cmdr | None = None) -> str:
     """Return a 'sensible' external editor"""
     editor = (
         c
@@ -3633,7 +3633,7 @@ def guessExternalEditor(c: Cmdr | None = None) -> str | None:
 Please set LEO_EDITOR or EDITOR environment variable,
 or do g.app.db['LEO_EDITOR'] = "gvim"''',
     )
-    return None
+    return ''
 
 
 # @+node:ekr.20160330204014.1: *3* g.init_dialog_folder
@@ -3681,7 +3681,7 @@ def is_binary_string(s: str) -> bool:
 
 
 # @+node:ekr.20031218072017.3119: *3* g.makeAllNonExistentDirectories
-def makeAllNonExistentDirectories(theDir: str) -> str | None:
+def makeAllNonExistentDirectories(theDir: str) -> str:
     """
     A wrapper from os.makedirs.
     Attempt to make all non-existent directories.
@@ -3698,7 +3698,7 @@ def makeAllNonExistentDirectories(theDir: str) -> str | None:
         os.makedirs(theDir, mode=0o777, exist_ok=False)
         return theDir
     except Exception:
-        return None
+        return ''
 
 
 # @+node:ekr.20071114113736: *3* g.makePathRelativeTo
@@ -8136,14 +8136,14 @@ findUNL = findUnl  # Compatibility.
 
 
 # @+node:ekr.20120311151914.9917: *3* g.getUrlFromNode
-def getUrlFromNode(p: Position) -> str | None:
+def getUrlFromNode(p: Position) -> str:
     """
     Get an url from node p:
     1. Use the headline if it contains a valid url.
     2. Otherwise, look *only* at the first line of the body.
     """
     if not p:
-        return None
+        return ''
     assert p.v
     c = p.v.context
     assert c
@@ -8169,7 +8169,7 @@ def getUrlFromNode(p: Position) -> str | None:
     for s in table:
         if s.startswith("#"):
             return s
-    return None
+    return ''
 
 
 # @+node:ekr.20170221063527.1: *3* g.handleUnl
@@ -8220,7 +8220,7 @@ def handleUnl(unl_s: str, c: Cmdr) -> Cmdr | None:
 
 
 # @+node:tbrown.20090219095555.63: *3* g.handleUrl & helpers
-def handleUrl(url: str, c: Cmdr, p: Position | None = None) -> None:  ### str | None:
+def handleUrl(url: str, c: Cmdr, p: Position | None = None) -> None:
     """Open a url or a unl."""
     if c and not p:
         p = c.p
@@ -8371,7 +8371,7 @@ def openUrl(p: Position) -> None:  # pragma: no cover
 
 
 # @+node:ekr.20110605121601.18135: *3* g.openUrlOnClick (open-url-under-cursor)
-def openUrlOnClick(event: QMouseEvent, url: str = '') -> str | None:  # pragma: no cover
+def openUrlOnClick(event: QMouseEvent, url: str = '') -> None:  # pragma: no cover
     """Open the URL under the cursor.  Return it for unit testing."""
     from leo.core.leoGui import LeoKeyEvent
     from leo.plugins.qt_text import QTextEditWrapper
@@ -8383,10 +8383,9 @@ def openUrlOnClick(event: QMouseEvent, url: str = '') -> str | None:  # pragma: 
         widget = c.frame.body.widget  # Another hack.
         wrapper = QTextEditWrapper(widget=widget, name='QMouseEvent-wrapper', c=c)
         leo_event = LeoKeyEvent(c, w=wrapper)
-        return openUrlHelper(leo_event, url)
+        openUrlHelper(leo_event, url)
     except Exception:
         g.es_exception()
-        return None
 
 
 # @+node:ekr.20170216091704.1: *4* g.openUrlHelper

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -8309,10 +8309,11 @@ def handleUnl(unl_s: str, c: Cmdr) -> Cmdr | None:
 
 
 # @+node:tbrown.20090219095555.63: *3* g.handleUrl & helpers
-def handleUrl(url: str, c: Cmdr | None = None, p: Position | None = None) -> str | None:
+def handleUrl(url: str, c: Cmdr, p: Position | None = None) -> None:  ### str | None:
     """Open a url or a unl."""
     if c and not p:
         p = c.p
+    assert p  # PR #4772: suppress mypy warning.
     # These two special cases should match the hacks in jedit.match_any_url.
     if url.endswith('.'):
         url = url[:-1]
@@ -8326,14 +8327,15 @@ def handleUrl(url: str, c: Cmdr | None = None, p: Position | None = None) -> str
         urll.startswith(('#', 'unl://', 'unl:gnx:')) or
         urll.startswith('file://') and '-->' in urll
     ):  # fmt: skip
-        return g.handleUnl(url, c)
+        g.handleUnl(url, c)
+        return
     try:
         g.handleUrlHelper(url, c, p)
-        return urll  # For unit tests.
+        ### return urll  # For unit tests.
     except Exception:
         g.es_print("g.handleUrl: exception opening", repr(url))
         g.es_exception()
-        return None
+        ### return None
 
 
 # @+node:ekr.20170226054459.1: *4* g.handleUrlHelper
@@ -8448,13 +8450,15 @@ def openUrl(p: Position) -> None:  # pragma: no cover
     Use the headline if it contains a valid url.
     Otherwise, look *only* at the first line of the body.
     """
-    if p:
-        url = g.getUrlFromNode(p)
-        if url:
-            c = p.v.context
-            if not g.doHook("@url1", c=c, p=p, url=url):
-                g.handleUrl(url, c=c, p=p)
-            g.doHook("@url2", c=c, p=p, url=url)
+    if not p:
+        return
+    if url := g.getUrlFromNode(p):
+        assert p.v  # PR #4772
+        c = p.v.context
+        assert c  # PR #4772
+        if not g.doHook("@url1", c=c, p=p, url=url):
+            g.handleUrl(url, c=c, p=p)
+        g.doHook("@url2", c=c, p=p, url=url)
 
 
 # @+node:ekr.20110605121601.18135: *3* g.openUrlOnClick (open-url-under-cursor)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -824,7 +824,7 @@ class KeyStroke:
         }
         if self.mods and s.lower() in shift_d:
             # Returning '' breaks existing code.
-            return shift_d.get(s.lower(), '')  # PR #4772
+            return shift_d.get(s.lower(), '')
         #
         # Make all other translations...
         #
@@ -975,7 +975,7 @@ class KeyStroke:
         }  # fmt: skip
         if 'shift' in self.mods and s in shift_d:
             self.mods.remove('shift')
-            s = shift_d.get(s, '')  # PR #4772
+            s = shift_d.get(s, '')
         return s
 
     # @+node:ekr.20120203053243.10124: *4* ks.find, lower & startswith
@@ -1121,7 +1121,7 @@ class KeyStroke:
             'Tab': '\t',
         }
         if s in d:
-            return d.get(s, '')  # PR #4772
+            return d.get(s, '')
         return s if len(s) == 1 else ''
 
     # @-others
@@ -8228,7 +8228,7 @@ def handleUrl(url: str, c: Cmdr, p: Position | None = None) -> None:
     """Open a url or a unl."""
     if c and not p:
         p = c.p
-    assert p  # PR #4772: suppress mypy warning.
+    assert p  # PR #4772
     # These two special cases should match the hacks in jedit.match_any_url.
     if url.endswith('.'):
         url = url[:-1]
@@ -8366,9 +8366,9 @@ def openUrl(p: Position) -> None:  # pragma: no cover
     if not p:
         return
     if url := g.getUrlFromNode(p):
-        assert p.v  # PR #4772
+        assert p.v
         c = p.v.context
-        assert c  # PR #4772
+        assert c
         if not g.doHook("@url1", c=c, p=p, url=url):
             g.handleUrl(url, c=c, p=p)
         g.doHook("@url2", c=c, p=p, url=url)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2510,28 +2510,28 @@ def dump_encoded_string(encoding: str, s: str) -> None:
 
 
 # @+node:ekr.20031218072017.1317: *4* g.file/module/plugin_date
-def module_date(mod: ModuleType, format: str | None = None) -> str:
+def module_date(mod: ModuleType, format: str = '') -> str:
     theFile = g.os_path_join(app.loadDir, mod.__file__)
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=format)
 
 
-def plugin_date(plugin_mod: ModuleType, format: str | None = None) -> str:
+def plugin_date(plugin_mod: ModuleType, format: str = '') -> str:
     theFile = g.os_path_join(app.loadDir, "..", "plugins", plugin_mod.__file__)
     root, ext = g.os_path_splitext(theFile)
-    return g.file_date(root + ".py", format=str)
+    return g.file_date(root + ".py", format=format)
 
 
-def file_date(theFile: IO, format: str | None = None) -> str:
+def file_date(theFile: str, format: str = '') -> str:
     if theFile and g.os_path_exists(theFile):
         try:
             n = g.os_path_getmtime(theFile)
-            if format is None:
+            if not format:
                 format = "%m/%d/%y %H:%M:%S"
             return time.strftime(format, time.gmtime(n))
         except (ImportError, NameError):
-            pass  # Time module is platform dependent.
-    return ""
+            pass
+    return ''  # Time module is platform dependent.
 
 
 # @+node:ekr.20031218072017.3127: *4* g.get_line & get_line__after

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5706,7 +5706,7 @@ def checkUnicode(s: str, encoding: str | None = None) -> str:
 
 
 # @+node:ekr.20100125073206.8709: *4* g.getPythonEncodingFromString
-def getPythonEncodingFromString(s: object) -> str:
+def getPythonEncodingFromString(s: bytes | str) -> str:
     """Return the encoding given by Python's encoding line.
     s is the entire file.
     """
@@ -5806,7 +5806,7 @@ def strToBytes(s: str, reportErrors: bool = False) -> bytes:
 
 
 # @+node:ekr.20050208093800: *4* g.toEncodedString
-def toEncodedString(s: bytes | str, encoding: str = 'utf-8', reportErrors: bool = False) -> bytes:
+def toEncodedString(s: bytes | str, encoding: str = '', reportErrors: bool = False) -> bytes:
     """Convert unicode string to an encoded string."""
     if not isinstance(s, str):
         return s
@@ -5823,33 +5823,21 @@ def toEncodedString(s: bytes | str, encoding: str = 'utf-8', reportErrors: bool 
 
 
 # @+node:ekr.20050208093800.1: *4* g.toUnicode
-def toUnicode(s: bytes | str, encoding: str | None = None, reportErrors: bool = False) -> str:
+def toUnicode(s: bytes | str, encoding: str = '', reportErrors: bool = False) -> str:
     """Convert bytes to unicode if necessary."""
     if isinstance(s, str):
         return s
     tag = 'g.toUnicode'
-    if not isinstance(s, bytes):
-        if reportErrors and not isinstance(s, (NullObject, TracingNullObject)):
-            message = (
-                f"{tag}: unexpected argument of type {s.__class__.__name__}\n"
-                f"Callers: {g.callers}"
-            )  # fmt: skip
-            g.es_print_unique_message(message)
-        return ''
     if not encoding:
         encoding = 'utf-8'
     try:
         return s.decode(encoding, 'strict')
     except (UnicodeDecodeError, UnicodeError):
         # https://wiki.python.org/moin/UnicodeDecodeError
-        s = s.decode(encoding, 'replace')
-        if g.unitTesting:
-            g.trace(f"{tag} unicode error. encoding: {encoding!r} len(s): {len(s)}")
-            g.trace(g.callers())
-        elif reportErrors:
+        if reportErrors:
             g.printObj(s, tag=f"{tag} unicode error. encoding: {encoding!r}")
             g.trace(g.callers())
-        return s
+        return s.decode(encoding, 'replace')
     except Exception:
         g.es_exception()
         g.error(f"{tag}: unexpected error! encoding: {encoding!r}, s:\n{s!r}")
@@ -6209,19 +6197,19 @@ def es(*args: Args, **kwargs: KWargs) -> None:
         return
     log = app.log
     # Compute the effective args.
-    d = {
-        'color': None,
+    d: dict[str, bool | str] = {
+        'color': '',
         'commas': False,
         'newline': True,
         'spaces': True,
         'tabName': 'Log',
-        'nodeLink': None,
+        'nodeLink': '',
     }
     d = g.doKeywordArgs(kwargs, d)
-    color = d.get('color')
+    color = d.get('color', '')
     if color == 'suppress':
         return  # New in 4.3.
-    color = g.actualColor(color)
+    color = g.actualColor(color)  # type:ignore
     tabName = d.get('tabName') or 'Log'
     newline = d.get('newline')
     s = g.translateArgs(args, d)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7662,8 +7662,12 @@ def extractExecutableString(c: Cmdr, p: Position, s: str) -> str:
 
 
 # @+node:ekr.20060624085200: *3* g.handleScriptException
-def handleScriptException(c: Cmdr, p: Position, script: str = '') -> None:
-    # PR #4772 Minor change to signature.
+def handleScriptException(
+    c: Cmdr,
+    p: Position,
+    script: str = '',
+    script1: Any = None,  # No longer used.
+) -> None:
     g.warning("exception executing script")
     g.es_exception()
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5654,22 +5654,17 @@ def unCamel(s: str) -> list[str]:
 # @+node:ekr.20240325175438.1: *4* g.bytesToStr
 def bytesToStr(b: bytes, reportErrors: bool = False) -> str:
     """Convert bytes to unicode."""
-    assert isinstance(b, bytes), g.callers()
     tag = 'g.bytesToStr'
-    encoding = 'utf-8'
-    try:
-        s = b.decode(encoding, 'strict')
-    except (UnicodeDecodeError, UnicodeError):  # noqa
-        # https://wiki.python.org/moin/UnicodeDecodeError
-        s = b.decode(encoding, 'replace')
-        if reportErrors:
-            g.error(f"{tag}: unicode error. encoding: {encoding!r}, s:\n{s!r}")
-            g.trace(g.callers())
-    except Exception:
-        g.es_exception()
-        g.error(f"{tag}: unexpected error! encoding: {encoding!r}, s:\n{s!r}")
-        g.trace(g.callers())
-    return s
+    if isinstance(b, bytes):
+        try:
+            return b.decode('utf-8', 'strict')
+        except (UnicodeDecodeError, UnicodeError):  # noqa
+            # https://wiki.python.org/moin/UnicodeDecodeError
+            if reportErrors:
+                g.error(f"{tag}: unicode error. {b!r}")
+                g.trace(g.callers())
+            return b.decode('utf-8', 'replace')
+    raise ValueError(f"g.byteToStr: {b!r} {g.callers()}")
 
 
 # @+node:ekr.20190505052756.1: *4* g.checkUnicode

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5658,13 +5658,12 @@ def bytesToStr(b: bytes, reportErrors: bool = False) -> str:
     if isinstance(b, bytes):
         try:
             return b.decode('utf-8', 'strict')
-        except (UnicodeDecodeError, UnicodeError):  # noqa
+        except (UnicodeDecodeError, UnicodeError) as e:
             # https://wiki.python.org/moin/UnicodeDecodeError
             if reportErrors:
-                g.error(f"{tag}: unicode error. {b!r}")
-                g.trace(g.callers())
+                g.error(f"{tag}: {e}! {b=}\n{g.callers()=}")
             return b.decode('utf-8', 'replace')
-    raise ValueError(f"g.byteToStr: {b!r} {g.callers()}")
+    raise ValueError(f"{tag}: {b=}\n{g.callers()=}")
 
 
 # @+node:ekr.20190505052756.1: *4* g.checkUnicode
@@ -5810,41 +5809,37 @@ def strToBytes(s: str, reportErrors: bool = False) -> bytes:
 # @+node:ekr.20050208093800: *4* g.toEncodedString
 def toEncodedString(s: bytes | str, encoding: str = '', reportErrors: bool = False) -> bytes:
     """Convert unicode string to an encoded string."""
-    if not isinstance(s, str):
+    tag = 'g.toEncodedString'
+    if isinstance(s, bytes):
         return s
-    if not encoding:
-        encoding = 'utf-8'
-    # These are the only significant calls to s.encode in Leo.
-    # Tracing these calls directly yields thousands of calls.
-    try:
-        return s.encode(encoding, "strict")
-    except UnicodeError:
-        if reportErrors:  # #4753.
-            g.error(f"Error converting {s!r} from unicode to {encoding} encoding")
-        return s.encode(encoding, "replace")
+    if isinstance(s, str):
+        if not encoding:
+            encoding = 'utf-8'
+        try:
+            return s.encode(encoding, "strict")
+        except UnicodeError as e:
+            if reportErrors:
+                g.error(f"{tag} {e}! {encoding=} {s=}\n{g.callers()=}")
+            return s.encode(encoding, "replace")
+    raise ValueError(f"{tag}: {s=} {g.callers()=}")
 
 
 # @+node:ekr.20050208093800.1: *4* g.toUnicode
 def toUnicode(s: bytes | str, encoding: str = '', reportErrors: bool = False) -> str:
     """Convert bytes to unicode if necessary."""
+    tag = 'g.toUnicode'
     if isinstance(s, str):
         return s
-    tag = 'g.toUnicode'
-    if not encoding:
-        encoding = 'utf-8'
-    try:
-        return s.decode(encoding, 'strict')
-    except (UnicodeDecodeError, UnicodeError):
-        # https://wiki.python.org/moin/UnicodeDecodeError
-        if reportErrors:
-            g.printObj(s, tag=f"{tag} unicode error. encoding: {encoding!r}")
-            g.trace(g.callers())
-        return s.decode(encoding, 'replace')
-    except Exception:
-        g.es_exception()
-        g.error(f"{tag}: unexpected error! encoding: {encoding!r}, s:\n{s!r}")
-        g.trace(g.callers())
-        return ''
+    if isinstance(s, bytes):
+        if not encoding:
+            encoding = 'utf-8'
+        try:
+            return s.decode(encoding, 'strict')
+        except (UnicodeDecodeError, UnicodeError) as e:
+            if reportErrors:
+                g.trace(f"{tag} {e}! {encoding=} {s=}\n{g.callers()=}")
+            return s.decode(encoding, 'replace')
+    raise ValueError(f"{tag}: {s=}\n{g.callers()=}")
 
 
 # @+node:ekr.20031218072017.3197: *3* g.Whitespace

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -8371,7 +8371,10 @@ def openUrl(p: Position) -> None:  # pragma: no cover
 
 
 # @+node:ekr.20110605121601.18135: *3* g.openUrlOnClick (open-url-under-cursor)
-def openUrlOnClick(event: QMouseEvent, url: str = '') -> None:  # pragma: no cover
+def openUrlOnClick(
+    event: QMouseEvent,
+    url: str | None = None,  # Don't change this.
+) -> None:
     """Open the URL under the cursor.  Return it for unit testing."""
     from leo.core.leoGui import LeoKeyEvent
     from leo.plugins.qt_text import QTextEditWrapper
@@ -8389,7 +8392,10 @@ def openUrlOnClick(event: QMouseEvent, url: str = '') -> None:  # pragma: no cov
 
 
 # @+node:ekr.20170216091704.1: *4* g.openUrlHelper
-def openUrlHelper(event: LeoKeyEvent, url: str = '') -> str | None:
+def openUrlHelper(
+    event: LeoKeyEvent,
+    url: str | None = None,  # Don't change this.
+) -> str | None:  # Don't change this.
     """Open the unl, url or gnx under the cursor.  Return it for unit testing."""
     if not event:
         return None

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3748,16 +3748,16 @@ def readFileIntoEncodedString(fn: str, silent: bool = False) -> bytes:
         if not silent:
             g.error(f"readFileIntoEncodedString: exception reading {fn}")
             g.es_exception()
-    return None
+    return b''
 
 
 # @+node:ekr.20100125073206.8710: *3* g.readFileIntoString
 def readFileIntoString(
     fileName: str,
     encoding: str = 'utf-8',  # BOM may override this.
-    kind: str | None = None,  # @file, @edit, ...
+    kind: str = '',  # @file, @edit, ...
     verbose: bool = True,
-) -> tuple[str, str] | tuple[None, None]:
+) -> tuple[str, str]:
     """
     Return the contents of the file whose full path is fileName.
 
@@ -3769,25 +3769,26 @@ def readFileIntoString(
     - The encoding given by the 'encoding' keyword arg.
     - None, which typically means 'utf-8'.
     """
+    fail = '', ''
     if not fileName:
         if verbose:
             g.trace('no fileName arg given')
-        return None, None
+        return fail
     if g.os_path_isdir(fileName):
         if verbose:
             g.trace('not a file:', fileName)
-        return None, None
+        return fail
     if not g.os_path_exists(fileName):
         if verbose:
             g.error('file not found:', fileName)
-        return None, None
+        return fail
     try:
-        e = None
+        e = ''
         with open(fileName, 'rb') as f:
             bytes_s = f.read()
         # Fix #391.
         if not bytes_s:
-            return '', None
+            return fail
         # New in Leo 4.11: check for unicode BOM first.
         e, bytes_s = g.stripBOM(bytes_s)
         if not e:
@@ -3802,17 +3803,13 @@ def readFileIntoString(
         if verbose:
             g.error('can not open', '', (kind or ''), fileName)
     except Exception:
-        g.error(f"readFileIntoString: unexpected exception reading {fileName}")
+        g.error(f"readFileIntoString: exception reading {fileName}")
         g.es_exception()
-    return None, None
+    return fail
 
 
 # @+node:ekr.20160504062833.1: *3* g.readFileIntoUnicodeString
-def readFileIntoUnicodeString(
-    fn: str,
-    encoding: str | None = None,
-    silent: bool = False,
-) -> str | None:
+def readFileIntoUnicodeString(fn: str, encoding: str = '', silent: bool = False) -> str:
     """Return the raw contents of the file whose full path is fn."""
     try:
         with open(fn, 'rb') as f:
@@ -3824,7 +3821,7 @@ def readFileIntoUnicodeString(
     except Exception:
         g.error(f"readFileIntoUnicodeString: unexpected exception reading {fn}")
         g.es_exception()
-    return None
+    return ''
 
 
 # @+node:ekr.20031218072017.3120: *3* g.readlineForceUnixNewline
@@ -4016,7 +4013,7 @@ def find_word(s: str, word: str, i: int = 0) -> int:
 
 
 # @+node:ekr.20211029090118.1: *3* g.findAncestorVnodeByPredicate
-def findAncestorVnodeByPredicate(p: Position, v_predicate: Callable | None) -> VNode | None:
+def findAncestorVnodeByPredicate(p: Position, v_predicate: Callable) -> VNode | None:
     """
     Return first ancestor vnode matching the predicate.
 
@@ -4032,6 +4029,7 @@ def findAncestorVnodeByPredicate(p: Position, v_predicate: Callable | None) -> V
     if not p.isCloned():
         return None
     seen = []  # vnodes that have already been searched.
+    assert p.v
     parents = p.v.parents[:]  # vnodes to be searched.
     while parents:
         parent_v = parents.pop()
@@ -4779,7 +4777,7 @@ def skip_ws_and_nl(s: str, i: int) -> int:
 
 # @+node:ekr.20170414034616.1: ** g.Git
 # @+node:ekr.20180325025502.1: *3* g.backupGitIssues
-def backupGitIssues(c: Cmdr, base_url: str | None = None) -> None:
+def backupGitIssues(c: Cmdr, base_url: str = '') -> None:
     """Get a list of issues from Leo's GitHub site."""
     if base_url is None:
         base_url = 'https://api.github.com/repos/leo-editor/leo-editor/issues'
@@ -4818,7 +4816,7 @@ def execGitCommand(command: str, directory: str) -> list[str]:
             shlex.split(command), stdout=subprocess.PIPE, stderr=None, shell=True
         )
         out, err = proc.communicate()
-        lines = [g.toUnicode(z) for z in g.splitLines(out or '')]
+        lines = [g.toUnicode(z) for z in g.splitLines(out or '')]  # type:ignore # Don't change this!
     finally:
         os.chdir(old_dir)
     return lines
@@ -4827,10 +4825,10 @@ def execGitCommand(command: str, directory: str) -> list[str]:
 # @+node:ekr.20180126043905.1: *3* g.getGitIssues
 def getGitIssues(
     c: Cmdr,
-    base_url: str | None = None,
+    base_url: str = '',
     label_list: list | None = None,
-    milestone: str | None = None,
-    state: str | None = None,  # in (None, 'closed', 'open')
+    milestone: str = '',
+    state: str = '',  # in (None, 'closed', 'open')
 ) -> None:
     """Get a list of issues from Leo's GitHub site."""
     if base_url is None:
@@ -4892,7 +4890,7 @@ class GitIssueController:
         except Exception:
             g.trace('requests not found: `pip install requests`')
             return
-        label = None
+        label = ''
         assert state in ('open', 'closed')
         page_url = self.base_url + '?&state=%s&page=%s'
         page, total = 1, 0
@@ -5019,11 +5017,13 @@ class GitIssueController:
 
 
 # @+node:ekr.20190428173354.1: *3* g.getGitVersion
-def getGitVersion(directory: str | None = None) -> tuple[str, str, str]:
+def getGitVersion(directory: str = '') -> tuple[str, str, str]:
     """Return a tuple (author, build, date) from the git log, or None."""
 
     # -n: Get only the last log.
     trace = 'git' in g.app.debug
+    fail = '', '', ''
+    s: bytes | str
     try:
         s = subprocess.check_output(
             'git log -n 1 --date=iso',
@@ -5040,12 +5040,12 @@ def getGitVersion(directory: str | None = None) -> tuple[str, str, str]:
             g.es_exception()
         s = g.toUnicode(s)
         if not isinstance(s, str):
-            return '', '', ''
+            return fail
     except Exception:
         if trace:
             g.es_print('Exception in g.getGitVersion')
             g.es_exception()
-        return '', '', ''
+        return fail
 
     info = [g.toUnicode(z) for z in s.splitlines()]
 
@@ -5083,7 +5083,7 @@ def getModifiedFiles(repo_path: str) -> list[str]:
 
 
 # @+node:ekr.20170414034616.2: *3* g.gitBranchName
-def gitBranchName(path: str | None = None) -> str:
+def gitBranchName(path: str = '') -> str:
     """
     Return the git branch name associated with path/.git, or the empty
     string if path/.git does not exist. If path is None, use the leo-editor
@@ -5094,7 +5094,7 @@ def gitBranchName(path: str | None = None) -> str:
 
 
 # @+node:ekr.20170414034616.4: *3* g.gitCommitNumber
-def gitCommitNumber(path: str | None = None) -> str:
+def gitCommitNumber(path: str = '') -> str:
     """
     Return the git commit number associated with path/.git, or the empty
     string if path/.git does not exist. If path is None, use the leo-editor
@@ -5105,7 +5105,7 @@ def gitCommitNumber(path: str | None = None) -> str:
 
 
 # @+node:maphew.20171112205129.1: *3* g.gitDescribe
-def gitDescribe(path: str | None = None) -> tuple[str, str, str]:
+def gitDescribe(path: str = '') -> tuple[str, str, str]:
     """
     Return the Git tag, distance-from-tag, and commit hash for the
     associated path. If path is None, use the leo-editor directory.
@@ -5765,7 +5765,7 @@ def isWordChar1(ch: str) -> bool:
 
 
 # @+node:ekr.20130910044521.11304: *4* g.stripBOM
-def stripBOM(s_bytes: bytes) -> tuple[str | None, bytes]:
+def stripBOM(s_bytes: bytes) -> tuple[str, bytes]:
     """
     If there is a BOM, return (e,s2) where e is the encoding
     implied by the BOM and s2 is the s stripped of the BOM.
@@ -5787,7 +5787,7 @@ def stripBOM(s_bytes: bytes) -> tuple[str | None, bytes]:
             assert len(bom) == n
             if bom == s_bytes[: len(bom)]:
                 return e, s_bytes[len(bom) :]
-    return None, s_bytes
+    return '', s_bytes
 
 
 # @+node:ekr.20240325175449.1: *4* g.strToBytes

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2886,7 +2886,7 @@ def comment_delims_from_extension(filename: str) -> tuple[str, str, str]:
     Return the comment delims corresponding to the filename's extension.
     """
     if filename.startswith('.'):
-        root, ext = None, filename
+        root, ext = '', filename
     else:
         root, ext = os.path.splitext(filename)
     if ext == '.tmp':
@@ -2914,8 +2914,8 @@ def findAllValidLanguageDirectives(s: str) -> list:
     return list(sorted(languages))
 
 
-# @+node:ekr.20090214075058.8: *3* g.findAtTabWidthDirectives (must be fast)
-def findTabWidthDirectives(c: Cmdr, p: Position) -> str | None:
+# @+node:ekr.20090214075058.8: *3* g.findAtTabWidthDirectives (not used)
+def findTabWidthDirectives(c: Cmdr, p: Position) -> int | None:
     """Return the tab width in effect at position p."""
     if c is None:
         return None  # c may be None for testing.
@@ -2954,12 +2954,13 @@ def findFirstValidAtLanguageDirective(s: str) -> str | None:
 
 
 # @+node:ekr.20090214075058.6: *3* g.findLanguageDirectives (must be fast)
-def findLanguageDirectives(c: Cmdr, p: Position) -> str | None:
+def findLanguageDirectives(c: Cmdr, p: Position) -> str:
     """Return the language in effect at position p."""
     if c is None or p is None:
         return None  # c may be None for testing.
 
     v0 = p.v
+    assert v0
 
     def find_language(p_or_v: Position | VNode) -> str | None:
         for s in p_or_v.h, p_or_v.b:
@@ -2967,7 +2968,7 @@ def findLanguageDirectives(c: Cmdr, p: Position) -> str | None:
                 language = m.group(1)
                 if g.isValidLanguage(language):
                     return language
-        return None
+        return ''
 
     # First, search up the tree.
     for p in p.self_and_parents(copy=False):
@@ -3019,7 +3020,7 @@ def get_directives_dict(p: Position) -> dict[str, str]:
     d = {}
     # The headline has higher precedence because it is more visible.
     for kind, s in (('head', p.h), ('body', p.b)):
-        anIter = g.directives_pat.finditer(s)
+        anIter = g.directives_pat.finditer(s)  # type:ignore # anIter will exist
         for m in anIter:
             word = m.group(1).strip()
             i = m.start(1)
@@ -3059,6 +3060,7 @@ def get_directives_dict_list(p: Position) -> list[dict]:
 def getLanguageFromAncestorAtFileNode(p: Position) -> str | None:
     """Return the language in effect at node p."""
     g.deprecated()
+    assert p.v
     c = p.v.context
     return c.getLanguage(p)
 
@@ -3330,7 +3332,7 @@ def set_delims_from_language(language: str) -> tuple[str, str, str]:
 
 
 # @+node:ekr.20031218072017.1383: *3* g.set_delims_from_string
-def set_delims_from_string(s: str) -> tuple[str, str, str] | tuple[None, None, None]:
+def set_delims_from_string(s: str) -> tuple[str, str, str]:
     """
     Return (delim1, delim2, delim2), the delims following the @comment
     directive.
@@ -3340,6 +3342,7 @@ def set_delims_from_string(s: str) -> tuple[str, str, str] | tuple[None, None, N
     """
     # Skip an optional @comment
     tag = "@comment"
+    fail = '', '', ''
     i = 0
     if g.match_word(s, i, tag):
         i += len(tag)
@@ -3366,12 +3369,12 @@ def set_delims_from_string(s: str) -> tuple[str, str, str] | tuple[None, None, N
                 # If used, whole delimiter must be encoded.
                 if len(delims[i]) == 3:
                     g.warning(f"'{delims[i]}' delimiter is invalid")
-                    return None, None, None
+                    return fail
                 try:
                     delims[i] = g.toUnicode(binascii.unhexlify(delims[i][3:]))  # #4753
                 except Exception as e:
                     g.warning(f"'{delims[i]}' delimiter is invalid: {e}")
-                    return None, None, None
+                    return fail
             else:
                 # 7/8/02: The "REM hack": replace underscores by blanks.
                 # 9/25/02: The "perlpod hack": replace double underscores by newlines.
@@ -3380,9 +3383,7 @@ def set_delims_from_string(s: str) -> tuple[str, str, str] | tuple[None, None, N
 
 
 # @+node:ekr.20031218072017.1384: *3* g.set_language
-def set_language(
-    s: str, i: int, issue_errors_flag: bool = False
-) -> tuple[str, str, str, str] | tuple[None, None, None, None]:
+def set_language(s: str, i: int, issue_errors_flag: bool = False) -> tuple[str, str, str, str]:
     """Scan the @language directive that appears at s[i:].
 
     The @language may have been stripped away.
@@ -3405,7 +3406,7 @@ def set_language(
         return language, delim1, delim2, delim3
     if issue_errors_flag:
         g.es("ignoring:", g.get_line(s, i))
-    return None, None, None, None
+    return '', '', '', ''
 
 
 # @+node:ekr.20071109165315: *3* g.stripPathCruft
@@ -3478,7 +3479,7 @@ def computeStandardDirectories() -> str:
 
 
 # @+node:ekr.20031218072017.3117: *3* g.create_temp_file
-def create_temp_file(textMode: bool = False) -> tuple[IO, str]:
+def create_temp_file(textMode: bool = False) -> tuple[IO | None, str]:
     """
     Return a tuple (theFile,theFileName)
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -4053,7 +4053,9 @@ def findAncestorVnodeByPredicate(p: Position, v_predicate: Callable) -> VNode | 
 
 # @+node:ekr.20170220103251.1: *3* g.findRootsWithPredicate
 def findRootsWithPredicate(
-    c: Cmdr, root: Position, predicate: Callable | None = None
+    c: Cmdr,
+    root: Position,
+    predicate: Callable | None = None,
 ) -> list[Position]:
     """
     Commands often want to find one or more **roots**, given a position p.
@@ -5714,23 +5716,27 @@ def getPythonEncodingFromString(s: bytes | str) -> str:
     encoding = 'utf-8'
     tag, tag2 = '# -*- coding:', '-*-'
     n1, n2 = len(tag), len(tag2)
-    if s:
-        # Convert to unicode before calling startswith.
-        # The encoding doesn't matter: we only look at the first line, and if
-        # the first line is an encoding line, it will contain only ascii characters.
-        s = g.toUnicode(s)  # Bug fix: 2025/03/24: do *not* force ascii encoding.
-        lines = g.splitLines(s)
-        line1 = lines[0].strip()
+    if not isinstance(s, (bytes, str)):
+        raise ValueError(f"{tag}: {s=}\n{g.callers()=}")
+    if not s:
+        return encoding
+
+    # Convert to unicode before calling startswith.
+    # The encoding doesn't matter: we only look at the first line, and if
+    # the first line is an encoding line, it will contain only ascii characters.
+    s = g.toUnicode(s)  # Bug fix: 2025/03/24: do *not* force ascii encoding.
+    lines = g.splitLines(s)
+    line1 = lines[0].strip()
+    if line1.startswith(tag) and line1.endswith(tag2):
+        e = line1[n1:-n2].strip()
+        if e and g.isValidEncoding(e):
+            encoding = e
+    elif g.match_word(line1, 0, '@first'):
+        line1 = line1[len('@first') :].strip()
         if line1.startswith(tag) and line1.endswith(tag2):
             e = line1[n1:-n2].strip()
             if e and g.isValidEncoding(e):
                 encoding = e
-        elif g.match_word(line1, 0, '@first'):
-            line1 = line1[len('@first') :].strip()
-            if line1.startswith(tag) and line1.endswith(tag2):
-                e = line1[n1:-n2].strip()
-                if e and g.isValidEncoding(e):
-                    encoding = e
     return encoding
 
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -421,7 +421,7 @@ def standard_timestamp() -> str:
 
 
 # @+node:ekr.20201211183100.1: *3* g.get_backup_directory
-def get_backup_path(sub_directory: str) -> str | None:
+def get_backup_path(sub_directory: str) -> str:
     """
     Return the full path to the subdirectory of the main backup directory.
 
@@ -436,7 +436,7 @@ def get_backup_path(sub_directory: str) -> str | None:
     try:
         backup = os.environ['LEO_BACKUP']
         if not os.path.exists(backup):
-            backup = None
+            backup = ''
     except KeyError:
         pass
     except Exception:
@@ -445,12 +445,12 @@ def get_backup_path(sub_directory: str) -> str | None:
     if not backup:
         backup = os.path.join(str(Path.home()), 'Backup')
         if not os.path.exists(backup):
-            backup = None
+            backup = ''
     if not backup:
-        return None
+        return ''
     # Compute the path to backup/sub_directory
     directory = os.path.join(backup, sub_directory)
-    return directory if os.path.exists(directory) else None
+    return directory if os.path.exists(directory) else ''
 
 
 # @+node:ekr.20140711071454.17644: ** g.Classes & class accessors
@@ -1827,16 +1827,15 @@ class SettingsDict(dict):
             self[key] = aList
 
     # @+node:ekr.20190903181030.1: *4* SettingsDict.get_setting & get_string_setting
-    def get_setting(self, key: str) -> str | None:
+    def get_setting(self, key: str) -> str:
         """Return the canonical setting name."""
         key = key.replace('-', '').replace('_', '')
         gs = self.get(key)
-        val = gs and gs.val
-        return val
+        return gs.val if gs else ''
 
-    def get_string_setting(self, key: str) -> str | None:
+    def get_string_setting(self, key: str) -> str:
         val = self.get_setting(key)
-        return val if val and isinstance(val, str) else None
+        return val if isinstance(val, str) else ''
 
     # @+node:ekr.20190904103552.1: *4* SettingsDict.name & setName
     def name(self) -> str:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -577,7 +577,7 @@ class Bunch:
         """Support aBunch[key]"""
         return operator.getitem(self.__dict__, key)
 
-    def get(self, key: str, theDefault: Value | None = None) -> Value:
+    def get(self, key: str, theDefault: Value = None) -> Value:
         return self.__dict__.get(key, theDefault)
 
     def __contains__(self, key: str) -> bool:
@@ -695,13 +695,13 @@ class GeneralSetting:
     def __init__(
         self,
         kind: str,
-        encoding: str | None = None,
-        ivar: str | None = None,
-        source: str | None = None,
-        val: Value | None = None,
-        path: str | None = None,
+        encoding: str = '',
+        ivar: str = '',
+        source: str = '',
+        val: Value = None,
+        path: str = '',
         tag: str = 'setting',
-        unl: str | None = None,
+        unl: str = '',
     ) -> None:
         self.encoding = encoding
         self.ivar = ivar

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3546,7 +3546,9 @@ def fullPath(c: Cmdr, p: Position) -> str:
 
 # @+node:ekr.20190327192721.1: *3* g.get_files_in_directory
 def get_files_in_directory(
-    directory: str, kinds: list | None = None, recursive: bool = True
+    directory: str,
+    kinds: list | None = None,
+    recursive: bool = True,
 ) -> list[str]:
     """
     Return a list of all files of the given file extensions in the directory.
@@ -3713,7 +3715,9 @@ def makePathRelativeTo(fullPath: str, basePath: str) -> str:
 
 # @+node:ekr.20090520055433.5945: *3* g.openWithFileName
 def openWithFileName(
-    fileName: str, old_c: Cmdr | None = None, gui: LeoGui | None = None
+    fileName: str,
+    old_c: Cmdr | None = None,
+    gui: LeoGui | None = None,
 ) -> Cmdr | None:
     """
     Load any kind of file in the appropriate way:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -38,7 +38,7 @@ import time
 import traceback
 import types
 from types import ModuleType
-from typing import cast, Any, IO, Iterable, Sequence, TYPE_CHECKING
+from typing import Any, IO, Iterable, Sequence, TYPE_CHECKING
 import unittest
 import urllib
 import urllib.parse as urlparse
@@ -207,7 +207,7 @@ def check_cmd_instance_dict(c: Cmdr, g: LeoGlobals) -> None:
     """
     d = cmd_instance_dict
     for key in d:
-        ivars = d.get(key)
+        ivars = d.get(key, [])
         # Produces warnings.
         obj = ivars2instance(c, g, ivars)
         if obj:
@@ -313,7 +313,7 @@ commander_command = CommanderCommand
 
 
 # @+node:ekr.20150508164812.1: *3* g.ivars2instance
-def ivars2instance(c: Cmdr, g: LeoGlobals, ivars: list[str] | None) -> Any | None:
+def ivars2instance(c: Cmdr, g: LeoGlobals, ivars: list[str]) -> Any:
     """
     Return the instance of c given by ivars.
     ivars is a list of strings.
@@ -406,7 +406,7 @@ url_regex = re.compile(rf"""\b{url_kinds}://[^\s'"]+""")
 # @-<< define regexes >>
 tree_popup_handlers: list[Callable] = []  # Set later.
 user_dict: dict[str, Value] = {}  # Non-persistent dictionary for scripts and plugins.
-app: LeoApp | None = None  # The singleton app object. Set by runLeo.py.
+app: LeoApp = None  # The singleton app object. Set by runLeo.py.
 # Global status vars.
 inScript = False  # A synonym for app.inScript
 unitTesting = False  # A synonym for app.unitTesting.
@@ -823,7 +823,7 @@ class KeyStroke:
         }
         if self.mods and s.lower() in shift_d:
             # Returning '' breaks existing code.
-            return shift_d.get(s.lower())
+            return shift_d.get(s.lower(), '')  # PR #4772
         #
         # Make all other translations...
         #
@@ -905,7 +905,7 @@ class KeyStroke:
         if s in (None, 'none', 'None'):
             return 'None'
         if s.lower() in translate_d:
-            s = translate_d.get(s.lower())
+            s = translate_d.get(s.lower(), '')
             return self.strip_shift(s)
         if len(s) > 1 and s.find(' ') > -1:
             # #917: not a pure, but should be ignored.
@@ -974,7 +974,7 @@ class KeyStroke:
         }  # fmt: skip
         if 'shift' in self.mods and s in shift_d:
             self.mods.remove('shift')
-            s = shift_d.get(s)
+            s = shift_d.get(s, '')  # PR #4772
         return s
 
     # @+node:ekr.20120203053243.10124: *4* ks.find, lower & startswith
@@ -1120,7 +1120,7 @@ class KeyStroke:
             'Tab': '\t',
         }
         if s in d:
-            return d.get(s)
+            return d.get(s, '')  # PR #4772
         return s if len(s) == 1 else ''
 
     # @-others

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -563,7 +563,9 @@ class Position:
 
     # @+node:ekr.20161120163203.1: *4* p.nearest_unique_roots (aka p.nearest)
     def nearest_unique_roots(
-        self, copy: bool = True, predicate: Callable | None = None
+        self,
+        copy: bool = True,
+        predicate: Callable | None = None,
     ) -> Generator:
         """
         A generator yielding all unique root positions "near" p1 = self that
@@ -635,7 +637,7 @@ class Position:
     def self_and_parents(self, copy: bool = True) -> Generator:
         """Yield p and all parent positions of p."""
         p = self
-        if not p:  # PR #4767 # p.v may be None.
+        if not p:  # Don't use assert p here.
             return
         p = p.copy()
         while p:
@@ -728,18 +730,21 @@ class Position:
     # @+node:ekr.20040323160302: *5* p.directParents
     def directParents(self) -> list[VNode]:
         p = self
-        return p.v.directParents() if p.v else []
+        assert p.v
+        return p.v.directParents()
 
     # @+node:ekr.20040306214240.3: *5* p.hasChildren & p.numberOfChildren
     def hasChildren(self) -> bool:
         p = self
-        return bool(p.v and len(p.v.children) > 0)
+        assert p.v
+        return len(p.v.children) > 0
 
     hasFirstChild = hasChildren
 
     def numberOfChildren(self) -> int:
         p = self
-        return len(p.v.children) if p.v else 0  # PR #4767
+        assert p.v
+        return len(p.v.children)  # PR #4767
 
     # @+node:ekr.20250405080955.1: *4* p.findDirective
     at_directive_pattern = re.compile(r'@([\w]+)', re.MULTILINE)
@@ -2231,9 +2236,9 @@ class Position:
         p.setDirty() is no longer expensive.
         """
         p = self
-        if v := p.v:
-            v.setAllAncestorAtFileNodesDirty()
-            v.setDirty()
+        assert p.v
+        p.v.setAllAncestorAtFileNodesDirty()
+        p.v.setDirty()
 
     # @+node:ekr.20160225153333.1: *3* p.Predicates
     # @+node:ekr.20160225153414.1: *4* p.is_at_all & is_at_all_tree
@@ -2567,9 +2572,9 @@ class VNode:
         v = self
         # Allocate a new vnode and gnx with empty children & parents.
         v2 = VNode(context=v.context, gnx=None)
-        assert v2.parents == [], v2.parents  # pylint: disable=use-implicit-booleaness-not-comparison
-        assert v2.gnx
-        assert v.gnx != v2.gnx
+        assert v2.parents, v2
+        assert v2.gnx, v2
+        assert v.gnx != v2.gnx, v2
         # Copy vnode fields. Do **not** set v2.parents.
         v2._headString = g.toUnicode(v._headString, reportErrors=True)
         v2._bodyString = g.toUnicode(v._bodyString, reportErrors=True)

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -2,6 +2,8 @@
 # @+node:ekr.20140907103315.18766: * @file ../plugins/qt_events.py
 """Leo's Qt event handling code."""
 
+from __future__ import annotations
+
 # @+<< about internal bindings >>
 # @+node:ekr.20110605121601.18538: ** << about internal bindings >>
 # @@language rest
@@ -35,10 +37,14 @@
 # rules.
 # @-<< about internal bindings >>
 import sys
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoGui
 from leo.core.leoQt import QtCore, QtGui, QtWidgets
 from leo.core.leoQt import Key, KeyboardModifier, Type
+
+if TYPE_CHECKING:
+    from leo.core.leoCommands import Commands as Cmdr
 
 
 # @+others
@@ -98,7 +104,7 @@ class LeoQtEventFilter(QtCore.QObject):
     # @+node:ekr.20110605121601.18540: *3* LeoQtEventFilter.eventFilter & helpers
     def eventFilter(self, obj, event):
         """Return False if Qt should handle the event."""
-        c, k = self.c, self.c.k
+        c = self.c
         # Handle non-key events first.
         if not g.app:
             return False  # For unit tests, but g.unitTesting may be False!
@@ -127,6 +133,8 @@ class LeoQtEventFilter(QtCore.QObject):
             binding, ch, lossage = self.toBinding(event)
             if not binding:
                 return False  # Let Qt handle the key.
+            c = self.currentCommander()
+            k = c.k
             # Pass the KeyStroke to masterKeyHandler.
             key_event = self.createKeyEvent(event, c, self.w, ch, binding)
             # #1933: Update the g.app.lossage
@@ -142,9 +150,11 @@ class LeoQtEventFilter(QtCore.QObject):
         return True  # Whatever happens, suppress all other Qt key handling.
 
     # @+node:ekr.20110605195119.16937: *4* LeoQtEventFilter.createKeyEvent
-    def createKeyEvent(self, event, c, w, ch, binding):
+    def createKeyEvent(
+        self, event: Any, c: Cmdr, w: Any, ch: str, binding: str
+    ) -> leoGui.LeoKeyEvent:
         return leoGui.LeoKeyEvent(
-            c=self.c,
+            c=c,
             # char = None doesn't work at present.
             # But really, the binding should suffice.
             char=ch,
@@ -155,6 +165,18 @@ class LeoQtEventFilter(QtCore.QObject):
             x_root=getattr(event, 'x_root', None) or 0,
             y_root=getattr(event, 'y_root', None) or 0,
         )
+
+    def currentCommander(self) -> Cmdr:
+        """Return the current tab's commander on macOS."""
+        c = self.c
+        if sys.platform != 'darwin':
+            return c
+        try:
+            master = getattr(c.frame.top, 'leo_master', None)
+            current = master.currentWidget()
+            return getattr(current, 'leo_c', None) or c
+        except Exception:
+            return c
 
     # @+node:ekr.20180413180751.2: *4* LeoQtEventFilter.doNonKeyEvent
     def doNonKeyEvent(self, event, obj):

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -1696,7 +1696,7 @@ class ViewRenderedController(QtWidgets.QWidget):
         return w
 
     # @+node:ekr.20110320120020.14483: *4* vr.get_kind
-    def get_kind(self, p: Position) -> str | None:
+    def get_kind(self, p: Position) -> str:
         """Return the proper rendering kind for node p."""
 
         p0 = p  # Special case selected position.
@@ -1728,19 +1728,19 @@ class ViewRenderedController(QtWidgets.QWidget):
                 language = m.group(1)
                 if g.isValidLanguage(language):
                     return language
-            return None
+            return ''
 
         # #1287: Honor both kind of directives node by node.
         for p1 in p.self_and_parents():
             language = get_language(p1)
             if language:
                 if language in ('md', 'markdown'):
-                    return language if got_markdown else None
+                    return language if got_markdown else ''
                 if language in ('rest', 'rst'):
-                    return language if got_docutils else None
+                    return language if got_docutils else ''
                 if language in self.dispatch_dict:
                     return language
-        return None
+        return ''
 
     # @+node:ekr.20110320233639.5776: *4* vr.get_fn
     def get_fn(self, s: str, tag: str) -> tuple[bool, str]:

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -53,7 +53,7 @@ follow_kind = 'normal' if follow else 'skip'
 args = f"--follow-imports={follow_kind} {incremental_arg}"
 files = ' '.join(files)
 command = rf"{python} -m mypy {args} {files}"
-print(f"{command=}")
+# print(f"{command=}")
 subprocess.Popen(command, shell=True).communicate()
 
 # @@language python

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -43,7 +43,7 @@ files = [
     #   'leo/plugins/qt_layout.py',
     #   'leo/plugins/qt_text.py',
     #   'leo/plugins/qt_tree.py',
-    #   'leo/plugins/viewrendered.py',
+    # 'leo/plugins/viewrendered.py',
     #   'leo/plugins/viewrendered3.py',
 ]  # fmt: skip
 python = sys.executable

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -1,7 +1,5 @@
 # @+leo-ver=5-thin
 # @+node:ekr.20240321122413.8: * @file ../scripts/mypy_leo.py
-# @@language python
-
 """
 mypy_leo.py: Run mypy on Leo's files.
 
@@ -13,6 +11,8 @@ EKR's mypy-leo.cmd:
     python -m leo.scripts.mypy_leo
 """
 
+# @+<< mypy_leo.py: imports & startup >>
+# @+node:ekr.20260703122126.1: ** << mypy_leo.py: imports & startup >>
 import os
 import subprocess
 import sys
@@ -22,10 +22,12 @@ print(os.path.basename(__file__))
 # cd to leo-editor
 leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
 os.chdir(leo_editor_dir)
-
-# args = ' '.join(sys.argv[1:])
-python = sys.executable
+# @-<< mypy_leo.py: imports & startup >>
+incremental = False
+follow = False
 files = [
+    # PR #47??. Require strict optional for leoGlobals.py.
+    'leo/core/leoGlobals.py',
     # PR #4766. Require strict optional for leoNodes.py.
     'leo/core/leoCommands.py',
     'leo/core/leoNodes.py',
@@ -33,7 +35,6 @@ files = [
     #   'leo/core/leoApp.py',
     #   'leo/core/leoAtFile.py',
     #   'leo/core/leoKeys.py',
-    #   'leo/core/leoGlobals.py',
     #   'leo/plugins/mod_scripting.py',
     #   'leo/plugins/qt_commands.py',
     #   'leo/plugins/qt_frame.py',
@@ -45,14 +46,15 @@ files = [
     #   'leo/plugins/viewrendered.py',
     #   'leo/plugins/viewrendered3.py',
 ]  # fmt: skip
-
-# The only way to enable strict_optional is within .mypy.ini.
-incremental = False
-follow = False
+python = sys.executable
 incremental_arg = '' if incremental else '--no-incremental'
 follow_kind = 'normal' if follow else 'skip'
+# args = ' '.join(sys.argv[1:])
 args = f"--follow-imports={follow_kind} {incremental_arg}"
 files = ' '.join(files)
 command = rf"{python} -m mypy {args} {files}"
+print(f"{command=}")
 subprocess.Popen(command, shell=True).communicate()
+
+# @@language python
 # @-leo


### PR DESCRIPTION
See #4766. 

Note: I mistakenly based this branch on the previous branch, which explains unrelated changes to qt_event.py and leoNodes.py.

- [x] Convert `: x aType = None` to `: x aType | None = None` *almost* everywhere in leoGlobals.py.
   Some strings *must* be annotated as `str | None = None`.
- [x] Remove execute_shell_commands_with_options and its helpers.
- [x] Fix all mypy complaints.
- [x] Make small changes to leoApp.py, leoAtFile.py, leoCommands.py, and viewrendered.py.

**Code changes**

- [x] Reimport leoGlobals.py at the start of the file. This seems like the only way to keep mypy happy.
- [x] The default values for most string vars and args is the empty string instead of None.
- [x] Revise and simplify g.bytesToStr, g.toUnicode and g.toEncodedString.
- [x] Raise ValueError in g.bytesToStr, g.toUnicode, g.toEncodedString and g.getPythonEncodingFromString.
    This should have been done long ago.

**Annotation changes**

- [x] Annotate g.handleUrl as returning `None`, not `str`. The old annotation was confusing.
- [x] Annotate g.getUrlFromNode as returning str, not `str | None`. The old annotation was confusing.
- [x] g.getPythonEncodingFromString: change the annotation of the `s` arg from `object` to `bytes | str`.