### PR TITLE
PR3: require strict_optional in leoCommands.py

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -38,6 +38,7 @@ exclude =
 [mypy-leo.core.*]
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
+strict_optional = False
 
 # #4766: more specific descriptions override less specific.
 [mypy-leo.core.leoNodes,leo.core.leoGlobals,leo.core.leoCommands]

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -40,7 +40,7 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 
 # #4766: more specific descriptions override less specific.
-[mypy-leo.core.leoNodes,leo.core.leoGlobals]
+[mypy-leo.core.leoNodes,leo.core.leoGlobals,leo.core.leoCommands]
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 strict_optional = True

--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -45,6 +45,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
         'scripting_enabled',
         'expanding',
         'number_regex',
+        'subst_env',
         'tree_abbrevs_d',
         'w',
     )
@@ -521,7 +522,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
             getBool('scripting-at-script-nodes') or
             getBool('scripting-abbreviations')
         )  # fmt: skip
-        self.globalDynamicAbbrevs = getBool('global-dynamic-abbrevs')
+        self.globalDynamicAbbrevs: bool = getBool('global-dynamic-abbrevs')
 
         # Allow @data abbreviations-subst-env *only* in leoSettings.leo or myLeoSettings.leo!
         key = 'abbreviations-subst-env'

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1550,7 +1550,7 @@ class LeoApp:
         fileName: str,
         gui: LeoGui = None,
         parentFrame: Any = None,
-        previousSettings: "PreviousSettings" = None,
+        previousSettings: PreviousSettings | None = None,
         relativeFileName: str = None,
     ) -> Cmdr:
         """Create a commander and its view frame for the Leo main window."""
@@ -2024,7 +2024,7 @@ class LoadManager:
         return None, None
 
     # @+node:ekr.20120223062418.10414: *4* LM.getPreviousSettings
-    def getPreviousSettings(self, fn: str) -> "PreviousSettings":
+    def getPreviousSettings(self, fn: str) -> PreviousSettings:
         """
         Return the settings in effect for fn. Typically, this involves
         pre-reading fn.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -156,7 +156,7 @@ class LeoApp:
         # @-<< LeoApp: command-line arguments >>
         # @+<< LeoApp: Debugging & statistics >>
         # @+node:ekr.20161028035835.1: *5* << LeoApp: Debugging & statistics >>
-        self.debug_dict: dict[str, Value] = {}  # For general use.
+        self.debug_dict: dict[str, set[Value]] = {}  # For general use.
         self.disable_redraw = False  # True: disable all redraws.
         self.disableSave = False  # May be set by plugins.
         self.idle_timers: list[IdleTime] = []  # A list of IdleTime instances, so they persist.
@@ -292,7 +292,7 @@ class LeoApp:
         # @+<< LeoApp: plugins and event handlers >>
         # @+node:ekr.20161028040229.1: *5* << LeoApp: plugins and event handlers >>
         self.hookError = False  # True: suppress further calls to hooks.
-        self.hookFunction = None  # Application wide hook function.
+        self.hookFunction: Callable | None = None  # Application wide hook function.
         self.idle_time_hooks_enabled = True  # True: idle-time hooks are enabled.
         # @-<< LeoApp: plugins and event handlers >>
         # @+<< LeoApp: scripting ivars >>
@@ -1725,7 +1725,7 @@ class LoadManager:
         g.app.testDir = join(g.app.loadDir, '..', 'test')
 
     # @+node:ekr.20120209051836.10253: *5* LM.computeGlobalConfigDir
-    def computeGlobalConfigDir(self) -> str | None:
+    def computeGlobalConfigDir(self) -> str:
         leo_config_dir = getattr(sys, 'leo_config_directory', None)
         if leo_config_dir:
             theDir = leo_config_dir
@@ -1734,11 +1734,11 @@ class LoadManager:
         if theDir:
             theDir = os.path.abspath(theDir)
         if not theDir or not g.os_path_exists(theDir) or not g.os_path_isdir(theDir):
-            theDir = None
+            theDir = ''
         return theDir
 
     # @+node:ekr.20120209051836.10254: *5* LM.computeHomeDir
-    def computeHomeDir(self) -> str | None:
+    def computeHomeDir(self) -> str:
         """Returns the user's home directory."""
         # Windows searches the HOME, HOMEPATH and HOMEDRIVE
         # environment vars, then gives up.
@@ -1751,7 +1751,7 @@ class LoadManager:
             # This was the source of the 4.3 .leoID.txt problems.
             home = g.finalize(home)
             if not g.os_path_exists(home) or not g.os_path_isdir(home):
-                home = None
+                home = ''
         return home
 
     # @+node:ekr.20120209051836.10260: *5* LM.computeHomeLeoDir
@@ -3137,7 +3137,7 @@ class LoadManager:
             return False
 
     # @+node:ekr.20120223062418.10393: *4* LM.openWithFileName & helpers
