### PR TITLE
PR: Require strict_optional for leoApp.py and leoConfig.py

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -41,7 +41,7 @@ disallow_incomplete_defs = True
 strict_optional = False
 
 # #4766: more specific descriptions override less specific.
-[mypy-leo.core.leoNodes,leo.core.leoGlobals,leo.core.leoCommands]
+[mypy-leo.core.leoApp,leo.core.leoNodes,leo.core.leoGlobals,leo.core.leoCommands]
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 strict_optional = True

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -38,6 +38,7 @@ exclude =
 [mypy-leo.core.*]
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
+# strict_optional = True: 1100+ errors.
 strict_optional = False
 
 # #4766: more specific descriptions override less specific.

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -41,7 +41,7 @@ disallow_incomplete_defs = True
 strict_optional = False
 
 # #4766: more specific descriptions override less specific.
-[mypy-leo.core.leoApp,leo.core.leoNodes,leo.core.leoGlobals,leo.core.leoCommands]
+[mypy-leo.core.leoApp,leo.core.leoConfig,leo.core.leoNodes,leo.core.leoGlobals,leo.core.leoCommands]
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 strict_optional = True

--- a/leo/commands/controlCommands.py
+++ b/leo/commands/controlCommands.py
@@ -142,7 +142,7 @@ class ControlCommandsClass(BaseEditCommandsClass):
     @cmd('save-buffers-kill-leo')
     def shutdown(self, event: LeoKeyEvent) -> None:
         """Quit Leo, prompting to save any unsaved files first."""
-        g.app.onQuit()
+        g.app.onQuit(event)  # PR #4773: Bug fix.
 
     saveBuffersKillLeo = shutdown
 

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -1394,8 +1394,13 @@ class GitDiffController:
             rev2 == 'HEAD' or
             rev1 == 'HEAD' and rev2 == ''  # diffing the latest changes.
         )  # fmt: skip
-        parent = self.file_node.insertAsLastChild()
-        parent.h = kind
+
+        # A useful hack: don't create an organizer node for changed nodes.
+        if kind == 'changed':
+            parent = self.file_node
+        else:
+            parent = self.file_node.insertAsLastChild()
+            parent.h = kind
         for key in d:
             if kind.lower() == 'changed':
                 v1, v2 = d.get(key)

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -1396,7 +1396,7 @@ class GitDiffController:
         )  # fmt: skip
 
         # A useful hack: don't create an organizer node for changed nodes.
-        if kind == 'changed':
+        if kind.lower() == 'changed':
             parent = self.file_node
         else:
             parent = self.file_node.insertAsLastChild()

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -1399,17 +1399,14 @@ class GitDiffController:
         for key in d:
             if kind.lower() == 'changed':
                 v1, v2 = d.get(key)
-                # Organizer node: empty bodyh
-                organizer = parent.insertAsLastChild()
-                organizer.h = v2.h.strip()
                 # Make a clone, if possible.
                 assert v1.fileIndex == v2.fileIndex
                 p_in_c = self.find_gnx(self.c, v1.fileIndex)
                 if p_in_c and branches_match:  # #4645.
                     p3 = p_in_c.clone()
-                    p3.moveToLastChildOf(organizer)
+                    p3.moveToLastChildOf(parent)
                 else:
-                    p3 = organizer.insertAsLastChild()
+                    p3 = parent.insertAsLastChild()
                     p3.h = 'New:' + v2.h
                     p3.b = v2.b
             elif kind.lower() == 'added':

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2159,7 +2159,7 @@ class LoadManager:
         Invert a shortcut dict whose keys are command names,
         returning a dict whose keys are strokes.
         """
-        if d is None:
+        if not d:
             d = {}
         result = g.SettingsDict(f"inverted {d.name()}")
         for commandName in d.keys():
@@ -2670,7 +2670,7 @@ class LoadManager:
     # @+node:ekr.20120219154958.10478: *5* LM.createGui
     def createGui(self, pymacs: bool) -> None:
         lm = self
-        gui_option = lm.options.get('gui')
+        gui_option = lm.options.get('gui', '')
         windowFlag = lm.options.get('windowFlag', False)
         script = lm.options.get('script', '')
         if g.app.gui:
@@ -2680,7 +2680,7 @@ class LoadManager:
             else:
                 # This can also happen when leoID does not exist.
                 pass
-        elif gui_option is None:
+        elif not gui_option:  # PR #4779
             if script and not windowFlag:
                 # Always use null gui for scripts.
                 g.app.createNullGuiWithScript(script)
@@ -3096,7 +3096,7 @@ class LoadManager:
                 color: str = d.get('color', '')
                 if color == 'suppress':
                     return
-                if log and color is None:
+                if log and not color:  # PR #4779
                     color = g.actualColor('black')
                 color = g.actualColor(color)
                 tabName = d.get('tabName') or 'Log'
@@ -3644,7 +3644,7 @@ class RecentFilesManager:
                 dirName, baseName = g.os_path_split(name)
                 entry = dirCount[baseName]
                 if len(entry['dirs']) > 1 or rf_always:  # sub menus
-                    if entry['entry'] is None:
+                    if not entry['entry']:
                         entry['entry'] = menu.createNewMenu(baseName, "Recent Files...")
                         # acts as a flag for the need to create the menu
                     c.add_command(

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1031,7 +1031,7 @@ class LeoApp:
             sys.exit(message)
 
     # @+node:ekr.20031218072017.1938: *5* app.createNullGuiWithScript
-    def createNullGuiWithScript(self, script: str = None) -> None:
+    def createNullGuiWithScript(self, script: str = '') -> None:
         app = self
         app.batchMode = True
         app.gui = g.app.nullGui
@@ -1283,7 +1283,12 @@ class LeoApp:
 
     # @+node:ekr.20171127111053.1: *3* app.Closing
     # @+node:ekr.20031218072017.2609: *4* app.closeLeoWindow
-    def closeLeoWindow(self, frame: LeoFrame, new_c: Cmdr = None, finish_quit: bool = True) -> bool:
+    def closeLeoWindow(
+        self,
+        frame: LeoFrame,
+        new_c: Cmdr | None = None,
+        finish_quit: bool = True,
+    ) -> bool:
         """
         Attempt to close a Leo window.
 
@@ -1401,7 +1406,7 @@ class LeoApp:
     # @+node:ekr.20031218072017.2617: *4* app.onQuit
     @cmd('exit-leo')
     @cmd('quit-leo')
-    def onQuit(self, event: LeoKeyEvent = None) -> None:
+    def onQuit(self, event: LeoKeyEvent | None = None) -> None:
         """Exit Leo, prompting to save unsaved outlines first."""
         if 'shutdown' in g.app.debug:
             g.trace()
@@ -1510,7 +1515,7 @@ class LeoApp:
     # @+node:ekr.20170429152049.1: *3* app.listenToLog
     @cmd('listen-to-log')
     @cmd('log-listen')
-    def listenToLog(self, event: LeoKeyEvent = None) -> None:
+    def listenToLog(self, event: LeoKeyEvent | None = None) -> None:
         """
         A socket listener, listening on localhost. See:
         https://docs.python.org/2/howto/logging-cookbook.html#sending-and-receiving-logging-events-across-a-network
@@ -1548,10 +1553,10 @@ class LeoApp:
     def newCommander(
         self,
         fileName: str,
-        gui: LeoGui = None,
+        gui: LeoGui | None = None,
         parentFrame: Any = None,
         previousSettings: PreviousSettings | None = None,
-        relativeFileName: str = None,
+        relativeFileName: str = '',
     ) -> Cmdr:
         """Create a commander and its view frame for the Leo main window."""
         # Create the commander and its subcommanders.
@@ -2284,7 +2289,7 @@ class LoadManager:
                 print('')
 
     # @+node:ekr.20120219154958.10452: *3* LM.load & helpers
-    def load(self, fileName: str = None, pymacs: bool = None) -> None:
+    def load(self, fileName: str = '', pymacs: bool = False) -> None:
         """This is Leo's main startup method."""
         lm = self
 
@@ -3179,7 +3184,7 @@ class LoadManager:
     loadLocalFile = openWithFileName  # Compatibility.
 
     # @+node:ekr.20120223062418.10405: *5* LM.createMenu
-    def createMenu(self, c: Cmdr, fn: str = None) -> None:
+    def createMenu(self, c: Cmdr, fn: str = '') -> None:
         # lm = self
         # Create the menu as late as possible so it can use user commands.
         if not g.doHook("menu1", c=c, p=c.p, v=c.p):
@@ -3632,7 +3637,7 @@ class RecentFilesManager:
                 continue  # happens with empty list/new file
 
             def recentFilesCallback(
-                event: LeoKeyEvent = None, c: Cmdr = c, name: str = name
+                event: LeoKeyEvent | None = None, c: Cmdr = c, name: str = name
             ) -> None:
                 c.openRecentFile(fn=name)
 
@@ -3969,7 +3974,7 @@ def toggle_idle_time_events(event: LeoKeyEvent) -> None:
 
 # @+node:ekr.20150514125218.5: *3* open-url
 @g.command('open-url')
