### PR TITLE
Preserve duplicate shortcuts across repeated binding rebuilds

### DIFF
--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1631,6 +1631,9 @@ class LocalConfigManager:
             self.shortcutsDict = d2 = lm.globalBindingsDict
             assert d1 is None or isinstance(d1, g.SettingsDict), d1.__class__.__name__
             assert d2 is None or isinstance(d2, g.SettingsDict), d2.__class__.__name__
+        # Preserve the raw shortcut settings so repeated binding rebuilds do not
+        # depend on mutations made while resolving duplicate strokes.
+        self.shortcutsDictRaw = self.shortcutsDict.copy() if self.shortcutsDict else None
         # Default encodings.
         self.default_at_auto_file_encoding = 'utf-8'
         self.default_derived_file_encoding = 'utf-8'

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2373,6 +2373,12 @@ class KeyHandlerClass:
     def makeAllBindings(self) -> None:
         """Make all key bindings in all of Leo's panes."""
         k = self
+        # Rebuild from the original shortcut settings each pass. The binding
+        # resolver mutates c.config.shortcutsDict while handling duplicate
+        # strokes, so repeated startup-wide rebuilds must not reuse that
+        # already-trimmed dict as input.
+        raw_shortcuts = k.c.config.shortcutsDictRaw
+        k.c.config.shortcutsDict = raw_shortcuts.copy() if raw_shortcuts else None
         k.bindingsDict = {}
         k.addModeCommands()
         k.makeBindingsFromCommandsDict()

--- a/leo/unittests/core/test_leoKeys.py
+++ b/leo/unittests/core/test_leoKeys.py
@@ -187,6 +187,35 @@ class TestKeys(LeoUnitTest):
         k.simulateCommand(commandName)
         assert self.callback_was_called, commandName
 
+    # @+node:axk.20260705193730.1: *3* TestKeys.test_k_makeAllBindings_rebuilds_from_raw_shortcuts
+    def test_k_makeAllBindings_rebuilds_from_raw_shortcuts(self):
+        c = self.c
+        raw_shortcuts = g.SettingsDict('raw shortcuts')
+        raw_shortcuts['find-next'] = [
+            g.BindingInfo(kind='unit-test', pane='all', stroke=g.KeyStroke('F3')),
+            g.BindingInfo(kind='unit-test', pane='all', stroke=g.KeyStroke('Meta+g')),
+            g.BindingInfo(kind='unit-test', pane='all', stroke=g.KeyStroke('Meta+g')),
+        ]
+        c.config.shortcutsDict = raw_shortcuts.copy()
+        c.config.shortcutsDictRaw = raw_shortcuts.copy()
+        stroke = g.KeyStroke('Meta+g')
+
+        c.k.makeAllBindings()
+        bi = c.k.masterBindingsDict.get('all', {}).get(stroke)
+        self.assertEqual(bi.commandName if bi else None, 'find-next')
+
+        # The first rebuild trims the duplicate override from shortcutsDict.
+        self.assertEqual(
+            [z.stroke.s for z in c.config.getShortcut('find-next')[1]],
+            ['F3'],
+        )
+
+        # A second rebuild must start from the original raw shortcuts, not the
+        # already-trimmed shortcutsDict.
+        c.k.makeAllBindings()
+        bi = c.k.masterBindingsDict.get('all', {}).get(stroke)
+        self.assertEqual(bi.commandName if bi else None, 'find-next')
+
     # @+node:ekr.20210901140645.8: *3* TestKeys.test_k_settings_ivars_match_settings
     def test_k_settings_ivars_match_settings(self):
         c = self.c


### PR DESCRIPTION
TL;DR; Fixes issue causing duplicating bindings in `myLeoSettings.leo` to be ignored.

## Summary

Fixes #4774 by making repeated key-binding rebuilds stable when duplicate shortcut definitions are present.

Leo was mutating `c.config.shortcutsDict` while constructing bindings. That meant an early `makeAllBindings()` pass could bind a duplicate user shortcut successfully, but also trim the underlying shortcut config. A later rebuild during startup could then recreate bindings from already-damaged shortcut data and lose user overrides.

This change preserves a raw snapshot of loaded shortcut settings and makes each `makeAllBindings()` pass rebuild from that original data.

## Changes

- Preserve the original loaded shortcut settings in `LocalConfigManager`
- Rebuild bindings from the raw shortcut snapshot on each `makeAllBindings()` pass
- Add a regression test covering duplicate override shortcuts across repeated rebuilds

## User-visible effect

Duplicate or overlapping shortcut definitions no longer are ignored after a later binding rebuild during startup (`myLeoSettings.leo`).

This was observed with duplicate Meta bindings, but the root cause is in Leo's generic binding rebuild logic and is not macOS-specific.

## Notes

Observed and validated on macOS while investigating duplicate Meta shortcut bindings during startup. Interesting tidbit: static code analysis pointed that code is correct, but it didn't match actual behavior. 

## LLM disclosure

I used Codex/LLM assistance to help trace the binding rebuild path, identify the mutation bug, draft the fix, and add the regression test. Contribution time: ~2h.