-    def openWithFileName(self, fn: str, gui: LeoGui, old_c: Cmdr) -> Cmdr | None:
+    def openWithFileName(self, fn: str, gui: LeoGui | None, old_c: Cmdr | None) -> Cmdr | None:
         """
         Completely read a file, creating the corresponding outline.
 

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -156,7 +156,7 @@ class LeoApp:
         # @-<< LeoApp: command-line arguments >>
         # @+<< LeoApp: Debugging & statistics >>
         # @+node:ekr.20161028035835.1: *5* << LeoApp: Debugging & statistics >>
-        self.debug_dict: dict[str, set[Value]] = {}  # For general use.
+        self.debug_dict: dict[str, Any] = {}  # For general use.
         self.disable_redraw = False  # True: disable all redraws.
         self.disableSave = False  # May be set by plugins.
         self.idle_timers: list[IdleTime] = []  # A list of IdleTime instances, so they persist.
@@ -164,7 +164,7 @@ class LeoApp:
         self.log_listener: Popen | None = None
         self.positions = 0  # The number of positions generated.
         self.scanErrors = 0  # The number of errors seen by g.scanError.
-        self.statsDict: dict[str, Value] = {}  # dict used by g.stat, g.clear_stats, g.print_stats.
+        self.statsDict: dict[str, Any] = {}  # dict used by g.stat, g.clear_stats, g.print_stats.
         self.statsLockout = False  # A lockout to prevent unbound recursion while gathering stats.
         self.validate_outline = False  # True: enables c.validate_outline. (slow)
         # @-<< LeoApp: Debugging & statistics >>

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -38,108 +38,108 @@ if TYPE_CHECKING:  # pragma: no cover
 
     from leo.core.leoAtFile import AtFile
 
-    assert AtFile
+    assert AtFile is not None
 
     from leo.core.leoChapters import ChapterController
 
-    assert ChapterController
+    assert ChapterController is not None
 
     from leo.core.leoFileCommands import FileCommands
 
-    assert FileCommands
+    assert FileCommands is not None
 
     from leo.core.leoFind import LeoFind
 
-    assert LeoFind
+    assert LeoFind is not None
 
     from leo.core.leoImport import LeoImportCommands
 
-    assert LeoImportCommands
+    assert LeoImportCommands is not None
 
     from leo.core.leoKeys import KeyHandlerClass
 
-    assert KeyHandlerClass  # type:ignore
+    assert KeyHandlerClass is not None
 
     from leo.core.leoHistory import NodeHistory
 
-    assert NodeHistory
+    assert NodeHistory is not None
 
     from leo.core.leoPersistence import PersistenceDataController
 
-    assert PersistenceDataController
+    assert PersistenceDataController is not None
 
     from leo.core.leoPrinting import PrintingController
 
-    assert PrintingController
+    assert PrintingController is not None
 
     from leo.core.leoShadow import ShadowController
 
-    assert ShadowController
+    assert ShadowController is not None
 
     from leo.core.leoUndo import Undoer
 
-    assert Undoer
+    assert Undoer is not None
 
     from leo.core.leoVim import VimCommands
 
-    assert VimCommands
+    assert VimCommands is not None
 
     # 14 command handlers...
     from leo.commands.abbrevCommands import AbbrevCommandsClass
 
-    assert AbbrevCommandsClass  # type:ignore  # Strange warning.
+    assert AbbrevCommandsClass is not None
 
     from leo.commands.bufferCommands import BufferCommandsClass
 
-    assert BufferCommandsClass
+    assert BufferCommandsClass is not None
 
     from leo.commands.controlCommands import ControlCommandsClass
 
-    assert ControlCommandsClass
+    assert ControlCommandsClass is not None
 
     from leo.commands.convertCommands import ConvertCommandsClass
 
-    assert ConvertCommandsClass
+    assert ConvertCommandsClass is not None
 
     from leo.commands.debugCommands import DebugCommandsClass
 
-    assert DebugCommandsClass
+    assert DebugCommandsClass is not None
 
     from leo.commands.editCommands import EditCommandsClass
 
-    assert EditCommandsClass
+    assert EditCommandsClass is not None
 
     from leo.commands.editFileCommands import EditFileCommandsClass
 
-    assert EditFileCommandsClass
+    assert EditFileCommandsClass is not None
 
     from leo.commands.gotoCommands import GoToCommands
 
-    assert GoToCommands
+    assert GoToCommands is not None
 
     from leo.commands.helpCommands import HelpCommandsClass
 
-    assert HelpCommandsClass
+    assert HelpCommandsClass is not None
 
     from leo.commands.keyCommands import KeyHandlerCommandsClass
 
-    assert KeyHandlerCommandsClass
+    assert KeyHandlerCommandsClass is not None
 
     from leo.commands.killBufferCommands import KillBufferCommandsClass
 
-    assert KillBufferCommandsClass
+    assert KillBufferCommandsClass is not None
 
     from leo.commands.rectangleCommands import RectangleCommandsClass
 
-    assert RectangleCommandsClass
+    assert RectangleCommandsClass is not None
 
     from leo.core.leoRst import RstCommands
 
-    assert RstCommands
+    assert RstCommands is not None
 
     from leo.commands.spellCommands import SpellCommandsClass
 
-    assert SpellCommandsClass
+    assert SpellCommandsClass is not None
 
     # Other objects...
     from leo.core.leoGui import LeoGui
@@ -551,10 +551,10 @@ class Commands:
         c.createCommandNames()
         k.finishCreate()
         c.findCommands.finishCreate()
-        if not c.gui.isNullGui:
+        if not c.gui.isNullGui and not g.unitTesting:
             # #2485: register idle_focus_helper in the proper context.
             assert g.app.pluginsController
-            try:
+            try:  # type:ignore
                 g.app.pluginsController.loadingModuleNameStack.append('leo.core.leoCommands')
                 g.registerHandler('idle', c.idle_focus_helper)
             finally:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -199,7 +199,7 @@ class Commands:
 
         # Official ivars.
         self._currentPosition = cast(Position, None)
-        self._topPosition = cast(Position, None)
+        self._topPosition: Position | None = None
         self.command_count = 0
         self.frame: Any = None  # This saves a lot of asserts.
         self.parentFrame: Widget = parentFrame  # New in Leo 6.0.
@@ -1850,7 +1850,7 @@ class Commands:
                     ending = m.group(1)
                     if ending in ("cr", "crlf", "lf", "nl", "platform"):
                         return g.getOutputNewline(name=ending)
-        return None
+        return ''
 
     # @+node:ekr.20250404153234.1: *5* c.getPageWidth
     # Use a regex to avoid allocating temp strings.
@@ -2105,6 +2105,8 @@ class Commands:
         if not p.hasChildren():
             return False
         # Always clear non-existent positions.
+        assert p.v
+        assert v
         v.expandedPositions = [z for z in v.expandedPositions if c.positionExists(z)]
         if not p.isCloned():
             # Do not call p.isExpanded here! It calls this method.
@@ -2163,7 +2165,7 @@ class Commands:
         return positions
 
     # @+node:ekr.20090107113956.1: *5* c.vnode2position
-    def vnode2position(self, v: VNode) -> Position:
+    def vnode2position(self, v: VNode) -> Position | None:
         """
         Given a VNode v, construct a valid position p such that p.v = v.
         """
@@ -2246,6 +2248,7 @@ class Commands:
     # @+node:ekr.20060906211138: *5* c.clearMarked
     def clearMarked(self, p: Position) -> None:
         c = self
+        assert p.v
         p.v.clearMarked()
         g.doHook("clear-mark", c=c, p=p)
 
@@ -2418,7 +2421,7 @@ class Commands:
                 new_gnx(v)
                 g.es_print(f"empty v.fileIndex: {v} new: {p.v.gnx!r}", color='red')
         for gnx in sorted(vnode_d.keys()):
-            aList = list(vnode_d.get(gnx))
+            aList = list(vnode_d.get(gnx) or [])
             ids = [id_ for (id_, v) in aList]
             if len(ids) > 1:
                 print('\nc.checkGnxs...')
@@ -2463,6 +2466,8 @@ class Commands:
     def checkParentAndChildren(self, p: Position) -> bool:
         """Check consistency of parent and child data structures."""
         c = self
+
+        assert p.v
 
         def _assert(condition: bool) -> bool:
             return g._assert(condition, show_callers=False)
@@ -2894,6 +2899,7 @@ class Commands:
             if g.unitTesting:
                 raise
             junk1, nag, junk2 = sys.exc_info()
+            assert nag
             badline = nag.get_lineno()
             line = nag.get_line()
             message = nag.get_msg()
@@ -3142,13 +3148,13 @@ class Commands:
         default_delims = g.set_delims_from_language(default_language)
         wrap = c.config.getBool("body-pane-wraps")
         table: tuple = (
-            ('encoding',    None,           g.scanAtEncodingDirectives),
-            ('lang-dict',   {},             g.scanAtCommentAndAtLanguageDirectives),
-            ('lineending',  None,           g.scanAtLineendingDirectives),
-            ('pagewidth',   c.page_width,   g.scanAtPagewidthDirectives),
-            ('path',        None,           c.scanAtPathDirectives),
-            ('tabwidth',    c.tab_width,    g.scanAtTabwidthDirectives),
-            ('wrap',        wrap,           g.scanAtWrapDirectives),
+            ('encoding',    '',           g.scanAtEncodingDirectives),
+            ('lang-dict',   {},           g.scanAtCommentAndAtLanguageDirectives),
+            ('lineending',  '',           g.scanAtLineendingDirectives),
+            ('pagewidth',   c.page_width, g.scanAtPagewidthDirectives),
+            ('path',        '',           c.scanAtPathDirectives),
+            ('tabwidth',    c.tab_width,  g.scanAtTabwidthDirectives),
+            ('wrap',        wrap,         g.scanAtWrapDirectives),
         )  # fmt: skip
 
         # Set d by scanning all directives.
@@ -3160,6 +3166,7 @@ class Commands:
 
         # Post process: do *not* set commander ivars.
         lang_dict = d.get('lang-dict')
+        assert lang_dict
         d = {
             "delims":       lang_dict.get('delims') or default_delims,
             "comment":      lang_dict.get('comment'),  # Leo 6.4: New.
@@ -3729,12 +3736,12 @@ class Commands:
                     base_dir = os.environ[env_key]
                 except KeyError:
                     print(f"No environment var: {env_key}")
-                    base_dir = None
+                    base_dir = ''
         if base_dir and g.os_path_exists(base_dir):
             if use_git_prefix:
                 git_branch, junk = g.gitInfo()
             else:
-                git_branch = None
+                git_branch = ''
             theDir, fn = g.os_path_split(c.fileName())
             backup_dir = join(base_dir, sub_dir) if sub_dir else base_dir
             path = join(backup_dir, fn)
@@ -3923,7 +3930,7 @@ class Commands:
         self,
         directory: str,
         extensions: list[str],
-        files: list[str],
+        files: list[str] | None,
         kind: str,
         links: list[str],
         outline_name: str,
@@ -4038,6 +4045,7 @@ class Commands:
                     if fileName not in todo and fileName not in scanned:
                         c2 = g.openWithFileName(fileName, gui=gui)
                         todo.append(fileName)
+                        assert c2
                         assert c2 not in result
                         result.append(c2)
 
@@ -4244,7 +4252,9 @@ class Commands:
             c.setChanged()
             c.redraw()
         # Restore the root position's body.
-        c.rootPosition().v.b = saved_body  # #1007: just set v.b.
+        p = c.rootPosition()
+        assert p.v
+        p.v.b = saved_body  # #1007: just set v.b.
         c.init_error_dialogs()
 
     # @+node:ekr.20150710083827.1: *5* c.syntaxErrorDialog
@@ -4280,13 +4290,14 @@ class Commands:
         c.redraw(p)
         c.updateSyntaxColorer(p)  # Dragging can change syntax coloring.
 
-    # @+node:ekr.20031218072017.2353: *5* c.dragAfter
-    def dragAfter(self, p: Position, after: Position | None) -> None:
+    # @+node:ekr.20031218072017.2353: *5* c.dragAfter (not used)
+    def dragAfter(self, p: Position, after: Position) -> None:
         c, p, u = self, self.p, self.undoer
         if not c.checkDrag(p, after):
             return
         if not c.checkMoveWithParentWithWarning(p, after.parent(), True):
             return
+        assert p.v
         c.endEditing()
         undoData = u.beforeMoveNode(p)
         p.setDirty()
@@ -4325,6 +4336,7 @@ class Commands:
         undoType = 'Clone Drag'
         current = c.p
         clone = p.clone()  # Creates clone.  Does not set undo.
+        assert clone.v
         if c.checkDrag(p, after) and c.checkMoveWithParentWithWarning(clone, after.parent(), True):
             c.endEditing()
             undoData = u.beforeInsertNode(current)
@@ -4357,6 +4369,7 @@ class Commands:
         # c = self
         redraw_flag = False
         for p in p.parents():
+            assert p.v
             if not p.v.isExpanded():
                 p.v.expand()
                 p.expand()
@@ -4950,7 +4963,7 @@ class Commands:
             return p and p.hasBack() and p != bunch.p
         return p and p.hasBack()
 
-    # @+node:ekr.20031218072017.2973: *6* c.canMoveOutlineUp
+    # @+node:ekr.20031218072017.2973: *6* c.canMoveOutlineUp Bug!
     def canMoveOutlineUp(self) -> bool:
         c, current = self, self.p
         visBack = current and current.visBack(c)
@@ -4960,10 +4973,13 @@ class Commands:
             return True
         if c.hoistStack:
             limit, limitIsVisible = c.visLimit()
+            ### g.trace(limitIsVisible, limit.h if limit else '<no limit>')  ###
             if limitIsVisible:  # A hoist
+                assert limit
                 return current != limit
             # A chapter.
-            return current != limit.firstChild()
+            assert not limit  ### Bug???
+            return current != limit.firstChild()  # type:ignore # Bug???
         return current != c.rootPosition()
 
     # @+node:ekr.20031218072017.2974: *6* c.canPasteOutline

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4449,7 +4449,7 @@ class Commands:
         c.enableRedrawFlag = True
 
     # @+node:ekr.20090110073010.1: *6* c.redraw
-    def redraw(self, p: LeoKeyEvent | None = None) -> None:
+    def redraw(self, p: Position | None = None) -> None:
         """
         Redraw the screen immediately.
         If p is given, set c.p to p.

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -119,8 +119,8 @@ class Commands:
         t1 = time.process_time()
         c = self
         # Official ivars.
-        self._currentPosition: Position | None = None
-        self._topPosition: Position | None = None
+        self._currentPosition = cast(Position, None)
+        self._topPosition = cast(Position, None)
         self.command_count = 0
         self.frame: Widget = None
         self.parentFrame: Widget = parentFrame  # New in Leo 6.0.

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -31,37 +31,115 @@ from leo.core.leoNodes import Position, VNode
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoApp import PreviousSettings
     from leo.core.leoGui import LeoKeyEvent
-    from leo.core.leoConfig import LocalConfigManager
+
+    # The following imports *are* required, but flake8 won't know that without the asserts.
 
     # 11 subcommanders...
+
     from leo.core.leoAtFile import AtFile
+
+    assert AtFile
+
     from leo.core.leoChapters import ChapterController
+
+    assert ChapterController
+
     from leo.core.leoFileCommands import FileCommands
+
+    assert FileCommands
+
     from leo.core.leoFind import LeoFind
+
+    assert LeoFind
+
     from leo.core.leoImport import LeoImportCommands
+
+    assert LeoImportCommands
+
     from leo.core.leoKeys import KeyHandlerClass
+
+    assert KeyHandlerClass  # type:ignore
+
     from leo.core.leoHistory import NodeHistory
+
+    assert NodeHistory
+
     from leo.core.leoPersistence import PersistenceDataController
+
+    assert PersistenceDataController
+
     from leo.core.leoPrinting import PrintingController
+
+    assert PrintingController
+
     from leo.core.leoShadow import ShadowController
+
+    assert ShadowController
+
     from leo.core.leoUndo import Undoer
+
+    assert Undoer
+
     from leo.core.leoVim import VimCommands
+
+    assert VimCommands
 
     # 14 command handlers...
     from leo.commands.abbrevCommands import AbbrevCommandsClass
+
+    assert AbbrevCommandsClass
+
     from leo.commands.bufferCommands import BufferCommandsClass
+
+    assert BufferCommandsClass
+
     from leo.commands.controlCommands import ControlCommandsClass
+
+    assert ControlCommandsClass
+
     from leo.commands.convertCommands import ConvertCommandsClass
+
+    assert ConvertCommandsClass
+
     from leo.commands.debugCommands import DebugCommandsClass
+
+    assert DebugCommandsClass
+
     from leo.commands.editCommands import EditCommandsClass
+
+    assert EditCommandsClass
+
     from leo.commands.editFileCommands import EditFileCommandsClass
+
+    assert EditFileCommandsClass
+
     from leo.commands.gotoCommands import GoToCommands
+
+    assert GoToCommands
+
     from leo.commands.helpCommands import HelpCommandsClass
+
+    assert HelpCommandsClass
+
     from leo.commands.keyCommands import KeyHandlerCommandsClass
+
+    assert KeyHandlerCommandsClass
+
     from leo.commands.killBufferCommands import KillBufferCommandsClass
+
+    assert KillBufferCommandsClass
+
     from leo.commands.rectangleCommands import RectangleCommandsClass
+
+    assert RectangleCommandsClass
+
     from leo.core.leoRst import RstCommands
+
+    assert RstCommands
+
     from leo.commands.spellCommands import SpellCommandsClass
+
+    assert SpellCommandsClass
 
     # Other objects...
     from leo.core.leoGui import LeoGui

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -5277,6 +5277,7 @@ class Commands:
     # @+node:ekr.20260110083713.1: *4* c.beautify_script_tree
     def beautify_script_tree(self, root: Position) -> None:
         """beautify root's entire tree. This code is not yet undoable."""
+        assert root.v
         c = root.v.context
         at = c.atFileCommands
         p = c.p
@@ -5301,7 +5302,7 @@ class Commands:
         else:
             g.trace('at.fast_read_into_root failed')  # Should not happen.
 