-def openUrl(event: LeoKeyEvent = None) -> None:
+def openUrl(event: LeoKeyEvent | None = None) -> None:
     """
     Open the url in the headline or body text of the selected node.
 
@@ -3983,7 +3988,7 @@ def openUrl(event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20150514125218.6: *3* open-url-under-cursor
 @g.command('open-url-under-cursor')
-def openUrlUnderCursor(event: LeoKeyEvent = None) -> None:
+def openUrlUnderCursor(event: LeoKeyEvent | None = None) -> None:
     """Open the url under the cursor."""
     g.openUrlOnClick(event)
 

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -12,6 +12,7 @@ import string
 import sys
 import textwrap
 import time
+import typing
 from typing import cast, Any, TYPE_CHECKING
 import zipfile
 import platform
@@ -1337,7 +1338,8 @@ class LeoApp:
             g.pr('destroyAllOpenWithFiles')
         if g.app.externalFilesController:
             g.app.externalFilesController.shut_down()
-            g.app.externalFilesController = None
+            # Disable further processing. Disable the otherwise valid mypy complaint.
+            g.app.externalFilesController = None  # type:ignore
 
     # @+node:ekr.20031218072017.2615: *4* app.destroyWindow
     def destroyWindow(self, frame: LeoFrame) -> None:
@@ -1643,7 +1645,7 @@ class LoadManager:
         self.leo_settings_c: Cmdr | None = None
         self.leo_settings_path = ''
         self.my_settings_c: Cmdr | None = None
-        self.my_settings_path = None
+        self.my_settings_path = ''
         self.theme_c: Cmdr | None = None  # #1374.
         self.theme_path = ''
 
@@ -1656,7 +1658,7 @@ class LoadManager:
         return fileName
 
     # @+node:ekr.20120209051836.10372: *4* LM.computeLeoSettingsPath
-    def computeLeoSettingsPath(self) -> str | None:
+    def computeLeoSettingsPath(self) -> str:
         """Return the full path to leoSettings.leo."""
         # lm = self
         join = g.finalize_join
@@ -1670,13 +1672,11 @@ class LoadManager:
         )
         for path in table:
             if g.os_path_exists(path):
-                break
-        else:
-            path = None
-        return path
+                return path
+        return ''
 
     # @+node:ekr.20120209051836.10373: *4* LM.computeMyLeoSettingsPath
-    def computeMyLeoSettingsPath(self) -> str | None:
+    def computeMyLeoSettingsPath(self) -> str:
         """
         Return the full path to either myLeoSettings.leo or myLeoSettings.leojs.
 
@@ -1708,7 +1708,7 @@ class LoadManager:
                 return path + ".leo"
             if g.os_path_exists(path + ".leojs"):
                 return path + ".leojs"
-        return None
+        return ''
 
     # @+node:ekr.20120209051836.10252: *4* LM.computeStandardDirectories & helpers
     def computeStandardDirectories(self) -> None:
@@ -1979,7 +1979,7 @@ class LoadManager:
     # @+node:ekr.20120223062418.10421: *4* LM.computeLocalSettings
     def computeLocalSettings(
         self,
-        c: Cmdr,
+        c: Cmdr | None,
         settings_d: g.SettingsDict,
         bindings_d: g.SettingsDict,
         localFlag: bool,
@@ -2016,7 +2016,9 @@ class LoadManager:
 
     # @+node:ekr.20120214165710.10726: *4* LM.createSettingsDicts
     def createSettingsDicts(
-        self, c: Cmdr, localFlag: bool
+        self,
+        c: Cmdr | None,
+        localFlag: bool,
     ) -> tuple[g.SettingsDict, g.SettingsDict] | tuple[None, None]:
         from leo.core import leoConfig
 
@@ -2061,13 +2063,13 @@ class LoadManager:
             d1 = lm.globalSettingsDict.copy()
             d2 = lm.globalBindingsDict.copy()
         else:
-            d1 = d2 = None
+            d1 = d2 = None  # type:ignore
         return PreviousSettings(d1, d2)
 
     # @+node:ekr.20120214132927.10723: *4* LM.mergeShortcutsDicts & helpers
     def mergeShortcutsDicts(
         self,
-        c: Cmdr,
+        c: Cmdr | None,
         old_d: g.SettingsDict,
         new_d: g.SettingsDict,
         localFlag: bool,
@@ -2085,42 +2087,44 @@ class LoadManager:
         inverted_old_d = lm.invert(old_d)
         inverted_new_d = lm.invert(new_d)
         # #510 & #327: always honor --trace-binding here.
-        if g.app.trace_binding:
-            # @+<< trace the binding >>
-            # @+node:ekr.20220820162604.1: *5* << trace the binding >>
-            binding = g.app.trace_binding
-            # First, see if the binding is for a command. (Doesn't work for plugin commands).
-            if localFlag and binding in c.k.killedBindings:
-                g.es_print(f"--trace-binding: {c.shortFileName()} sets {binding} to None")
-            elif localFlag and binding in c.commandsDict:
-                d = c.k.computeInverseBindingDict()
-                g.trace(
-                    f"--trace-binding: {c.shortFileName():20} binds {binding} to {d.get(binding) or []}"
-                )
-            else:
-                stroke = g.KeyStroke(binding)
-                bi_list = inverted_new_d.get(stroke)
-                if bi_list:
-                    print('')
-                    for bi in bi_list:
-                        fn = bi.kind.split(' ')[-1]  # bi.kind #
-                        stroke2 = c.k.prettyPrintKey(stroke)
-                        if bi.pane and bi.pane != 'all':
-                            pane = f" in {bi.pane} panes"
-                        else:
-                            pane = ''
-                        g.es_print(
-                            f"--trace-binding: {fn:20} binds {stroke2} to {bi.commandName:>20}{pane}"
-                        )
-                    print('')
-            # @-<< trace the binding >>
         # Check for duplicate shortcuts only in the new file.
-        lm.checkForDuplicateShortcuts(c, inverted_new_d)
+        if c:  # PR #4779
+            if g.app.trace_binding:
+                # @+<< trace the binding >>
+                # @+node:ekr.20220820162604.1: *5* << trace the binding >>
+                binding = g.app.trace_binding
+                # First, see if the binding is for a command. (Doesn't work for plugin commands).
+                if localFlag and binding in c.k.killedBindings:
+                    g.es_print(f"--trace-binding: {c.shortFileName()} sets {binding} to None")
+                elif localFlag and binding in c.commandsDict:
+                    d = c.k.computeInverseBindingDict()
+                    g.trace(
+                        f"--trace-binding: {c.shortFileName():20} binds {binding} to {d.get(binding) or []}"
+                    )
+                else:
+                    stroke = g.KeyStroke(binding)
+                    bi_list = inverted_new_d.get(stroke)
+                    if bi_list:
+                        print('')
+                        for bi in bi_list:
+                            fn = bi.kind.split(' ')[-1]  # bi.kind #
+                            stroke2 = c.k.prettyPrintKey(stroke)
+                            if bi.pane and bi.pane != 'all':
+                                pane = f" in {bi.pane} panes"
+                            else:
+                                pane = ''
+                            g.es_print(
+                                f"--trace-binding: {fn:20} binds {stroke2} to {bi.commandName:>20}{pane}"
+                            )
+                        print('')
+                # @-<< trace the binding >>
+            lm.checkForDuplicateShortcuts(c, inverted_new_d)
         inverted_old_d.update(inverted_new_d)  # Updates inverted_old_d in place.
         result = lm.uninvert(inverted_old_d)
         return result
 
     # @+node:ekr.20120311070142.9904: *5* LM.checkForDuplicateShortcuts
+    @typing.no_type_check
     def checkForDuplicateShortcuts(self, c: Cmdr, d: dict[str, str]) -> None:
         """
         Check for duplicates in an "inverted" dictionary d
@@ -2128,10 +2132,10 @@ class LoadManager:
 
         Duplicates happen only if panes conflict.
         """
-        # Fix bug 951921: check for duplicate shortcuts only in the new file.
+        # Check for duplicate shortcuts only in the new file.
         for ks in sorted(list(d.keys())):
             duplicates, panes = [], ['all']
-            aList = d.get(ks)  # A list of bi objects.
+            aList: list[g.BindingInfo] = d.get(ks, [])
             aList2 = [z for z in aList if z and not z.pane.startswith('mode')]
             if len(aList) > 1:
                 for bi in aList2:
@@ -3502,8 +3506,8 @@ class PreviousSettings:
         if not shortcutsDict or not settingsDict:  # #1766: unit tests.
             lm = g.app.loadManager
             settingsDict, shortcutsDict = lm.createDefaultSettingsDicts()
-        self.settingsDict = settingsDict
-        self.shortcutsDict = shortcutsDict
+        self.settingsDict: g.SettingsDict = settingsDict
+        self.shortcutsDict: g.SettingsDict = shortcutsDict
 
     def __repr__(self) -> str:
         # Returning the length of the inner dicts is usually best.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1406,7 +1406,7 @@ class LeoApp:
     # @+node:ekr.20031218072017.2617: *4* app.onQuit
     @cmd('exit-leo')
     @cmd('quit-leo')
-    def onQuit(self, event: LeoKeyEvent | None = None) -> None:
+    def onQuit(self, event: LeoKeyEvent) -> None:
         """Exit Leo, prompting to save unsaved outlines first."""
         if 'shutdown' in g.app.debug:
             g.trace()
@@ -1515,7 +1515,7 @@ class LeoApp:
     # @+node:ekr.20170429152049.1: *3* app.listenToLog
     @cmd('listen-to-log')
     @cmd('log-listen')
-    def listenToLog(self, event: LeoKeyEvent | None = None) -> None:
+    def listenToLog(self, event: LeoKeyEvent) -> None:
         """
         A socket listener, listening on localhost. See:
         https://docs.python.org/2/howto/logging-cookbook.html#sending-and-receiving-logging-events-across-a-network
@@ -3636,9 +3636,7 @@ class RecentFilesManager:
             if name.strip() == "":
                 continue  # happens with empty list/new file
 
-            def recentFilesCallback(
-                event: LeoKeyEvent | None = None, c: Cmdr = c, name: str = name
-            ) -> None:
+            def recentFilesCallback(event: LeoKeyEvent, c: Cmdr = c, name: str = name) -> None:
                 c.openRecentFile(fn=name)
 
             if groupedEntries:
@@ -3974,7 +3972,7 @@ def toggle_idle_time_events(event: LeoKeyEvent) -> None:
 
 # @+node:ekr.20150514125218.5: *3* open-url
 @g.command('open-url')
-def openUrl(event: LeoKeyEvent | None = None) -> None:
+def openUrl(event: LeoKeyEvent) -> None:
     """
     Open the url in the headline or body text of the selected node.
 
@@ -3988,7 +3986,7 @@ def openUrl(event: LeoKeyEvent | None = None) -> None:
 
 # @+node:ekr.20150514125218.6: *3* open-url-under-cursor
 @g.command('open-url-under-cursor')
-def openUrlUnderCursor(event: LeoKeyEvent | None = None) -> None:
+def openUrlUnderCursor(event: LeoKeyEvent) -> None:
     """Open the url under the cursor."""
     g.openUrlOnClick(event)
 

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2468,6 +2468,7 @@ class LoadManager:
         exists = fn and os.path.exists(fn)
         if not fn:
             # The usual directory does not exist. Create an empty file.
+            fn = ''  # PR #4773
             c = self.openEmptyLeoFile(fn, gui=g.app.gui, old_c=None)
             c.rootPosition().h = 'Workbook'
             g.app.numberOfUntitledWindows += 1
@@ -2559,7 +2560,7 @@ class LoadManager:
 
         # Leo 6.7.8: Create g.app.importerClassesDict.
         for language_name in g.app.importerModulesDict:
-            m = g.app.importerModulesDict.get(language_name)
+            m = g.app.importerModulesDict.get(language_name, '')
             for z in dir(m):
                 # A hack: all importer subclasses should end with '_Importer'.
                 if z.endswith('_Importer'):
@@ -3143,7 +3144,7 @@ class LoadManager:
             return False
 
     # @+node:ekr.20120223062418.10393: *4* LM.openWithFileName & helpers
-    def openWithFileName(self, fn: str, gui: LeoGui | None, old_c: Cmdr | None) -> Cmdr | None:
+    def openWithFileName(self, fn: str, gui: LeoGui | None, old_c: Cmdr | None) -> Cmdr:
         """
         Completely read a file, creating the corresponding outline.
 

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3308,7 +3308,7 @@ class LoadManager:
             p.h = f"@auto {fn}" if func else f"@edit {fn}"
             c.refreshFromDisk(p)  # pylint: disable=no-member
 
-        c.mFileName = None  # #3546: Do *not* automatically save the .leo file.
+        c.mFileName = ''  # #3546: Do *not* automatically save the .leo file.
         c.frame.title = c.computeTabTitle()
         c.frame.setTitle(c.frame.title)
 
@@ -3413,9 +3413,7 @@ class LoadManager:
 
         if c.looksLikeDerivedFile(fn):
             # Create an @file node. Not undoable!
-            p = c.importCommands.importDerivedFiles(
-                parent=c.rootPosition(), paths=[fn], command=None
-            )
+            p = c.importCommands.importDerivedFiles(parent=c.rootPosition(), paths=[fn], command='')
             if not p:
                 return
             if p.hasBack():

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2429,7 +2429,7 @@ class LoadManager:
         if not c:
             # Leo is out of options: Force an immediate exit.
             return False
-        g.app.runAlreadyOpenDialog(c1)  # #199.
+        g.app.runAlreadyOpenDialog(c)  # #199.
 
         # Final inits...
         try:  # qt only: select the first-loaded tab.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2273,7 +2273,7 @@ class LoadManager:
     def traceSettingsDict(self, d: dict[str, str], verbose: bool = False) -> None:
         if verbose:
             print(d)
-            for key, gs in sorted(list(d.items())):  # PR #4773
+            for key, gs in sorted(list(d.items())):  # PR #4779
                 print(f"{key:35} {g.shortFileName(gs.path):17} {gs.val}")
             if d:
                 print('')
@@ -2284,7 +2284,7 @@ class LoadManager:
     def traceShortcutsDict(self, d: dict[str, str], verbose: bool = True) -> None:
         print(d)
         if verbose:
-            for key, val in sorted(list(d.items())):  # PR #4773
+            for key, val in sorted(list(d.items())):  # PR #4779
                 print(f"{key:35} {[z.stroke for z in val]}")
             if d:
                 print('')
@@ -2468,7 +2468,7 @@ class LoadManager:
         exists = fn and os.path.exists(fn)
         if not fn:
             # The usual directory does not exist. Create an empty file.
-            fn = ''  # PR #4773
+            fn = ''  # PR #4779
             c = self.openEmptyLeoFile(fn, gui=g.app.gui, old_c=None)
             c.rootPosition().h = 'Workbook'
             g.app.numberOfUntitledWindows += 1
@@ -3184,7 +3184,7 @@ class LoadManager:
         c = lm.openExternalFile(file_name, gui, old_c)
         if c:
             return c
-        return lm.openEmptyLeoFile(file_name, gui, old_c)  # PR #4773
+        return lm.openEmptyLeoFile(file_name, gui, old_c)  # PR #4779
 
     loadLocalFile = openWithFileName  # Compatibility.
 

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2671,8 +2671,8 @@ class LoadManager:
     def createGui(self, pymacs: bool) -> None:
         lm = self
         gui_option = lm.options.get('gui')
-        windowFlag = lm.options.get('windowFlag')
-        script = lm.options.get('script')
+        windowFlag = lm.options.get('windowFlag', False)
+        script = lm.options.get('script', '')
         if g.app.gui:
             if g.app.gui == g.app.nullGui:
                 g.app.gui = None  # Enable g.app.createDefaultGui
@@ -2693,7 +2693,7 @@ class LoadManager:
     def createSpecialGui(self, gui: str, pymacs: bool, script: str, windowFlag: bool) -> None:
         # lm = self
         if pymacs:
-            g.app.createNullGuiWithScript(script=None)
+            g.app.createNullGuiWithScript(script=script)
         elif script:
             if windowFlag:
                 g.app.createDefaultGui()
@@ -3093,7 +3093,7 @@ class LoadManager:
                 }
                 # Handle keywords for g.pr and g.es_print.
                 d = g.doKeywordArgs(keys, d)
-                color: str = d.get('color')
+                color: str = d.get('color', '')
                 if color == 'suppress':
                     return
                 if log and color is None:
@@ -3163,7 +3163,7 @@ class LoadManager:
         """
         lm = self
 
-        file_name = g.finalize(fn) if fn else None
+        file_name = g.finalize(fn) if fn else ''
 
         # #2489: If file_name is empty, open an empty, untitled .leo file.
         if not file_name:
@@ -3248,7 +3248,7 @@ class LoadManager:
         c.initialFocusHelper()
 
     # @+node:ekr.20120223062418.10408: *5* LM.openExternalFile
-    def openExternalFile(self, fn: str, gui: LeoGui | None, old_c: Cmdr | None) -> Cmdr | None:
+    def openExternalFile(self, fn: str, gui: LeoGui | None, old_c: Cmdr | None) -> Cmdr:
         """
         Create a wrapper commander (in a new tab) for the given external file.
 
@@ -3361,15 +3361,11 @@ class LoadManager:
         return c
 
     # @+node:ekr.20231124134846.1: *5* LM.openExistingLeoFile & helper
-    def openExistingLeoFile(self, fn: str, gui: LeoGui | None, old_c: Cmdr | None) -> Cmdr | None:
+    def openExistingLeoFile(self, fn: str, gui: LeoGui | None, old_c: Cmdr | None) -> Cmdr:
         """
         Create a commander for an existing .leo, .db, or .leojs file.
         """
         lm = self
-        if not fn:
-            return None  # Should not happen.
-        if not os.path.exists(fn):
-            return None  # Should not happen.
 
         # Disable the log.
         g.app.setLog(None)

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -12,7 +12,7 @@ import string
 import sys
 import textwrap
 import time
-from typing import Any, TYPE_CHECKING
+from typing import cast, Any, TYPE_CHECKING
 import zipfile
 import platform
 from leo.core import leoGlobals as g
@@ -20,31 +20,31 @@ from leo.core import leoExternalFiles
 from leo.core.leoCache import GlobalCacher
 from leo.core.leoQt import QCloseEvent
 
+# For casts
+from leo.core.leoBackground import BackgroundProcessManager
+from leo.core.leoCommands import Commands as Cmdr
+from leo.core.leoExternalFiles import ExternalFilesController
+from leo.core.leoNodes import NodeIndices, Position
+from leo.core.leoPlugins import LeoPluginsController
+from leo.core.leoSessions import SessionManager
+from leo.plugins.qt_events import LossageData
+from leo.plugins.qt_idle_time import IdleTime
 
-if TYPE_CHECKING:
-    from leo.core.leoJupytext import JupytextManager
-
-    StringIO = io.StringIO
-    SpellDict = Any  # dict[str, list[str]]
 # @-<< leoApp imports >>
 # @+<< leoApp annotations >>
 # @+node:ekr.20220819191617.1: ** << leoApp annotations >>
 if TYPE_CHECKING:  # pragma: no cover
     from subprocess import Popen
     from types import ModuleType
-    from leo.commands.spellCommands import SqlitePickleShare
-    from leo.core.leoBackground import BackgroundProcessManager
-    from leo.core.leoCommands import Commands as Cmdr
-    from leo.core.leoConfig import GlobalConfigManager
-    from leo.core.leoExternalFiles import ExternalFilesController
-    from leo.core.leoGui import LeoKeyEvent, LeoFrame, LeoGui
-    from leo.core.leoNodes import NodeIndices, Position
-    from leo.core.leoPlugins import LeoPluginsController
-    from leo.core.leoSessions import SessionManager
-    from leo.plugins.qt_events import LossageData
-    from leo.plugins.qt_idle_time import IdleTime
 
-    Value = Any
+    # Do not import these at the top level: they would cause circular imports.
+    from leo.core.leoConfig import GlobalConfigManager
+    from leo.core.leoGui import LeoKeyEvent, LeoFrame, LeoGui
+    from leo.core.leoJupytext import JupytextManager
+    from leo.commands.spellCommands import SqlitePickleShare
+
+    StringIO = io.StringIO
+    SpellDict = Any  # dict[str, list[str]]
 
 
 # @-<< leoApp annotations >>
@@ -206,21 +206,21 @@ class LeoApp:
         # Singleton applications objects...
 
         # A BackgroundProcessManager.
-        self.backgroundProcessManager: BackgroundProcessManager = None
-        self.config: GlobalConfigManager = None  # g.app.config.
+        self.backgroundProcessManager = cast(BackgroundProcessManager, None)
+        self.config: GlobalConfigManager | None = None  # g.app.config. Can't use a cast.
         # A global db, managed by g.app.global_cacher.
-        self.db: dict | SqlitePickleShare | g.NullObject = None
-        self.externalFilesController: ExternalFilesController | None = None
-        self.global_cacher: dict | GlobalCacher | g.NullObject | None = None
-        self.idleTimeManager: IdleTimeManager | None = None
-        self.jupytextManager: JupytextManager = None
-        self.loadManager: LoadManager | None = None
-        self.nodeIndices: NodeIndices | None = None
-        self.pluginsController: LeoPluginsController | None = None
-        self.sessionManager: SessionManager | None = None
+        self.db: dict | SqlitePickleShare | g.NullObject = {}
+        self.externalFilesController = cast(ExternalFilesController, None)
+        self.global_cacher: dict | GlobalCacher | g.NullObject = {}
+        self.idleTimeManager = cast(IdleTimeManager, None)
+        self.jupytextManager: JupytextManager | None = None  # Can't use a cast.
+        self.loadManager = cast(LoadManager, None)
+        self.nodeIndices = cast(NodeIndices, None)
+        self.pluginsController = cast(LeoPluginsController, None)
+        self.sessionManager = cast(SessionManager, None)
 
         # Global status vars for the Commands class...
-        self.commandName: str | None = None  # The name of the command being executed.
+        self.commandName = ''  # The name of the command being executed.
         self.commandInterruptFlag = False  # True: command within a command.
         # @-<< LeoApp: global controller/manager objects >>
         # @+<< LeoApp: global importer/reader/writer data >>
@@ -297,13 +297,11 @@ class LeoApp:
         # @-<< LeoApp: plugins and event handlers >>
         # @+<< LeoApp: scripting ivars >>
         # @+node:ekr.20161028040303.1: *5* << LeoApp: scripting ivars >>
-        self.scriptDict: dict[
-            str, Value
-        ] = {}  # For use by scripts. Cleared before running each script.
-        self.scriptResult: Value = None  # For use by leoPymacs.
-        self.permanentScriptDict: dict[
-            str, Value
-        ] = {}  # For use by scripts. Never cleared automatically.
+        # For use by scripts. Cleared before running each script.
+        self.scriptDict: dict[str, Any] = {}
+        self.scriptResult: Any = None  # For use by leoPymacs.
+        # For use by scripts. Never cleared automatically.
+        self.permanentScriptDict: dict[str, Any] = {}
         # @-<< LeoApp: scripting ivars >>
         # Define all global data.
         self.init_at_auto_names()
@@ -1630,7 +1628,7 @@ class LoadManager:
         # LoadManager ivars corresponding to user options...
 
         self.files: list[str] = []  # List of files to be loaded.
-        self.options: dict[str, Value] = {}  # Keys are option names; values are user options.
+        self.options: dict[str, Any] = {}  # Keys are option names; values are user options.
         self.old_argv: list[str] = []  # A copy of sys.argv for debugging.
 
         # True when more files remain on the command line to be loaded.
@@ -2748,7 +2746,7 @@ class LoadManager:
         g.app.pluginsController.finishCreate()
 
     # @+node:ekr.20210927034148.1: *5* LM.scanOptions & helpers
-    def scanOptions(self, fileName: str, pymacs: bool) -> dict[str, Value]:
+    def scanOptions(self, fileName: str, pymacs: bool) -> dict[str, Any]:
         """Handle all options, remove them from sys.argv and set lm.options."""
 
         # Define helper functions.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -203,17 +203,18 @@ class LeoApp:
         # @-<< LeoApp: global data >>
         # @+<< LeoApp: global controller/manager objects >>
         # @+node:ekr.20161028040028.1: *5* << LeoApp: global controller/manager objects >>
-        # Singleton applications objects...
+        # Singleton applications objects which all exist.
 
-        # A BackgroundProcessManager.
+        # We can't always use a cast here because doing so would create circular imports.
+        # In those two places we suppress the otherwise valid mypy complaints.
+
         self.backgroundProcessManager = cast(BackgroundProcessManager, None)
-        self.config: GlobalConfigManager | None = None  # g.app.config. Can't use a cast.
-        # A global db, managed by g.app.global_cacher.
-        self.db: dict | SqlitePickleShare | g.NullObject = {}
-        self.externalFilesController: ExternalFilesController | None = None  # May be None.
+        self.config: GlobalConfigManager = None  # type:ignore  # g.app.config
+        self.externalFilesController = cast(ExternalFilesController, None)
+        self.db: dict | SqlitePickleShare | g.NullObject = {}  # g.app.global_cacher.
         self.global_cacher: dict | GlobalCacher | g.NullObject = {}
         self.idleTimeManager = cast(IdleTimeManager, None)
-        self.jupytextManager: JupytextManager | None = None  # Can't use a cast.
+        self.jupytextManager: JupytextManager = None  # type:ignore
         self.loadManager = cast(LoadManager, None)
         self.nodeIndices = cast(NodeIndices, None)
         self.pluginsController = cast(LeoPluginsController, None)
@@ -1866,7 +1867,7 @@ class LoadManager:
         resolve = self.resolve_theme_path
 
         # Step 1: Use the --theme command-line options if it exists
-        path = resolve(lm.options.get('theme_path'), tag='--theme')
+        path = resolve(lm.options.get('theme_path', ''), tag='--theme')
         if path:
             # Caller (LM.readGlobalSettingsFiles) sets lm.theme_path
             if trace:
@@ -1908,7 +1909,7 @@ class LoadManager:
     def resolve_theme_path(self, fn: str, tag: str) -> str:
         """Search theme directories for the given .leo file."""
         if not fn:
-            return None
+            return ''
         # Make --theme and theme-name setting do the same thing for "None"
         if fn.lower().strip() == 'none':
             return LoadManager.LM_NOTHEME_FLAG

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3181,7 +3181,10 @@ class LoadManager:
             if exists:
                 return lm.openExistingLeoFile(file_name, gui, old_c)
             return lm.openEmptyLeoFile(file_name, gui, old_c)
-        return lm.openExternalFile(file_name, gui, old_c)
+        c = lm.openExternalFile(file_name, gui, old_c)
+        if c:
+            return c
+        return lm.openEmptyLeoFile(file_name, gui, old_c)  # PR #4773
 
     loadLocalFile = openWithFileName  # Compatibility.
 
@@ -3248,7 +3251,7 @@ class LoadManager:
         c.initialFocusHelper()
 
     # @+node:ekr.20120223062418.10408: *5* LM.openExternalFile
-    def openExternalFile(self, fn: str, gui: LeoGui | None, old_c: Cmdr | None) -> Cmdr:
+    def openExternalFile(self, fn: str, gui: LeoGui | None, old_c: Cmdr | None) -> Cmdr | None:
         """
         Create a wrapper commander (in a new tab) for the given external file.
 
@@ -3264,7 +3267,7 @@ class LoadManager:
         c = g.app.newCommander(
             fileName=fn,
             gui=gui,
-            previousSettings=lm.getPreviousSettings(None),
+            previousSettings=lm.getPreviousSettings(''),
         )
         # Use the config params to set the size and location of the window.
         g.doHook('open0')
@@ -3285,8 +3288,10 @@ class LoadManager:
             c.redraw()
         elif c.looksLikeDerivedFile(fn):
             # Create an @file node. Not undoable!
-            p = c.importCommands.importDerivedFiles(
-                parent=c.rootPosition(), paths=[fn], command=None
+            p = c.importCommands.importDerivedFiles(  # type:ignore  # We will test p next.
+                parent=c.rootPosition(),
+                paths=[fn],
+                command='',
             )
             if not p:
                 return None

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -71,7 +71,7 @@ class IdleTimeManager:
         """Ctor for IdleTimeManager class."""
         self.callback_list: list[Callable] = []
         self.on_idle_count = 0
-        self.timer: IdleTime = None
+        self.timer: IdleTime | None = None  # May not exist.
 
     # @+others
     # @+node:ekr.20161026125611.1: *3* itm.add_callback
@@ -138,8 +138,8 @@ class LeoApp:
         self.diff = False  # True: run Leo in diff mode.
         self.enablePlugins = True  # True: run start1 hook to load plugins. --no-plugins
         self.failFast = False  # True: Use the failfast option in unit tests.
-        self.gui: LeoGui = None  # The gui class.
-        self.guiArgName: str = None  # The gui name given in --gui option.
+        self.gui: Any = None  # The gui class. Really LeoGui, but we can't use casts.
+        self.guiArgName: str = ''  # The gui name given in --gui option.
         self.isTheme = False  # True: load files as theme files (ignore myLeoSettings.leo).
         self.listen_to_log_flag = False  # True: execute listen-to-log command.
         # Set by startup logic to True if no files specified on the command line.
@@ -148,8 +148,8 @@ class LeoApp:
         self.start_fullscreen = False  # For qt_frame plugin.
         self.start_maximized = False  # For qt_frame plugin.
         self.start_minimized = False  # For qt_frame plugin.
-        self.trace_binding: str | None = None  # The name of a binding to trace, or None.
-        self.trace_setting: str | None = None  # The name of a setting to trace, or None.
+        self.trace_binding = ''  # The name of a binding to trace, or None.
+        self.trace_setting = ''  # The name of a setting to trace, or None.
         self.translateToUpperCase = False  # Never set to True.
         self.use_splash_screen = True  # True: put up a splash screen.
 
@@ -175,16 +175,16 @@ class LeoApp:
         # @-<< LeoApp: error messages >>
         # @+<< LeoApp: global directories >>
         # @+node:ekr.20161028035924.1: *5* << LeoApp: global directories >>
-        self.extensionsDir: str = None  # The leo/extensions directory
-        self.globalConfigDir: str = None  # leo/config directory
-        self.globalOpenDir: str = None  # The directory last used to open a file.
-        self.homeDir: str = None  # The user's home directory.
-        self.homeLeoDir: str = None  # The user's home/.leo directory.
-        self.leoEditorDir: str = None  # The leo-editor directory.
-        self.loadDir: str = None  # The leo/core directory.
-        self.machineDir: str = None  # The machine-specific directory.
+        self.extensionsDir = ''  # The leo/extensions directory
+        self.globalConfigDir = ''  # leo/config directory
+        self.globalOpenDir = ''  # The directory last used to open a file.
+        self.homeDir = ''  # The user's home directory.
+        self.homeLeoDir = ''  # The user's home/.leo directory.
+        self.leoEditorDir = ''  # The leo-editor directory.
+        self.loadDir = ''  # The leo/core directory.
+        self.machineDir = ''  # The machine-specific directory.
         # The directory from which the theme file was loaded, if any.
-        self.theme_directory: str = None
+        self.theme_directory = ''
         # @-<< LeoApp: global directories >>
         # @+<< LeoApp: global data >>
         # @+node:ekr.20161028035956.1: *5* << LeoApp: global data >>
@@ -193,7 +193,7 @@ class LeoApp:
         self.globalKillBuffer: list[str] = []  # The global kill buffer.
         self.globalRegisters: dict[str, str] = {}  # The global register list.
         self.initial_cwd: str = os.getcwd()  # For restart-leo.
-        self.leoID: str = None  # The id part of gnx's.
+        self.leoID = ''  # The id part of gnx's.
         self.lossage: list[LossageData] = []  # List of last 100 keystrokes.
         self.paste_c: Cmdr = None  # The commander that pasted the last outline.
         self.spellDict: SpellDict = None  # A pyenchant dict or a DefaultDict.
@@ -1077,7 +1077,7 @@ class LeoApp:
     # @+node:ekr.20031218072017.1978: *4* app.setLeoID & helpers
     def setLeoID(self, useDialog: bool = True, verbose: bool = True) -> str:
         """Get g.app.leoID from various sources."""
-        self.leoID = None
+        self.leoID = ''
         assert self == g.app
         verbose = verbose and not g.unitTesting and not self.silentMode
         table = (self.setIDFromSys, self.setIDFromFile, self.setIDFromEnv)
@@ -1513,7 +1513,7 @@ class LeoApp:
     # @+node:ekr.20170429152049.1: *3* app.listenToLog
     @cmd('listen-to-log')
     @cmd('log-listen')
-    def listenToLog(self, event: LeoKeyEvent) -> None:
+    def listenToLog(self) -> None:
         """
         A socket listener, listening on localhost. See:
         https://docs.python.org/2/howto/logging-cookbook.html#sending-and-receiving-logging-events-across-a-network

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -195,8 +195,8 @@ class LeoApp:
         self.initial_cwd: str = os.getcwd()  # For restart-leo.
         self.leoID = ''  # The id part of gnx's.
         self.lossage: list[LossageData] = []  # List of last 100 keystrokes.
-        self.paste_c: Cmdr = None  # The commander that pasted the last outline.
-        self.spellDict: SpellDict = None  # A pyenchant dict or a DefaultDict.
+        self.paste_c: Cmdr | None = None  # The commander that pasted the last outline.
+        self.spellDict: Any = None  # A pyenchant dict or a DefaultDict.
         self.numberOfUntitledWindows = 0  # Number of opened untitled windows.
         self.windowList: list[LeoFrame] = []  # Global list of all frames.
         self.realMenuNameDict: dict[str, str] = {}  # Translations of menu names.
@@ -210,7 +210,7 @@ class LeoApp:
         self.config: GlobalConfigManager | None = None  # g.app.config. Can't use a cast.
         # A global db, managed by g.app.global_cacher.
         self.db: dict | SqlitePickleShare | g.NullObject = {}
-        self.externalFilesController = cast(ExternalFilesController, None)
+        self.externalFilesController: ExternalFilesController | None = None  # May be None.
         self.global_cacher: dict | GlobalCacher | g.NullObject = {}
         self.idleTimeManager = cast(IdleTimeManager, None)
         self.jupytextManager: JupytextManager | None = None  # Can't use a cast.
@@ -1045,7 +1045,7 @@ class LeoApp:
             from leo.core.leoQt import Qt
             from leo.plugins import qt_gui
 
-            assert Qt
+            assert Qt is not None
         except Exception:
             return  # Other methods will report startup problems.
         try:
@@ -1621,9 +1621,9 @@ class LoadManager:
         # The are the defaults for computing settings and shortcuts for all loaded files.
 
         # A g.SettingsDict: the join of settings in leoSettings.leo & myLeoSettings.leo
-        self.globalSettingsDict: g.SettingsDict = None
+        self.globalSettingsDict = cast(g.SettingsDict, None)
         # A g.SettingsDict: the join of shortcuts in leoSettings.leo & myLeoSettings.leo.
-        self.globalBindingsDict: g.SettingsDict = None
+        self.globalBindingsDict = cast(g.SettingsDict, None)
 
         # LoadManager ivars corresponding to user options...
 
@@ -1639,12 +1639,12 @@ class LoadManager:
         self.more_cmdline_files = False
 
         # Themes...
-        self.leo_settings_c: Cmdr = None
-        self.leo_settings_path: str = None
-        self.my_settings_c: Cmdr = None
-        self.my_settings_path: str = None
-        self.theme_c: Cmdr = None  # #1374.
-        self.theme_path: str = None
+        self.leo_settings_c: Cmdr | None = None
+        self.leo_settings_path = ''
+        self.my_settings_c: Cmdr | None = None
+        self.my_settings_path = None
+        self.theme_c: Cmdr | None = None  # #1374.
+        self.theme_path = ''
 
     # @+node:ekr.20120211121736.10812: *3* LM.Directory & file utils
     # @+node:ekr.20120219154958.10481: *4* LM.completeFileName
@@ -1748,7 +1748,7 @@ class LoadManager:
         home = os.path.expanduser("~")
         if home and len(home) > 1 and home[0] == '%' and home[-1] == '%':
             # Get the indirect reference to the true home.
-            home = os.getenv(home[1:-1], default=None)
+            home = os.getenv(home[1:-1], default='')
         if home:
             # Important: This returns the _working_ directory if home is None!
             # This was the source of the 4.3 .leoID.txt problems.
@@ -1905,7 +1905,7 @@ class LoadManager:
         return path
 
     # @+node:ekr.20180321124503.1: *5* LM.resolve_theme_path
-    def resolve_theme_path(self, fn: str, tag: str) -> str | None:
+    def resolve_theme_path(self, fn: str, tag: str) -> str:
         """Search theme directories for the given .leo file."""
         if not fn:
             return None
@@ -1919,7 +1919,7 @@ class LoadManager:
             if g.os_path_exists(path):
                 return path
         print(f"theme .leo file not found: {fn}")
-        return None
+        return ''
 
     # @+node:ekr.20120211121736.10772: *4* LM.computeWorkbookFileName
     def computeWorkbookFileName(self) -> str | None:
@@ -2131,7 +2131,7 @@ class LoadManager:
         for ks in sorted(list(d.keys())):
             duplicates, panes = [], ['all']
             aList = d.get(ks)  # A list of bi objects.
-            aList2 = [z for z in aList if not z.pane.startswith('mode')]
+            aList2 = [z for z in aList if z and not z.pane.startswith('mode')]
             if len(aList) > 1:
                 for bi in aList2:
                     if bi.pane in panes:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1850,7 +1850,7 @@ class LoadManager:
         return [g.os_path_normslashes(z) for z in table if g.os_path_exists(z)]
 
     # @+node:ekr.20180318133620.1: *4* LM.computeThemeFilePath & helper
-    def computeThemeFilePath(self) -> str | None:
+    def computeThemeFilePath(self) -> str:
         """
         Return the absolute path to the theme .leo file, resolved using the search order for themes.
 
@@ -2266,15 +2266,14 @@ class LoadManager:
         # Clear the cache entries for the commanders.
         # This allows this method to be called outside the startup logic.
         for c in commanders:
-            if c not in old_commanders:
+            if c and c not in old_commanders:
                 g.app.forgetOpenFile(c.fileName())
 
     # @+node:ekr.20120214165710.10838: *4* LM.traceSettingsDict
     def traceSettingsDict(self, d: dict[str, str], verbose: bool = False) -> None:
         if verbose:
             print(d)
-            for key in sorted(list(d.keys())):
-                gs = d.get(key)
+            for key, gs in sorted(list(d.items())):  # PR #4773
                 print(f"{key:35} {g.shortFileName(gs.path):17} {gs.val}")
             if d:
                 print('')
@@ -2285,8 +2284,7 @@ class LoadManager:
     def traceShortcutsDict(self, d: dict[str, str], verbose: bool = True) -> None:
         print(d)
         if verbose:
-            for key in sorted(list(d.keys())):
-                val = d.get(key)
+            for key, val in sorted(list(d.items())):  # PR #4773
                 print(f"{key:35} {[z.stroke for z in val]}")
             if d:
                 print('')

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3626,11 +3626,11 @@ class RecentFilesManager:
         rf_always = c.config.getBool("recent-files-group-always")
         groupedEntries = rf_group or rf_always
         if groupedEntries:  # if so, make dict of groups
-            dirCount: dict[str, dict[str, list[str]]] | None = {}
+            dirCount: dict[str, dict[str, Any]] = {}
             for fileName in rf.getRecentFiles()[:n]:
                 dirName, baseName = g.os_path_split(fileName)
                 if baseName not in dirCount:
-                    dirCount[baseName] = {'dirs': [], 'entry': None}
+                    dirCount[baseName] = {'dirs': [], 'entry': ''}
                 dirCount[baseName]['dirs'].append(dirName)
         for name in rf.getRecentFiles()[:n]:
             if name.strip() == "":
@@ -3672,7 +3672,7 @@ class RecentFilesManager:
                 )
             i += 1
         if groupedEntries:  # store so we can delete them later
-            rf.groupedMenus = [z for z in dirCount if dirCount[z]['entry'] is not None]
+            rf.groupedMenus = [z for z in dirCount if dirCount[z]['entry']]
 
     # @+node:vitalije.20170703115609.1: *3* rf.editRecentFiles
     def editRecentFiles(self, c: Cmdr) -> None:
@@ -3837,7 +3837,7 @@ class RecentFilesManager:
             files = [z for z in p.b.splitlines() if z and g.os_path_exists(z)]
             rf.recentFiles = files
             rf.writeRecentFilesFile(c)
-            rf.updateRecentFiles(None)
+            rf.updateRecentFiles('')
             c.selectPosition(p)
             c.deleteOutline()
         else:

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -152,7 +152,7 @@ class BridgeController:
             g.app = leoApp.LeoApp()
         except ImportError:
             print("Error importing leoApp.py")
-        g.app.leoID = None
+        g.app.leoID = ''
         if self.tracePlugins:
             g.app.debug.append('plugins')
         g.app.silentMode = self.silentMode

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -690,14 +690,14 @@ class Commands:
     # @+node:ekr.20260619060020.1: *3* @cmd commands
     # @+node:ekr.20250508044308.1: *4* @cmd beautify-tree
     @cmd('beautify-tree')
-    def beautify_tree_command(self, event: LeoKeyEvent | None = None) -> None:
+    def beautify_tree_command(self, event: LeoKeyEvent) -> None:
         """Undoably beautify c.p and its subtree."""
         c = self
         c.beautify_script_tree(c.p)
 
     # @+node:ekr.20210530065748.1: *4* @cmd c.execute-general-script
     @cmd('execute-general-script')
-    def execute_general_script_command(self, event: LeoKeyEvent | None = None) -> None:
+    def execute_general_script_command(self, event: LeoKeyEvent) -> None:
         """
         Execute c.p and all its descendants as a script.
 
@@ -747,7 +747,7 @@ class Commands:
     # @+node:tom.20241014154415.1: *4* @cmd c.execute-external-file
     # @@language python
     @cmd('execute-external-file')
-    def execute_external_file(self, event: LeoKeyEvent | None = None) -> None:
+    def execute_external_file(self, event: LeoKeyEvent) -> None:
         r"""
         # @+<< docstring >>
         # @+node:tom.20241014154415.2: *5* << docstring >>
@@ -1207,7 +1207,7 @@ class Commands:
 
     # @+node:vitalije.20190924191405.1: *4* @cmd execute-pytest
     @cmd('execute-pytest')
-    def execute_pytest(self, event: LeoKeyEvent | None = None) -> None:
+    def execute_pytest(self, event: LeoKeyEvent) -> None:
         """Using pytest, execute all @test nodes for p, p's parents and p's subtree."""
         c = self
 
@@ -1459,7 +1459,7 @@ class Commands:
 
     # @+node:ekr.20080514131122.12: *4* @cmd recolor (c.recolorCommand)
     @cmd('recolor')
-    def recolorCommand(self, event: LeoKeyEvent | None = None) -> None:
+    def recolorCommand(self, event: LeoKeyEvent) -> None:
         """Force a full recolor."""
         c = self
         colorer = c.frame.body.colorizer

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2744,7 +2744,10 @@ class Commands:
     # @+node:ekr.20031218072017.1765: *4* c.validateOutline (compatibility only)
     # Makes sure all nodes are valid.
 
-    def validateOutline(self, event: LeoKeyEvent | None = None) -> bool:
+    def validateOutline(
+        self,
+        event: Any = None,  # not used.
+    ) -> bool:
         """
         A legacy outline checker, retained only for compatibility.
 
@@ -2791,7 +2794,9 @@ class Commands:
     # but it will be retained for use of scripts.
     # @+node:ekr.20040723094220.1: *4* c.checkAllPythonCode
     def checkAllPythonCode(
-        self, event: LeoKeyEvent | None = None, ignoreAtIgnore: bool = True
+        self,
+        event: LeoKeyEvent | None = None,  # Not used.
+        ignoreAtIgnore: bool = True,
     ) -> str:
         """Check all nodes in the selected tree for syntax and tab errors."""
         c = self
@@ -2827,7 +2832,7 @@ class Commands:
     # @+node:ekr.20040723094220.3: *4* c.checkPythonCode
     def checkPythonCode(
         self,
-        event: LeoKeyEvent | None = None,
+        event: Any = None,  # not used.
         ignoreAtIgnore: bool = True,
         checkOnSave: bool = False,
     ) -> str:
@@ -3293,7 +3298,11 @@ class Commands:
         return return_value
 
     # @+node:ekr.20200522075411.1: *4* c.doCommandByName
-    def doCommandByName(self, command_name: str, event: LeoKeyEvent | None = None) -> Value:
+    def doCommandByName(
+        self,
+        command_name: str,
+        event: LeoKeyEvent | None = None,  # This is used.
+    ) -> Value:
         """
         Execute one command, given the name of the command.
 
@@ -3983,7 +3992,10 @@ class Commands:
         c2.close()
 
     # @+node:ekr.20031218072017.2925: *4* c.markAllAtFileNodesDirty
-    def markAllAtFileNodesDirty(self, event: LeoKeyEvent | None = None) -> None:
+    def markAllAtFileNodesDirty(
+        self,
+        event: Any = None,  # not used.
+    ) -> None:
         """Mark all @file nodes as changed."""
         c = self
         c.endEditing()
@@ -3997,7 +4009,10 @@ class Commands:
                 p.moveToThreadNext()
 
     # @+node:ekr.20031218072017.2926: *4* c.markAtFileNodesDirty
-    def markAtFileNodesDirty(self, event: LeoKeyEvent | None = None) -> None:
+    def markAtFileNodesDirty(
+        self,
+        event: Any = None,  # not used.
+    ) -> None:
         """Mark all @file nodes in the selected tree as changed."""
         c = self
         p = c.p
@@ -4072,7 +4087,11 @@ class Commands:
         return result
 
     # @+node:ekr.20031218072017.2081: *4* c.openRecentFile
-    def openRecentFile(self, event: LeoKeyEvent | None = None, fn: str = '') -> None:
+    def openRecentFile(
+        self,
+        event: Any = None,  # not used.
+        fn: str = '',
+    ) -> None:
         """
         c.openRecentFile: This is not a command!
 
@@ -4090,7 +4109,7 @@ class Commands:
     # @+node:ekr.20031218072017.2823: *4* c.openWith
     def openWith(
         self,
-        event: LeoKeyEvent | None = None,
+        event: Any = None,  # not used.
         d: dict[str, Any] | None = None,
     ) -> None:
         """
@@ -4609,7 +4628,10 @@ class Commands:
 
     # @+node:ekr.20031218072017.2909: *4* c.Expand/contract
     # @+node:ekr.20171124091426.1: *5* c.contractAllHeadlines
-    def contractAllHeadlines(self, event: LeoKeyEvent | None = None) -> None:
+    def contractAllHeadlines(
+        self,
+        event: Any = None,  # not used.
+    ) -> None:
         """Contract all nodes in the outline."""
         c = self
         for v in c.all_nodes():

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1274,7 +1274,7 @@ class Commands:
     def executeScript(
         self,
         *,
-        event: LeoKeyEvent | None = None,
+        event: LeoKeyEvent | None = None,  # not used.
         args: Args | None = None,
         p: Position | None = None,
         script: str = '',

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1370,7 +1370,7 @@ class Commands:
                 sys.path.insert(0, g.os_path_dirname(c.fileName()))  # per SegundoBob
                 script += '\n'  # Make sure we end the script properly.
                 try:
-                    if not namespace or namespace.get('script_gnx') is None:
+                    if not namespace or not namespace.get('script_gnx'):
                         namespace = namespace or {}
                         namespace.update(script_gnx=script_p.gnx)
                     # We *always* execute the script with p = c.p.

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1087,6 +1087,7 @@ class ActiveSettingsOutline:
         #
         # Create all the inner settings outlines.
         for kind, commander in self.commanders:
+            assert commander
             p = root.insertAfter()
             p.h = g.shortFileName(commander.fileName())
             p.b = '@language rest\n@wrap\n'
@@ -1216,6 +1217,7 @@ class ActiveSettingsOutline:
             print(pad, p.h)
         p_level = p.level()
         if p_level > self.level + 1:
+            assert p.v
             g.trace('OOPS', p.v.context.shortFileName(), self.level, p_level, p.h)
             return
         while p_level < self.level + 1 and len(self.parents) > 1:
@@ -1466,10 +1468,10 @@ class GlobalConfigManager:
     # @+node:ekr.20041122070339: *4* gcm.getColor
     def getColor(self, setting: str) -> str:
         """Return the value of @color setting."""
-        col = self.get(setting, "color")
-        while col and col.startswith('@'):
-            col = self.get(col[1:], "color")
-        return col
+        color = self.get(setting, 'color') or ''
+        while color and color.startswith('@'):
+            color = self.get(color[1:], "color")
+        return color
 
     # @+node:ekr.20080312071248.7: *4* gcm.getCommonCommands
     def getCommonAtCommands(self) -> list[tuple[Position, str]]:
@@ -1497,13 +1499,15 @@ class GlobalConfigManager:
         return self.get(setting, "outlinedata")
 
     # @+node:ekr.20041117093009.1: *4* gcm.getDirectory
-    def getDirectory(self, setting: str) -> str | None:
-        """Return the value of @directory setting, or None if the directory does not exist."""
+    def getDirectory(self, setting: str) -> str:
+        """
+        Return the value of @directory setting, or the empty string if the directory does not exist.
+        """
         # Fix https://bugs.launchpad.net/leo-editor/+bug/1173763
         theDir = self.get(setting, 'directory')
         if g.os_path_exists(theDir) and g.os_path_isdir(theDir):
             return theDir
-        return None
+        return ''
 
     # @+node:ekr.20070224075914.1: *4* gcm.getEnabledPlugins
     def getEnabledPlugins(self) -> str:
@@ -1889,7 +1893,7 @@ class LocalConfigManager:
         theDir = self.get(setting, 'directory')
         if g.os_path_exists(theDir) and g.os_path_isdir(theDir):
             return theDir
-        return None
+        return ''
 
     # @+node:ekr.20120215072959.12530: *5* c.config.getFloat
     def getFloat(self, setting: str) -> float:

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -9,6 +9,7 @@ import os
 import sys
 import re
 import textwrap
+import typing
 from typing import Any, Callable, Generator, TYPE_CHECKING
 from leo.plugins.mod_scripting import build_rclick_tree
 from leo.core import leoGlobals as g
@@ -1504,7 +1505,7 @@ class GlobalConfigManager:
         Return the value of @directory setting, or the empty string if the directory does not exist.
         """
         # Fix https://bugs.launchpad.net/leo-editor/+bug/1173763
-        theDir = self.get(setting, 'directory')
+        theDir = self.get(setting, 'directory') or ''
         if g.os_path_exists(theDir) and g.os_path_isdir(theDir):
             return theDir
         return ''
@@ -1519,12 +1520,12 @@ class GlobalConfigManager:
         """Return the value of @float setting."""
         val = self.get(setting, "float")
         try:
-            val = float(val)
-            return val
+            return float(val)  # type:ignore
         except TypeError:
             return None
 
     # @+node:ekr.20041117062717.13: *4* gcm.getFontFromParams
+    @typing.no_type_check
     def getFontFromParams(
         self,
         family: str,
@@ -1559,8 +1560,7 @@ class GlobalConfigManager:
         """Return the value of @int setting."""
         val = self.get(setting, "int")
         try:
-            val = int(val)
-            return val
+            return int(val)  # type:ignore
         except TypeError:
             return None
 
@@ -1580,8 +1580,7 @@ class GlobalConfigManager:
     # @+node:ekr.20070411101643: *4* gcm.getOpenWith
     def getOpenWith(self) -> list[dict[str, Any]]:
         """Return a list of dictionaries corresponding to @openwith nodes."""
-        val = self.get('openwithtable', 'openwithtable')
-        return val
+        return self.get('openwithtable', 'openwithtable') or []  # PR #4779
 
     # @+node:ekr.20041122070752: *4* gcm.getRatio
     def getRatio(self, setting: str) -> float | None:
@@ -1590,9 +1589,9 @@ class GlobalConfigManager:
         """
         val = self.get(setting, "ratio")
         try:
-            val = float(val)
-            if 0.0 <= val <= 1.0:
-                return val
+            val_f = float(val)  # type:ignore
+            if 0.0 <= val_f <= 1.0:
+                return val_f
         except TypeError:
             pass
         return None
@@ -1976,8 +1975,7 @@ class LocalConfigManager:
     # @+node:ekr.20120215072959.12535: *5* c.config.getOpenWith
     def getOpenWith(self) -> list[dict[str, Any]]:
         """Return a list of dictionaries corresponding to @openwith nodes."""
-        val = self.get('openwithtable', 'openwithtable')
-        return val
+        return self.get('openwithtable', 'openwithtable') or []  # PR #4779
 
     # @+node:ekr.20120215072959.12536: *5* c.config.getRatio
     def getRatio(self, setting: str) -> float | None:

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -163,6 +163,7 @@ class ParserBaseClass:
         seen: list[VNode] = []
         after = p.nodeAfterTree()
         while p and p != after:
+            assert p.v
             if p.v in seen:
                 p.moveToNodeAfterTree()
             elif p.isAtIgnoreNode():
@@ -592,7 +593,7 @@ class ParserBaseClass:
         for line in lines:
             line = line.strip()
             if line and not g.match(line, 0, '#'):
-                name, bi = self.parseShortcutLine('*mode-setting*', line)
+                name, bi = self.parseShortcutLine('*mode-setting*', line)  # type:ignore
                 if not name:
                     # An entry command: put it in the special *entry-commands* key.
                     d.add_to_list('*entry-commands*', bi)
@@ -698,11 +699,11 @@ class ParserBaseClass:
                     print(f"\nWarning: bad shortcut specifier: {line!r}\n")
                 else:
                     if bi and bi.stroke not in (None, 'none', 'None'):
-                        self.doOneShortcut(bi, commandName, p)
+                        self.doOneShortcut(bi, commandName or '', p)
                     else:
                         # New in Leo 5.7: Add local assignments to None to c.k.killedBindings.
                         if c.config.isLocalSettingsFile():
-                            c.k.killedBindings.append(commandName)
+                            c.k.killedBindings.append(commandName or '')
 
     # @+node:ekr.20111020144401.9585: *5* pbc.doOneShortcut
     def doOneShortcut(self, bi: g.BindingInfo, commandName: str, p: Position) -> None:
@@ -754,7 +755,7 @@ class ParserBaseClass:
         lines = g.splitLines(s)
         for line in lines:
             self.parseFontLine(line, d)
-        comments = d.get('comments')
+        comments = d.get('comments', '')
         d['comments'] = '\n'.join(comments)
         return d
 
@@ -769,7 +770,7 @@ class ParserBaseClass:
             pass
         if g.match(s, 0, '#'):
             s = s[1:].strip()
-            comments = d.get('comments')
+            comments = d.get('comments', '')
             comments.append(s)
             d['comments'] = comments
             return
@@ -794,7 +795,7 @@ class ParserBaseClass:
         Return (kind,name,val).
         Leo 4.11.1: Ignore everything after @data name.
         """
-        kind = name = val = None
+        kind = name = val = ''
         if g.match(s, 0, '@'):
             i = g.skip_id(s, 1, chars='-')
             i = g.skip_ws(s, i)

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -463,7 +463,7 @@ class ParserBaseClass:
             g.es_print("ERROR: @menuat found but no menu tree to patch")
 
     # @+node:tbrown.20080514180046.9: *5* pbc.getName
-    def getName(self, val: str, val2: str = None) -> str:
+    def getName(self, val: str, val2: str = '') -> str:
         if val2 and val2.strip():
             val = val2
         val = val.split('\n', 1)[0]
@@ -678,7 +678,12 @@ class ParserBaseClass:
 
     # @+node:ekr.20041120105609: *4* pbc.doShortcuts
     def doShortcuts(
-        self, p: Position, kind: str, junk_name: str, junk_val: Any, s: str = None
+        self,
+        p: Position,
+        kind: str,
+        junk_name: str,
+        junk_val: Any,
+        s: str = None,  # Don't change this.
     ) -> None:
         """Handle an @shortcut or @shortcuts node."""
         c, d = self.c, self.shortcutsDict
@@ -1194,7 +1199,11 @@ class ActiveSettingsOutline:
                 self.add(p)
 
     # @+node:ekr.20190905091614.12: *3* aso.add
-    def add(self, p: Position, h: str = None) -> None:
+    def add(
+        self,
+        p: Position,
+        h: str = None,  # Don't change this.
+    ) -> None:
         """
         Add a node for p.
 
@@ -1287,7 +1296,7 @@ class GlobalConfigManager:
         self.buttonsFileName = ''
         self.configsExist = False  # True when we successfully open a setting file.
         self.default_derived_file_encoding = 'utf-8'
-        self.enabledPluginsFileName: str = None
+        self.enabledPluginsFileName: str = ''
         self.enabledPluginsString: str = ''
         self.menusList: list[Any] = []
         self.menusFileName = ''

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -598,7 +598,7 @@ class ParserBaseClass:
                 if not name:
                     # An entry command: put it in the special *entry-commands* key.
                     d.add_to_list('*entry-commands*', bi)
-                elif bi is not None:
+                elif bi:  # PR #4779
                     # A regular shortcut.
                     bi.pane = modeName
                     aList: list[g.BindingInfo] = d.get(name, [])
@@ -680,23 +680,18 @@ class ParserBaseClass:
 
     # @+node:ekr.20041120105609: *4* pbc.doShortcuts
     def doShortcuts(
-        self,
-        p: Position,
-        kind: str,
-        junk_name: str,
-        junk_val: Any,
-        s: str | None = None,  # Don't change this.
+        self, p: Position, kind: str, junk_name: str, junk_val: Any, s: str = ''
     ) -> None:
         """Handle an @shortcut or @shortcuts node."""
         c, d = self.c, self.shortcutsDict
-        if s is None:
+        if not s:
             s = p.b
         fn = d.name()
         for line in g.splitLines(s):
             line = line.strip()
             if line and not g.match(line, 0, '#'):
                 commandName, bi = self.parseShortcutLine(fn, line)
-                if bi is None:  # Fix #718.
+                if not bi:  # Fix #718. # PR #4779
                     print(f"\nWarning: bad shortcut specifier: {line!r}\n")
                 else:
                     if bi and bi.stroke not in (None, 'none', 'None'):

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -683,7 +683,7 @@ class ParserBaseClass:
         kind: str,
         junk_name: str,
         junk_val: Any,
-        s: str = None,  # Don't change this.
+        s: str | None = None,  # Don't change this.
     ) -> None:
         """Handle an @shortcut or @shortcuts node."""
         c, d = self.c, self.shortcutsDict
@@ -1202,7 +1202,7 @@ class ActiveSettingsOutline:
     def add(
         self,
         p: Position,
-        h: str = None,  # Don't change this.
+        h: str | None = None,  # Don't change this.
     ) -> None:
         """
         Add a node for p.
@@ -1450,7 +1450,7 @@ class GlobalConfigManager:
         return d or {}
 
     # @+node:ekr.20041117081009.3: *4* gcm.getBool
-    def getBool(self, setting: str, default: bool = None) -> bool:
+    def getBool(self, setting: str, default: bool = False) -> bool:
         """Return the value of @bool setting, or the default if the setting is not found."""
         val = self.get(setting, "bool")
         if val in (True, False):
@@ -1818,7 +1818,7 @@ class LocalConfigManager:
         return d or {}
 
     # @+node:ekr.20120215072959.12523: *5* c.config.getBool
-    def getBool(self, setting: str, default: bool = None) -> bool:
+    def getBool(self, setting: str, default: bool = False) -> bool:
         """Return the value of @bool setting, or the default if the setting is not found."""
         val = self.get(setting, "bool")
         if val in (True, False):

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -976,7 +976,7 @@ class ParserBaseClass:
         self.error(f"{val} is not a valid {kind} for {name}")
 
     # @+node:ekr.20041119204700.3: *3* pbc.visitNode (must be overwritten in subclasses)
-    def visitNode(self, p: Position) -> str:
+    def visitNode(self, p: Position) -> str | None:
         raise NotImplementedError
 
     # @-others
@@ -1604,7 +1604,7 @@ class GlobalConfigManager:
     # @+node:ekr.20041117081009.4: *4* gcm.getString
     def getString(self, setting: str) -> str:
         """Return the value of @string setting."""
-        return self.get(setting, "string")
+        return self.get(setting, "string") or ''
 
     # @+node:ekr.20171115062202.1: *3* gcm.valueInMyLeoSettings
     def valueInMyLeoSettings(self, settingName: str) -> Any | None:
@@ -1694,7 +1694,7 @@ class LocalConfigManager:
     # @+node:ekr.20041123092357: *4* c.config.findSettingsPosition & helper
     # This was not used prior to Leo 4.5.
 
-    def findSettingsPosition(self, setting: Any) -> Position:
+    def findSettingsPosition(self, setting: Any) -> Position | None:
         """Return the position for the setting in the @settings tree for c."""
         munge = g.app.config.munge
         root = self.settingsRoot()
@@ -1709,7 +1709,7 @@ class LocalConfigManager:
         return None
 
     # @+node:ekr.20041120074536: *5* c.config.settingsRoot
-    def settingsRoot(self) -> Position:
+    def settingsRoot(self) -> Position | None:
         """Return the position of the @settings tree."""
         c = self.c
         for p in c.all_unique_positions():
@@ -1895,12 +1895,11 @@ class LocalConfigManager:
         return ''
 
     # @+node:ekr.20120215072959.12530: *5* c.config.getFloat
-    def getFloat(self, setting: str) -> float:
+    def getFloat(self, setting: str) -> float | None:
         """Return the value of @float setting."""
         val = self.get(setting, "float")
         try:
-            val = float(val)
-            return val
+            return float(val)  # type:ignore
         except TypeError:
             return None
 
@@ -1936,12 +1935,11 @@ class LocalConfigManager:
         return g.app.gui.getFontFromParams(family, size, slant, weight)
 
     # @+node:ekr.20120215072959.12532: *5* c.config.getInt
-    def getInt(self, setting: str) -> int:
+    def getInt(self, setting: str) -> int | None:
         """Return the value of @int setting."""
         val = self.get(setting, "int")
         try:
-            val = int(val)
-            return val
+            return int(val)  # type:ignore
         except TypeError:
             return None
 
@@ -1967,7 +1965,7 @@ class LocalConfigManager:
         if self.c.menulist_pass == 2:
             lm = g.app.loadManager
             lm.globalSettingsDict['menus'] = None
-            self.set(None, 'menus', 'menus', None)
+            self.set(None, 'menus', 'menus', None)  # type:ignore
             self.c.menulist_pass = 0
 
         return aList or g.app.config.menusList
@@ -2008,7 +2006,7 @@ class LocalConfigManager:
         return None
 
     # @+node:ekr.20120215072959.12539: *5* c.config.getShortcut
-    def getShortcut(self, commandName: str) -> tuple[str, list]:
+    def getShortcut(self, commandName: str) -> tuple[str | None, list]:
         """Return rawKey,accel for shortcutName"""
         c = self.c
         d = self.shortcutsDict
@@ -2314,11 +2312,11 @@ class SettingsTreeParser(ParserBaseClass):
 
 # @+node:ekr.20171229131953.1: ** parseFont (leoConfig.py)
 def parseFont(b: str) -> tuple[str, str, bool, bool, float]:
-    family = None
-    weight = None
-    slant = None
-    size = None
-    settings_name = None
+    family = ''
+    weight = ''
+    slant = ''
+    size = 0.0
+    settings_name = ''
     for line in g.splitLines(b):
         line = line.strip()
         if line.startswith('#'):

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3736,7 +3736,7 @@ def openWithFileName(
     fileName: str,
     old_c: Cmdr | None = None,
     gui: LeoGui | None = None,
-) -> Cmdr | None:
+) -> Cmdr:
     """
     Load any kind of file in the appropriate way:
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2811,7 +2811,9 @@ def clearStats() -> None:
 
 # @+node:ekr.20031218072017.3135: *4* g.printStats
 @command('show-stats')
-def printStats(event: LeoKeyEvent | None = None) -> None:
+def printStats(
+    event: Any = None,  # not used.
+) -> None:
     """
     Print all stats created by g.stat(), counts first.
     """
@@ -6855,7 +6857,9 @@ def CheckVersionToInt(s: str) -> int:
 
 # @+node:ekr.20111103205308.9657: *3* g.cls
 @command('cls')
-def cls(event: LeoKeyEvent | None = None) -> None:
+def cls(
+    event: Any = None,  # not used.
+) -> None:
     """Clear the screen."""
     if g.isWindows:
         # Leo 6.7.5: Two calls seem to be required!

--- a/leo/core/leoSessions.py
+++ b/leo/core/leoSessions.py
@@ -61,7 +61,7 @@ class SessionManager:
         return None
 
     # @+node:ekr.20120420054855.14247: *3* SessionManager.load_session
-    def load_session(self, c: Cmdr = None, unls: list[str] = None) -> None:
+    def load_session(self, c: Cmdr | None = None, unls: list[str] = None) -> None:
         """
         Open a tab for each item in UNLs & select the indicated node in each.
 

--- a/leo/core/leoSessions.py
+++ b/leo/core/leoSessions.py
@@ -61,7 +61,7 @@ class SessionManager:
         return None
 
     # @+node:ekr.20120420054855.14247: *3* SessionManager.load_session
-    def load_session(self, c: Cmdr | None = None, unls: list[str] = None) -> None:
+    def load_session(self, c: Cmdr | None = None, unls: list[str] | None = None) -> None:
         """
         Open a tab for each item in UNLs & select the indicated node in each.
 

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -4792,6 +4792,80 @@ def editLabel(
 def headline_wrapper(self, p: Position) -> Widget:
     raise NotImplementedError
 
+# @+node:ekr.20260707105715.1: *3* @@@button clone-callers (abandoned)
+g.cls()
+
+import re
+
+h = '--- signatures return str'
+p = g.findNodeAnywhere(c, h)
+u = c.undoer
+assert p, h
+
+@others  # Define helpers
+
+# Make root node
+undoData = u.beforeInsertNode(c.p)  # c.p is subject of 'insertAfter'
+root = c.lastTopLevel().insertAfter()
+root.h = 'Callers'
+# Discover all names.
+names = set()
+for p in p.children():
+    if p.h.startswith('class '):
+        continue
+    s = g.splitLines(p.b)[0]
+    if m := re.match(r'^def ([_\w]+)', s):
+        names.add(m.group(1))
+        # find_clones(c, m.group(1))
+    else:
+        print(f"Skip: {p.h}")
+# Do cff for all names:
+for name in sorted(names):
+    find_clones(c, name)
+    
+# Finish
+c.selectPosition(root)
+c.demote()
+u.afterInsertNode(root, 'clone-callers', undoData)
+c.redraw(root)
+# @+node:ekr.20260707111229.1: *4* function: find_clones
+def find_clones(c, name):
+    """
+    do clone-find-all for name(...)
+    """
+    finder = c.findCommands
+    # find_text = rf'\.{name}\(.*?\)'
+    find_text = f"[ .]{name}\(.*?\)"
+    print(f"cff: {name}")
+    settings = g.Bunch(
+        # State...
+        in_headline     = False,
+        reverse         = False,
+        # Find/change strings...
+        find_text       = find_text,
+        change_text     = '',
+        # Find options...
+        file_only       = False,
+        ignore_case     = False,
+        mark_changes    = False,
+        mark_finds      = False,
+        node_only       = False,
+        pattern_match   = True,
+        search_body     = True,
+        search_headline = False,
+        suboutline_only = False,
+        whole_word      = False
+    )  # fmt: skip
+    finder.do_clone_find_all_flattened(settings)
+    # for p in c.all_unique_positions():
+    #     for s in g.splitLines(p.b):
+    #         if m := re.match(rf'^.*?\b{name}\(', s):
+    #             if s.strip().startswith('def'):
+    #                 continue
+    #             else:
+    #                 where_s = f"{g.truncate(p.h, 30):>40} {name:>30}"
+    #                 print(f"{where_s:<70} {g.truncate(s.strip(), 80)}")
+    #                 break
 # @-all
 # @@nosearch
 # @-leo

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -32,6 +32,7 @@ if 1:  # Test all files.
 else:
     files = [
         # Files to check with strict_optional in .mypy.ini.
+        'leo/core/leoApp.py',
         'leo/core/leoGlobals.py',
         'leo/core/leoCommands.py',
         'leo/core/leoNodes.py',

--- a/leo/unittests/core/test_leoCommands.py
+++ b/leo/unittests/core/test_leoCommands.py
@@ -317,7 +317,7 @@ class TestCommands(LeoUnitTest):
         table = (
             ('@nowrap\n', False),
             ('@wrap\n', True),
-            (p.b, None),
+            (p.b, False),
         )
         for s, expected_val in table:
             p.b = s


### PR DESCRIPTION
See #4766.

This PR annotates the modules corresponding to g.app and g.app.config.

### Phase 1: Annotate leoApp.py

The acid test: does Leo crash during startup?

- [x] Change .mypy.ini to require strict_optional in leoApp.py, in addition to all previously strict modules.
- [x] Fix all mypy complaints, including follow-on complaints.
- [x] Annotate all ivars of the LeoApp class as well as possible.
    Some compromises were necessary. Better annotations would create circular imports.
- [x] Annotate all functional event args as `event: LeoKeyEvent`. They are not optional.
- [x] Annotate all unused event args as `event: Any = None  # Unused`.

### Phase 2: Annotate leoConfig.py

The acid test: does Leo honor its settings?

- [x] Change .mypy.ini to require strict_optional in leoConfig.py, in addition to all previously strict modules.
- [x] Fix all mypy complaints, including follow-on complaints.

### Phase 3: Generalize Leo's *code* while restricting the *annotations*

See the motivating example in #4780 for details and a discussion of why limiting the *annotations* of strings does not break existing code.

- [x] Rev 759b118: Using the new clone-diff-pr command, in the files this PR changes, do a regex search for:
```python
if x is None:
if x is not None:
```
   replacing them with the more general (and more pythonic) code:
```python
if not x:
if x:
```
Notice that rev 759b118 contains other self-explanatory changes.
    
### Bug fixes

- [x] LM.openWithFileName and g.openWithFileName now *always* return a commander. Hurray!
- [x] Fix the save-buffers-kill-leo command.

### Extras

- [x] Tweak the new clone-diff-pr command in leoEditFileCommands.py.