-    # @+node:ekr.20160201072634.1: *4* c.cloneFindByPredicate
+    # @+node:ekr.20160201072634.1: *4* c.cloneFindByPredicate & helpers
     def cloneFindByPredicate(
         self,
         generator: Callable,
@@ -5310,7 +5311,7 @@ class Commands:
         flatten: bool = False,
         iconPath: str = '',
         undoType: str = '',
-    ) -> Position:
+    ) -> Position | None:  # PR #4773
         """
         Traverse the tree given using the generator, cloning all positions for
         which predicate(p) is True. Undoably move all clones to a new node, created
@@ -5356,6 +5357,7 @@ class Commands:
     # @+node:ekr.20160304054950.1: *5* c.setCloneFindByPredicateIcon
     def setCloneFindByPredicateIcon(self, iconPath: str, p: Position) -> None:
         """Attach an icon to p.v.u."""
+        assert p.v
         if iconPath and g.os_path_exists(iconPath) and not g.os_path_isdir(iconPath):
             aList = p.v.u.get('icons', [])
             for d in aList:
@@ -5390,7 +5392,7 @@ class Commands:
     def createNodeHierarchy(
         self,
         heads: list[str],
-        parent: Position | None = None,
+        parent: Position,  # PR #4773
         forcecreate: bool = False,
     ) -> Position:
         """

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -735,13 +735,13 @@ class Commands:
             print(f"{tag}: No command for {language} in @data exec-script-commands")
             return
         # Get the optional pattern.
-        regex = get_setting_for_language('exec-script-patterns')
+        regex = get_setting_for_language('exec-script-patterns') or ''
         # Set the directory, if possible.
         if p.isAnyAtFileNode():
             path = c.fullPath(p)
             directory = os.path.dirname(path)
         else:
-            directory = None
+            directory = ''
         c.general_script_helper(command, ext, language, directory=directory, regex=regex, root=p)
 
     # @+node:tom.20241014154415.1: *4* @cmd c.execute-external-file
@@ -944,7 +944,7 @@ class Commands:
             If there is a language directive in effect, return it,
             otherwise use the file extension.
             """
-            return c.getLanguage(c.p) or LANGUAGE_EXTENSION_MAP.get(ext, None)
+            return c.getLanguage(c.p) or LANGUAGE_EXTENSION_MAP.get(ext, '')
 
         # @+node:tom.20241014154415.10: *5* getProcessor
         def getProcessor(language: str, path: str, extension: str) -> str:
@@ -1050,7 +1050,7 @@ class Commands:
                 names = (names,)
             term = ''
             for name in names:
-                term = which(name)
+                term = which(name) or ''
                 if term:
                     break
             return term
@@ -1065,6 +1065,7 @@ class Commands:
                 or getTerminalFromDirectory('/usr/bin')
                 or getTerminalFromDirectory('/usr/local/bin')
                 or getTerminalFromDirectory('/bin')
+                or ''
             )
 
         # @+node:tom.20241014154415.16: *5* getTermExecuteCmd
@@ -1188,13 +1189,13 @@ class Commands:
             _, ext = os.path.splitext(path)
 
             # Check terminal from MAP_SETTING_NODE setting
-            setting_terminal = terminal
+            setting_terminal = terminal or ''
             if setting_terminal:
-                terminal = which(terminal)
+                terminal = which(terminal) or ''
                 if not terminal:
                     g.es(f'Cannot find terminal specified in setting: {setting_terminal}')
                     g.es('Trying an alternative')
-                    terminal = getTerminal()
+                    terminal = getTerminal() or ''
                     g.es('using', terminal)
 
             path = c.fullPath(root)
@@ -1374,7 +1375,7 @@ class Commands:
                         namespace.update(script_gnx=script_p.gnx)
                     # We *always* execute the script with p = c.p.
                     callResult = c.executeScriptHelper(
-                        args, define_g, define_name, namespace, script
+                        args or [], define_g, define_name, namespace, script
                     )
                 except KeyboardInterrupt:
                     g.es('interrupted')
@@ -1768,6 +1769,8 @@ class Commands:
         """
         Return the language in effect at node p, checking that the language is valid."""
         v0 = p.v
+        assert v0
+        assert p.v
         seen: set[VNode]
 
         # The same generator as in v.setAllAncestorAtFileNodesDirty.
@@ -1805,7 +1808,7 @@ class Commands:
 
         # Passes 3 & 4: Use the file extension in @<file> nodes.
 
-        def get_language_from_headline(v: VNode) -> str | None:
+        def get_language_from_headline(v: VNode) -> str:
             """Return the extension for @<file> nodes."""
             if v.isAnyAtFileNode():
                 name = v.anyAtFileNodeName()
@@ -1814,7 +1817,7 @@ class Commands:
                 language = g.app.extension_dict.get(ext)
                 if g.isValidLanguage(language):
                     return language
-            return None
+            return ''
 
         # Pass 3: Use file extension in headline of @<file> in direct parents.
         for p2 in p.self_and_parents(copy=False):
@@ -1825,6 +1828,7 @@ class Commands:
         # Pass 4: Use file extension in headline of @<file> nodes in extended parents.
         seen = set([v0.context.hiddenRootNode])
         for v in v_and_parents(v0):
+            assert v
             language = get_language_from_headline(v)
             if language:
                 return language

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -371,8 +371,11 @@ class Commands:
     # @+node:ekr.20120217070122.10470: *5* c.initObjects
     def initObjects(self, gui: LeoGui) -> None:
         c = self
+
+        # Create the hidden root VNode.
         self.hiddenRootNode = VNode(context=c, gnx='hidden-root-vnode-gnx')
         self.hiddenRootNode.h = '<hidden root vnode>'
+
         # Create the gui frame.
         title = c.computeTabTitle()
         if not g.app.initing:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -22,7 +22,6 @@ from leo.core import leoGlobals as g
 
 # The leoCommands ctor now does most leo.core.leo* imports,
 # thereby breaking circular dependencies.
-### from leo.core import leoNodes
 from leo.core.leoNodes import Position, VNode
 
 # @-<< leoCommands imports >>

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -189,7 +189,7 @@ class Commands:
     def __init__(
         self,
         fileName: str,
-        gui: LeoGui = None,
+        gui: LeoGui | None = None,
         parentFrame: Any = None,
         previousSettings: "PreviousSettings" = None,
         relativeFileName: str = '',
@@ -200,45 +200,12 @@ class Commands:
         self._currentPosition = cast(Position, None)
         self._topPosition = cast(Position, None)
         self.command_count = 0
-        self.frame: Widget = None
+        self.frame: Widget | None = None
         self.parentFrame: Widget = parentFrame  # New in Leo 6.0.
         self.gui: LeoGui = gui or g.app.gui
 
-        ###
-        # Declare subcommanders (and one alias) (created later).
-        # self.config: LocalConfigManager = None
-        # self.atFileCommands: AtFile = None
-        # self.chapterController: ChapterController = None
-        # self.fileCommands: FileCommands = None
-        # self.findCommands: LeoFind = None
-        # self.importCommands: LeoImportCommands = None
-        # self.keyHandler: KeyHandlerClass = None
-        # self.nodeHistory: NodeHistory = None
-        # self.persistenceController: PersistenceDataController = None
-        # self.printingController: PrintingController = None
-        # self.shadowController: ShadowController = None
-        # self.undoer: Undoer = None
-        # self.vimCommands: VimCommands = None
-
-        ###
-        # Declare command handlers (created later).
-        # self.abbrevCommands: AbbrevCommandsClass = None
-        # self.bufferCommands: BufferCommandsClass = None
-        # self.controlCommands: ControlCommandsClass = None
-        # self.convertCommands: ConvertCommandsClass = None
-        # self.debugCommands: DebugCommandsClass = None
-        # self.editCommands: EditCommandsClass = None
-        # self.editFileCommands: EditFileCommandsClass = None
-        # self.gotoCommands: GoToCommands = None
-        # self.helpCommands: HelpCommandsClass = None
-        # self.keyHandlerCommands: KeyHandlerCommandsClass = None
-        # self.killBufferCommands: KillBufferCommandsClass = None
-        # self.rectangleCommands: RectangleCommandsClass = None
-        # self.rstCommands: RstCommands = None
-        # self.spellCommands: SpellCommandsClass = None
-
         # Declare alias for self.keyHandler.
-        self.k: KeyHandlerClass = None
+        self.k: KeyHandlerClass | None = None
 
         # The stylesheet manager does not exist in all guis.
         self.styleSheetManager: StyleSheetManager | None = None
@@ -353,7 +320,7 @@ class Commands:
         # Flags for c.outerUpdate...
         self.enableRedrawFlag = True
         self.requestCloseWindow = False
-        self.requestedFocusWidget: Widget = None
+        self.requestedFocusWidget: Widget | None = None
         self.requestLaterRedraw = False
 
     # @+node:ekr.20120217070122.10472: *5* c.initFileIvars
@@ -723,14 +690,14 @@ class Commands:
     # @+node:ekr.20260619060020.1: *3* @cmd commands
     # @+node:ekr.20250508044308.1: *4* @cmd beautify-tree
     @cmd('beautify-tree')
-    def beautify_tree_command(self, event: LeoKeyEvent = None) -> None:
+    def beautify_tree_command(self, event: LeoKeyEvent | None = None) -> None:
         """Undoably beautify c.p and its subtree."""
         c = self
         c.beautify_script_tree(c.p)
 
     # @+node:ekr.20210530065748.1: *4* @cmd c.execute-general-script
     @cmd('execute-general-script')
-    def execute_general_script_command(self, event: LeoKeyEvent = None) -> None:
+    def execute_general_script_command(self, event: LeoKeyEvent | None = None) -> None:
         """
         Execute c.p and all its descendants as a script.
 
@@ -780,7 +747,7 @@ class Commands:
     # @+node:tom.20241014154415.1: *4* @cmd c.execute-external-file
     # @@language python
     @cmd('execute-external-file')
-    def execute_external_file(self, event: LeoKeyEvent = None) -> None:
+    def execute_external_file(self, event: LeoKeyEvent | None = None) -> None:
         r"""
         # @+<< docstring >>
         # @+node:tom.20241014154415.2: *5* << docstring >>
@@ -1239,7 +1206,7 @@ class Commands:
 
     # @+node:vitalije.20190924191405.1: *4* @cmd execute-pytest
     @cmd('execute-pytest')
-    def execute_pytest(self, event: LeoKeyEvent = None) -> None:
+    def execute_pytest(self, event: LeoKeyEvent | None = None) -> None:
         """Using pytest, execute all @test nodes for p, p's parents and p's subtree."""
         c = self
 
@@ -1306,9 +1273,9 @@ class Commands:
     def executeScript(
         self,
         *,
-        event: LeoKeyEvent = None,
-        args: Args = None,
-        p: Position = None,
+        event: LeoKeyEvent | None = None,
+        args: Args | None = None,
+        p: Position | None = None,
         script: str = '',
         useSelectedText: bool = True,
         define_g: bool = True,
@@ -1550,7 +1517,7 @@ class Commands:
     safe_all_positions = all_positions
 
     # @+node:ekr.20191014093239.1: *5* c.all_positions_for_v
-    def all_positions_for_v(self, v: VNode, stack: list[tuple] = None) -> Generator:
+    def all_positions_for_v(self, v: VNode, stack: list[tuple] | None = None) -> Generator:
         """
         Generates all positions p in this outline where p.v is v.
 
@@ -3820,7 +3787,7 @@ class Commands:
         top_directory: str,
         kind: str = '@clean',  # Any @<file> type. @clean is recommended.
         report_changed_at_clean_nodes: bool = True,  # Recommended.
-        sub_directories: list[str] = None,
+        sub_directories: list[str] | None = None,
         top_outline_name: str = '',
     ) -> None:
         # @+<< c.makeLinkLeoFiles: docstring >>
@@ -4107,7 +4074,11 @@ class Commands:
             g.doHook("recentfiles2", c=c2, p=c2.p, v=c2.p, fileName=fn)
 
     # @+node:ekr.20031218072017.2823: *4* c.openWith
-    def openWith(self, event: LeoKeyEvent | None = None, d: dict[str, Any] = None) -> None:
+    def openWith(
+        self,
+        event: LeoKeyEvent | None = None,
+        d: dict[str, Any] | None = None,
+    ) -> None:
         """
         This is *not* a command.
 
@@ -4370,7 +4341,7 @@ class Commands:
 
     # @+node:ekr.20031218072017.2949: *4* c.Drawing
     # @+node:ekr.20080514131122.8: *5* c.bringToFront
-    def bringToFront(self, c2: "Commands" = None) -> None:
+    def bringToFront(self, c2: Commands | None = None) -> None:
         c = self
         c2 = c2 or c
         g.app.gui.ensure_commander_visible(c2)
@@ -5207,11 +5178,11 @@ class Commands:
         self,
         *,  # All arguments are kwargs.
         dir_: str = '',  # A directory or file name.
-        ignore_pattern: re.Pattern = None,  # Ignore files matching this regex pattern.
+        ignore_pattern: re.Pattern | None = None,  # Ignore files matching this regex pattern.
         kind: str = '@file',
         recursive: bool = True,
         safe_at_file: bool = True,
-        theTypes: list[str] = None,
+        theTypes: list[str] | None = None,
         verbose: bool = True,
     ) -> None:
         # @+<< docstring >>
@@ -5564,7 +5535,7 @@ class Commands:
         self,
         regex: re.Pattern,
         flags: re.RegexFlag = re.IGNORECASE,
-        it: Iterable[Position] = None,
+        it: Iterable[Position] | None = None,
     ) -> list[Position]:
         """
         Return list of all Positions whose body matches the regex at least once.
@@ -5585,7 +5556,7 @@ class Commands:
         self,
         regex: re.Pattern,
         flags: re.RegexFlag = re.IGNORECASE,
-        it: Iterable[Position] = None,
+        it: Iterable[Position] | None = None,
     ) -> list[Position]:
         """
         Return list of all Positions whose headline matches the regex.

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -515,7 +515,7 @@ class Commands:
             self.spellCommands,
             self.vimCommands,
             self.undoer,
-        ]  # fmt: skip
+        ]
 
         # Other objects
         # A list of other classes that have a reloadSettings method

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -125,40 +125,46 @@ class Commands:
         self.frame: Widget = None
         self.parentFrame: Widget = parentFrame  # New in Leo 6.0.
         self.gui: LeoGui = gui or g.app.gui
-        # New ivars
-        self.config: LocalConfigManager = None
+
+        ###
         # Declare subcommanders (and one alias) (created later).
-        self.atFileCommands: AtFile = None
-        self.chapterController: ChapterController = None
-        self.fileCommands: FileCommands = None
-        self.findCommands: LeoFind = None
-        self.importCommands: LeoImportCommands = None
-        self.keyHandler: KeyHandlerClass = None
-        self.nodeHistory: NodeHistory = None
-        self.persistenceController: PersistenceDataController = None
-        self.printingController: PrintingController = None
-        self.shadowController: ShadowController = None
-        self.undoer: Undoer = None
-        self.vimCommands: VimCommands = None
+        # self.config: LocalConfigManager = None
+        # self.atFileCommands: AtFile = None
+        # self.chapterController: ChapterController = None
+        # self.fileCommands: FileCommands = None
+        # self.findCommands: LeoFind = None
+        # self.importCommands: LeoImportCommands = None
+        # self.keyHandler: KeyHandlerClass = None
+        # self.nodeHistory: NodeHistory = None
+        # self.persistenceController: PersistenceDataController = None
+        # self.printingController: PrintingController = None
+        # self.shadowController: ShadowController = None
+        # self.undoer: Undoer = None
+        # self.vimCommands: VimCommands = None
+
+        ###
         # Declare command handlers (created later).
-        self.abbrevCommands: AbbrevCommandsClass = None
-        self.bufferCommands: BufferCommandsClass = None
-        self.controlCommands: ControlCommandsClass = None
-        self.convertCommands: ConvertCommandsClass = None
-        self.debugCommands: DebugCommandsClass = None
-        self.editCommands: EditCommandsClass = None
-        self.editFileCommands: EditFileCommandsClass = None
-        self.gotoCommands: GoToCommands = None
-        self.helpCommands: HelpCommandsClass = None
-        self.keyHandlerCommands: KeyHandlerCommandsClass = None
-        self.killBufferCommands: KillBufferCommandsClass = None
-        self.rectangleCommands: RectangleCommandsClass = None
-        self.rstCommands: RstCommands = None
-        self.spellCommands: SpellCommandsClass = None
+        # self.abbrevCommands: AbbrevCommandsClass = None
+        # self.bufferCommands: BufferCommandsClass = None
+        # self.controlCommands: ControlCommandsClass = None
+        # self.convertCommands: ConvertCommandsClass = None
+        # self.debugCommands: DebugCommandsClass = None
+        # self.editCommands: EditCommandsClass = None
+        # self.editFileCommands: EditFileCommandsClass = None
+        # self.gotoCommands: GoToCommands = None
+        # self.helpCommands: HelpCommandsClass = None
+        # self.keyHandlerCommands: KeyHandlerCommandsClass = None
+        # self.killBufferCommands: KillBufferCommandsClass = None
+        # self.rectangleCommands: RectangleCommandsClass = None
+        # self.rstCommands: RstCommands = None
+        # self.spellCommands: SpellCommandsClass = None
+
         # Declare alias for self.keyHandler.
         self.k: KeyHandlerClass = None
+
         # The stylesheet manager does not exist in all guis.
-        self.styleSheetManager: StyleSheetManager = None
+        self.styleSheetManager: StyleSheetManager | None = None
+
         # The order of these calls does not matter.
         c.initCommandIvars()
         c.initDebugIvars()
@@ -315,11 +321,10 @@ class Commands:
         # User commands...
         from leo.commands import abbrevCommands
         from leo.commands import bufferCommands
-        from leo.commands import (
-            checkerCommands,
-        )  # The import *is* required to define commands.
+        from leo.commands import checkerCommands  # Required.
 
         assert checkerCommands  # To suppress a pyflakes warning.
+
         from leo.commands import controlCommands
         from leo.commands import convertCommands
         from leo.commands import debugCommands

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -191,7 +191,7 @@ class Commands:
         fileName: str,
         gui: LeoGui | None = None,
         parentFrame: Any = None,
-        previousSettings: "PreviousSettings" = None,
+        previousSettings: PreviousSettings | None = None,
         relativeFileName: str = '',
     ) -> None:
         t1 = time.process_time()
@@ -519,12 +519,12 @@ class Commands:
         self.vim_mode = False
 
     # @+node:ekr.20140815160132.18837: *5* c.initSettings
-    def initSettings(self, previousSettings: "PreviousSettings") -> None:
+    def initSettings(self, previousSettings: PreviousSettings | None = None) -> None:
         """Instantiate c.config from previous settings."""
         c = self
         from leo.core import leoConfig
 
-        c.config = leoConfig.LocalConfigManager(c, previousSettings)
+        c.config = leoConfig.LocalConfigManager(c, previousSettings)  # type:ignore
 
     # @+node:ekr.20031218072017.2814: *4* c.__repr__ & __str__
     def __repr__(self) -> str:
@@ -553,6 +553,7 @@ class Commands:
         c.findCommands.finishCreate()
         if not c.gui.isNullGui:
             # #2485: register idle_focus_helper in the proper context.
+            assert g.app.pluginsController
             try:
                 g.app.pluginsController.loadingModuleNameStack.append('leo.core.leoCommands')
                 g.registerHandler('idle', c.idle_focus_helper)
@@ -1814,7 +1815,7 @@ class Commands:
                 name = v.anyAtFileNodeName()
                 junk, ext = g.os_path_splitext(name)
                 ext = ext[1:]  # strip the leading period.
-                language = g.app.extension_dict.get(ext)
+                language = g.app.extension_dict.get(ext, '')
                 if g.isValidLanguage(language):
                     return language
             return ''
@@ -2406,6 +2407,7 @@ class Commands:
         # Keys are gnx's; values are lists of (id(v), v).
         vnode_d: dict[str, list[tuple[int, VNode]]] = {}
         ni = g.app.nodeIndices
+        assert ni
         t1 = time.time()
 
         def new_gnx(v: VNode) -> None:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2418,6 +2418,7 @@ class Commands:
             count += 1
             v = p.v
             gnx = v.fileIndex
+            assert isinstance(gnx, str)  # PR #4773
             if gnx:  # gnx must be a string.
                 aList = vnode_d.get(gnx, [])
                 aList.append((id(v), v))

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -5313,7 +5313,7 @@ class Commands:
 
         # Update root's tree.
         d: dict[str, VNode] = {p.v.gnx: p.v for p in root.self_and_subtree()}
-        ok = at.fast_read_into_root(c, results, gnx2vnode=d, path=None, root=root)
+        ok = at.fast_read_into_root(c, results, gnx2vnode=d, path='', root=root)
         if ok:
             c.redraw()
             g.es_print(f"beautified: {root.h}", color='blue')

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1314,7 +1314,7 @@ class Commands:
         define_g: bool = True,
         define_name: str = '__main__',
         silent: bool = False,
-        namespace: dict = None,
+        namespace: dict | None = None,
         raiseFlag: bool = False,
         runPyflakes: bool = True,
     ) -> Value:
@@ -1491,7 +1491,7 @@ class Commands:
 
     # @+node:ekr.20080514131122.12: *4* @cmd recolor (c.recolorCommand)
     @cmd('recolor')
-    def recolorCommand(self, event: LeoKeyEvent = None) -> None:
+    def recolorCommand(self, event: LeoKeyEvent | None = None) -> None:
         """Force a full recolor."""
         c = self
         colorer = c.frame.body.colorizer
@@ -1590,7 +1590,7 @@ class Commands:
                 stack.pop(0)
 
     # @+node:ekr.20161120121226.1: *5* c.all_roots
-    def all_roots(self, copy: bool = True, predicate: Callable = None) -> Generator:
+    def all_roots(self, copy: bool = True, predicate: Callable | None = None) -> Generator:
         """
         A generator yielding *all* the root positions in the outline that
         satisfy the given predicate. p.isAnyAtFileNode is the default
@@ -1633,7 +1633,7 @@ class Commands:
     all_positions_with_unique_vnodes_iter = all_unique_positions
 
     # @+node:ekr.20161120125322.1: *5* c.all_unique_roots
-    def all_unique_roots(self, copy: bool = True, predicate: Callable = None) -> Generator:
+    def all_unique_roots(self, copy: bool = True, predicate: Callable | None = None) -> Generator:
         """
         A generator yielding all unique root positions in the outline that
         satisfy the given predicate. p.isAnyAtFileNode is the default
@@ -2077,7 +2077,9 @@ class Commands:
         return p
 
     # @+node:ekr.20040307104131.3: *5* c.positionExists
-    def positionExists(self, p: Position, root: Position = None, trace: bool = False) -> bool:
+    def positionExists(
+        self, p: Position, root: Position | None = None, trace: bool = False
+    ) -> bool:
         """Return True if a position exists in c's tree"""
         if not p or not p.v:
             return False
@@ -2386,7 +2388,7 @@ class Commands:
         g.doHook("set-mark", c=c, p=p)
 
     # @+node:ekr.20040803140033.3: *5* c.setRootPosition (A do-nothing)
-    def setRootPosition(self, unused_p: Position = None) -> None:
+    def setRootPosition(self, unused_p: Position | None = None) -> None:
         """Set c._rootPosition."""
         # 2011/03/03: No longer used.
 
@@ -2764,7 +2766,7 @@ class Commands:
     # @+node:ekr.20031218072017.1765: *4* c.validateOutline (compatibility only)
     # Makes sure all nodes are valid.
 
-    def validateOutline(self, event: LeoKeyEvent = None) -> bool:
+    def validateOutline(self, event: LeoKeyEvent | None = None) -> bool:
         """
         A legacy outline checker, retained only for compatibility.
 
@@ -2810,7 +2812,9 @@ class Commands:
     # This code is no longer used by any Leo command,
     # but it will be retained for use of scripts.
     # @+node:ekr.20040723094220.1: *4* c.checkAllPythonCode
-    def checkAllPythonCode(self, event: LeoKeyEvent = None, ignoreAtIgnore: bool = True) -> str:
+    def checkAllPythonCode(
+        self, event: LeoKeyEvent | None = None, ignoreAtIgnore: bool = True
+    ) -> str:
         """Check all nodes in the selected tree for syntax and tab errors."""
         c = self
         count = 0
@@ -2845,7 +2849,7 @@ class Commands:
     # @+node:ekr.20040723094220.3: *4* c.checkPythonCode
     def checkPythonCode(
         self,
-        event: LeoKeyEvent = None,
+        event: LeoKeyEvent | None = None,
         ignoreAtIgnore: bool = True,
         checkOnSave: bool = False,
     ) -> str:
@@ -3309,7 +3313,7 @@ class Commands:
         return return_value
 
     # @+node:ekr.20200522075411.1: *4* c.doCommandByName
-    def doCommandByName(self, command_name: str, event: LeoKeyEvent = None) -> Value:
+    def doCommandByName(self, command_name: str, event: LeoKeyEvent | None = None) -> Value:
         """
         Execute one command, given the name of the command.
 
@@ -3999,7 +4003,7 @@ class Commands:
         c2.close()
 
     # @+node:ekr.20031218072017.2925: *4* c.markAllAtFileNodesDirty
-    def markAllAtFileNodesDirty(self, event: LeoKeyEvent = None) -> None:
+    def markAllAtFileNodesDirty(self, event: LeoKeyEvent | None = None) -> None:
         """Mark all @file nodes as changed."""
         c = self
         c.endEditing()
@@ -4013,7 +4017,7 @@ class Commands:
                 p.moveToThreadNext()
 
     # @+node:ekr.20031218072017.2926: *4* c.markAtFileNodesDirty
-    def markAtFileNodesDirty(self, event: LeoKeyEvent = None) -> None:
+    def markAtFileNodesDirty(self, event: LeoKeyEvent | None = None) -> None:
         """Mark all @file nodes in the selected tree as changed."""
         c = self
         p = c.p
@@ -4030,7 +4034,7 @@ class Commands:
                 p.moveToThreadNext()
 
     # @+node:ekr.20250717080554.1: *4* c.openAllLinkedFiles (transitive closure)
-    def openAllLinkedFiles(self, gui: LeoGui = None) -> list[Commands]:
+    def openAllLinkedFiles(self, gui: LeoGui | None = None) -> list[Commands]:
         """
         Open the transitive closure of all outlines reachable from any @leo
         node in this outline.
@@ -4087,7 +4091,7 @@ class Commands:
         return result
 
     # @+node:ekr.20031218072017.2081: *4* c.openRecentFile
-    def openRecentFile(self, event: LeoKeyEvent = None, fn: str = '') -> None:
+    def openRecentFile(self, event: LeoKeyEvent | None = None, fn: str = '') -> None:
         """
         c.openRecentFile: This is not a command!
 
@@ -4103,7 +4107,7 @@ class Commands:
             g.doHook("recentfiles2", c=c2, p=c2.p, v=c2.p, fileName=fn)
 
     # @+node:ekr.20031218072017.2823: *4* c.openWith
-    def openWith(self, event: LeoKeyEvent = None, d: dict[str, Any] = None) -> None:
+    def openWith(self, event: LeoKeyEvent | None = None, d: dict[str, Any] = None) -> None:
         """
         This is *not* a command.
 
@@ -4425,7 +4429,7 @@ class Commands:
                 mods.clear()
 
     # @+node:ekr.20080514131122.13: *5* c.recolor
-    def recolor(self, p: Position = None) -> None:
+    def recolor(self, p: Position | None = None) -> None:
         """
         Force a full recolor when using the Scintilla text widget.
         This method has no effect when using the default Qt colorizer.
@@ -4457,7 +4461,7 @@ class Commands:
         c.enableRedrawFlag = True
 
     # @+node:ekr.20090110073010.1: *6* c.redraw
-    def redraw(self, p: Position = None) -> None:
+    def redraw(self, p: LeoKeyEvent | None = None) -> None:
         """
         Redraw the screen immediately.
         If p is given, set c.p to p.
@@ -4615,7 +4619,7 @@ class Commands:
 
     # @+node:ekr.20031218072017.2909: *4* c.Expand/contract
     # @+node:ekr.20171124091426.1: *5* c.contractAllHeadlines
-    def contractAllHeadlines(self, event: LeoKeyEvent = None) -> None:
+    def contractAllHeadlines(self, event: LeoKeyEvent | None = None) -> None:
         """Contract all nodes in the outline."""
         c = self
         for v in c.all_nodes():
@@ -4788,7 +4792,7 @@ class Commands:
         self,
         menu: LeoQtMenu,
         accelerator: str = '',  # Not used.
-        command: Callable = None,
+        command: Callable | None = None,
         commandName: str = '',  # Not used.
         label: str = '',  # Not used.
         underline: int = 0,
@@ -5121,7 +5125,7 @@ class Commands:
         self,
         p: Position,
         selectAll: bool = False,
-        selection: tuple = None,
+        selection: tuple | None = None,
         keepMinibuffer: bool = False,
     ) -> None:
         """Redraw the screen and edit p's headline."""
@@ -5415,7 +5419,7 @@ class Commands:
     def createNodeHierarchy(
         self,
         heads: list[str],
-        parent: Position = None,
+        parent: Position | None = None,
         forcecreate: bool = False,
     ) -> Position:
         """
@@ -5518,7 +5522,7 @@ class Commands:
     undoableDeletePositions = deletePositionsInList
 
     # @+node:ekr.20091211111443.6265: *4* c.doBatchOperations & helpers
-    def doBatchOperations(self, aList: list = None) -> None:
+    def doBatchOperations(self, aList: list | None = None) -> None:
         # Validate aList and create the parents dict
         if aList is None:
             aList = []

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -114,7 +114,7 @@ class Commands:
         gui: LeoGui = None,
         parentFrame: Any = None,
         previousSettings: "PreviousSettings" = None,
-        relativeFileName: str = None,
+        relativeFileName: str = '',
     ) -> None:
         t1 = time.process_time()
         c = self
@@ -201,7 +201,7 @@ class Commands:
         return title
 
     # @+node:ekr.20120217070122.10475: *5* c.computeWindowTitle
-    def computeWindowTitle(self, fileName: str = None) -> str:
+    def computeWindowTitle(self, fileName: str = '') -> str:
         """
         Return the title for the top-level window.
         """
@@ -252,7 +252,7 @@ class Commands:
         self.expansionLevel = 0  # The expansion level of this outline.
         self.expansionNode = None  # The last node we expanded or contracted.
         self.nodeConflictList: list[Position] = []  # List of nodes with conflicting read-time data.
-        self.nodeConflictFileName: str = None  # The fileName for c.nodeConflictList.
+        self.nodeConflictFileName: str = ''  # The fileName for c.nodeConflictList.
         # Non-persistent dictionary for free use by scripts and plugins.
         self.user_dict: dict[str, Value] = {}
 
@@ -277,7 +277,7 @@ class Commands:
         """Init file-related ivars of the commander."""
         self.changed = False  # True: the outline has changed since the last save.
         self.ignored_at_file_nodes: list[str] = []  # List of headlines for c.raise_error_dialogs.
-        self.last_dir: str = None  # The last used directory.
+        self.last_dir: str = ''  # The last used directory.
         # Do _not_ use os_path_norm: it converts an empty path to '.' (!!)
         self.mFileName: str = fileName or ''
         self.mRelativeFileName = relativeFileName or ''
@@ -1223,7 +1223,7 @@ class Commands:
         event: LeoKeyEvent = None,
         args: Args = None,
         p: Position = None,
-        script: str = None,
+        script: str = '',
         useSelectedText: bool = True,
         define_g: bool = True,
         define_name: str = '__main__',
@@ -3265,8 +3265,8 @@ class Commands:
         ext: str,
         language: str,
         root: Position,
-        directory: str = None,
-        regex: str = None,
+        directory: str = '',
+        regex: str = '',
     ) -> None:
         """
         The official helper for the execute-general-script command.
@@ -3620,8 +3620,8 @@ class Commands:
     # @+node:ekr.20150422080541.1: *4* c.backup
     def backup(
         self,
-        fileName: str = None,
-        prefix: str = None,
+        fileName: str = '',
+        prefix: str = '',
         silent: bool = False,
         useTimeStamp: bool = True,
     ) -> str | None:
@@ -3653,9 +3653,9 @@ class Commands:
     # @+node:ekr.20180210092235.1: *4* c.backup_helper
     def backup_helper(
         self,
-        base_dir: str = None,
+        base_dir: str = '',
         env_key: str = 'LEO_BACKUP',
-        sub_dir: str = None,
+        sub_dir: str = '',
         use_git_prefix: bool = True,
     ) -> None:
         """
@@ -3731,7 +3731,7 @@ class Commands:
         kind: str = '@clean',  # Any @<file> type. @clean is recommended.
         report_changed_at_clean_nodes: bool = True,  # Recommended.
         sub_directories: list[str] = None,
-        top_outline_name: str = None,
+        top_outline_name: str = '',
     ) -> None:
         # @+<< c.makeLinkLeoFiles: docstring >>
         # @+node:ekr.20250717132150.1: *5* << c.makeLinkLeoFiles: docstring >>
@@ -4001,7 +4001,7 @@ class Commands:
         return result
 
     # @+node:ekr.20031218072017.2081: *4* c.openRecentFile
-    def openRecentFile(self, event: LeoKeyEvent = None, fn: str = None) -> None:
+    def openRecentFile(self, event: LeoKeyEvent = None, fn: str = '') -> None:
         """
         c.openRecentFile: This is not a command!
 
@@ -4071,7 +4071,7 @@ class Commands:
         x.diff_file(fn=fn, rev1=rev1, rev2=rev2)
 
     # @+node:ekr.20180508110755.1: *4* c.diff_two_revs
-    def diff_two_revs(self, directory: str = None, rev1: str = '', rev2: str = '') -> None:
+    def diff_two_revs(self, directory: str = '', rev1: str = '', rev2: str = '') -> None:
         """
         Create an outline describing the git diffs for all files changed
         between rev1 and rev2.
@@ -4703,8 +4703,8 @@ class Commands:
         menu: LeoQtMenu,
         accelerator: str = '',  # Not used.
         command: Callable = None,
-        commandName: str = None,  # Not used.
-        label: str = None,  # Not used.
+        commandName: str = '',  # Not used.
+        label: str = '',  # Not used.
         underline: int = 0,
     ) -> None:
         c = self
@@ -4906,7 +4906,7 @@ class Commands:
         return current != c.rootPosition()
 
     # @+node:ekr.20031218072017.2974: *6* c.canPasteOutline
-    def canPasteOutline(self, s: str = None) -> bool:
+    def canPasteOutline(self, s: str = '') -> bool:
         # c = self
         if not s:
             s = g.app.gui.getTextFromClipboard()
@@ -5116,7 +5116,7 @@ class Commands:
     def recursiveImport(
         self,
         *,  # All arguments are kwargs.
-        dir_: str = None,  # A directory or file name.
+        dir_: str = '',  # A directory or file name.
         ignore_pattern: re.Pattern = None,  # Ignore files matching this regex pattern.
         kind: str = '@file',
         recursive: bool = True,
@@ -5245,10 +5245,10 @@ class Commands:
         self,
         generator: Callable,
         predicate: Callable,
-        failMsg: str = None,
+        failMsg: str = '',
         flatten: bool = False,
-        iconPath: str = None,
-        undoType: str = None,
+        iconPath: str = '',
+        undoType: str = '',
     ) -> Position:
         """
         Traverse the tree given using the generator, cloning all positions for

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -196,16 +196,14 @@ class Commands:
     ) -> None:
         t1 = time.process_time()
         c = self
+
         # Official ivars.
         self._currentPosition = cast(Position, None)
         self._topPosition = cast(Position, None)
         self.command_count = 0
-        self.frame: Widget | None = None
+        self.frame: Any = None  # This saves a lot of asserts.
         self.parentFrame: Widget = parentFrame  # New in Leo 6.0.
         self.gui: LeoGui = gui or g.app.gui
-
-        # Declare alias for self.keyHandler.
-        self.k: KeyHandlerClass | None = None
 
         # The stylesheet manager does not exist in all guis.
         self.styleSheetManager: StyleSheetManager | None = None
@@ -220,10 +218,12 @@ class Commands:
         # Instantiate c.config *before* initing objects.
         self.config = None
         c.initSettings(previousSettings)
+
         # Initialize all subsidiary objects, including subcommanders.
         c.initObjects(self.gui)
         assert c.frame
         assert c.frame.c
+
         # Complete the init!
         t2 = time.process_time()
         c.finishCreate()  # Slightly slow.

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -87,7 +87,7 @@ if TYPE_CHECKING:  # pragma: no cover
     # 14 command handlers...
     from leo.commands.abbrevCommands import AbbrevCommandsClass
 
-    assert AbbrevCommandsClass
+    assert AbbrevCommandsClass  # type:ignore  # Strange warning.
 
     from leo.commands.bufferCommands import BufferCommandsClass
 

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4977,13 +4977,11 @@ class Commands:
             return True
         if c.hoistStack:
             limit, limitIsVisible = c.visLimit()
-            ### g.trace(limitIsVisible, limit.h if limit else '<no limit>')  ###
             if limitIsVisible:  # A hoist
                 assert limit
                 return current != limit
             # A chapter.
-            assert not limit  ### Bug???
-            return current != limit.firstChild()  # type:ignore # Bug???
+            return current != limit.firstChild()  # type:ignore # Bug!?!
         return current != c.rootPosition()
 
     # @+node:ekr.20031218072017.2974: *6* c.canPasteOutline

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1337,13 +1337,13 @@ class GlobalConfigManager:
                 yield key2, val, c, letter
 
     # @+node:ekr.20041123070429: *3* gcm.canonicalizeSettingName (munge)
-    def canonicalizeSettingName(self, name: str) -> str | None:
-        if name is None:
-            return None
+    def canonicalizeSettingName(self, name: str) -> str:
+        if not name:
+            return ''  # PR #4773
         name = name.lower()
         for ch in ('-', '_', ' ', '\n'):
             name = name.replace(ch, '')
-        return name if name else None
+        return name
 
     munge = canonicalizeSettingName
 

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1614,7 +1614,7 @@ class LocalConfigManager:
 
     # @+others
     # @+node:ekr.20041118104831.2: *3*  c.config.ctor
-    def __init__(self, c: Cmdr, previousSettings: PreviousSettings = None) -> None:
+    def __init__(self, c: Cmdr, previousSettings: PreviousSettings | None = None) -> None:
         self.c = c
         lm = g.app.loadManager
         if previousSettings:

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -92,7 +92,7 @@ class ExternalFilesController:
         # DO NOT alter directly, use set_time(path) and
         # get_time(path), see set_time() for notes.
         self._time_d: dict[str, float] = {}
-        self.yesno_all_answer: str = None  # answer, 'yes-all', or 'no-all'
+        self.yesno_all_answer: str = ''  # answer, 'yes-all', or 'no-all'
         g.app.idleTimeManager.add_callback(self.on_idle)
 
     # @+node:ekr.20150405105938.1: *3* efc.entries

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1505,7 +1505,8 @@ class MatchBrackets:
         """
 
         # A partial fix for bug 127: Bracket matching is buggy.
-        w = self.c.frame.body.wrapper
+        c = self.c
+        w = c.frame.body.wrapper
         s = w.getAllText() or ''
         _mb = self.c.user_dict['_match_brackets']
         sel_range = w.getSelectionRange()
@@ -3515,8 +3516,9 @@ def createHiddenCommander(fn: str) -> Cmdr | None:
 
 # @+node:vitalije.20170714085545.1: *3* g.defaultLeoFileExtension
 def defaultLeoFileExtension(c: Cmdr | None = None) -> str:
-    conf = c.config if c else g.app.config
-    return conf.getString('default-leo-extension') or '.leo'
+    config = c.config if c else g.app.config
+    assert config
+    return config.getString('default-leo-extension') or '.leo'
 
 
 # @+node:ekr.20031218072017.3118: *3* g.ensure_extension

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -4811,9 +4811,8 @@ def skip_ws_and_nl(s: str, i: int) -> int:
 # @+node:ekr.20180325025502.1: *3* g.backupGitIssues
 def backupGitIssues(c: Cmdr, base_url: str = '') -> None:
     """Get a list of issues from Leo's GitHub site."""
-    if base_url is None:
+    if not base_url:
         base_url = 'https://api.github.com/repos/leo-editor/leo-editor/issues'
-
     root = c.lastTopLevel().insertAfter()
     root.h = f'Backup of issues: {time.strftime("%Y/%m/%d")}'
     label_list: list[str] = []
@@ -4863,7 +4862,7 @@ def getGitIssues(
     state: str = '',  # in (None, 'closed', 'open')
 ) -> None:
     """Get a list of issues from Leo's GitHub site."""
-    if base_url is None:
+    if not base_url:
         base_url = 'https://api.github.com/repos/leo-editor/leo-editor/issues'
     if isinstance(label_list, (list, tuple)):
         root = c.lastTopLevel().insertAfter()
@@ -4902,7 +4901,7 @@ class GitIssueController:
             for state in ('closed', 'open'):
                 for label in label_list:
                     self.get_one_issue(label, state)
-        elif state is None:
+        elif not state:
             for state in ('closed', 'open'):
                 organizer = root.insertAsLastChild()
                 organizer.h = f"{state} issues..."
@@ -4910,7 +4909,7 @@ class GitIssueController:
         elif state in ('closed', 'open'):
             self.get_all_issues(label_list, root, state)
         else:
-            g.es_print('state must be in (None, "open", "closed")')
+            g.es_print('state must be in ("", "open", "closed")')
 
     # @+node:ekr.20180325024334.1: *5* git.get_all_issues
     def get_all_issues(
@@ -5014,11 +5013,10 @@ class GitIssueController:
     ) -> tuple[bool, int]:
         if self.milestone:
             aList = [
-                z
-                for z in r.json()
-                if z.get('milestone') is not None
-                and self.milestone == z.get('milestone').get('title')
-            ]
+                z for z in r.json()
+                if z.get('milestone', '') and
+                self.milestone == z.get('milestone').get('title')
+            ]  # fmt: skip
         else:
             aList = [z for z in r.json()]
         for d in aList:
@@ -5050,7 +5048,7 @@ class GitIssueController:
 
 # @+node:ekr.20190428173354.1: *3* g.getGitVersion
 def getGitVersion(directory: str = '') -> tuple[str, str, str]:
-    """Return a tuple (author, build, date) from the git log, or None."""
+    """Return a tuple (author, build, date) from the git log, where all may be empty."""
 
     # -n: Get only the last log.
     trace = 'git' in g.app.debug
@@ -5118,7 +5116,7 @@ def getModifiedFiles(repo_path: str) -> list[str]:
 def gitBranchName(path: str = '') -> str:
     """
     Return the git branch name associated with path/.git, or the empty
-    string if path/.git does not exist. If path is None, use the leo-editor
+    string if path/.git does not exist. If path is empty, use the leo-editor
     directory.
     """
     branch, commit = g.gitInfo(path)
@@ -5129,7 +5127,7 @@ def gitBranchName(path: str = '') -> str:
 def gitCommitNumber(path: str = '') -> str:
     """
     Return the git commit number associated with path/.git, or the empty
-    string if path/.git does not exist. If path is None, use the leo-editor
+    string if path/.git does not exist. If path is empty, use the leo-editor
     directory.
     """
     branch, commit = g.gitInfo(path)
@@ -5140,7 +5138,7 @@ def gitCommitNumber(path: str = '') -> str:
 def gitDescribe(path: str = '') -> tuple[str, str, str]:
     """
     Return the Git tag, distance-from-tag, and commit hash for the
-    associated path. If path is None, use the leo-editor directory.
+    associated path. If path is empty, use the leo-editor directory.
 
     Given `git describe` cmd line output: `x-leo-v5.6-55-ge1129da\n`
     This function returns ('x-leo-v5.6', '55', 'e1129da')
@@ -5180,7 +5178,7 @@ def gitInfo(path: str = '') -> tuple[str, str]:
     Return the branch and commit number or ('', '').
     """
     branch, commit = '', ''  # Set defaults.
-    if path is None:
+    if not path:
         # Default to leo/core.
         path = os.path.dirname(__file__)
     if not os.path.isdir(path):

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1505,8 +1505,7 @@ class MatchBrackets:
         """
 
         # A partial fix for bug 127: Bracket matching is buggy.
-        c = self.c
-        w = c.frame.body.wrapper
+        w = self.c.frame.body.wrapper
         s = w.getAllText() or ''
         _mb = self.c.user_dict['_match_brackets']
         sel_range = w.getSelectionRange()

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -239,9 +239,15 @@ class Command:
     def __call__(self, func: Callable) -> Callable:
         """Register command for all future commanders."""
         global_commands_dict[self.name] = func
-        if app:
-            for c in app.commanders():
-                c.k.registerCommand(self.name, func)
+        if not g.app:  # PR #4773
+            # This module has not been fully imported.
+            if False:
+                print(f"@g.command.__call__: {self.name:>35}")
+            return func
+
+        for c in app.commanders():
+            c.k.registerCommand(self.name, func)
+
         # Inject ivars for plugins_menu.py.
         func.__func_name__ = func.__name__  # For leoInteg.
         func.is_command = True
@@ -406,7 +412,10 @@ url_regex = re.compile(rf"""\b{url_kinds}://[^\s'"]+""")
 # @-<< define regexes >>
 tree_popup_handlers: list[Callable] = []  # Set later.
 user_dict: dict[str, Value] = {}  # Non-persistent dictionary for scripts and plugins.
-app: LeoApp = None  # The singleton app object. Set by runLeo.py.
+
+# The singleton app object. Set by runLeo.py.
+app: LeoApp = None  # type:ignore # There seems to be no way to init g.app here.
+
 # Global status vars.
 inScript = False  # A synonym for app.inScript
 unitTesting = False  # A synonym for app.unitTesting.
@@ -2819,9 +2828,9 @@ def printStats(event: LeoKeyEvent | None = None) -> None:
             print(f"  {d.get(key):4}: {key_s}")
 
     # Print the other stats: calls to g.stat(whatever)
-    for key in sorted(d.keys()):
+    for key, value in sorted(d.items()):  # PR #4773
         if not key.startswith(_int_stat_prefix):
-            inner_keys = (z if isinstance(z, str) else repr(z) for z in d.get(key))
+            inner_keys = (z if isinstance(z, str) else repr(z) for z in value)  # PR #4773
             print(f"{key}:")
             for z in sorted(inner_keys):
                 print(f"    {z.strip()}")
@@ -2897,7 +2906,7 @@ def comment_delims_from_extension(filename: str) -> tuple[str, str, str]:
         root, ext = os.path.splitext(filename)
     if ext == '.tmp':
         root, ext = os.path.splitext(root)
-    language = g.app.extension_dict.get(ext[1:])
+    language = g.app.extension_dict.get(ext[1:], '')
     if ext:
         return g.set_delims_from_language(language)
     g.trace(f"unknown extension: {ext!r}, filename: {filename!r}, root: {root!r}")
@@ -3316,6 +3325,7 @@ def scanForAtLanguage(c: Cmdr, p: Position) -> str:
 # @+node:ekr.20041123094807: *3* g.scanForAtSettings
 def scanForAtSettings(p: Position) -> bool:
     """Scan position p and its ancestors looking for @settings nodes."""
+    assert g.app.config
     for p in p.self_and_parents(copy=False):
         h = p.h
         h = g.app.config.canonicalizeSettingName(h)
@@ -3461,27 +3471,33 @@ def chdir(path: str) -> None:
 
 
 def computeGlobalConfigDir() -> str:
+    assert g.app.loadManager
     return g.app.loadManager.computeGlobalConfigDir()
 
 
 def computeHomeDir() -> str:
+    assert g.app.loadManager
     return g.app.loadManager.computeHomeDir()
 
 
 def computeLeoDir() -> str:
+    assert g.app.loadManager
     return g.app.loadManager.computeLeoDir()
 
 
 def computeLoadDir() -> str:
+    assert g.app.loadManager
     return g.app.loadManager.computeLoadDir()
 
 
 def computeMachineName() -> str:
+    assert g.app.loadManager
     return g.app.loadManager.computeMachineName()
 
 
-def computeStandardDirectories() -> str:
-    return g.app.loadManager.computeStandardDirectories()
+def computeStandardDirectories() -> None:
+    assert g.app.loadManager
+    g.app.loadManager.computeStandardDirectories()
 
 
 # @+node:ekr.20031218072017.3117: *3* g.create_temp_file
@@ -3508,6 +3524,7 @@ def create_temp_file(textMode: bool = False) -> tuple[IO | None, str]:
 def createHiddenCommander(fn: str) -> Cmdr | None:
     """Read the given outline into a hidden commander."""
     lm = g.app.loadManager
+    assert lm
     if lm.isLeoFile(fn):
         return g.openWithFileName(fn, gui=g.app.nullGui)
     return None
@@ -3725,6 +3742,7 @@ def openWithFileName(
 
     Return the commander of the newly-opened file, which may be old_c or another commander.
     """
+    assert g.app.loadManager
     return g.app.loadManager.openWithFileName(fileName, gui, old_c)
 
 
@@ -5257,6 +5275,8 @@ def doHook(tag: str, *args: Args, **kwargs: KWargs) -> Value | None:
     """
     if g.app.killed or g.app.hookError:
         return None
+    if g.unitTesting:
+        return None  # PR #4773
     if args:
         # A minor error in Leo's core.
         g.pr(f"***ignoring args param.  tag = {tag}")
@@ -5269,6 +5289,7 @@ def doHook(tag: str, *args: Args, **kwargs: KWargs) -> Value | None:
     # pylint: disable=consider-using-ternary
     f = (c and c.hookFunction) or g.app.hookFunction
     if not f:
+        assert g.app.pluginsController
         g.app.hookFunction = f = g.app.pluginsController.doPlugins
     try:
         # Pass the hook to the hook handler.
@@ -5284,54 +5305,72 @@ def doHook(tag: str, *args: Args, **kwargs: KWargs) -> Value | None:
 # @+node:ekr.20100910075900.5950: *3* g.Wrappers for g.app.pluginController methods
 # Important: we can not define g.pc here!
 # @+node:ekr.20100910075900.5951: *4* g.Loading & registration
-def loadOnePlugin(pluginName: str, verbose: bool = False) -> ModuleType:
+def loadOnePlugin(pluginName: str, verbose: bool = False) -> Any:
+    if g.unitTesting:
+        return None
     pc = g.app.pluginsController
+    assert pc
     return pc.loadOnePlugin(pluginName, verbose=verbose)
 
 
-def registerExclusiveHandler(tags: Tags, fn: str) -> ModuleType:
+def registerExclusiveHandler(tags: Tags, fn: Callable) -> None:
+    if g.unitTesting:
+        return
     pc = g.app.pluginsController
-    return pc.registerExclusiveHandler(tags, fn)
+    assert pc
+    pc.registerExclusiveHandler(tags, fn)
 
 
-def registerHandler(tags: Tags, fn: Callable) -> ModuleType:
+def registerHandler(tags: Tags, fn: Callable) -> None:
+    if g.unitTesting:
+        return
     pc = g.app.pluginsController
-    return pc.registerHandler(tags, fn)
+    assert pc
+    pc.registerHandler(tags, fn)
 
 
-def plugin_signon(module_name: str, verbose: bool = False) -> ModuleType:
+def plugin_signon(module_name: str, verbose: bool = False) -> None:
+    if g.unitTesting:
+        return
     pc = g.app.pluginsController
-    return pc.plugin_signon(module_name, verbose)
+    assert pc
+    pc.plugin_signon(module_name, verbose)
 
 
-def unloadOnePlugin(moduleOrFileName: str, verbose: bool = False) -> ModuleType:
+def unloadOnePlugin(moduleOrFileName: str, verbose: bool = False) -> None:
     pc = g.app.pluginsController
-    return pc.unloadOnePlugin(moduleOrFileName, verbose)
+    assert pc
+    pc.unloadOnePlugin(moduleOrFileName, verbose)
 
 
-def unregisterHandler(tags: Tags, fn: Callable) -> ModuleType:
+def unregisterHandler(tags: Tags, fn: Callable) -> None:
     pc = g.app.pluginsController
-    return pc.unregisterHandler(tags, fn)
+    assert pc
+    pc.unregisterHandler(tags, fn)
 
 
 # @+node:ekr.20100910075900.5952: *4* g.Information
 def getHandlersForTag(tags: list[str]) -> list:
     pc = g.app.pluginsController
+    assert pc
     return pc.getHandlersForTag(tags)
 
 
 def getLoadedPlugins() -> list:
     pc = g.app.pluginsController
+    assert pc
     return pc.getLoadedPlugins()
 
 
 def getPluginModule(moduleName: str) -> ModuleType | None:
     pc = g.app.pluginsController
+    assert pc
     return pc.getPluginModule(moduleName)
 
 
 def pluginIsLoaded(fn: str) -> bool:
     pc = g.app.pluginsController
+    assert pc
     return pc.isLoaded(fn)
 
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -441,7 +441,7 @@ def get_backup_path(sub_directory: str) -> str:
     """
     # Compute the main backup directory.
     # First, try the LEO_BACKUP directory.
-    backup = None
+    backup = ''
     try:
         backup = os.environ['LEO_BACKUP']
         if not os.path.exists(backup):
@@ -2391,7 +2391,7 @@ def checkQtTextWidget(obj: Any, *, other_classes: list[str] | None = None) -> No
         g.traceUniqueClass(obj, n=2)
     # g.stat()
     all_classes = g.qt_text_classes
-    if other_classes is not None:
+    if other_classes:
         all_classes.extend(other_classes)
     g._check_class_helper(obj, key=g.caller(), class_names=all_classes)
 
@@ -5255,7 +5255,7 @@ contentModifiedSet: set[VNode] = set()
 
 
 # @+node:ekr.20031218072017.1596: *3* g.doHook
-def doHook(tag: str, *args: Args, **kwargs: KWargs) -> Value | None:
+def doHook(tag: str, *args: Args, **kwargs: KWargs) -> Any:
     """
     This global function calls a hook routine. Hooks are identified by the
     tag param.
@@ -5360,7 +5360,7 @@ def getLoadedPlugins() -> list:
     return pc.getLoadedPlugins()
 
 
-def getPluginModule(moduleName: str) -> ModuleType | None:
+def getPluginModule(moduleName: str) -> ModuleType:
     pc = g.app.pluginsController
     assert pc
     return pc.getPluginModule(moduleName)
@@ -5720,7 +5720,7 @@ def checkUnicode(s: str, encoding: str = '') -> str:
     user-defined plugins or scripts.
     """
     tag = 'g.checkUnicode'
-    if s is None and g.unitTesting:
+    if not s and g.unitTesting:
         return ''
     if isinstance(s, str):
         return s
@@ -6295,14 +6295,14 @@ def es_dump(s: str, n: int = 30, title: str = '') -> None:
 # @+node:ekr.20031218072017.3110: *3* g.es_error & es_print_error
 def es_error(*args: Args, **kwargs: KWargs) -> None:
     color = kwargs.get('color')
-    if color is None and g.app.config:
+    if not color and g.app.config:
         kwargs['color'] = g.app.config.getColor("log-error-color") or 'red'
     g.es(*args, **kwargs)
 
 
 def es_print_error(*args: Args, **kwargs: KWargs) -> None:
     color = kwargs.get('color')
-    if color is None and g.app and g.app.config:
+    if not color and g.app and g.app.config:
         kwargs['color'] = g.app.config.getColor("log-error-color") or 'red'
     g.es_print(*args, **kwargs)
 
@@ -6776,7 +6776,7 @@ def actualColor(color: str) -> str:
     if color and color.startswith('#'):
         return color
     # #788: Translate colors to theme-defined colors.
-    if color is None:
+    if not color:
         # Prefer text_foreground_color'
         color2 = c.config.getColor('log-text-foreground-color')
         if color2:
@@ -6804,7 +6804,6 @@ def CheckVersion(
     s1: str,
     s2: str,
     condition: str = ">=",
-    stringCompare: bool | None = None,
     delimiter: str = '.',
     trace: bool = False,
 ) -> bool:
@@ -7411,7 +7410,7 @@ def getDocStringForFunction(func: Callable) -> str:
 
     def get_defaults(func: Callable, i: int) -> Value:
         defaults = inspect.getfullargspec(func)[3]
-        return defaults[i] if defaults else None
+        return defaults[i] if defaults else ''
 
     # Fix bug 1251252: https://bugs.launchpad.net/leo-editor/+bug/1251252
     # Minibuffer commands created by mod_scripting.py have no docstrings.
@@ -7473,7 +7472,7 @@ def python_tokenize(s: str) -> list:
 # @+node:ekr.20161223090721.1: *3* g.exec_file
 def exec_file(path: str, d: dict[str, Value], script: str = '') -> None:
     """Simulate python's execfile statement for python 3."""
-    if script is None:
+    if not script:
         with open(path) as f:
             script = f.read()
     exec(compile(script, path, 'exec'), d)

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1733,7 +1733,7 @@ class RecursiveImportController:
         c: Cmdr,
         *,  # All other args are kwargs.
         dir_: str | None,
-        ignore_pattern: re.Pattern = None,
+        ignore_pattern: re.Pattern | None = None,
         kind: str,
         recursive: bool = True,
         safe_at_file: bool = True,

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -119,7 +119,7 @@ class NodeIndices:
         #    parse all forms of gnx properly.
         # 2. NodeIndicds.compute_last_index ignores UUIDs and KSUIDs,
         #    so it will allocate a new legacy gnx properly.
-        gnx = None
+        gnx = ''  # PR #4773
         try:
             if uuid_kind == 'uuid':
                 gnx = str(uuid.uuid4())

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -11,7 +11,7 @@ import os
 import re
 import time
 import uuid
-from typing import cast, Any, Generator, Iterable, TYPE_CHECKING
+from typing import Any, Generator, Iterable, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import signal_manager
 

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2326,7 +2326,7 @@ class VNode:
         self.children: list[VNode] = []  # Ordered list of all children of this node.
         self.parents: list[VNode] = []  # Unordered list of all parents of this node.
         # The immutable fileIndex (gnx) for this node. Set below.
-        self.fileIndex = cast(str, None)
+        self.fileIndex: str = ''  # PR #4773
         self.iconVal = 0  # The present value of the node's icon.
         self.statusBits = 0  # status bits
 

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -515,7 +515,7 @@ class LeoPluginsController:
     # @+node:ekr.20100908125007.6024: *4* plugins.loadOnePlugin & helper functions
     def loadOnePlugin(
         self, moduleOrFileName: str, tag: str = 'open0', verbose: bool = False
-    ) -> Any | None:
+    ) -> Any:
         """
         Load one plugin from a file name or module.
         Use extensive tracing if --trace-plugins is in effect.

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -30,7 +30,7 @@ import textwrap
 import time
 import hmac
 import ssl
-from typing import Any, Generator, Iterable, Iterator
+from typing import Any, Generator, Iterable, Iterator, TYPE_CHECKING
 import warnings
 
 # Third-party.
@@ -71,6 +71,7 @@ assert os.path.exists(leo_path), repr(leo_path)
 if leo_path not in sys.path:
     sys.path.insert(0, leo_path)
 del core_dir, leo_path
+
 # Leo: suppress pyflakes warnings about imports not at top of file.
 from leo.core import leoImport  # noqa
 from leo.core.leoCommands import Commands as Cmdr  # noqa
@@ -81,16 +82,16 @@ from leo.core.leoExternalFiles import ExternalFilesController  # noqa
 # @-<< leoserver imports >>
 # @+<< leoserver annotations >>
 # @+node:ekr.20220820155747.1: ** << leoserver annotations >>
-Event = Any  # More than one kind of Event!
-Loop = Any
-Match = re.Match
-Match_Iter = Iterator[re.Match[str]]
-Package = dict[str, Any]
-Param = dict[str, Any]
-RegexFlag = int | re.RegexFlag  # re.RegexFlag does not define 0
-Response = str  # See _make_response.
-Socket = Any
-
+if TYPE_CHECKING:
+    Event = Any  # More than one kind of Event!
+    Loop = Any
+    Match = re.Match
+    Match_Iter = Iterator[re.Match[str]]
+    Package = dict[str, Any]
+    Param = dict[str, Any]
+    RegexFlag = int | re.RegexFlag  # re.RegexFlag does not define 0
+    Response = str  # See _make_response.
+    Socket = Any
 # @-<< leoserver annotations >>
 # @+<< leoserver version >>
 # @+node:ekr.20220820160619.1: ** << leoserver version >>
@@ -196,7 +197,7 @@ class ServerExternalFilesController(ExternalFilesController):
         # DO NOT alter directly, use set_time(path) and
         # get_time(path), see set_time() for notes.
         self.yesno_all_time: float = 0.0  # time of answer (previous yes/no to all answer)
-        self.yesno_all_answer = None  # answer, 'yes-all', or 'no-all'
+        self.yesno_all_answer = ''  # answer, 'yes-all', or 'no-all'
 
         # if yesAll/noAll forced, then just show info message after idle_check_commander
         self.infoMessage: str = None  # False or "detected", "refreshed" or "ignored"
@@ -207,6 +208,7 @@ class ServerExternalFilesController(ExternalFilesController):
         # last p node that was asked for if not set to "AllYes\AllNo"
         self.lastPNode: Position = None
         self.lastCommander: Cmdr = None
+        self.unchecked_commanders: list[Cmdr] = []
 
     # @+node:felix.20210626222905.6: *3* sefc.clientResult
     def clientResult(self, p_result: Response) -> None:
@@ -6149,7 +6151,7 @@ def main() -> None:  # pragma: no cover (tested in client)
     # Start the server.
     if sys.version_info >= (3, 14):
         # For Python 3.14+
-        async def start_server():
+        async def start_server() -> None:
             realtime_server = None
             try:
                 try:

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -32,6 +32,10 @@ files = [
     'leo/core/leoGlobals.py',
     'leo/core/leoCommands.py',
     'leo/core/leoNodes.py',
+    
+    # Follow-on files, checked by checking leoCommands.py.
+    'leo/core/leoExternalFiles.py',
+    'leo/core/leoserver.py',
 
     # To be checked in other PRs...
     #   'leo/core/leoApp.py',

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -26,9 +26,8 @@ os.chdir(leo_editor_dir)
 incremental = False
 follow = False
 files = [
-    # PR #47??. Require strict optional for leoGlobals.py.
+    # Files to check with strict_optional in .mypy.ini.
     'leo/core/leoGlobals.py',
-    # PR #4766. Require strict optional for leoNodes.py.
     'leo/core/leoCommands.py',
     'leo/core/leoNodes.py',
     # To be checked in other PRs...

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -25,33 +25,38 @@ os.chdir(leo_editor_dir)
 # @-<< mypy_leo.py: imports & startup >>
 incremental = False
 follow = False
-files = [
-    # 'leo',
+if 0:
+    files = [
+        'leo',
+    ]  # Test all files.
+else:
+    files = [
+        # Files to check with strict_optional in .mypy.ini.
+        'leo/core/leoGlobals.py',
+        'leo/core/leoCommands.py',
+        'leo/core/leoNodes.py',
 
-    # Files to check with strict_optional in .mypy.ini.
-    'leo/core/leoGlobals.py',
-    'leo/core/leoCommands.py',
-    'leo/core/leoNodes.py',
-    
-    # Follow-on files, with errors uncovered by checking leoCommands.py.
-    'leo/core/leoExternalFiles.py',
-    'leo/core/leoserver.py',
+        # Follow-on files, with errors uncovered by checking leoCommands.py.
+        'leo/commands/abbrevCommands.py',
+        'leo/core/leoExternalFiles.py',
+        'leo/core/leoserver.py',
 
-    # To be checked in other PRs...
-    #   'leo/core/leoApp.py',
-    #   'leo/core/leoAtFile.py',
-    #   'leo/core/leoKeys.py',
-    #   'leo/plugins/mod_scripting.py',
-    #   'leo/plugins/qt_commands.py',
-    #   'leo/plugins/qt_frame.py',
-    #   'leo/plugins/qt_gui.py',
-    #   'leo/plugins/qt_idle_time.py',
-    #   'leo/plugins/qt_layout.py',
-    #   'leo/plugins/qt_text.py',
-    #   'leo/plugins/qt_tree.py',
-    # 'leo/plugins/viewrendered.py',
-    #   'leo/plugins/viewrendered3.py',
-]  # fmt: skip
+        # To be checked in other PRs...
+        #   'leo/core/leoApp.py',
+        #   'leo/core/leoAtFile.py',
+        #   'leo/core/leoKeys.py',
+        #   'leo/plugins/mod_scripting.py',
+        #   'leo/plugins/qt_commands.py',
+        #   'leo/plugins/qt_frame.py',
+        #   'leo/plugins/qt_gui.py',
+        #   'leo/plugins/qt_idle_time.py',
+        #   'leo/plugins/qt_layout.py',
+        #   'leo/plugins/qt_text.py',
+        #   'leo/plugins/qt_tree.py',
+        # 'leo/plugins/viewrendered.py',
+        #   'leo/plugins/viewrendered3.py',
+    ]  # fmt: skip
+
 python = sys.executable
 incremental_arg = '' if incremental else '--no-incremental'
 follow_kind = 'normal' if follow else 'skip'

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -26,10 +26,13 @@ os.chdir(leo_editor_dir)
 incremental = False
 follow = False
 files = [
+    # 'leo',
+
     # Files to check with strict_optional in .mypy.ini.
     'leo/core/leoGlobals.py',
     'leo/core/leoCommands.py',
     'leo/core/leoNodes.py',
+
     # To be checked in other PRs...
     #   'leo/core/leoApp.py',
     #   'leo/core/leoAtFile.py',

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -33,7 +33,7 @@ files = [
     'leo/core/leoCommands.py',
     'leo/core/leoNodes.py',
     
-    # Follow-on files, checked by checking leoCommands.py.
+    # Follow-on files, with errors uncovered by checking leoCommands.py.
     'leo/core/leoExternalFiles.py',
     'leo/core/leoserver.py',
 

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -23,12 +23,12 @@ print(os.path.basename(__file__))
 leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
 os.chdir(leo_editor_dir)
 # @-<< mypy_leo.py: imports & startup >>
-incremental = False
+incremental = True
 follow = False
-if 0:
+if 1:  # Test all files.
     files = [
         'leo',
-    ]  # Test all files.
+    ]
 else:
     files = [
         # Files to check with strict_optional in .mypy.ini.


### PR DESCRIPTION
See #4766.

- [x] Change .mypy.ini to require strict_optional in leoCommands.py.
- [x] Fix all mypy complaints.

**Discussion**

This PR uses a new pattern for improving annotations:

- For just *one additional* file (in this PR, it's leoCommands.py) change .mypy.ini to require strict_optional checking.
- Run mypy_leo.py with files = ['leo']. mypy will check all files in the leo/core directory
  However, mypy_leo.py tells mypy *not* to follow imports, thereby preventing mypy from checking plugins, etc.
- With these settings, mypy initially complained about many lines in leoCommands.py and leoGlobals.py.
  mypy also complained about a few lines each in a few other files.
- Some annotations fixes resulted in *new* complaints. I fixed complaints until none were left.

The following changes are relatively minor:

- [x] Clean c.__init__ and its helpers. Tricky, because almost no imports are allowed at the top level.
- [x] leoNodes.py: v.fileIndex is *always* a (possibly) empty string (instead of a string or None).
- [x] Add various asserts to suppress mypy complaints.
- [x] Found a likely bug in c.canMoveOutlineUp. This is a task for a separate PR.
- [x] Recheck with `files = ['leo'] in mypy_leo.py. That generates warnings about real annotation issues.
   - [x] Fix 30+ issues in leoCommands.py.
   - [x] Fix 30+ issues in leoGlobals.py.
   - [x] Fix minor related annotations complaints in leoserver.py and leoExternalFiles.py.
   - [x] Fix minor complaints in abbrevCommands.py, leoConfig.py, leoImport.py, leoNodes.py, and leoPlugins.py.