### PR TITLE
PR: Use full optional syntax for vars and kwargs

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -9,15 +9,15 @@ from collections.abc import Callable
 import functools
 import re
 import string
-from typing import TYPE_CHECKING
+from typing import cast, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoNodes
 from leo.commands.baseCommands import BaseEditCommandsClass
+from leo.plugins.qt_text import QTextMixin
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
-    from leo.plugins.qt_text import QTextMixin
 
 # @-<< abbrevCommands imports & abbreviations >>
 
@@ -68,7 +68,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
         self.expanding = False  # True: expanding abbreviations.
         self.subst_env: list[str] = []  # The scripting environment.
         self.tree_abbrevs_d: dict[str, str] = {}  # Keys are names, values are (tree,tag).
-        self.w: QTextMixin = None
+        self.w = cast(QTextMixin, None)
 
     # @+node:ekr.20150514043850.11: *3* abbrev.expandAbbrev & helpers (entry point)
     def expandAbbrev(self, event: LeoKeyEvent, stroke: g.KeyStroke) -> bool:
@@ -615,7 +615,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514043850.20: *4* abbrev.dynamicCompletion C-M-/
     @cmd('dabbrev-completion')
-    def dynamicCompletion(self, event: LeoKeyEvent = None) -> None:
+    def dynamicCompletion(self, event: LeoKeyEvent | None = None) -> None:
         """
         dabbrev-completion
         Insert the common prefix of all dynamic abbrev's matching the present word.
@@ -650,7 +650,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514043850.21: *4* abbrev.dynamicExpansion M-/ & helper
     @cmd('dabbrev-expands')
-    def dynamicExpansion(self, event: LeoKeyEvent = None) -> None:
+    def dynamicExpansion(self, event: LeoKeyEvent | None = None) -> None:
         """
         dabbrev-expands (M-/ in Emacs).
 
@@ -682,9 +682,9 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
     def dynamicExpandHelper(
         self,
         event: LeoKeyEvent,
-        prefix: str = None,
+        prefix: str | None = None,
         aList: list[str] = None,
-        w: QTextMixin = None,
+        w: QTextMixin | None = None,
     ) -> None:
         """State handler for dabbrev-expands command."""
         c, k = self.c, self.c.k
@@ -731,7 +731,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514043850.29: *4* abbrev.listAbbrevs
     @cmd('abbrev-list')
-    def listAbbrevs(self, event: LeoKeyEvent = None) -> None:
+    def listAbbrevs(self, event: LeoKeyEvent | None = None) -> None:
         """List all abbreviations."""
         d = self.abbrevs
         if not d:
@@ -745,7 +745,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514043850.32: *4* abbrev.toggleAbbrevMode
     @cmd('toggle-abbrev-mode')
-    def toggleAbbrevMode(self, event: LeoKeyEvent = None) -> None:
+    def toggleAbbrevMode(self, event: LeoKeyEvent | None = None) -> None:
         """Toggle abbreviation mode."""
         k = self.c.k
         k.abbrevOn = not k.abbrevOn

--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -52,7 +52,12 @@ class BaseEditCommandsClass:
         return w
 
     # @+node:ekr.20150514043714.6: *3* BaseEdit.endCommand
-    def endCommand(self, label: str = None, changed: bool = True, setLabel: bool = True) -> None:
+    def endCommand(
+        self,
+        label: str | None = None,
+        changed: bool = True,
+        setLabel: bool = True,
+    ) -> None:
         """
         Do the common processing at the end of each command.
         Handles undo only if we are in the body pane.

--- a/leo/commands/bufferCommands.py
+++ b/leo/commands/bufferCommands.py
@@ -6,15 +6,15 @@
 # @+node:ekr.20150514045750.1: ** << bufferCommands imports & annotations >>
 from __future__ import annotations
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import cast, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
+from leo.plugins.qt_text import QTextMixin
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position, VNode
-    from leo.plugins.qt_text import QTextMixin
 # @-<< bufferCommands imports & annotations >>
 
 
@@ -42,7 +42,7 @@ class BufferCommandsClass(BaseEditCommandsClass):
         self.nameList: list[str] = []  # [n: <headline>]
         self.names: dict[str, list[str]] = {}
         self.vnodes: dict[str, VNode] = {}  # Keys are n: <headline>, values are vnodes.
-        self.w: QTextMixin = None
+        self.w = cast(QTextMixin, None)
 
     # @+node:ekr.20150514045829.5: *3* buffer.Entry points
     # @+node:ekr.20150514045829.6: *4* appendToBuffer

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -324,7 +324,7 @@ def pyflakes_command(event: LeoKeyEvent) -> None:
 
 
 # @+node:ekr.20150514125218.7: *3* pylint command
-last_pylint_path: str = None
+last_pylint_path: str | None = None
 
 
 @g.command('pylint')
@@ -636,11 +636,16 @@ class PylintCommand:
 
     def __init__(self, c: Cmdr) -> None:
         self.c = c
-        self.rc_fn: str = None  # Name of the rc file.
+        self.rc_fn: str | None = None  # Name of the rc file.
 
     # @+others
     # @+node:ekr.20150514125218.11: *3* 1. pylint.run
-    def run(self, root: Position, *, last_path: str = None) -> tuple[str, Position] | None:
+    def run(
+        self,
+        root: Position,
+        *,
+        last_path: str | None = None,
+    ) -> tuple[str, Position] | None:
         """Run Pylint on all Python @<file> nodes in root's tree."""
         c = self.c
         if not lint:

--- a/leo/commands/commanderEditCommands.py
+++ b/leo/commands/commanderEditCommands.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # @+others
 # @+node:ekr.20171123135625.34: ** c_ec.addComments
 @g.commander_command('add-comments')
-def addComments(self: Self, event: LeoKeyEvent = None) -> None:
+def addComments(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Undoably add comments to the selected text."""
     c, p, u, w = self, self.p, self.undoer, self.frame.body.wrapper
     # "Before" snapshot.
@@ -45,7 +45,7 @@ def addComments(self: Self, event: LeoKeyEvent = None) -> None:
         openDelim, closeDelim = d2 + ' ', ' ' + d3
     # Calculate the result.
     result = []
-    i: int = None
+    i: int | None = None
     for line in lines:
         if line.strip():
             if i is None:
@@ -69,7 +69,7 @@ def addComments(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.16: ** c_ec.convertAllBlanks
 @g.commander_command('convert-all-blanks')
-def convertAllBlanks(self: Self, event: LeoKeyEvent = None) -> None:
+def convertAllBlanks(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Convert all blanks to tabs in the selected outline."""
     c, u = self, self.undoer
     undoType = 'Convert All Blanks'
@@ -110,7 +110,7 @@ def convertAllBlanks(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.17: ** c_ec.convertAllTabs
 @g.commander_command('convert-all-tabs')
-def convertAllTabs(self: Self, event: LeoKeyEvent = None) -> None:
+def convertAllTabs(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Convert all tabs to blanks in the selected outline."""
     c = self
     u = c.undoer
@@ -151,7 +151,7 @@ def convertAllTabs(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.18: ** c_ec.convertBlanks
 @g.commander_command('convert-blanks')
-def convertBlanks(self: Self, event: LeoKeyEvent = None) -> bool:
+def convertBlanks(self: Self, event: LeoKeyEvent | None = None) -> bool:
     """
     Convert *all* blanks to tabs in the selected node.
     Return True if the the p.b was changed.
@@ -186,7 +186,7 @@ def convertBlanks(self: Self, event: LeoKeyEvent = None) -> bool:
 
 # @+node:ekr.20171123135625.19: ** c_ec.convertTabs
 @g.commander_command('convert-tabs')
-def convertTabs(self: Self, event: LeoKeyEvent = None) -> bool:
+def convertTabs(self: Self, event: LeoKeyEvent | None = None) -> bool:
     """Convert all tabs to blanks in the selected node."""
     c, p, u, w = self, self.p, self.undoer, self.frame.body.wrapper
     #
@@ -227,7 +227,7 @@ def convertTabs(self: Self, event: LeoKeyEvent = None) -> bool:
 
 # @+node:ekr.20171123135625.21: ** c_ec.dedentBody (unindent-region)
 @g.commander_command('unindent-region')
-def dedentBody(self: Self, event: LeoKeyEvent = None) -> None:
+def dedentBody(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Remove one tab's worth of indentation from all presently selected lines."""
     c, p, u, w = self, self.p, self.undoer, self.frame.body.wrapper
     #
@@ -273,7 +273,7 @@ def dedentBody(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.36: ** c_ec.deleteComments
 @g.commander_command('delete-comments')
-def deleteComments(self: Self, event: LeoKeyEvent = None) -> None:
+def deleteComments(self: Self, event: LeoKeyEvent | None = None) -> None:
     # @+<< deleteComments docstring >>
     # @+node:ekr.20171123135625.37: *3* << deleteComments docstring >>
     # @@pagewidth 50
@@ -358,7 +358,7 @@ def deleteComments(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.54: ** c_ec.editHeadline (edit-headline)
 @g.commander_command('edit-headline')
-def editHeadline(self: Self, event: LeoKeyEvent = None) -> None:
+def editHeadline(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Begin editing the headline of the selected node.
     """
@@ -376,7 +376,7 @@ def editHeadline(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.23: ** c_ec.extract
 @g.commander_command('extract')
-def extract(self: Self, event: LeoKeyEvent = None) -> None:
+def extract(self: Self, event: LeoKeyEvent | None = None) -> None:
     # @+<< docstring for extract command >>
     # @+node:ekr.20201113130021.1: *3* << docstring for extract command >>
     r"""
@@ -542,7 +542,7 @@ def extractRef(c: Cmdr, s: str) -> str:
 
 # @+node:ekr.20171123135625.27: ** c_ec.extractSectionNames
 @g.commander_command('extract-names')
-def extractSectionNames(self: Self, event: LeoKeyEvent = None) -> None:
+def extractSectionNames(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Create child nodes for every section reference in the selected text.
     - The headline of each new child node is the section reference.
@@ -600,7 +600,7 @@ def findSectionName(self: Self, s: str) -> str | None:
 # @+node:ekr.20171123135625.15: ** c_ec.findMatchingBracket
 @g.commander_command('match-brackets')
 @g.commander_command('select-to-matching-bracket')
-def findMatchingBracket(self: Self, event: LeoKeyEvent = None) -> None:
+def findMatchingBracket(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Select the text between matching brackets."""
     c, p = self, self.p
     if g.app.batchMode:
@@ -616,7 +616,7 @@ def findMatchingBracket(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.30: ** c_ec.alwaysIndentBody (always-indent-region)
 @g.commander_command('always-indent-region')
-def alwaysIndentBody(self: Self, event: LeoKeyEvent = None) -> None:
+def alwaysIndentBody(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     The always-indent-region command indents each line of the selected body
     text. The @tabwidth directive in effect determines amount of
@@ -679,7 +679,7 @@ def alwaysIndentBody(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20210104123442.1: ** c_ec.indentBody (indent-region)
 @g.commander_command('indent-region')
-def indentBody(self: Self, event: LeoKeyEvent = None) -> None:
+def indentBody(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     The indent-region command indents each line of the selected body text.
     Unlike the always-indent-region command, this command inserts a tab
@@ -705,7 +705,7 @@ def indentBody(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.38: ** c_ec.insertBodyTime
 @g.commander_command('insert-body-time')
-def insertBodyTime(self: Self, event: LeoKeyEvent = None) -> None:
+def insertBodyTime(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Insert a time/date stamp at the cursor."""
     c, p, u = self, self.p, self.undoer
     w = c.frame.body.wrapper
@@ -724,7 +724,7 @@ def insertBodyTime(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.52: ** c_ec.justify-toggle-auto
 @g.commander_command("justify-toggle-auto")
-def justify_toggle_auto(self: Self, event: LeoKeyEvent = None) -> None:
+def justify_toggle_auto(self: Self, event: LeoKeyEvent | None = None) -> None:
     c = self
     if c.editCommands.autojustify == 0:
         c.editCommands.autojustify = abs(c.config.getInt("autojustify") or 0)
@@ -739,7 +739,7 @@ def justify_toggle_auto(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20190210095609.1: ** c_ec.line_to_headline
 @g.commander_command('line-to-headline')
-def line_to_headline(self: Self, event: LeoKeyEvent = None) -> None:
+def line_to_headline(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Create child node from the selected line.
 
@@ -780,7 +780,7 @@ def line_to_headline(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.11: ** c_ec.preferences
 @g.commander_command('settings')
-def preferences(self: Self, event: LeoKeyEvent = None) -> None:
+def preferences(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Handle the preferences command."""
     c = self
     c.openLeoSettings()
@@ -788,7 +788,7 @@ def preferences(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.40: ** c_ec.reformatBody
 @g.commander_command('reformat-body')
-def reformatBody(self: Self, event: LeoKeyEvent = None) -> None:
+def reformatBody(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Reformat all paragraphs in the body."""
     c, p = self, self.p
     undoType = 'reformat-body'
@@ -810,7 +810,7 @@ def reformatBody(self: Self, event: LeoKeyEvent = None) -> None:
 @g.commander_command('reformat-paragraph')
 def reformatParagraph(
     self: Self,
-    event: LeoKeyEvent = None,
+    event: LeoKeyEvent | None = None,
     undoType: str = 'Reformat Paragraph',
 ) -> None:
     """
@@ -1055,7 +1055,7 @@ def startsParagraph(s: str) -> bool:
 # @+node:ekr.20201124191844.1: ** c_ec.reformatSelection
 @g.commander_command('reformat-selection')
 def reformatSelection(
-    self: Self, event: LeoKeyEvent = None, undoType: str = 'Reformat Selection'
+    self: Self, event: LeoKeyEvent | None = None, undoType: str = 'Reformat Selection'
 ) -> None:
     """
     Reformat the selected text, as in reformat-paragraph, but without
@@ -1093,21 +1093,21 @@ def reformatSelection(
 
 # @+node:ekr.20171123135625.12: ** c_ec.show/hide/toggleInvisibles
 @g.commander_command('hide-invisibles')
-def hideInvisibles(self: Self, event: LeoKeyEvent = None) -> None:
+def hideInvisibles(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Hide invisible (whitespace) characters."""
     c = self
     showInvisiblesHelper(c, False)
 
 
 @g.commander_command('show-invisibles')
-def showInvisibles(self: Self, event: LeoKeyEvent = None) -> None:
+def showInvisibles(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Show invisible (whitespace) characters."""
     c = self
     showInvisiblesHelper(c, True)
 
 
 @g.commander_command('toggle-invisibles')
-def toggleShowInvisibles(self: Self, event: LeoKeyEvent = None) -> None:
+def toggleShowInvisibles(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Toggle showing of invisible (whitespace) characters."""
     c = self
     colorizer = c.frame.body.getColorizer()
@@ -1135,7 +1135,7 @@ def showInvisiblesHelper(c: Cmdr, val: Value) -> None:
 
 # @+node:ekr.20171123135625.55: ** c_ec.toggleAngleBrackets
 @g.commander_command('toggle-angle-brackets')
-def toggleAngleBrackets(self: Self, event: LeoKeyEvent = None) -> None:
+def toggleAngleBrackets(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Add or remove double angle brackets from the headline of the selected node."""
     c, p, u = self, self.p, self.undoer
     if g.app.batchMode:
@@ -1165,7 +1165,7 @@ def toggleAngleBrackets(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20171123135625.49: ** c_ec.unformatParagraph & helper
 @g.commander_command('unformat-paragraph')
 def unformatParagraph(
-    self: Self, event: LeoKeyEvent = None, undoType: str = 'Unformat Paragraph'
+    self: Self, event: LeoKeyEvent | None = None, undoType: str = 'Unformat Paragraph'
 ) -> None:
     """
     Unformat a text paragraph. Removes all extra whitespace in a paragraph.
@@ -1230,7 +1230,7 @@ def unreformat(
 
 # @+node:ekr.20180410054716.1: ** c_ec: insert-jupyter-toc & insert-markdown-toc
 @g.commander_command('insert-jupyter-toc')
-def insertJupyterTOC(self: Self, event: LeoKeyEvent = None) -> None:
+def insertJupyterTOC(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Insert a Jupyter table of contents at the cursor,
     replacing any selected text.
@@ -1239,7 +1239,7 @@ def insertJupyterTOC(self: Self, event: LeoKeyEvent = None) -> None:
 
 
 @g.commander_command('insert-markdown-toc')
-def insertMarkdownTOC(self: Self, event: LeoKeyEvent = None) -> None:
+def insertMarkdownTOC(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Insert a Markdown table of contents at the cursor,
     replacing any selected text.

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -65,7 +65,7 @@ def set_name_and_title(c: Cmdr, fileName: str) -> str:
 
 # @+node:ekr.20170221033738.1: ** c_file.reloadSettings
 @g.commander_command('reload-settings')
-def reloadSettings(self: Self, event: LeoKeyEvent = None) -> None:
+def reloadSettings(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Reload settings in all commanders, saving all existing opened files first"""
     lm = g.app.loadManager
     # Save any changes so they can be seen, for existing files that are not new/untitled.
@@ -87,7 +87,7 @@ def reloadSettings(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20200422075655.1: ** c_file.restartLeo
 @g.commander_command('restart-leo')
-def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
+def restartLeo(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Restart Leo, reloading all presently open outlines."""
     verbose = False
     c = self
@@ -163,7 +163,7 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.2820: ** c_file.top level
 # @+node:ekr.20031218072017.2833: *3* c_file.close
 @g.commander_command('close-window')
-def close(self: Self, event: LeoKeyEvent = None, new_c: Cmdr = None) -> None:
+def close(self: Self, event: LeoKeyEvent | None = None, new_c: Cmdr | None = None) -> None:
     """Close the Leo window, prompting to save it if it has been changed."""
     g.app.closeLeoWindow(self.frame, new_c=new_c)
 
@@ -171,7 +171,7 @@ def close(self: Self, event: LeoKeyEvent = None, new_c: Cmdr = None) -> None:
 # @+node:ekr.20110530124245.18245: *3* c_file.importAnyFile
 @g.commander_command('import-any-file')
 @g.commander_command('import-file')
-def importAnyFile(self: Self, event: LeoKeyEvent = None) -> None:
+def importAnyFile(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Import one or more files."""
     c = self
     ic = c.importCommands
@@ -294,7 +294,7 @@ def import_txt_file(self: Self, fn: str) -> None:
 # @+node:ekr.20031218072017.1623: *3* c_file.new
 @g.commander_command('file-new')
 @g.commander_command('new')
-def new(self: Self, event: LeoKeyEvent = None, gui: LeoGui = None) -> Cmdr:
+def new(self: Self, event: LeoKeyEvent | None = None, gui: LeoGui | None = None) -> Cmdr:
     """Create a new Leo window."""
     t1 = time.process_time()
     from leo.core import leoApp
@@ -363,7 +363,7 @@ def new(self: Self, event: LeoKeyEvent = None, gui: LeoGui = None) -> Cmdr:
 # @+node:ekr.20031218072017.2821: *3* c_file.open_outline
 @g.commander_command('open-file')
 @g.commander_command('open-outline')
-def open_outline(self: Self, event: LeoKeyEvent = None) -> None:
+def open_outline(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open a Leo window containing the contents of a .leo file."""
     c = self
     filetypes = [
@@ -380,9 +380,9 @@ def open_outline(self: Self, event: LeoKeyEvent = None) -> None:
 @g.commander_command('refresh-from-disk')
 def refreshFromDisk(
     self: Self,
-    p: Position = None,  # For compatibility with existing scripts.
+    p: Position | None = None,  # For compatibility with existing scripts.
     *,
-    event: LeoKeyEvent = None,  # Required for all commands.
+    event: LeoKeyEvent | None = None,  # Required for all commands.
     silent: bool = True,  # No longer used.
 ) -> None:
     """
@@ -437,7 +437,7 @@ def refreshFromDisk(
 
 # @+node:ekr.20210610083257.1: *3* c_file.pwd
 @g.commander_command('pwd')
-def pwd_command(self: Self, event: LeoKeyEvent = None) -> None:
+def pwd_command(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Print the current working directory."""
     g.es_print('pwd:', os.getcwd())
 
@@ -446,7 +446,7 @@ def pwd_command(self: Self, event: LeoKeyEvent = None) -> None:
 @g.commander_command('save')
 @g.commander_command('file-save')
 @g.commander_command('save-file')
-def save(self: Self, event: LeoKeyEvent = None, fileName: str = None) -> None:
+def save(self: Self, event: LeoKeyEvent | None = None, fileName: str | None = None) -> None:
     """
     Save a Leo outline to a file, using the existing file name unless
     the fileName kwarg is given.
@@ -504,7 +504,7 @@ def save(self: Self, event: LeoKeyEvent = None, fileName: str = None) -> None:
 
 # @+node:ekr.20110228162720.13980: *3* c_file.saveAll
 @g.commander_command('save-all')
-def saveAll(self: Self, event: LeoKeyEvent = None) -> None:
+def saveAll(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Save all open tabs windows/tabs."""
     c = self
     c.save()  # Force a write of the present window.
@@ -521,7 +521,7 @@ def saveAll(self: Self, event: LeoKeyEvent = None) -> None:
 @g.commander_command('save-as')
 @g.commander_command('file-save-as')
 @g.commander_command('save-file-as')
-def saveAs(self: Self, event: LeoKeyEvent = None, fileName: str = None) -> None:
+def saveAs(self: Self, event: LeoKeyEvent | None = None, fileName: str | None = None) -> None:
     """
     Save a Leo outline to a file, prompting for a new filename unless the
     fileName kwarg is given.
@@ -576,7 +576,7 @@ def saveAs(self: Self, event: LeoKeyEvent = None, fileName: str = None) -> None:
 @g.commander_command('file-save-to')
 @g.commander_command('save-file-to')
 def saveTo(
-    self: Self, event: LeoKeyEvent = None, fileName: str = None, silent: bool = False
+    self: Self, event: LeoKeyEvent | None = None, fileName: str | None = None, silent: bool = False
 ) -> None:
     """
     Save a copy of the Leo outline to a file, prompting for a new file name.
@@ -621,7 +621,7 @@ def saveTo(
 
 # @+node:ekr.20031218072017.2837: *3* c_file.revert
 @g.commander_command('revert')
-def revert(self: Self, event: LeoKeyEvent = None) -> None:
+def revert(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Revert the contents of a Leo outline to last saved contents."""
     c = self
     u = c.undoer
@@ -643,7 +643,7 @@ def revert(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20210316075815.1: *3* c_file.save-as-leojs
 @g.commander_command('file-save-as-leojs')
 @g.commander_command('save-file-as-leojs')
-def save_as_leojs(self: Self, event: LeoKeyEvent = None) -> None:
+def save_as_leojs(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Save a copy of the Leo outline as a JSON (.leojs) file with a new file name.
     Leave the file name of the Leo outline unchanged.
@@ -668,7 +668,7 @@ def save_as_leojs(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20070413045221: *3* c_file.save-as-zipped
 @g.commander_command('file-save-as-db')
 @g.commander_command('save-file-as-db')
-def save_as_db(self: Self, event: LeoKeyEvent = None) -> None:
+def save_as_db(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Save a copy of the Leo outline as a SQLite (.db) file with a new file name.
     Leave the file name of the Leo outline unchanged.
@@ -693,7 +693,7 @@ def save_as_db(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20210316075357.1: *3* c_file.save-as-xml
 @g.commander_command('file-save-as-xml')
 @g.commander_command('save-file-as-xml')
-def save_as_xml(self: Self, event: LeoKeyEvent = None) -> None:
+def save_as_xml(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Save a copy of the Leo outline as an XML .leo file with a new file name.
     Leave the file name of the Leo outline unchanged.
@@ -718,7 +718,7 @@ def save_as_xml(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:tom.20220310092720.1: *3* c_file.save-node-as-xml
 @g.commander_command('save-node-as-xml')
-def save_node_as_xml_outline(self: Self, event: LeoKeyEvent = None) -> None:
+def save_node_as_xml_outline(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Save a node with its subtree as an XML .leo outline file.
     Leave the outline and the file name of the Leo outline unchanged.
@@ -741,7 +741,7 @@ def save_node_as_xml_outline(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.2849: ** Export
 # @+node:ekr.20031218072017.2850: *3* c_file.exportHeadlines
 @g.commander_command('export-headlines')
-def exportHeadlines(self: Self, event: LeoKeyEvent = None) -> None:
+def exportHeadlines(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Export headlines for c.p and its subtree to an external file."""
     c = self
     filetypes = [
@@ -758,7 +758,7 @@ def exportHeadlines(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2851: *3* c_file.flattenOutline
 @g.commander_command('flatten-outline')
-def flattenOutline(self: Self, event: LeoKeyEvent = None) -> None:
+def flattenOutline(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Export the selected outline to an external file.
     The outline is represented in MORE format.
@@ -778,7 +778,7 @@ def flattenOutline(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20141030120755.12: *3* c_file.flattenOutlineToNode
 @g.commander_command('flatten-outline-to-node')
-def flattenOutlineToNode(self: Self, event: LeoKeyEvent = None) -> None:
+def flattenOutlineToNode(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Append the body text of all descendants of the selected node to the
     body text of a new (last) top-level node.
@@ -806,7 +806,7 @@ def flattenOutlineToNode(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2857: *3* c_file.outlineToCWEB
 @g.commander_command('outline-to-cweb')
-def outlineToCWEB(self: Self, event: LeoKeyEvent = None) -> None:
+def outlineToCWEB(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Export the selected outline to an external file.
     The outline is represented in CWEB format.
@@ -827,7 +827,7 @@ def outlineToCWEB(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2858: *3* c_file.outlineToNoweb
 @g.commander_command('outline-to-noweb')
-def outlineToNoweb(self: Self, event: LeoKeyEvent = None) -> None:
+def outlineToNoweb(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Export the selected outline to an external file.
     The outline is represented in noweb format.
@@ -849,7 +849,7 @@ def outlineToNoweb(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2859: *3* c_file.removeSentinels
 @g.commander_command('remove-sentinels')
-def removeSentinels(self: Self, event: LeoKeyEvent = None) -> None:
+def removeSentinels(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Convert one or more files, replacing the original files
     while removing any sentinels they contain.
@@ -872,7 +872,7 @@ def removeSentinels(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2860: *3* c_file.weave
 @g.commander_command('weave')
-def weave(self: Self, event: LeoKeyEvent = None) -> None:
+def weave(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Simulate a literate-programming weave operation by writing the outline to a text file."""
     c = self
     fileName = g.app.gui.runSaveFileDialog(
@@ -893,7 +893,7 @@ def weave(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.2838: ** Read/Write
 # @+node:ekr.20070806105721.1: *3* c_file.readAtAutoNodes
 @g.commander_command('read-at-auto-nodes')
-def readAtAutoNodes(self: Self, event: LeoKeyEvent = None) -> None:
+def readAtAutoNodes(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Read all @auto nodes in the presently selected outline.
 
@@ -910,7 +910,7 @@ def readAtAutoNodes(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.1839: *3* c_file.readAtFileNodes
 @g.commander_command('read-at-file-nodes')
-def readAtFileNodes(self: Self, event: LeoKeyEvent = None) -> None:
+def readAtFileNodes(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Read all @file nodes in the presently selected outline.
 
@@ -928,7 +928,7 @@ def readAtFileNodes(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20080801071227.4: *3* c_file.readAtShadowNodes
 @g.commander_command('read-at-shadow-nodes')
-def readAtShadowNodes(self: Self, event: LeoKeyEvent = None) -> None:
+def readAtShadowNodes(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Read all @shadow nodes in the presently selected outline.
 
@@ -945,7 +945,7 @@ def readAtShadowNodes(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20070915134101: *3* c_file.readFileIntoNode
 @g.commander_command('read-file-into-node')
-def readFileIntoNode(self: Self, event: LeoKeyEvent = None) -> None:
+def readFileIntoNode(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Read a file into a single node."""
     c = self
     u = c.undoer
@@ -978,7 +978,7 @@ def readFileIntoNode(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20070915142635: *3* c_file.writeFileFromNode
 @g.commander_command('write-file-from-node')
-def writeFileFromNode(self: Self, event: LeoKeyEvent = None) -> None:
+def writeFileFromNode(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     If node starts with @read-file-into-node, use the full path name in the headline.
     Otherwise, prompt for a file name.
@@ -1017,7 +1017,7 @@ def writeFileFromNode(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:tom.20230201124905.1: *3* c_file.writeFileFromSubtree
 @g.commander_command('write-file-from-subtree')
-def writeFileFromSubtree(self: Self, event: LeoKeyEvent = None) -> None:
+def writeFileFromSubtree(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Write the entire tree from the selected node as text to a file.
 
     If node starts with @read-file-into-node, use the full path name in the headline.
@@ -1060,7 +1060,7 @@ def writeFileFromSubtree(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.2079: ** Recent Files
 # @+node:tbrown.20080509212202.6: *3* c_file.cleanRecentFiles
 @g.commander_command('clean-recent-files')
-def cleanRecentFiles(self: Self, event: LeoKeyEvent = None) -> None:
+def cleanRecentFiles(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Remove items from the recent files list that no longer exist.
 
@@ -1073,7 +1073,7 @@ def cleanRecentFiles(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2080: *3* c_file.clearRecentFiles
 @g.commander_command('clear-recent-files')
-def clearRecentFiles(self: Self, event: LeoKeyEvent = None) -> None:
+def clearRecentFiles(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Clear the recent files list, then add the present file."""
     c = self
     g.app.recentFilesManager.clearRecentFiles(c)
@@ -1081,7 +1081,7 @@ def clearRecentFiles(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:vitalije.20170703115710.1: *3* c_file.editRecentFiles
 @g.commander_command('edit-recent-files')
-def editRecentFiles(self: Self, event: LeoKeyEvent = None) -> None:
+def editRecentFiles(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Opens recent files list in a new node for editing."""
     c = self
     g.app.recentFilesManager.editRecentFiles(c)
@@ -1089,7 +1089,7 @@ def editRecentFiles(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:tbrown.20080509212202.8: *3* c_file.sortRecentFiles
 @g.commander_command('sort-recent-files')
-def sortRecentFiles(self: Self, event: LeoKeyEvent = None) -> None:
+def sortRecentFiles(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Sort the recent files list."""
     c = self
     g.app.recentFilesManager.sortRecentFiles(c)
@@ -1097,7 +1097,7 @@ def sortRecentFiles(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:vitalije.20170703115710.2: *3* c_file.writeEditedRecentFiles
 @g.commander_command('write-edited-recent-files')
-def writeEditedRecentFiles(self: Self, event: LeoKeyEvent = None) -> None:
+def writeEditedRecentFiles(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Write content of "edit_headline" node as recentFiles and recreates
     menus.

--- a/leo/commands/commanderHelpCommands.py
+++ b/leo/commands/commanderHelpCommands.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # @+others
 # @+node:ekr.20031218072017.2939: ** c_help.about (version number & date)
 @g.commander_command('about-leo')
-def about(self: Self, event: LeoKeyEvent = None) -> None:
+def about(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Bring up an About Leo Dialog."""
     c = self
     import datetime
@@ -42,7 +42,7 @@ def about(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:vitalije.20170713174950.1: ** c_help.editOneSetting
 @g.commander_command('edit-setting')
-def editOneSetting(self: Self, event: LeoKeyEvent = None) -> None:
+def editOneSetting(self: Self, event: LeoKeyEvent | None = None) -> None:
     """
     Opens dialog for editing @button, @command, @color, @font, or @shortcuts nodes.
     """
@@ -65,7 +65,7 @@ def editOneSetting(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:vitalije.20170708172746.1: ** c_help.editShortcut
 @g.commander_command('edit-shortcut')
-def editShortcut(self: Self, event: LeoKeyEvent = None) -> None:
+def editShortcut(self: Self, event: LeoKeyEvent | None = None) -> None:
     k = self.k
     if k.isEditShortcutSensible():
         # k.setState('input-shortcut', 'input-shortcut')
@@ -80,7 +80,7 @@ def editShortcut(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.2940: *3* c_help.leoDocumentation
 @g.commander_command('open-leo-docs-leo')
 @g.commander_command('leo-docs-leo')
-def leoDocumentation(self: Self, event: LeoKeyEvent = None) -> None:
+def leoDocumentation(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open LeoDocs.leo in a new Leo window."""
     c = self
     name = "LeoDocs.leo"
@@ -95,7 +95,7 @@ def leoDocumentation(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20090628075121.5994: *3* c_help.leoQuickStart
 @g.commander_command('open-quickstart-leo')
 @g.commander_command('leo-quickstart-leo')
-def leoQuickStart(self: Self, event: LeoKeyEvent = None) -> None:
+def leoQuickStart(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open quickstart.leo in a new Leo window."""
     c = self
     name = "quickstart.leo"
@@ -111,7 +111,7 @@ def leoQuickStart(self: Self, event: LeoKeyEvent = None) -> None:
 @g.commander_command('open-cheat-sheet-leo')
 @g.commander_command('leo-cheat-sheet')
 @g.commander_command('cheat-sheet')
-def openCheatSheet(self: Self, event: LeoKeyEvent = None) -> None:
+def openCheatSheet(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open leo/doc/cheatSheet.leo"""
     c = self
     fn = g.finalize_join(g.app.loadDir, '..', 'doc', 'CheatSheet.leo')
@@ -129,7 +129,7 @@ def openCheatSheet(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:lkj.20190714022527.1: *3* c_help.openDesktopIntegration
 @g.commander_command('open-desktop-integration-leo')
 @g.commander_command('desktop-integration-leo')
-def openDesktopIntegration(self: Self, event: LeoKeyEvent = None) -> None:
+def openDesktopIntegration(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open Desktop-integration.leo."""
     c = self
     fileName = g.finalize_join(g.app.loadDir, '..', 'scripts', 'desktop-integration.leo')
@@ -143,7 +143,7 @@ def openDesktopIntegration(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20161025090405.1: *3* c_help.openLeoDist
 @g.commander_command('open-leo-dist-leo')
 @g.commander_command('leo-dist-leo')
-def openLeoDist(self: Self, event: LeoKeyEvent = None) -> None:
+def openLeoDist(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open leoDist.leo in a new Leo window."""
     c = self
     name = "leoDist.leo"
@@ -158,7 +158,7 @@ def openLeoDist(self: Self, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20151225193723.1: *3* c_help.openLeoPy
 @g.commander_command('open-leo-py-leo')
 @g.commander_command('leo-py-leo')
-def openLeoPy(self: Self, event: LeoKeyEvent = None) -> Cmdr | None:
+def openLeoPy(self: Self, event: LeoKeyEvent | None = None) -> Cmdr | None:
     """Open leoPy.leo or LeoPyRef.leo in a new Leo window."""
     c = self
     names = (
@@ -179,7 +179,7 @@ def openLeoPy(self: Self, event: LeoKeyEvent = None) -> Cmdr | None:
 # @+node:ekr.20201013105418.1: *3* c_help.openLeoPyRef
 @g.commander_command('open-leo-py-ref-leo')
 @g.commander_command('leo-py-ref-leo')
-def openLeoPyRef(self: Self, event: LeoKeyEvent = None) -> Cmdr | None:
+def openLeoPyRef(self: Self, event: LeoKeyEvent | None = None) -> Cmdr | None:
     """Open leoPyRef.leo in a new Leo window."""
     c = self
     path = g.finalize_join(g.app.loadDir, "..", "core", "LeoPyRef.leo")
@@ -194,7 +194,7 @@ def openLeoPyRef(self: Self, event: LeoKeyEvent = None) -> Cmdr | None:
 # @+node:ekr.20061018094539: *3* c_help.openLeoScripts
 @g.commander_command('open-scripts-leo')
 @g.commander_command('leo-scripts-leo')
-def openLeoScripts(self: Self, event: LeoKeyEvent = None) -> None:
+def openLeoScripts(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open scripts.leo."""
     c = self
     fileName = g.finalize_join(g.app.loadDir, '..', 'scripts', 'scripts.leo')
@@ -209,7 +209,7 @@ def openLeoScripts(self: Self, event: LeoKeyEvent = None) -> None:
 @g.commander_command('open-leo-settings')
 @g.commander_command('open-leo-settings-leo')  # #1343.
 @g.commander_command('leo-settings')
-def openLeoSettings(self: Self, event: LeoKeyEvent = None) -> Cmdr | None:
+def openLeoSettings(self: Self, event: LeoKeyEvent | None = None) -> Cmdr | None:
     """Open leoSettings.leo in a new Leo window."""
     c, lm = self, g.app.loadManager
     path = lm.computeLeoSettingsPath()
@@ -223,7 +223,7 @@ def openLeoSettings(self: Self, event: LeoKeyEvent = None) -> Cmdr | None:
 @g.commander_command('open-my-leo-settings')
 @g.commander_command('open-my-leo-settings-leo')  # #1343.
 @g.commander_command('my-leo-settings')
-def openMyLeoSettings(self: Self, event: LeoKeyEvent = None) -> Cmdr:
+def openMyLeoSettings(self: Self, event: LeoKeyEvent | None = None) -> Cmdr:
     """Open myLeoSettings.leo in a new Leo window."""
     c, lm = self, g.app.loadManager
     path = lm.computeMyLeoSettingsPath()
@@ -298,7 +298,7 @@ def createMyLeoSettings(c: Cmdr) -> Cmdr | None:
 # @+node:ekr.20171124093507.1: ** c_help.Open Leo web pages
 # @+node:ekr.20031218072017.2941: *3* c_help.leoHome
 @g.commander_command('open-online-home')
-def leoHome(self: Self, event: LeoKeyEvent = None) -> None:
+def leoHome(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open Leo's Home page in a web browser."""
     import webbrowser
 
@@ -311,7 +311,7 @@ def leoHome(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20131213072223.19441: *3* c_help.openLeoTOC
 @g.commander_command('open-online-toc')
-def openLeoTOC(self: Self, event: LeoKeyEvent = None) -> None:
+def openLeoTOC(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open Leo's tutorials page in a web browser."""
     import webbrowser
 
@@ -324,7 +324,7 @@ def openLeoTOC(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20230104130712.1: *3* c_help.openLeoScriptingMiscellany
 @g.commander_command('open-online-scripting-miscellany')
-def openLeoScriptingMiscellany(self: Self, event: LeoKeyEvent = None) -> None:
+def openLeoScriptingMiscellany(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open Leo's scripting miscellany page in a web browser."""
     import webbrowser
 
@@ -337,7 +337,7 @@ def openLeoScriptingMiscellany(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20131213072223.19435: *3* c_help.openLeoTutorials
 @g.commander_command('open-online-tutorials')
-def openLeoTutorials(self: Self, event: LeoKeyEvent = None) -> None:
+def openLeoTutorials(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open Leo's tutorials page in a web browser."""
     import webbrowser
 
@@ -350,7 +350,7 @@ def openLeoTutorials(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20060613082924: *3* c_help.openLeoUsersGuide
 @g.commander_command('open-users-guide')
-def openLeoUsersGuide(self: Self, event: LeoKeyEvent = None) -> None:
+def openLeoUsersGuide(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open Leo's users guide in a web browser."""
     import webbrowser
 
@@ -363,7 +363,7 @@ def openLeoUsersGuide(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20131213072223.19437: *3* c_help.openLeoVideos
 @g.commander_command('open-online-videos')
-def openLeoVideos(self: Self, event: LeoKeyEvent = None) -> None:
+def openLeoVideos(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open Leo's videos page in a web browser."""
     import webbrowser
 
@@ -376,7 +376,7 @@ def openLeoVideos(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2932: ** c_help.openPythonWindow
 @g.commander_command('open-python-window')
-def openPythonWindow(self: Self, event: LeoKeyEvent = None) -> None:
+def openPythonWindow(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Open Python's Idle debugger in a separate process."""
     m = g.import_module('idlelib')
     if not m:
@@ -393,7 +393,7 @@ def openPythonWindow(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20131213072223.19532: ** c_help.selectAtSettingsNode
 @g.commander_command('open-local-settings')
-def selectAtSettingsNode(self: Self, event: LeoKeyEvent = None) -> None:
+def selectAtSettingsNode(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Select the @settings node, if there is one."""
     c = self
     p = c.config.settingsRoot()

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # @+node:ekr.20031218072017.1548: ** c_oc.Cut & Paste Outlines
 # @+node:ekr.20031218072017.1550: *3* c_oc.copyOutline
 @g.commander_command('copy-node')
-def copyOutline(self: Cmdr, event: LeoKeyEvent = None) -> str:
+def copyOutline(self: Cmdr, event: LeoKeyEvent | None = None) -> str:
     """Copy the selected outline to the clipboard."""
     # Copying an outline has no undo consequences.
     c = self
@@ -41,7 +41,7 @@ def copyOutline(self: Cmdr, event: LeoKeyEvent = None) -> str:
 
 # @+node:ekr.20220314071523.1: *3* c_oc.copyOutlineAsJson & helpers
 @g.commander_command('copy-node-as-json')
-def copyOutlineAsJSON(self: Cmdr, event: LeoKeyEvent = None) -> str | None:
+def copyOutlineAsJSON(self: Cmdr, event: LeoKeyEvent | None = None) -> str | None:
     """Copy the selected outline as JSON to the clipboard"""
     # Copying an outline has no undo consequences.
     c = self
@@ -56,7 +56,7 @@ def copyOutlineAsJSON(self: Cmdr, event: LeoKeyEvent = None) -> str | None:
 
 # @+node:ekr.20031218072017.1549: *3* c_oc.cutOutline
 @g.commander_command('cut-node')
-def cutOutline(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def cutOutline(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Delete the selected outline and send it to the clipboard."""
     c = self
     if c.canDeleteHeadline():
@@ -68,8 +68,8 @@ def cutOutline(self: Cmdr, event: LeoKeyEvent = None) -> None:
 @g.commander_command('paste-node')
 def pasteOutline(
     self: Cmdr,
-    event: LeoKeyEvent = None,
-    s: str = None,
+    event: LeoKeyEvent | None = None,
+    s: str | None = None,
     undoFlag: bool = True,  # A hack for abbrev.paste_tree.
 ) -> Position | None:
     """
@@ -119,8 +119,8 @@ def pasteOutline(
 @g.commander_command('paste-retaining-clones')
 def pasteOutlineRetainingClones(
     self: Cmdr,
-    event: LeoKeyEvent = None,
-    s: str = None,
+    event: LeoKeyEvent | None = None,
+    s: str | None = None,
 ) -> Position | None:
     """
     Paste an outline into the present outline from the clipboard.
@@ -202,7 +202,7 @@ def computeVnodeInfoDict(c: Cmdr) -> dict[VNode, g.Bunch]:
 
 # @+node:vitalije.20200529105105.1: *3* c_oc.pasteAsTemplate
 @g.commander_command('paste-as-template')
-def pasteAsTemplate(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def pasteAsTemplate(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Paste as template clones only nodes that were already clones"""
     c = self
     p = c.p
@@ -420,7 +420,7 @@ def pasteAsTemplate(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20040412060927: ** c_oc.dumpOutline
 @g.commander_command('dump-outline')
-def dumpOutline(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def dumpOutline(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Dump all nodes in the outline."""
     c = self
     seen = {}
@@ -438,7 +438,7 @@ def dumpOutline(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.2898: ** c_oc.Expand & contract commands
 # @+node:ekr.20031218072017.2900: *3* c_oc.contract-all
 @g.commander_command('contract-all')
-def contractAllHeadlinesCommand(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def contractAllHeadlinesCommand(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Contract all nodes in the outline."""
     # The helper does all the work.
     c = self
@@ -448,7 +448,7 @@ def contractAllHeadlinesCommand(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20080819075811.3: *3* c_oc.contractAllOtherNodes & helper
 @g.commander_command('contract-all-other-nodes')
-def contractAllOtherNodes(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def contractAllOtherNodes(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Contract all nodes except those needed to make the
     presently selected node visible.
@@ -474,7 +474,7 @@ def contractIfNotCurrent(c: Cmdr, p: Position, leaveOpen: Position) -> None:
 
 # @+node:ekr.20200824130837.1: *3* c_oc.contractAllSubheads (new)
 @g.commander_command('contract-all-subheads')
-def contractAllSubheads(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def contractAllSubheads(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Contract all children of the presently selected node."""
     c, p = self, self.p
     if not p:
@@ -489,7 +489,7 @@ def contractAllSubheads(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2901: *3* c_oc.contractNode
 @g.commander_command('contract-node')
-def contractNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def contractNode(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Contract the presently selected node."""
     c = self
     p = c.p
@@ -501,7 +501,7 @@ def contractNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20040930064232: *3* c_oc.contractNodeOrGoToParent
 @g.commander_command('contract-or-go-left')
-def contractNodeOrGoToParent(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def contractNodeOrGoToParent(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Simulate the left Arrow Key in folder of Windows Explorer."""
     c, cc, p = self, self.chapterController, self.p
     parent = p.parent()
@@ -528,7 +528,7 @@ def contractNodeOrGoToParent(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2902: *3* c_oc.contractParent
 @g.commander_command('contract-parent')
-def contractParent(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def contractParent(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Contract the parent of the presently selected node."""
     c = self
     c.endEditing()
@@ -543,7 +543,7 @@ def contractParent(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2903: *3* c_oc.expandAllHeadlines
 @g.commander_command('expand-all')
-def expandAllHeadlines(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandAllHeadlines(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand all headlines.
     Warning: this can take a long time for large outlines."""
     c = self
@@ -559,7 +559,7 @@ def expandAllHeadlines(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2904: *3* c_oc.expandAllSubheads
 @g.commander_command('expand-all-subheads')
-def expandAllSubheads(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandAllSubheads(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand all children of the presently selected node."""
     c, p = self, self.p
     if not p:
@@ -574,62 +574,62 @@ def expandAllSubheads(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2905: *3* c_oc.expandLevel1..9
 @g.commander_command('expand-to-level-1')
-def expandLevel1(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandLevel1(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the outline to level 1"""
     self.expandToLevel(1)
 
 
 @g.commander_command('expand-to-level-2')
-def expandLevel2(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandLevel2(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the outline to level 2"""
     self.expandToLevel(2)
 
 
 @g.commander_command('expand-to-level-3')
-def expandLevel3(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandLevel3(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the outline to level 3"""
     self.expandToLevel(3)
 
 
 @g.commander_command('expand-to-level-4')
-def expandLevel4(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandLevel4(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the outline to level 4"""
     self.expandToLevel(4)
 
 
 @g.commander_command('expand-to-level-5')
-def expandLevel5(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandLevel5(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the outline to level 5"""
     self.expandToLevel(5)
 
 
 @g.commander_command('expand-to-level-6')
-def expandLevel6(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandLevel6(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the outline to level 6"""
     self.expandToLevel(6)
 
 
 @g.commander_command('expand-to-level-7')
-def expandLevel7(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandLevel7(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the outline to level 7"""
     self.expandToLevel(7)
 
 
 @g.commander_command('expand-to-level-8')
-def expandLevel8(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandLevel8(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the outline to level 8"""
     self.expandToLevel(8)
 
 
 @g.commander_command('expand-to-level-9')
-def expandLevel9(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandLevel9(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the outline to level 9"""
     self.expandToLevel(9)
 
 
 # @+node:ekr.20031218072017.2906: *3* c_oc.expandNextLevel
 @g.commander_command('expand-next-level')
-def expandNextLevel(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandNextLevel(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Increase the expansion level of the outline and
     Expand all nodes at that level or lower.
@@ -644,7 +644,7 @@ def expandNextLevel(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2907: *3* c_oc.expandNode
 @g.commander_command('expand-node')
-def expandNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandNode(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Expand the presently selected node."""
     c = self
     p = c.p
@@ -656,7 +656,7 @@ def expandNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20040930064232.1: *3* c_oc.expandNodeAndGoToFirstChild
 @g.commander_command('expand-and-go-right')
-def expandNodeAndGoToFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandNodeAndGoToFirstChild(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """If a node has children, expand it if needed and go to the first child."""
     c, p = self, self.p
     c.endEditing()
@@ -669,7 +669,7 @@ def expandNodeAndGoToFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171125082744.1: *3* c_oc.expandNodeOrGoToFirstChild
 @g.commander_command('expand-or-go-right')
-def expandNodeOrGoToFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandNodeOrGoToFirstChild(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Simulate the Right Arrow Key in folder of Windows Explorer.
     if c.p has no children, do nothing.
@@ -689,8 +689,8 @@ def expandNodeOrGoToFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
 @g.commander_command('expand-ancestors-only')
 def expandOnlyAncestorsOfNode(
     self: Cmdr,
-    event: LeoKeyEvent = None,
-    p: Position = None,
+    event: LeoKeyEvent | None = None,
+    p: Position | None = None,
 ) -> None:
     """Contract all nodes except ancestors of the selected node."""
     c = self
@@ -709,7 +709,7 @@ def expandOnlyAncestorsOfNode(
 
 # @+node:ekr.20031218072017.2908: *3* c_oc.expandPrevLevel
 @g.commander_command('expand-prev-level')
-def expandPrevLevel(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def expandPrevLevel(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Decrease the expansion level of the outline and
     Expand all nodes at that level or lower."""
     c = self
@@ -722,7 +722,7 @@ def expandPrevLevel(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171124081846.1: ** c_oc.fullCheckOutline
 @g.commander_command('check-outline')
-def fullCheckOutline(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def fullCheckOutline(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Do a full check of the consistency of a .leo file."""
     c = self
     t1 = time.process_time()
@@ -734,7 +734,7 @@ def fullCheckOutline(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.2913: ** c_oc.Goto commands
 # @+node:ekr.20071213123942: *3* c_oc.findNextClone
 @g.commander_command('find-next-clone')
-def findNextClone(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def findNextClone(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the next cloned node."""
     c, p = self, self.p
     cc = c.chapterController
@@ -760,7 +760,7 @@ def findNextClone(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.1628: *3* c_oc.goNextVisitedNode
 @g.commander_command('go-forward')
 @g.commander_command('goto-next-history-node')
-def goNextVisitedNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goNextVisitedNode(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the next visited node."""
     c = self
     c.nodeHistory.goNext()
@@ -769,7 +769,7 @@ def goNextVisitedNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.1627: *3* c_oc.goPrevVisitedNode
 @g.commander_command('go-back')
 @g.commander_command('goto-prev-history-node')
-def goPrevVisitedNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goPrevVisitedNode(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the previously visited node."""
     c = self
     c.nodeHistory.goPrev()
@@ -777,7 +777,7 @@ def goPrevVisitedNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2914: *3* c_oc.goToFirstNode
 @g.commander_command('goto-first-node')
-def goToFirstNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToFirstNode(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Select the first node of the entire outline.
     Or the first visible node if Leo is hoisted or within a chapter.
@@ -790,7 +790,7 @@ def goToFirstNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20051012092453: *3* c_oc.goToFirstSibling
 @g.commander_command('goto-first-sibling')
-def goToFirstSibling(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToFirstSibling(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the first sibling of the selected node."""
     c, p = self, self.p
     if p.hasBack():
@@ -801,7 +801,7 @@ def goToFirstSibling(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20070615070925: *3* c_oc.goToFirstVisibleNode
 @g.commander_command('goto-first-visible-node')
-def goToFirstVisibleNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToFirstVisibleNode(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the first visible node of the selected chapter or hoist."""
     c = self
     p = c.firstVisible()
@@ -815,7 +815,7 @@ def goToFirstVisibleNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2915: *3* c_oc.goToLastNode
 @g.commander_command('goto-last-node')
-def goToLastNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToLastNode(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the last node in the entire tree."""
     c = self
     p = c.rootPosition()
@@ -827,7 +827,7 @@ def goToLastNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20051012092847.1: *3* c_oc.goToLastSibling
 @g.commander_command('goto-last-sibling')
-def goToLastSibling(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToLastSibling(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the last sibling of the selected node."""
     c, p = self, self.p
     if p.hasNext():
@@ -838,7 +838,7 @@ def goToLastSibling(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20050711153537: *3* c_oc.goToLastVisibleNode
 @g.commander_command('goto-last-visible-node')
-def goToLastVisibleNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToLastVisibleNode(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the last visible node of selected chapter or hoist."""
     c = self
     p = c.lastVisible()
@@ -852,7 +852,7 @@ def goToLastVisibleNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2916: *3* c_oc.goToNextClone
 @g.commander_command('goto-next-clone')
-def goToNextClone(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToNextClone(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Select the next node that is a clone of the selected node.
     If the selected node is not a clone, do find-next-clone.
@@ -894,7 +894,7 @@ def goToNextClone(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2917: *3* c_oc.goToNextDirtyHeadline
 @g.commander_command('goto-next-changed')
-def goToNextDirtyHeadline(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToNextDirtyHeadline(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the node that is marked as changed."""
     c, p = self, self.p
     if not p:
@@ -918,7 +918,7 @@ def goToNextDirtyHeadline(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2918: *3* c_oc.goToNextMarkedHeadline
 @g.commander_command('goto-next-marked')
-def goToNextMarkedHeadline(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToNextMarkedHeadline(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the next marked node."""
     c, p = self, self.p
     if not p:
@@ -942,7 +942,7 @@ def goToNextMarkedHeadline(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2919: *3* c_oc.goToNextSibling
 @g.commander_command('goto-next-sibling')
-def goToNextSibling(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToNextSibling(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the next sibling of the selected node."""
     c, p = self, self.p
     c.treeSelectHelper(p and p.next())
@@ -950,7 +950,7 @@ def goToNextSibling(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2920: *3* c_oc.goToParent
 @g.commander_command('goto-parent')
-def goToParent(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToParent(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the parent of the selected node."""
     c, p = self, self.p
     c.treeSelectHelper(p and p.parent())
@@ -958,7 +958,7 @@ def goToParent(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20190211104913.1: *3* c_oc.goToPrevMarkedHeadline
 @g.commander_command('goto-prev-marked')
-def goToPrevMarkedHeadline(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToPrevMarkedHeadline(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the previous marked node."""
     c, p = self, self.p
     if not p:
@@ -982,7 +982,7 @@ def goToPrevMarkedHeadline(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2921: *3* c_oc.goToPrevSibling
 @g.commander_command('goto-prev-sibling')
-def goToPrevSibling(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def goToPrevSibling(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the previous sibling of the selected node."""
     c, p = self, self.p
     c.treeSelectHelper(p and p.back())
@@ -990,7 +990,7 @@ def goToPrevSibling(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2993: *3* c_oc.selectThreadBack
 @g.commander_command('goto-prev-node')
-def selectThreadBack(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def selectThreadBack(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the node preceding the selected node in outline order."""
     c, p = self, self.p
     if not p:
@@ -1001,7 +1001,7 @@ def selectThreadBack(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2994: *3* c_oc.selectThreadNext
 @g.commander_command('goto-next-node')
-def selectThreadNext(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def selectThreadNext(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the node following the selected node in outline order."""
     c, p = self, self.p
     if not p:
@@ -1012,7 +1012,7 @@ def selectThreadNext(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2995: *3* c_oc.selectVisBack
 @g.commander_command('goto-prev-visible')
-def selectVisBack(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def selectVisBack(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the visible node preceding the presently selected node."""
     # This has an up arrow for a control key.
     c, p = self, self.p
@@ -1027,7 +1027,7 @@ def selectVisBack(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2996: *3* c_oc.selectVisNext
 @g.commander_command('goto-next-visible')
-def selectVisNext(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def selectVisNext(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Select the visible node following the presently selected node."""
     c, p = self, self.p
     if not p:
@@ -1043,7 +1043,7 @@ def selectVisNext(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20120308061112.9865: *3* c_oc.deHoist
 @g.commander_command('de-hoist')
 @g.commander_command('dehoist')
-def dehoist(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def dehoist(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Undo a previous hoist of an outline."""
     c, cc, tag = self, self.chapterController, '@chapter '
     if not c.p or not c.hoistStack:
@@ -1069,7 +1069,7 @@ def dehoist(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20120308061112.9866: *3* c_oc.clearAllHoists
 @g.commander_command('clear-all-hoists')
-def clearAllHoists(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def clearAllHoists(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Undo a previous hoist of an outline."""
     c = self
     c.hoistStack = []
@@ -1079,7 +1079,7 @@ def clearAllHoists(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20120308061112.9867: *3* c_oc.hoist
 @g.commander_command('hoist')
-def hoist(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def hoist(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Make only the selected outline visible."""
     c, p = self, self.p
     if not p:
@@ -1102,7 +1102,7 @@ def hoist(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.1759: ** c_oc.Insert, Delete & Clone commands
 # @+node:ekr.20031218072017.1762: *3* c_oc.clone
 @g.commander_command('clone-node')
-def clone(self: Cmdr, event: LeoKeyEvent = None) -> Position | None:
+def clone(self: Cmdr, event: LeoKeyEvent | None = None) -> Position | None:
     """Create a clone of the selected outline."""
     c, p, u = self, self.p, self.undoer
     if not p:
@@ -1124,7 +1124,7 @@ def clone(self: Cmdr, event: LeoKeyEvent = None) -> Position | None:
 
 # @+node:ekr.20150630152607.1: *3* c_oc.cloneToAtSpot
 @g.commander_command('clone-to-at-spot')
-def cloneToAtSpot(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def cloneToAtSpot(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Create a clone of the selected node and move it to the last @spot node
     of the outline. Create the @spot node if necessary.
@@ -1176,7 +1176,7 @@ def cloneToAtSpot(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20141023154408.5: *3* c_oc.cloneToLastNode
 @g.commander_command('clone-node-to-last-node')
-def cloneToLastNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def cloneToLastNode(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Clone the selected node and move it to the last node.
     Do *not* change the selected node.
@@ -1201,7 +1201,9 @@ def cloneToLastNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.1193: *3* c_oc.deleteOutline
 @g.commander_command('delete-node')
-def deleteOutline(self: Cmdr, event: LeoKeyEvent = None, op_name: str = "Delete Node") -> None:
+def deleteOutline(
+    self: Cmdr, event: LeoKeyEvent | None = None, op_name: str = "Delete Node"
+) -> None:
     """Deletes the selected outline."""
     c, u = self, self.undoer
     p = c.p
@@ -1235,7 +1237,7 @@ def deleteOutline(self: Cmdr, event: LeoKeyEvent = None, op_name: str = "Delete 
 
 # @+node:ekr.20071005173203.1: *3* c_oc.insertChild
 @g.commander_command('insert-child')
-def insertChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def insertChild(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Insert a node after the presently selected node."""
     c = self
     return c.insertHeadline(event=event, op_name='Insert Child', as_child=True)
@@ -1245,7 +1247,7 @@ def insertChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
 @g.commander_command('insert-node')
 def insertHeadline(
     self: Cmdr,
-    event: LeoKeyEvent = None,
+    event: LeoKeyEvent | None = None,
     op_name: str = "Insert Node",
     as_child: bool = False,
 ) -> Position | None:
@@ -1261,14 +1263,14 @@ def insertHeadline(
 
 
 @g.commander_command('insert-as-first-child')
-def insertNodeAsFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> Position | None:
+def insertNodeAsFirstChild(self: Cmdr, event: LeoKeyEvent | None = None) -> Position | None:
     """Insert a node as the first child of the previous node."""
     c = self
     return insertHeadlineHelper(c, event=event, as_first_child=True)
 
 
 @g.commander_command('insert-as-last-child')
-def insertNodeAsLastChild(self: Cmdr, event: LeoKeyEvent = None) -> Position | None:
+def insertNodeAsLastChild(self: Cmdr, event: LeoKeyEvent | None = None) -> Position | None:
     """Insert a node as the last child of the previous node."""
     c = self
     return insertHeadlineHelper(c, event=event, as_last_child=True)
@@ -1277,7 +1279,7 @@ def insertNodeAsLastChild(self: Cmdr, event: LeoKeyEvent = None) -> Position | N
 # @+node:ekr.20171124091846.1: *4* function: insertHeadlineHelper
 def insertHeadlineHelper(
     c: Cmdr,
-    event: LeoKeyEvent = None,
+    event: LeoKeyEvent | None = None,
     op_name: str = "Insert Node",
     as_child: bool = False,
     as_first_child: bool = False,
@@ -1316,7 +1318,7 @@ def insertHeadlineHelper(
 
 # @+node:ekr.20130922133218.11540: *3* c_oc.insertHeadlineBefore
 @g.commander_command('insert-node-before')
-def insertHeadlineBefore(self: Cmdr, event: LeoKeyEvent = None) -> Position | None:
+def insertHeadlineBefore(self: Cmdr, event: LeoKeyEvent | None = None) -> Position | None:
     """Insert a node before the presently selected node."""
     c, current, u = self, self.p, self.undoer
     op_name = 'Insert Node Before'
@@ -1340,7 +1342,7 @@ def insertHeadlineBefore(self: Cmdr, event: LeoKeyEvent = None) -> Position | No
 # @+node:ekr.20031218072017.2922: ** c_oc.Mark commands
 # @+node:ekr.20090905110447.6098: *3* c_oc.cloneMarked
 @g.commander_command('clone-marked-nodes')
-def cloneMarked(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def cloneMarked(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Clone all marked nodes as children of a new node."""
     c, u = self, self.undoer
     p1 = c.p.copy()
@@ -1381,7 +1383,7 @@ def cloneMarked(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20160502090456.1: *3* c_oc.copyMarked
 @g.commander_command('copy-marked-nodes')
-def copyMarked(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def copyMarked(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Copy all marked nodes as children of a new node."""
     c, u = self, self.undoer
     p1 = c.p.copy()
@@ -1416,7 +1418,7 @@ def copyMarked(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20111005081134.15540: *3* c_oc.deleteMarked
 @g.commander_command('delete-marked-nodes')
-def deleteMarked(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def deleteMarked(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Delete all marked nodes."""
     c, u = self, self.undoer
     p1 = c.p.copy()
@@ -1441,7 +1443,7 @@ def deleteMarked(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20111005081134.15539: *3* c_oc.moveMarked & helper
 @g.commander_command('move-marked-nodes')
-def moveMarked(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def moveMarked(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Move all marked nodes as children of a new node.
     This command is not undoable.
@@ -1514,7 +1516,7 @@ def createMoveMarkedNode(c: Cmdr) -> Position:
 # @+node:ekr.20031218072017.2923: *3* c_oc.markChangedHeadlines
 @g.commander_command('mark-changed-items')
 @g.commander_command('mark-changed-nodes')
-def markChangedHeadlines(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def markChangedHeadlines(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Mark all nodes that have been changed."""
     c, current, u = self, self.p, self.undoer
     undoType = 'Mark Changed'
@@ -1538,7 +1540,7 @@ def markChangedHeadlines(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 
 # @+node:ekr.20031218072017.2924: *3* c_oc.markChangedRoots
-def markChangedRoots(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def markChangedRoots(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Mark all changed @root nodes."""
     c, current, u = self, self.p, self.undoer
     undoType = 'Mark Changed'
@@ -1566,7 +1568,7 @@ def markChangedRoots(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.2928: *3* c_oc.markHeadline
 @g.commander_command('mark')  # Compatibility
 @g.commander_command('toggle-mark')
-def markHeadline(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def markHeadline(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Toggle the mark of the selected node."""
     c, p, u = self, self.p, self.undoer
     if not p:
@@ -1586,7 +1588,7 @@ def markHeadline(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2929: *3* c_oc.markSubheads
 @g.commander_command('mark-subheads')
-def markSubheads(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def markSubheads(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Mark all children of the selected node as changed."""
     c, current, u = self, self.p, self.undoer
     undoType = 'Mark Subheads'
@@ -1610,7 +1612,7 @@ def markSubheads(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.2930: *3* c_oc.unmarkAll
 @g.commander_command('unmark-all')
-def unmarkAll(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def unmarkAll(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Unmark all nodes in the entire outline."""
     c, current, u = self, self.p, self.undoer
     undoType = 'Unmark All'
@@ -1638,7 +1640,7 @@ def unmarkAll(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20031218072017.1766: ** c_oc.Move commands
 # @+node:ekr.20031218072017.1767: *3* c_oc.demote
 @g.commander_command('demote')
-def demote(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def demote(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Make all following siblings children of the selected node."""
     c, p, u = self, self.p, self.undoer
     if not p or not p.hasNext():
@@ -1674,7 +1676,7 @@ def demote(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.1768: *3* c_oc.moveOutlineDown
 @g.commander_command('move-outline-down')
-def moveOutlineDown(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def moveOutlineDown(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Move the selected node down."""
     # Moving down is more tricky than moving up because we can't
     # move p to be a child of itself.
@@ -1734,7 +1736,7 @@ def moveOutlineDown(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.1770: *3* c_oc.moveOutlineLeft
 @g.commander_command('move-outline-left')
-def moveOutlineLeft(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def moveOutlineLeft(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Move the selected node left if possible."""
     c, p, u = self, self.p, self.undoer
     if not p:
@@ -1763,7 +1765,7 @@ def moveOutlineLeft(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.1771: *3* c_oc.moveOutlineRight
 @g.commander_command('move-outline-right')
-def moveOutlineRight(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def moveOutlineRight(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Move the selected node right if possible."""
     c, p, u = self, self.p, self.undoer
     if not p:
@@ -1793,7 +1795,7 @@ def moveOutlineRight(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.1772: *3* c_oc.moveOutlineUp
 @g.commander_command('move-outline-up')
-def moveOutlineUp(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def moveOutlineUp(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Move the selected node up if possible."""
     c, p, u = self, self.p, self.undoer
     if not p:
@@ -1858,7 +1860,7 @@ def moveOutlineUp(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20230902051130.1: *3* c_oc.moveOutlineToFirstChild
 @g.commander_command('move-outline-to-first-child')
-def moveOutlineToFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def moveOutlineToFirstChild(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Move the selected node so that it is the first child of its parent.
 
@@ -1885,7 +1887,7 @@ def moveOutlineToFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20230902051833.1: *3* c_oc.moveOutlineToLastChild
 @g.commander_command('move-outline-to-last-child')
-def moveOutlineToLastChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def moveOutlineToLastChild(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """
     Move the selected node so that it is the last child of its parent.
 
@@ -1912,7 +1914,7 @@ def moveOutlineToLastChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.1774: *3* c_oc.promote
 @g.commander_command('promote')
-def promote(self: Cmdr, event: LeoKeyEvent = None, undoFlag: bool = True) -> None:
+def promote(self: Cmdr, event: LeoKeyEvent | None = None, undoFlag: bool = True) -> None:
     """Make all children of the selected nodes siblings of the selected node."""
     c, p, u = self, self.p, self.undoer
     if not p or not p.hasChildren():
@@ -1931,7 +1933,7 @@ def promote(self: Cmdr, event: LeoKeyEvent = None, undoFlag: bool = True) -> Non
 
 # @+node:ekr.20071213185710: *3* c_oc.toggleSparseMove
 @g.commander_command('toggle-sparse-move')
-def toggleSparseMove(self: Cmdr, event: LeoKeyEvent = None) -> None:
+def toggleSparseMove(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
     """Toggle whether moves collapse the outline."""
     c = self
     c.sparse_move = not c.sparse_move
@@ -1942,14 +1944,18 @@ def toggleSparseMove(self: Cmdr, event: LeoKeyEvent = None) -> None:
 # @+node:ekr.20080425060424.1: ** c_oc.Sort commands
 # @+node:felix.20230318172503.1: *3* c_oc.reverseSortChildren
 @g.commander_command('reverse-sort-children')
-def reverseSortChildren(self: Cmdr, event: LeoKeyEvent = None, key: str = None) -> None:
+def reverseSortChildren(
+    self: Cmdr, event: LeoKeyEvent | None = None, key: str | None = None
+) -> None:
     """Sort the children of a node in reverse order."""
     self.sortChildren(key=key, reverse=True)  # as reverse, Fixes #3188
 
 
 # @+node:felix.20230318172511.1: *3* c_oc.reverseSortSiblings
 @g.commander_command('reverse-sort-siblings')
-def reverseSortSiblings(self: Cmdr, event: LeoKeyEvent = None, key: str = None) -> None:
+def reverseSortSiblings(
+    self: Cmdr, event: LeoKeyEvent | None = None, key: str | None = None
+) -> None:
     """Sort the siblings of a node in reverse order."""
     self.sortSiblings(key=key, reverse=True)  # as reverse, Fixes #3188
 
@@ -1957,7 +1963,7 @@ def reverseSortSiblings(self: Cmdr, event: LeoKeyEvent = None, key: str = None) 
 # @+node:ekr.20050415134809: *3* c_oc.sortChildren
 @g.commander_command('sort-children')
 def sortChildren(
-    self: Cmdr, event: LeoKeyEvent = None, key: Callable = None, reverse: bool = False
+    self: Cmdr, event: LeoKeyEvent | None = None, key: Callable | None = None, reverse: bool = False
 ) -> None:
     """Sort the children of a node."""
     # This method no longer supports the 'cmp' keyword arg.
@@ -1970,9 +1976,9 @@ def sortChildren(
 @g.commander_command('sort-siblings')
 def sortSiblings(
     self: Cmdr,
-    event: LeoKeyEvent = None,  # cmp keyword is no longer supported.
-    key: Callable = None,
-    p: Position = None,
+    event: LeoKeyEvent | None = None,  # cmp keyword is no longer supported.
+    key: Callable | None = None,
+    p: Position | None = None,
     sortChildren: bool = False,
     reverse: bool = False,
 ) -> None:
@@ -2030,7 +2036,7 @@ def cantMoveMessage(c: Cmdr) -> None:
 
 # @+node:ekr.20180201040936.1: ** count-children
 @g.command('count-children')
-def count_children(event: LeoKeyEvent = None) -> None:
+def count_children(event: LeoKeyEvent | None = None) -> None:
     """Print out the number of children for the currently selected node"""
     c = event and event.get('c')
     if c:

--- a/leo/commands/controlCommands.py
+++ b/leo/commands/controlCommands.py
@@ -55,11 +55,11 @@ class ControlCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.92: *3* print plugins info...
     @cmd('show-plugin-handlers')
-    def printPluginHandlers(self, event: LeoKeyEvent = None) -> None:
+    def printPluginHandlers(self, event: LeoKeyEvent | None = None) -> None:
         """Print the handlers for each plugin."""
         g.app.pluginsController.printHandlers(self.c)
 
-    def printPlugins(self, event: LeoKeyEvent = None) -> None:
+    def printPlugins(self, event: LeoKeyEvent | None = None) -> None:
         """
         Print the file name responsible for loading a plugin.
 
@@ -69,7 +69,7 @@ class ControlCommandsClass(BaseEditCommandsClass):
         g.app.pluginsController.printPlugins(self.c)
 
     @cmd('show-plugins-info')
-    def printPluginsInfo(self, event: LeoKeyEvent = None) -> None:
+    def printPluginsInfo(self, event: LeoKeyEvent | None = None) -> None:
         """
         Print the file name responsible for loading a plugin.
 
@@ -80,7 +80,7 @@ class ControlCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.93: *3* setSilentMode
     @cmd('set-silent-mode')
-    def setSilentMode(self, event: LeoKeyEvent = None) -> None:
+    def setSilentMode(self, event: LeoKeyEvent | None = None) -> None:
         """
         Set the mode to be run silently, without the minibuffer.
         The only use for this command is to put the following in an @mode node::

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -1369,7 +1369,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 self.output_directory = self.finalize(
                     c.config.getString('stub-output-directory') or '.'
                 )
-                self.output_fn: str = None
+                self.output_fn: str | None = None
                 self.overwrite = c.config.getBool('stub-overwrite', default=False)
                 self.trace_matches = c.config.getBool('stub-trace-matches', default=False)
                 self.trace_patterns = c.config.getBool('stub-trace-patterns', default=False)
@@ -1657,7 +1657,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
 
         # @+others
         # @+node:ekr.20231119103026.2: *5* py2rust.ctor
-        def __init__(self, c: Cmdr, alias: str = None) -> None:
+        def __init__(self, c: Cmdr, alias: str | None = None) -> None:
             self.c = c
             self.alias = alias  # For scripts. An alias for 'self'.
             data = c.config.getData('python-to-typescript-types') or []
@@ -2387,7 +2387,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
 
         # @+others
         # @+node:ekr.20211020162251.1: *5* py2ts.ctor
-        def __init__(self, c: Cmdr, alias: str = None) -> None:
+        def __init__(self, c: Cmdr, alias: str | None = None) -> None:
             self.c = c
             self.alias = alias  # For scripts. An alias for 'self'.
             data = c.config.getData('python-to-typescript-types') or []

--- a/leo/commands/debugCommands.py
+++ b/leo/commands/debugCommands.py
@@ -27,7 +27,7 @@ class DebugCommandsClass(BaseEditCommandsClass):
     # @+others
     # @+node:ekr.20150514063305.104: ** debug.debug & helper
     @cmd('debug')
-    def invoke_debugger(self, event: LeoKeyEvent = None) -> None:
+    def invoke_debugger(self, event: LeoKeyEvent | None = None) -> None:
         """
         Start an external debugger in another process to debug a script. The
         script is the presently selected text or then entire tree's script.
@@ -89,7 +89,7 @@ class DebugCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20170713112849.1: ** debug.dump-node
     @cmd('dump-node')
-    def dumpNode(self, event: LeoKeyEvent = None) -> None:
+    def dumpNode(self, event: LeoKeyEvent | None = None) -> None:
         """Dump c.p.v, including gnx, uA's, etc."""
         p = self.c.p
         if p:
@@ -102,7 +102,7 @@ class DebugCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.103: ** debug.gc-collect-garbage
     @cmd('gc-collect-garbage')
-    def collectGarbage(self, event: LeoKeyEvent = None) -> None:
+    def collectGarbage(self, event: LeoKeyEvent | None = None) -> None:
         """Run Python's Garbage Collector."""
         import gc
 
@@ -110,20 +110,20 @@ class DebugCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.106: ** debug.gc-dump-all-objects
     @cmd('gc-dump-all-objects')
-    def dumpAllObjects(self, event: LeoKeyEvent = None) -> None:
+    def dumpAllObjects(self, event: LeoKeyEvent | None = None) -> None:
         """Print a summary of all existing Python objects."""
         g.printGc()
 
     # @+node:ekr.20150514063305.111: ** debug.gc-show-summary
     @cmd('gc-show-summary')
-    def printGcSummary(self, event: LeoKeyEvent = None) -> None:
+    def printGcSummary(self, event: LeoKeyEvent | None = None) -> None:
         """Print a brief summary of all Python objects."""
         g.printGcSummary()
 
     # @+node:ekr.20170429154309.1: ** debug.kill-log-listener
     @cmd('kill-log-listener')
     @cmd('log-kill-listener')
-    def killLogListener(self, event: LeoKeyEvent = None) -> None:
+    def killLogListener(self, event: LeoKeyEvent | None = None) -> None:
         """Kill the listener started by listen-for-log."""
         if g.app.log_listener:
             try:
@@ -137,7 +137,7 @@ class DebugCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.110: ** debug.show-focus
     @cmd('show-focus')
-    def printFocus(self, event: LeoKeyEvent = None) -> None:
+    def printFocus(self, event: LeoKeyEvent | None = None) -> None:
         """
         Print information about the requested focus.
 

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -8,15 +8,15 @@ from __future__ import annotations
 from collections.abc import Callable
 import os
 import re
-from typing import Any, TYPE_CHECKING
+from typing import cast, Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
+from leo.plugins.qt_text import QTextMixin
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position, VNode
-    from leo.plugins.qt_text import QTextMixin
 
     KWargs = Any
     Value = Any
@@ -93,7 +93,7 @@ def lineScrollHelper(c: Cmdr, prefix1: str, prefix2: str, suffix: str) -> None:
 # @+node:ekr.20201129164455.1: **  Top-level commands
 # @+node:ekr.20180504180134.1: *3* @g.command('delete-trace-statements')
 @g.command('delete-trace-statements')
-def delete_trace_statements(event: LeoKeyEvent = None) -> None:
+def delete_trace_statements(event: LeoKeyEvent | None = None) -> None:
     """
     Delete all trace statements/blocks from c.p to the end of the outline.
 
@@ -203,7 +203,7 @@ def promote_section_definition(event: LeoKeyEvent) -> None:
 
 # @+node:ekr.20220515193048.1: *3* @g.command('merge-node-with-next-node')
 @g.command('merge-node-with-next-node')
-def merge_node_with_next_node(event: LeoKeyEvent = None) -> None:
+def merge_node_with_next_node(event: LeoKeyEvent | None = None) -> None:
     """
     Merge p.b into p.next().b and delete p, *provided* that p has no children.
     """
@@ -235,7 +235,7 @@ def merge_node_with_next_node(event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20220515193124.1: *3* @g.command('merge-node-with-prev-node')
 @g.command('merge-node-with-prev-node')
-def merge_node_with_prev_node(event: LeoKeyEvent = None) -> None:
+def merge_node_with_prev_node(event: LeoKeyEvent | None = None) -> None:
     """
     Merge p.b into p.back().b and delete p, *provided* that p has no children.
     """
@@ -332,7 +332,7 @@ def promoteHeadlines(event: LeoKeyEvent) -> None:
 
 # @+node:ekr.20180504180647.1: *3* @g.command('select-next-trace-statement')
 @g.command('select-next-trace-statement')
-def select_next_trace_statement(event: LeoKeyEvent = None) -> None:
+def select_next_trace_statement(event: LeoKeyEvent | None = None) -> None:
     """Select the next statement/block enabled by `if trace...:`"""
     c = event.get('c')
     if not c:
@@ -351,7 +351,7 @@ def select_next_trace_statement(event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20191010112910.1: *3* @g.command('show-clone-ancestors')
 @g.command('show-clone-ancestors')
-def show_clone_ancestors(event: LeoKeyEvent = None) -> None:
+def show_clone_ancestors(event: LeoKeyEvent | None = None) -> None:
     """Display links to all ancestor nodes of the node c.p."""
     c = event.get('c')
     if not c:
@@ -377,7 +377,7 @@ def show_clone_ancestors(event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20260622102739.1: *3* @g.command('show-node-files')
 @g.command('show-node-files')
-def show_node_files(event: LeoKeyEvent = None) -> None:
+def show_node_files(event: LeoKeyEvent | None = None) -> None:
     """Display the headlines of all @<file> nodes containing this node."""
     c = event.get('c')
     if c and c.p:
@@ -388,7 +388,7 @@ def show_node_files(event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20191007034723.1: *3* @g.command('show-clone-parents')
 @g.command('show-clone-parents')
-def show_clones(event: LeoKeyEvent = None) -> None:
+def show_clones(event: LeoKeyEvent | None = None) -> None:
     """Display links to all parent nodes of the node c.p."""
     c = event.get('c')
     if not c:
@@ -410,7 +410,7 @@ def show_clones(event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20180210161001.1: *3* @g.command('unmark-node-and-parents')
 @g.command('unmark-node-and-parents')
-def unmark_node_and_parents(event: LeoKeyEvent = None) -> list[Position]:
+def unmark_node_and_parents(event: LeoKeyEvent | None = None) -> list[Position]:
     """Unmark the node and all its parents."""
     c = event.get('c')
     changed: list[Position] = []
@@ -452,10 +452,10 @@ class EditCommandsClass(BaseEditCommandsClass):
         # Set by the set-fill-column command.
         self.fillColumn = 0  # For line centering. If zero, use @pagewidth value.
         self.moveSpotNode = None  # A VNode.
-        self.moveSpot: int = None  # For retaining preferred column when moving up or down.
-        self.moveCol: int = None  # For retaining preferred column when moving up or down.
+        self.moveSpot: int | None = None  # For retaining preferred column when moving up or down.
+        self.moveCol: int | None = None  # For retaining preferred column when moving up or down.
         self.sampleWidget = None  # Created later.
-        self.w: QTextMixin = None  # For use by state handlers.
+        self.w = cast(QTextMixin, None)  # For use by state handlers.
         # Settings...
         cf = c.config
         self.autocompleteBrackets = cf.getBool('autocomplete-brackets')
@@ -477,12 +477,12 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.190: *3* ec.cache
     @cmd('clear-all-caches')
     @cmd('clear-cache')
-    def clearAllCaches(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def clearAllCaches(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Clear all of Leo's file caches."""
         g.app.global_cacher.clear()
 
     @cmd('dump-caches')
-    def dumpCaches(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def dumpCaches(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Dump, all of Leo's file caches."""
         if hasattr(g.app.global_cacher, 'dump'):
             g.app.global_cacher.dump()
@@ -497,7 +497,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.278: *3* ec.insertFileName
     @cmd('insert-file-name')
-    def insertFileName(self, event: LeoKeyEvent = None) -> None:
+    def insertFileName(self, event: LeoKeyEvent | None = None) -> None:
         """
         Prompt for a file name, then insert it at the cursor position.
         This operation is undoable if done in the body pane.
@@ -544,7 +544,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.279: *3* ec.insertHeadlineTime
     @cmd('insert-headline-time')
-    def insertHeadlineTime(self, event: LeoKeyEvent = None) -> None:
+    def insertHeadlineTime(self, event: LeoKeyEvent | None = None) -> None:
         """Insert a date/time stamp in the headline of the selected node."""
         frame = self
         c, p = frame.c, self.c.p
@@ -585,7 +585,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:tom.20210922140250.1: *3* ec.capitalizeHeadline
     @cmd('capitalize-headline')
-    def capitalizeHeadline(self, event: LeoKeyEvent = None) -> None:
+    def capitalizeHeadline(self, event: LeoKeyEvent | None = None) -> None:
         """Capitalize all words in the headline of the selected node."""
         frame = self
         c, p, u = frame.c, self.c.p, self.c.undoer
@@ -720,7 +720,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:tom.20210922171731.1: *4* ec.capitalizeWords & selection
     @cmd('capitalize-words-or-selection')
-    def capitalizeWords(self, event: LeoKeyEvent = None) -> None:
+    def capitalizeWords(self, event: LeoKeyEvent | None = None) -> None:
         """Capitalize Entire Body Or Selection."""
         frame = self
         c, p, u = frame.c, self.c.p, self.c.undoer
@@ -762,37 +762,37 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.195: *3* ec: clicks and focus
     # @+node:ekr.20150514063305.196: *4* ec.activate-x-menu & activateMenu
     @cmd('activate-cmds-menu')
-    def activateCmdsMenu(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def activateCmdsMenu(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Activate Leo's Cmnds menu."""
         self.activateMenu('Cmds')
 
     @cmd('activate-edit-menu')
-    def activateEditMenu(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def activateEditMenu(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Activate Leo's Edit menu."""
         self.activateMenu('Edit')
 
     @cmd('activate-file-menu')
-    def activateFileMenu(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def activateFileMenu(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Activate Leo's File menu."""
         self.activateMenu('File')
 
     @cmd('activate-help-menu')
-    def activateHelpMenu(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def activateHelpMenu(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Activate Leo's Help menu."""
         self.activateMenu('Help')
 
     @cmd('activate-outline-menu')
-    def activateOutlineMenu(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def activateOutlineMenu(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Activate Leo's Outline menu."""
         self.activateMenu('Outline')
 
     @cmd('activate-plugins-menu')
-    def activatePluginsMenu(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def activatePluginsMenu(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Activate Leo's Plugins menu."""
         self.activateMenu('Plugins')
 
     @cmd('activate-window-menu')
-    def activateWindowMenu(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def activateWindowMenu(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Activate Leo's Window menu."""
         self.activateMenu('Window')
 
@@ -802,7 +802,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.199: *4* ec.focusTo...
     @cmd('focus-to-body')
-    def focusToBody(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def focusToBody(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Put the keyboard focus in Leo's body pane."""
         c, k = self.c, self.c.k
         c.bodyWantsFocus()
@@ -811,17 +811,17 @@ class EditCommandsClass(BaseEditCommandsClass):
             k.showStateAndMode()
 
     @cmd('focus-to-log')
-    def focusToLog(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def focusToLog(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Put the keyboard focus in Leo's log pane."""
         self.c.logWantsFocusNow()
 
     @cmd('focus-to-minibuffer')
-    def focusToMinibuffer(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def focusToMinibuffer(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Put the keyboard focus in Leo's minibuffer."""
         self.c.minibufferWantsFocusNow()
 
     @cmd('focus-to-tree')
-    def focusToTree(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def focusToTree(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Put the keyboard focus in Leo's outline pane."""
         self.c.treeWantsFocusNow()
 
@@ -829,32 +829,32 @@ class EditCommandsClass(BaseEditCommandsClass):
     # These call the actual event handlers so as to trigger hooks.
 
     @cmd('ctrl-click-icon')
-    def ctrlClickIconBox(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def ctrlClickIconBox(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Simulate a ctrl-click in the icon box of the presently selected node."""
         c = self.c
         c.frame.tree.OnIconCtrlClick(c.p)  # Calls the base LeoTree method.
 
     @cmd('click-icon-box')
-    def clickIconBox(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def clickIconBox(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Simulate a click in the icon box of the presently selected node."""
         c = self.c
         c.frame.tree.onIconBoxClick(event, p=c.p)
 
     @cmd('double-click-icon-box')
-    def doubleClickIconBox(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def doubleClickIconBox(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Simulate a double-click in the icon box of the presently selected node."""
         c = self.c
         c.frame.tree.onIconBoxDoubleClick(event, p=c.p)
 
     @cmd('right-click-icon')
-    def rightClickIconBox(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def rightClickIconBox(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Simulate a right click in the icon box of the presently selected node."""
         c = self.c
         c.frame.tree.onIconBoxRightClick(event, p=c.p)
 
     # @+node:ekr.20150514063305.202: *4* ec.clickClickBox
     @cmd('click-click-box')
-    def clickClickBox(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def clickClickBox(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """
         Simulate a click in the click box (+- box) of the presently selected node.
 
@@ -1125,7 +1125,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.225: *3* ec: goto node
     # @+node:ekr.20170411065920.1: *4* goto-any-clone
     @cmd('goto-any-clone')
-    def gotoAnyClone(self, event: LeoKeyEvent = None) -> None:
+    def gotoAnyClone(self, event: LeoKeyEvent | None = None) -> None:
         """Select then next cloned node, regardless of whether c.p is a clone."""
         c = self.c
         p = c.p.threadNext()
@@ -1220,7 +1220,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('hn-add-all')
     @cmd('headline-number-add-all')
     @cmd('add-all-headline-numbers')
-    def hn_add_all(self, event: LeoKeyEvent = None) -> None:
+    def hn_add_all(self, event: LeoKeyEvent | None = None) -> None:
         """
         Add headline numbers to all nodes of the outline *except*:
         -  @<file> nodes and their descendants.
@@ -1267,7 +1267,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('hn-add-subtree')
     @cmd('headline-number-add-subtree')
     @cmd('add-subtree-headline-numbers')
-    def hn_add_children(self, event: LeoKeyEvent = None) -> None:
+    def hn_add_children(self, event: LeoKeyEvent | None = None) -> None:
         """
         Add headline numbers to *all* children of c.p, *including*:
         -  @<file> nodes and their descendants.
@@ -1307,7 +1307,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('hn-delete-all')
     @cmd('headline-number-delete-all')
     @cmd('delete-all-headline-numbers')
-    def hn_delete_all(self, event: LeoKeyEvent = None) -> None:
+    def hn_delete_all(self, event: LeoKeyEvent | None = None) -> None:
         """Delete all headline numbers in the entire outline."""
         c, command = self.c, 'delete-all-headline-numbers'
         u = c.undoer
@@ -1322,7 +1322,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('hn-delete-subtree')
     @cmd('headline-number-delete-subtree')
     @cmd('delete-subtree-headline-numbers')
-    def hn_delete_tree(self, event: LeoKeyEvent = None) -> None:
+    def hn_delete_tree(self, event: LeoKeyEvent | None = None) -> None:
         """Delete all headline numbers in c.p's subtree."""
         c, command = self.c, 'delete-subtree-headline-numbers'
         u = c.undoer
@@ -1427,7 +1427,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.236: *4* ec.deleteFirstIcon
     @cmd('delete-first-icon')
-    def deleteFirstIcon(self, event: LeoKeyEvent = None) -> None:
+    def deleteFirstIcon(self, event: LeoKeyEvent | None = None) -> None:
         """Delete the first icon in the selected node's icon list."""
         c, p = self.c, self.c.p
         aList = self.getIconList(c.p.v)
@@ -1462,7 +1462,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.238: *4* ec.deleteLastIcon
     @cmd('delete-last-icon')
-    def deleteLastIcon(self, event: LeoKeyEvent = None) -> None:
+    def deleteLastIcon(self, event: LeoKeyEvent | None = None) -> None:
         """Delete the first icon in the selected node's icon list."""
         c, p = self.c, self.c.p
         aList = self.getIconList(p.v)
@@ -1473,7 +1473,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.239: *4* ec.deleteNodeIcons
     @cmd('delete-node-icons')
-    def deleteNodeIcons(self, event: LeoKeyEvent = None, p: Position = None) -> None:
+    def deleteNodeIcons(self, event: LeoKeyEvent | None = None, p: Position | None = None) -> None:
         """Delete all of the selected node's icons."""
         c = self.c
         p = p or c.p
@@ -1485,7 +1485,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.240: *4* ec.insertIcon
     @cmd('insert-icon')
-    def insertIcon(self, event: LeoKeyEvent = None) -> None:
+    def insertIcon(self, event: LeoKeyEvent | None = None) -> None:
         """Prompt for an icon, and insert it into the node's icon list."""
         c, p = self.c, self.c.p
         iconDir = g.finalize_join(g.app.loadDir, "..", "Icons")
@@ -1514,7 +1514,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.241: *4* ec.insertIconFromFile
     def insertIconFromFile(
-        self, path: str, p: Position = None, pos: int = None, **kargs: KWargs
+        self, path: str, p: Position | None = None, pos: int | None = None, **kargs: KWargs
     ) -> None:
         c = self.c
         if not p:
@@ -1723,7 +1723,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.253: *4* ec.backwardDeleteCharacter
     @cmd('backward-delete-char')
-    def backwardDeleteCharacter(self, event: LeoKeyEvent = None) -> None:
+    def backwardDeleteCharacter(self, event: LeoKeyEvent | None = None) -> None:
         """Delete the character to the left of the cursor."""
         c = self.c
         w = event.w if event else c.frame.body.wrapper
@@ -1863,24 +1863,24 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.258: *4* ec.delete-word & backward-delete-word
     @cmd('delete-word')
-    def deleteWord(self, event: LeoKeyEvent = None) -> None:
+    def deleteWord(self, event: LeoKeyEvent | None = None) -> None:
         """Delete the word at the cursor."""
         self.deleteWordHelper(event, forward=True)
 
     @cmd('backward-delete-word')
-    def backwardDeleteWord(self, event: LeoKeyEvent = None) -> None:
+    def backwardDeleteWord(self, event: LeoKeyEvent | None = None) -> None:
         """Delete the word in front of the cursor."""
         self.deleteWordHelper(event, forward=False)
 
     # Patch by NH2.
 
     @cmd('delete-word-smart')
-    def deleteWordSmart(self, event: LeoKeyEvent = None) -> None:
+    def deleteWordSmart(self, event: LeoKeyEvent | None = None) -> None:
         """Delete the word at the cursor, treating whitespace and symbols smartly."""
         self.deleteWordHelper(event, forward=True, smart=True)
 
     @cmd('backward-delete-word-smart')
-    def backwardDeleteWordSmart(self, event: LeoKeyEvent = None) -> None:
+    def backwardDeleteWordSmart(self, event: LeoKeyEvent | None = None) -> None:
         """Delete the word in front of the cursor, treating whitespace and symbols smartly."""
         self.deleteWordHelper(event, forward=False, smart=True)
 
@@ -3077,13 +3077,14 @@ class EditCommandsClass(BaseEditCommandsClass):
         self,
         event: LeoKeyEvent,
         select: bool = True,
-        w: QTextMixin = None,
+        w: QTextMixin | None = None,
     ) -> tuple[int, int]:
         """Compute the word at the cursor. Select it if select arg is True."""
         c = self.c
         w = event.w if event else c.frame.body.wrapper
         if not g.isTextWrapper(w):
             return 0, 0
+        assert isinstance(w, QTextMixin)
         s = w.getAllText()
         n = len(s)
         i = i1 = w.getInsertPoint()
@@ -3335,7 +3336,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20170707093335.1: *4* ec.pushCursor and popCursor
     @cmd('pop-cursor')
-    def popCursor(self, event: LeoKeyEvent = None) -> None:
+    def popCursor(self, event: LeoKeyEvent | None = None) -> None:
         """Restore the node, selection range and insert point from the stack."""
         c = self.c
         w = event.w if event else None
@@ -3352,7 +3353,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             g.es('no stacked cursor', color='blue')
 
     @cmd('push-cursor')
-    def pushCursor(self, event: LeoKeyEvent = None) -> None:
+    def pushCursor(self, event: LeoKeyEvent | None = None) -> None:
         """Push the selection range and insert point on the stack."""
         c = self.c
         w = event.w if event else None
@@ -3899,7 +3900,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.337: *4* ec.scrollOutlineUp/Down/Line/Page
     @cmd('scroll-outline-down-line')
-    def scrollOutlineDownLine(self, event: LeoKeyEvent = None) -> None:
+    def scrollOutlineDownLine(self, event: LeoKeyEvent | None = None) -> None:
         """Scroll the outline pane down one line."""
         tree = self.c.frame.tree
         if hasattr(tree, 'scrollDelegate'):
@@ -3910,7 +3911,7 @@ class EditCommandsClass(BaseEditCommandsClass):
                 tree.canvas.yview_scroll(1, "unit")
 
     @cmd('scroll-outline-down-page')
-    def scrollOutlineDownPage(self, event: LeoKeyEvent = None) -> None:
+    def scrollOutlineDownPage(self, event: LeoKeyEvent | None = None) -> None:
         """Scroll the outline pane down one page."""
         tree = self.c.frame.tree
         if hasattr(tree, 'scrollDelegate'):
@@ -3921,7 +3922,7 @@ class EditCommandsClass(BaseEditCommandsClass):
                 tree.canvas.yview_scroll(1, "page")
 
     @cmd('scroll-outline-up-line')
-    def scrollOutlineUpLine(self, event: LeoKeyEvent = None) -> None:
+    def scrollOutlineUpLine(self, event: LeoKeyEvent | None = None) -> None:
         """Scroll the outline pane up one line."""
         tree = self.c.frame.tree
         if hasattr(tree, 'scrollDelegate'):
@@ -3932,7 +3933,7 @@ class EditCommandsClass(BaseEditCommandsClass):
                 tree.canvas.yview_scroll(-1, "unit")
 
     @cmd('scroll-outline-up-page')
-    def scrollOutlineUpPage(self, event: LeoKeyEvent = None) -> None:
+    def scrollOutlineUpPage(self, event: LeoKeyEvent | None = None) -> None:
         """Scroll the outline pane up one page."""
         tree = self.c.frame.tree
         if hasattr(tree, 'scrollDelegate'):
@@ -3944,7 +3945,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.338: *4* ec.scrollOutlineLeftRight
     @cmd('scroll-outline-left')
-    def scrollOutlineLeft(self, event: LeoKeyEvent = None) -> None:
+    def scrollOutlineLeft(self, event: LeoKeyEvent | None = None) -> None:
         """Scroll the outline left."""
         tree = self.c.frame.tree
         if hasattr(tree, 'scrollDelegate'):
@@ -3953,7 +3954,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             tree.canvas.xview_scroll(1, "unit")
 
     @cmd('scroll-outline-right')
-    def scrollOutlineRight(self, event: LeoKeyEvent = None) -> None:
+    def scrollOutlineRight(self, event: LeoKeyEvent | None = None) -> None:
         """Scroll the outline left."""
         tree = self.c.frame.tree
         if hasattr(tree, 'scrollDelegate'):
@@ -4139,7 +4140,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.348: *3* ec: uA's
     # @+node:ekr.20150514063305.349: *4* ec.clearNodeUas & clearAllUas
     @cmd('clear-node-uas')
-    def clearNodeUas(self, event: LeoKeyEvent = None) -> None:
+    def clearNodeUas(self, event: LeoKeyEvent | None = None) -> None:
         """Clear the uA's in the selected VNode."""
         c = self.c
         p = c and c.p
@@ -4154,7 +4155,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             c.redraw()
 
     @cmd('clear-all-uas')
-    def clearAllUas(self, event: LeoKeyEvent = None) -> None:
+    def clearAllUas(self, event: LeoKeyEvent | None = None) -> None:
         """Clear all uAs in the entire outline."""
         c, u, undoType = self.c, self.c.undoer, 'clear-all-uas'
         # #1276.
@@ -4176,7 +4177,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.350: *4* ec.showUas & showAllUas
     @cmd('show-all-uas')
-    def showAllUas(self, event: LeoKeyEvent = None) -> None:
+    def showAllUas(self, event: LeoKeyEvent | None = None) -> None:
         """Print all uA's in the outline."""
         g.es_print('Dump of uAs...')
         for v in self.c.all_unique_nodes():
@@ -4184,7 +4185,7 @@ class EditCommandsClass(BaseEditCommandsClass):
                 self.showNodeUas(v=v)
 
     @cmd('show-node-uas')
-    def showNodeUas(self, event: LeoKeyEvent = None, v: VNode = None) -> None:
+    def showNodeUas(self, event: LeoKeyEvent | None = None, v: VNode | None = None) -> None:
         """Print the uA's in the selected node."""
         c = self.c
         if v:

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -172,7 +172,7 @@ class EditFileCommandsClass(BaseEditCommandsClass):
     # @+others
     # @+node:ekr.20210308051724.1: *3* efc.convert-at-root
     @cmd('convert-at-root')
-    def convert_at_root(self, event: LeoKeyEvent = None) -> None:
+    def convert_at_root(self, event: LeoKeyEvent | None = None) -> None:
         # @+<< convert-at-root docstring >>
         # @+node:ekr.20210309035627.1: *4* << convert-at-root docstring >>
         # @@wrap
@@ -508,7 +508,7 @@ class EditFileCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20170806094318.3: *3* efc.diff (file-diff-files)
     @cmd('file-diff-files')
-    def diff(self, event: LeoKeyEvent = None) -> None:
+    def diff(self, event: LeoKeyEvent | None = None) -> None:
         """Creates a node and puts the diff between 2 files into it."""
         c, u = self.c, self.c.undoer
         fn = self.getReadableTextFile()
@@ -551,14 +551,14 @@ class EditFileCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20170819035801.90: *3* efc.gitDiff (gd & git-diff)
     @cmd('git-diff')
     @cmd('gd')
-    def gitDiff(self, event: LeoKeyEvent = None) -> None:
+    def gitDiff(self, event: LeoKeyEvent | None = None) -> None:
         """Produce a Leonine git diff."""
         GitDiffController(c=self.c).git_diff(rev1='HEAD')
 
     # @+node:ekr.20201215093414.1: *3* efc.gitDiffPR (git-diff-pr & git-diff-pull-request)
     @cmd('git-diff-pull-request')
     @cmd('git-diff-pr')
-    def gitDiffPullRequest(self, event: LeoKeyEvent = None) -> None:
+    def gitDiffPullRequest(self, event: LeoKeyEvent | None = None) -> None:
         """
         Produce a Leonine diff of pull request in the current branch.
         """
@@ -566,7 +566,7 @@ class EditFileCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20260707054655.1: *3* efc.cloneDiffPR (clone-diff-pr)
     @cmd('clone-diff-pr')
-    def cloneDiffPR(self, event: LeoKeyEvent = None) -> None:
+    def cloneDiffPR(self, event: LeoKeyEvent | None = None) -> None:
         """
         Show the added, deleted and changed nodes (without diffs) of the given PR.
         """
@@ -697,8 +697,8 @@ class GitDiffController:
     def __init__(self, c: Cmdr) -> None:
         self.c = c
         self.diff_leo_files = True
-        self.file_node: Position = None
-        self.root: Position = None
+        self.file_node: Position | None = None
+        self.root: Position | None = None
         self.reloadSettings()
 
     def reloadSettings(self) -> None:
@@ -887,7 +887,7 @@ class GitDiffController:
         self.finish()
 
     # @+node:ekr.20180507212821.1: *4* gdc.diff_two_revs
-    def diff_two_revs(self, rev1: str = 'HEAD', rev2: str = '', path: str = None) -> None:
+    def diff_two_revs(self, rev1: str = 'HEAD', rev2: str = '', path: str | None = None) -> None:
         """
         Create an outline describing the git diffs for all files changed
         between rev1 and rev2.
@@ -969,7 +969,7 @@ class GitDiffController:
         return True
 
     # @+node:ekr.20230705082614.1: *4* gdc.node_history & helpers
-    def node_history(self, path: str, gnxs: list[str], limit: int = None) -> None:
+    def node_history(self, path: str, gnxs: list[str], limit: int | None = None) -> None:
         """Produce a Leonine history of the node whose file name and gnx are given."""
         c = self.c
         # The path must be absolute.
@@ -1277,7 +1277,9 @@ class GitDiffController:
             g.trace('Unknown kind', repr(b.kind))
 
     # @+node:ekr.20260112115313.1: *4* gdc.summary_diff_two_revs
-    def summary_diff_two_revs(self, rev1: str = 'HEAD', rev2: str = '', path: str = None) -> None:
+    def summary_diff_two_revs(
+        self, rev1: str = 'HEAD', rev2: str = '', path: str | None = None
+    ) -> None:
         """
         Create an outline describing the git diffs for all files changed
         between rev1 and rev2.
@@ -1654,7 +1656,7 @@ class GitDiffController:
             return ''
 
     # @+node:ekr.20170806094320.9: *4* gdc.get_files
-    def get_files(self, rev1: str, rev2: str, path: str = None) -> list[str]:
+    def get_files(self, rev1: str, rev2: str, path: str | None = None) -> list[str]:
         """Return a list of changed files."""
         # #2143
         git_directory = self.get_parent_of_git_directory()
@@ -1857,7 +1859,9 @@ class GitDiffController:
         return hidden_c
 
     # @+node:ekr.20260707055326.1: *4* gdc.clone_diff_two_revs
-    def clone_diff_two_revs(self, rev1: str = 'HEAD', rev2: str = '', path: str = None) -> None:
+    def clone_diff_two_revs(
+        self, rev1: str = 'HEAD', rev2: str = '', path: str | None = None
+    ) -> None:
         """
         Like diff_two_revs showing only clones of changed nodes, organized by file:
         - Omit the diffs.

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -27,7 +27,7 @@ class GoToCommands:
 
     # @+others
     # @+node:ekr.20100216141722.5622: *3* goto.find_file_line & helper
-    def find_file_line(self, n: int, p: Position = None) -> tuple[Position, int]:
+    def find_file_line(self, n: int, p: Position | None = None) -> tuple[Position, int]:
         """
         Helper for goto-global-line command.
 
@@ -48,7 +48,7 @@ class GoToCommands:
         return p, offset
 
     # @+node:ekr.20230727074847.1: *4* goto.find_file_line_helper
-    def find_file_line_helper(self, n: int, p: Position = None) -> tuple[Position, int]:
+    def find_file_line_helper(self, n: int, p: Position | None = None) -> tuple[Position, int]:
         c = self.c
         if n < 0:
             return None, -1
@@ -97,7 +97,7 @@ class GoToCommands:
         return None, -1
 
     # @+node:ekr.20160921210529.1: *3* goto.find_node_start & helper
-    def find_node_start(self, p: Position, s: str = None) -> int | None:
+    def find_node_start(self, p: Position, s: str | None = None) -> int | None:
         """
         Helper for show-file-line command.
 

--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -32,7 +32,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
     # @+others
     # @+node:ekr.20150514063305.373: *3* help
     @cmd('help')
-    def help_command(self, event: LeoKeyEvent = None) -> None:
+    def help_command(self, event: LeoKeyEvent | None = None) -> None:
         """Prints an introduction to Leo's help system."""
         # @+<< define rst_s >>
         # @+node:ekr.20150514063305.374: *4* << define rst_s >> (F1)
@@ -72,7 +72,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.375: *3* helpForAbbreviations
     @cmd('help-for-abbreviations')
-    def helpForAbbreviations(self, event: LeoKeyEvent = None) -> None:
+    def helpForAbbreviations(self, event: LeoKeyEvent | None = None) -> None:
         """Explains Leo's abbreviations."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.376: *4* << define s >> (helpForAbbreviations)
@@ -133,7 +133,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.377: *3* helpForAutocompletion
     @cmd('help-for-autocompletion')
-    def helpForAutocompletion(self, event: LeoKeyEvent = None) -> None:
+    def helpForAutocompletion(self, event: LeoKeyEvent | None = None) -> None:
         """Explains how to use autocompletion."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.378: *4* << define s >> (helpForAutocompletion)
@@ -251,7 +251,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.379: *3* helpForBindings
     @cmd('help-for-bindings')
-    def helpForBindings(self, event: LeoKeyEvent = None) -> None:
+    def helpForBindings(self, event: LeoKeyEvent | None = None) -> None:
         """Explains Leo's keyboard bindings."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.380: *4* << define s >> (helpForBindings)
@@ -461,7 +461,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.386: *3* helpForCreatingExternalFiles
     @cmd('help-for-creating-external-files')
-    def helpForCreatingExternalFiles(self, event: LeoKeyEvent = None) -> None:
+    def helpForCreatingExternalFiles(self, event: LeoKeyEvent | None = None) -> None:
         """Explains how to create external files."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.387: *4* << define s >> (helpForCreatingExternalFiles)
@@ -597,7 +597,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.388: *3* helpForDebuggingCommands
     @cmd('help-for-debugging-commands')
-    def helpForDebuggingCommands(self, event: LeoKeyEvent = None) -> None:
+    def helpForDebuggingCommands(self, event: LeoKeyEvent | None = None) -> None:
         """Explains Leo's debugging commands."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.389: *4* << define s >> (helpForDebuggingCommands)
@@ -630,7 +630,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.390: *3* helpForDragAndDrop
     @cmd('help-for-drag-and-drop')
-    def helpForDragAndDrop(self, event: LeoKeyEvent = None) -> None:
+    def helpForDragAndDrop(self, event: LeoKeyEvent | None = None) -> None:
         """Explains Leo's drag-and-drop commands."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.391: *4* << define s >> (helpForDragAndDrop
@@ -671,7 +671,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.392: *3* helpForDynamicAbbreviations
     @cmd('help-for-dynamic-abbreviations')
-    def helpForDynamicAbbreviations(self, event: LeoKeyEvent = None) -> None:
+    def helpForDynamicAbbreviations(self, event: LeoKeyEvent | None = None) -> None:
         """Explains Leo's abbreviations."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.393: *4* << define s >> (helpForDynamicAbbreviations)
@@ -718,7 +718,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.394: *3* helpForFindCommands
     @cmd('help-for-find-commands')
-    def helpForFindCommands(self, event: LeoKeyEvent = None) -> None:
+    def helpForFindCommands(self, event: LeoKeyEvent | None = None) -> None:
         """Explains Leo's find commands."""
         c = self.c
         d = c.k.computeInverseBindingDict()
@@ -841,7 +841,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20240822071015.1: *3* helpForLayouts
     @cmd('help-for-layouts')
-    def helpForLayouts(self, event: LeoKeyEvent = None) -> None:
+    def helpForLayouts(self, event: LeoKeyEvent | None = None) -> None:
         """Print a message telling you how to use Leo's layouts."""
         c = self.c
         # @+<< create listing list>>
@@ -898,7 +898,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.396: *3* helpForMinibuffer
     @cmd('help-for-minibuffer')
-    def helpForMinibuffer(self, event: LeoKeyEvent = None) -> None:
+    def helpForMinibuffer(self, event: LeoKeyEvent | None = None) -> None:
         """Print a messages telling you how to get started with Leo."""
         # A bug in Leo: triple quotes puts indentation before each line.
         c = self.c
@@ -936,7 +936,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.398: *3* helpForRegularExpressions
     @cmd('help-for-regular-expressions')
-    def helpForRegularExpressions(self, event: LeoKeyEvent = None) -> None:
+    def helpForRegularExpressions(self, event: LeoKeyEvent | None = None) -> None:
         """Explains the regular expressions used by Leo's find commands."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.399: *4* << define s >> (helpForRegularExpressions)
@@ -1008,7 +1008,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.400: *3* helpForScripting
     @cmd('help-for-scripting')
-    def helpForScripting(self, event: LeoKeyEvent = None) -> None:
+    def helpForScripting(self, event: LeoKeyEvent | None = None) -> None:
         """Shows a tutorial about scripting Leo."""
         # @+<< define s >>
         # @+node:ekr.20150514063305.401: *4* << define s >> (helpForScripting)
@@ -1225,7 +1225,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20170823084423.1: *3* helpForSettings
     @cmd('help-for-settings')
-    def helpForSettings(self, event: LeoKeyEvent = None) -> None:
+    def helpForSettings(self, event: LeoKeyEvent | None = None) -> None:
         """Explains Leo's settings."""
         # @+<< define s >>
         # @+node:ekr.20170823084456.1: *4* << define s >> (helpForSettings)
@@ -1255,7 +1255,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20230306104232.1: *3* help.showColorSettings
     @cmd('show-color-settings')
-    def showColorSettings(self, event: LeoKeyEvent = None) -> None:
+    def showColorSettings(self, event: LeoKeyEvent | None = None) -> None:
         """
         Print the value of all @color settings.
 
@@ -1272,7 +1272,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20230306104131.1: *3* help.showFontSettings
     @cmd('show-font-settings')
-    def showFontSettings(self, event: LeoKeyEvent = None) -> None:
+    def showFontSettings(self, event: LeoKeyEvent | None = None) -> None:
         """
         Print the value of every @font setting.
 
@@ -1289,7 +1289,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.402: *3* help.showSettings
     @cmd('show-settings')
-    def showSettings(self, event: LeoKeyEvent = None) -> None:
+    def showSettings(self, event: LeoKeyEvent | None = None) -> None:
         """
         Print the value of every setting, except key bindings, commands, and
         open-with tables.
@@ -1307,7 +1307,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20190831025811.1: *3* help.showSettingsOutline
     @cmd('show-settings-outline')
-    def showSettingsOutline(self, event: LeoKeyEvent = None) -> None:
+    def showSettingsOutline(self, event: LeoKeyEvent | None = None) -> None:
         """
         Create and open an outline, summarizing all presently active settings.
 
@@ -1320,7 +1320,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.403: *3* pythonHelp
     @cmd('help-for-python')
-    def pythonHelp(self, event: LeoKeyEvent = None) -> None:
+    def pythonHelp(self, event: LeoKeyEvent | None = None) -> None:
         """Prompt for a arg for Python's help function, and put it to the VR pane."""
         c, k = self.c, self.c.k
         c.minibufferWantsFocus()

--- a/leo/commands/keyCommands.py
+++ b/leo/commands/keyCommands.py
@@ -23,7 +23,7 @@ class KeyHandlerCommandsClass(BaseEditCommandsClass):
     # @+others
     # @+node:ekr.20150514063305.406: *3* menuShortcutPlaceHolder
     @g.command('menu-shortcut')
-    def menuShortcutPlaceHolder(self, event: LeoKeyEvent = None) -> None:
+    def menuShortcutPlaceHolder(self, event: LeoKeyEvent | None = None) -> None:
         """
         This will never be called.
         A placeholder for the show-bindings command.

--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -44,12 +44,12 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         self.c = c
         self.kbiterator = self.iterateKillBuffer()  # An instance of KillBufferIterClass.
         # For interacting with system clipboard.
-        self.last_clipboard: str = None
+        self.last_clipboard: str | None = None
         # Position of the last item returned by iterateKillBuffer.
-        self.lastYankP: Position = None
+        self.lastYankP: Position | None = None
         # The index of the next item to be returned in
         # g.app.globalKillBuffer by iterateKillBuffer.
-        self.reset: int = None
+        self.reset: int | None = None
         self.reloadSettings()
 
     def reloadSettings(self) -> None:
@@ -117,7 +117,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.414: *3* clearKillRing
     @cmd('clear-kill-ring')
-    def clearKillRing(self, event: LeoKeyEvent = None) -> None:
+    def clearKillRing(self, event: LeoKeyEvent | None = None) -> None:
         """Clear the kill ring."""
         g.app.globalKillBuffer = []
 
@@ -178,7 +178,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         frm: int,
         to: int,
         w: QTextMixin,
-        undoType: str = None,
+        undoType: str | None = None,
     ) -> None:
         """
         A helper method for all kill commands except kill-paragraph commands.
@@ -209,7 +209,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         event: LeoKeyEvent,
         frm: int,
         to: int,
-        undoType: str = None,
+        undoType: str | None = None,
     ) -> None:
         """A helper method for kill-paragraph commands."""
         w = event.w if event else None
@@ -349,12 +349,12 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.425: *3* yank & yankPop
     @cmd('yank')
-    def yank(self, event: LeoKeyEvent = None) -> None:
+    def yank(self, event: LeoKeyEvent | None = None) -> None:
         """Insert the next entry of the kill ring."""
         self.yankHelper(event, pop=False)
 
     @cmd('yank-pop')
-    def yankPop(self, event: LeoKeyEvent = None) -> None:
+    def yankPop(self, event: LeoKeyEvent | None = None) -> None:
         """Insert the first entry of the kill ring."""
         self.yankHelper(event, pop=True)
 

--- a/leo/commands/rectangleCommands.py
+++ b/leo/commands/rectangleCommands.py
@@ -6,14 +6,14 @@
 # @+node:ekr.20150514050446.1: ** << rectangleCommands imports & annotations >>
 from __future__ import annotations
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import cast, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
+from leo.plugins.qt_text import QTextMixin
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
-    from leo.plugins.qt_text import QTextMixin
 # @-<< rectangleCommands imports & annotations >>
 
 
@@ -42,7 +42,7 @@ class RectangleCommandsClass(BaseEditCommandsClass):
             't': ('string-rectangle', self.stringRectangle),
             'y': ('yank-rectangle', self.yankRectangle),
         }
-        self.w: QTextMixin = None
+        self.w = cast(QTextMixin, None)
 
     # @+node:ekr.20150514043714.13: *3* RectangleCommandsClass.getRectanglePoints
     def getRectanglePoints(self, w: QTextMixin) -> tuple[int, int, int, int]:

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -455,7 +455,7 @@ class SpellCommandsClass(BaseEditCommandsClass):
         """
         # pylint: disable=super-init-not-called
         self.c = c
-        self.handler: SpellTabHandler = None
+        self.handler: SpellTabHandler | None = None
         self.suggestion_idx = 0
         self.reloadSettings()
 
@@ -466,7 +466,7 @@ class SpellCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.484: *3* openSpellTab
     @cmd('spell-tab-open')
-    def openSpellTab(self, event: LeoKeyEvent = None) -> None:
+    def openSpellTab(self, event: LeoKeyEvent | None = None) -> None:
         """Open the Spell Checker tab in the log pane."""
         if g.unitTesting:
             return
@@ -483,8 +483,8 @@ class SpellCommandsClass(BaseEditCommandsClass):
             log.deleteTab(tabName)
         # spell as you type stuff
         self.suggestions: list[str] = []
-        self.suggestions_idx: int = None
-        self.word: str = None
+        self.suggestions_idx: int | None = None
+        self.word: str | None = None
         self.spell_as_you_type = False
         self.wrap_as_you_type = False
 
@@ -635,7 +635,7 @@ class SpellTabHandler:
         # New in Leo 6.7.5: This class works in a null gui.
         self.c = c
         self.body = c.frame.body
-        self.currentWord: str = None
+        self.currentWord: str | None = None
         self.outerScrolledFrame = None
         self.seen: set[str] = set()  # Adding a word to seen will ignore it until restart.
         self.spellController: EnchantWrapper | DefaultWrapper
@@ -656,7 +656,7 @@ class SpellTabHandler:
 
     # @+node:ekr.20150514063305.502: *3* Commands
     # @+node:ekr.20150514063305.503: *4* SpellTabHandler.add
-    def add(self, event: LeoKeyEvent = None) -> None:
+    def add(self, event: LeoKeyEvent | None = None) -> None:
         """Add the selected suggestion to the dictionary."""
         if self.loaded:
             w = self.currentWord
@@ -665,7 +665,7 @@ class SpellTabHandler:
                 self.tab.onFindButton()
 
     # @+node:ekr.20150514063305.504: *4* SpellTabHandler.change
-    def change(self, event: LeoKeyEvent = None) -> bool:
+    def change(self, event: LeoKeyEvent | None = None) -> bool:
         """Make the selected change to the text"""
         if not self.loaded:
             return False
@@ -707,7 +707,7 @@ class SpellTabHandler:
     re_part = re.compile(r'[a-zA-z]+')
     re_http = re.compile(r'.*?(http|https)://(.*?)$')
 
-    def find(self, event: LeoKeyEvent = None) -> str | None:
+    def find(self, event: LeoKeyEvent | None = None) -> str | None:
         """
         Find the next unknown word.
 
@@ -870,11 +870,11 @@ class SpellTabHandler:
             c.selectPosition(p)
 
     # @+node:ekr.20150514063305.508: *4* SpellTabHandler.hide
-    def hide(self, event: LeoKeyEvent = None) -> None:
+    def hide(self, event: LeoKeyEvent | None = None) -> None:
         self.c.frame.log.selectTab('Log')
 
     # @+node:ekr.20150514063305.509: *4* SpellTabHandler.ignore
-    def ignore(self, event: LeoKeyEvent = None) -> None:
+    def ignore(self, event: LeoKeyEvent | None = None) -> None:
         """Ignore the incorrect word for the duration of this spell check session."""
         if self.loaded:
             w = self.currentWord
@@ -887,7 +887,7 @@ class SpellTabHandler:
 
 # @+node:ekr.20180209141207.1: ** @g.command('show-spell-info')
 @g.command('show-spell-info')
-def show_spell_info(event: LeoKeyEvent = None) -> None:
+def show_spell_info(event: LeoKeyEvent | None = None) -> None:
     c = event.get('c')
     if c:
         c.spellCommands.handler.spellController.show_info()

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -101,7 +101,7 @@ class StringTextWrapper(QTextMixin):
         self.sel = self.ins, self.ins
 
     # @+node:ekr.20140903172510.18593: *4* StringTextWrapper.delete
-    def delete(self, i: int, j: int = None) -> None:
+    def delete(self, i: int, j: int | None = None) -> None:
         """StringTextWrapper."""
         if j is None:
             j = i + 1
@@ -189,7 +189,7 @@ class StringTextWrapper(QTextMixin):
         self.sel = i, i
 
     # @+node:ekr.20140903172510.18589: *4* StringTextWrapper.selectAllText
-    def selectAllText(self, insert: int = None) -> None:
+    def selectAllText(self, insert: int | None = None) -> None:
         """StringTextWrapper."""
         self.setSelectionRange(0, len(self.s), insert=insert)
 
@@ -202,14 +202,14 @@ class StringTextWrapper(QTextMixin):
         self.sel = i, i
 
     # @+node:ekr.20140903172510.18587: *4* StringTextWrapper.setInsertPoint
-    def setInsertPoint(self, i: int, s: str = None) -> None:
+    def setInsertPoint(self, i: int, s: str | None = None) -> None:
         """StringTextWrapper."""
         self.virtualInsertPoint = i
         self.ins = i
         self.sel = i, i
 
     # @+node:ekr.20070228111853: *4* StringTextWrapper.setSelectionRange
-    def setSelectionRange(self, i: int, j: int, insert: int = None) -> None:
+    def setSelectionRange(self, i: int, j: int, insert: int | None = None) -> None:
         """StringTextWrapper."""
         # Note: leoFind.py may set those to None. See its 'save' and 'restore' methods.
         self.sel = i, j

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -122,8 +122,8 @@ class AtFile:
         self.fileCommands = c.fileCommands
         # Basic status vars.
         self.errors = 0
-        self.language: str = None
-        self.root: Position = None
+        self.language: str | None = None
+        self.root: Position | None = None
         # Dialogs.
         self.canCancelFlag = False
         self.cancelFlag = False
@@ -139,7 +139,7 @@ class AtFile:
         self.endSentinelComment = ""
         # Writing.
         self.indent = 0  # write indentation, in blanks.
-        self.outputFile: io.StringIO = None
+        self.outputFile: io.StringIO | None = None
         self.outputList: list[str] = []
         self.sentinels = False
         self.section_delim1 = '<<'
@@ -314,7 +314,7 @@ class AtFile:
     # @+node:ekr.20041005105605.18: *4* at.Reading (top level)
     # @+node:ekr.20070919133659: *5* at.checkExternalFile
     @cmd('check-external-file')
-    def checkExternalFile(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def checkExternalFile(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Make sure an external file written by Leo may be read properly."""
         c, p = self.c, self.c.p
         if not p.isAtFileNode() and not p.isAtThinFileNode():
@@ -336,7 +336,7 @@ class AtFile:
 
     # @+node:ekr.20250724123631.1: *5* at.openAtLeoFile
     @cmd('open-at-leo-file')
-    def openAtLeoFile(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def openAtLeoFile(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """
         Open the outline given by the @leo node at c.p.
         If the outline has already been loaded, switch to its tab.
@@ -354,7 +354,7 @@ class AtFile:
             g.red(f"file not found: {path}")
 
     # @+node:ekr.20041005105605.19: *5* at.openFileForReading & helper
-    def openFileForReading(self, fromString: str = None) -> tuple[str | None, str | None]:
+    def openFileForReading(self, fromString: str | None = None) -> tuple[str | None, str | None]:
         """
         Open the file given by at.root.
         This will be the private file for @shadow nodes.
@@ -408,7 +408,7 @@ class AtFile:
         return shadow_fn
 
     # @+node:ekr.20041005105605.21: *5* at.read & helpers
-    def read(self, root: Position, fromString: str = None) -> bool:
+    def read(self, root: Position, fromString: str | None = None) -> bool:
         """Read an @thin or @file tree."""
         at, c = self, self.c
         fileName = c.fullPath(root)
@@ -723,7 +723,7 @@ class AtFile:
         return p  # For #451: return p.
 
     # @+node:ekr.20150204165040.5: *5* at.readOneAtCleanNode & helpers
-    def readOneAtCleanNode(self, root: Position, *, new_contents: str = None) -> None:
+    def readOneAtCleanNode(self, root: Position, *, new_contents: str | None = None) -> None:
         """Update the @clean/@nosent node at root."""
         at, c, x = self, self.c, self.c.shadowController
 
@@ -1196,7 +1196,7 @@ class AtFile:
     # @+node:ekr.20190111153551.1: *5* at.commands
     # @+node:ekr.20070806105859: *6* at.writeAtAutoNodes
     @cmd('write-at-auto-nodes')
-    def writeAtAutoNodes(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def writeAtAutoNodes(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Write all @auto nodes in the selected outline."""
         at, c, p = self, self.c, self.c.p
         c.init_error_dialogs()
@@ -1221,7 +1221,7 @@ class AtFile:
 
     # @+node:ekr.20220120072251.1: *6* at.writeDirtyAtAutoNodes
     @cmd('write-dirty-at-auto-nodes')  # pragma: no cover
-    def writeDirtyAtAutoNodes(self, event: LeoKeyEvent = None) -> None:
+    def writeDirtyAtAutoNodes(self, event: LeoKeyEvent | None = None) -> None:
         """Write all dirty @auto nodes in the selected outline."""
         at, c, p = self, self.c, self.c.p
         c.init_error_dialogs()
@@ -1246,7 +1246,7 @@ class AtFile:
 
     # @+node:ekr.20080711093251.3: *6* at.writeAtShadowNodes
     @cmd('write-at-shadow-nodes')
-    def writeAtShadowNodes(self, event: LeoKeyEvent = None) -> bool:  # pragma: no cover
+    def writeAtShadowNodes(self, event: LeoKeyEvent | None = None) -> bool:  # pragma: no cover
         """Write all @shadow nodes in the selected outline."""
         at, c, p = self, self.c, self.c.p
         c.init_error_dialogs()
@@ -1273,7 +1273,7 @@ class AtFile:
 
     # @+node:ekr.20220120072917.1: *6* at.writeDirtyAtShadowNodes
     @cmd('write-dirty-at-shadow-nodes')
-    def writeDirtyAtShadowNodes(self, event: LeoKeyEvent = None) -> bool:  # pragma: no cover
+    def writeDirtyAtShadowNodes(self, event: LeoKeyEvent | None = None) -> bool:  # pragma: no cover
         """Write all @shadow nodes in the selected outline."""
         at, c, p = self, self.c, self.c.p
         c.init_error_dialogs()
@@ -3347,7 +3347,7 @@ class AtFile:
 
     # @+node:ekr.20090712050729.6017: *4* at.promptForDangerousWrite
     def promptForDangerousWrite(
-        self, fileName: str, message: str = None
+        self, fileName: str, message: str | None = None
     ) -> bool:  # pragma: no cover
         """Raise a dialog asking the user whether to overwrite an existing file."""
         at, c, root = self, self.c, self.root
@@ -3495,21 +3495,21 @@ class FastAtRead:
         assert gnx2vnode is not None
         # The global fc.gnxDict. Keys are gnx's, values are vnodes.
         self.gnx2vnode: dict[str, VNode] = gnx2vnode
-        self.path: str = None
-        self.root: Position = None
+        self.path: str | None = None
+        self.root: Position | None = None
         # compiled patterns...
-        self.after_pat: re.Pattern = None
-        self.all_pat: re.Pattern = None
-        self.code_pat: re.Pattern = None
-        self.comment_pat: re.Pattern = None
-        self.delims_pat: re.Pattern = None
-        self.doc_pat: re.Pattern = None
-        self.first_pat: re.Pattern = None
-        self.last_pat: re.Pattern = None
-        self.node_start_pat: re.Pattern = None
-        self.others_pat: re.Pattern = None
-        self.ref_pat: re.Pattern = None
-        self.section_delims_pat: re.Pattern = None
+        self.after_pat: re.Pattern | None = None
+        self.all_pat: re.Pattern | None = None
+        self.code_pat: re.Pattern | None = None
+        self.comment_pat: re.Pattern | None = None
+        self.delims_pat: re.Pattern | None = None
+        self.doc_pat: re.Pattern | None = None
+        self.first_pat: re.Pattern | None = None
+        self.last_pat: re.Pattern | None = None
+        self.node_start_pat: re.Pattern | None = None
+        self.others_pat: re.Pattern | None = None
+        self.ref_pat: re.Pattern | None = None
+        self.section_delims_pat: re.Pattern | None = None
 
     # @+node:ekr.20180602103135.3: *3* fast_at.get_patterns
     def get_patterns(self, comment_delims: tuple) -> None:
@@ -3596,7 +3596,7 @@ class FastAtRead:
         #
         # Simple vars...
         afterref = False  # True: the next line follows @afterref.
-        clone_v: VNode = None  # The root of the clone tree.
+        clone_v: VNode | None = None  # The root of the clone tree.
         # The start/end *comment* delims.
         # Important: scan_header ends comment_delim1 with a blank when using black sentinels.
         comment_delim1, comment_delim2 = comment_delims

--- a/leo/core/leoBackground.py
+++ b/leo/core/leoBackground.py
@@ -99,9 +99,9 @@ class BackgroundProcessManager:
     # @+node:ekr.20180522085807.1: *3* bpm.__init__
     def __init__(self) -> None:
         """Ctor for the base BackgroundProcessManager class."""
-        self.data: ProcessData = None  # a ProcessData instance.
+        self.data: ProcessData | None = None  # a ProcessData instance.
         self.process_queue: list = []  # List of g.Bunches.
-        self.pid: Popen = None  # The process id of the running process.
+        self.pid: Popen | None = None  # The process id of the running process.
         self.lock = thread.allocate_lock()
         self.process_return_data: list[str] = None
         # #2528: A timer that runs independently of idle time.
@@ -141,7 +141,7 @@ class BackgroundProcessManager:
         self.pid = None
 
     # @+node:ekr.20161026193609.3: *3* bpm.kill
-    def kill(self, kind: str = None) -> None:
+    def kill(self, kind: str | None = None) -> None:
         """Kill the presently running process, if any."""
         if kind is None:
             kind = 'all'
@@ -240,7 +240,7 @@ class BackgroundProcessManager:
             self.timer.stop()
 
     # @+node:ekr.20161026193609.5: *3* bpm.start_process (creates callback)
-    def start_process(self, c: Cmdr, command: str, kind: str, fn: str = None) -> None:
+    def start_process(self, c: Cmdr, command: str, kind: str, fn: str | None = None) -> None:
         """
         Start or queue a process described by command and fn.
         """

--- a/leo/core/leoBeautify.py
+++ b/leo/core/leoBeautify.py
@@ -242,7 +242,7 @@ class CPrettyPrinter:
         """Ctor for CPrettyPrinter class."""
         self.c = c
         self.brackets = 0  # The brackets indentation level.
-        self.p: Position = None  # Set in indent.
+        self.p: Position | None = None  # Set in indent.
         self.parens = 0  # The parenthesis nesting level.
         self.result: list[str] = []  # The list of tokens that form the final result.
         self.tab_width = 4  # The number of spaces in each unit of leading indentation.

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -105,7 +105,7 @@ class BridgeController:
         vs_code_flag: bool = False,  # #2098.
     ) -> None:
         """Ctor for the BridgeController class."""
-        self.g: ModuleType = None  # leo.core.leoGlobals.
+        self.g: ModuleType | None = None  # leo.core.leoGlobals.
         self.guiName = guiName or 'nullGui'
         self.loadPlugins = loadPlugins
         self.readSettings = readSettings

--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -49,7 +49,7 @@ class CommanderWrapper:
         self.db = g.app.db
         self.user_keys: set[str] = set()
 
-    def get(self, key: str, default: Value = None) -> Value:
+    def get(self, key: str, default: Value | None = None) -> Value:
         value = self.db.get(f"{self.c.mFileName}:::{key}")
         return default if value is None else value
 
@@ -255,7 +255,7 @@ class SqlitePickleShare:
         os.makedirs(fn, mode)
 
     # @+node:vitalije.20170716201700.12: *3* _walkfiles & helpers
-    def _walkfiles(self, s: str, pattern: str = None) -> None:
+    def _walkfiles(self, s: str, pattern: str | None = None) -> None:
         """D.walkfiles() -> iterator over files in D, recursively.
 
         The optional argument, pattern, limits the results to files
@@ -265,7 +265,7 @@ class SqlitePickleShare:
         """
 
     # @+node:vitalije.20170716201700.13: *4* _listdir
-    def _listdir(self, s: str, pattern: str = None) -> list[str]:
+    def _listdir(self, s: str, pattern: str | None = None) -> list[str]:
         """D.listdir() -> List of items in this directory.
 
         Use D.files() or D.dirs() instead if you want a listing
@@ -300,7 +300,7 @@ class SqlitePickleShare:
         self.conn.execute('delete from cachevalues;')
 
     # @+node:vitalije.20170716201700.16: *3* get  (SqlitePickleShare)
-    def get(self, key: str, default: Value = None) -> Value:
+    def get(self, key: str, default: Value | None = None) -> Value:
         if not self.has_key(key):  # noqa
             return default
         try:
@@ -328,7 +328,7 @@ class SqlitePickleShare:
     # @+node:vitalije.20170716201700.19: *3* keys (SqlitePickleShare)
     # Called by clear, and during unit testing.
 
-    def keys(self, globpat: str = None) -> Generator:
+    def keys(self, globpat: str | None = None) -> Generator:
         """Return all keys in DB, or all keys matching a glob"""
         args: tuple
         if globpat is None:

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -75,7 +75,7 @@ class ChapterController:
         c.redraw()
 
     # @+node:ekr.20160411145155.1: *4* cc.makeCommand
-    def makeCommand(self, chapterName: str, binding: str = None) -> None:
+    def makeCommand(self, chapterName: str, binding: str | None = None) -> None:
         """Make chapter-select-<chapterName> command."""
         c, cc = self.c, self
         commandName = f"chapter-select-{chapterName}"
@@ -122,7 +122,7 @@ class ChapterController:
 
     # @+node:ekr.20070604165126: *3* cc: chapter-select
     @cmd('chapter-select')
-    def selectChapter(self, event: LeoKeyEvent = None) -> None:
+    def selectChapter(self, event: LeoKeyEvent | None = None) -> None:
         """Prompt for a chapter name and select the given chapter."""
         cc, k = self, self.c.k
         names = cc.setAllChapterNames()
@@ -139,7 +139,7 @@ class ChapterController:
 
     # @+node:ekr.20170202061705.1: *3* cc: chapter-back/next
     @cmd('chapter-back')
-    def backChapter(self, event: LeoKeyEvent = None) -> None:
+    def backChapter(self, event: LeoKeyEvent | None = None) -> None:
         """Select the previous chapter."""
         cc = self
         names = cc.setAllChapterNames()
@@ -149,7 +149,7 @@ class ChapterController:
         cc.selectChapterByName(new_name)
 
     @cmd('chapter-next')
-    def nextChapter(self, event: LeoKeyEvent = None) -> None:
+    def nextChapter(self, event: LeoKeyEvent | None = None) -> None:
         """Select the next chapter."""
         cc = self
         names = cc.setAllChapterNames()

--- a/leo/core/leoColor.py
+++ b/leo/core/leoColor.py
@@ -734,7 +734,7 @@ for key in leo_color_database:
 # @+others
 # @+node:bob.20080115070511.3: ** color database functions
 # @+node:bob.20071231111744.2: *3* function: leoColor.get / getColor
-def getColor(name: str, default: str = None) -> str | None:
+def getColor(name: str, default: str | None = None) -> str | None:
     """Translate a named color into #rrggbb' format.
 
     if 'name' is not a string it is returned unchanged.
@@ -761,7 +761,7 @@ get = getColor
 
 
 # @+node:bob.20080115070511.4: *3* function: leoColor.getRGB / getColorRGB
-def getColorRGB(name: str, default: str = None) -> tuple[int, int, int]:
+def getColorRGB(name: str, default: str | None = None) -> tuple[int, int, int]:
     """Convert a named color into an (r, g, b) tuple."""
     s = getColor(name, default)
     try:
@@ -775,7 +775,7 @@ getRGB = getColorRGB
 
 
 # @+node:bob.20080115072302: *3* function: leoColor.getCairo / getColorCairo
-def getColorCairo(name: str, default: str = None) -> tuple[float, float, float] | None:
+def getColorCairo(name: str, default: str | None = None) -> tuple[float, float, float] | None:
     """Convert a named color into a cairo color tuple."""
     color = getColorRGB(name, default)
     if color is None:

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -495,14 +495,14 @@ class JEditColorizer(BaseColorizer):
             )
 
         # *Global* state data. This is not entirely correct, but it's not worth fixing.
-        self.after_doc_language: str = None
+        self.after_doc_language: str | None = None
         self.in_killcolor: bool = False
 
         # *Local* state data. Such state is harmless.
         self.delegate_stack: list[str] = []
         self.initialStateNumber = -1
         self.n2languageDict: dict[int, str] = {-1: c.target_language}
-        self.mode: JEditModeDescriptor = None
+        self.mode: JEditModeDescriptor | None = None
         self.nested = False  # True: allow nested comments, etc.
         self.nested_level = 0  # Nesting level if self.nested is True.
         self.nextState = 1  # Don't use 0.
@@ -917,9 +917,9 @@ class JEditColorizer(BaseColorizer):
         self.init()
 
     # @+node:ekr.20190327053604.1: *4* jedit.report_changes
-    prev_use_pygments: bool = None
-    prev_use_styles: bool = None
-    prev_style: str = None
+    prev_use_pygments: bool | None = None
+    prev_use_styles: bool | None = None
+    prev_style: str | None = None
 
     def report_changes(self) -> None:
         """Report changes to pygments settings"""
@@ -1491,7 +1491,7 @@ class JEditColorizer(BaseColorizer):
         """Set the tag in the highlighter."""
         default_tag = f"{tag}_font"  # See default_font_dict.
         full_tag = f"{self.language}.{tag}"
-        font: QtGui.QFont = None  # Set below. Define here for report().
+        font: QtGui.QFont | None = None  # Set below. Define here for report().
         self.n_setTag += 1
         if i == j:
             return
@@ -2051,7 +2051,7 @@ class JEditColorizer(BaseColorizer):
         s: str,
         i: int,
         *,
-        kind: str = None,
+        kind: str | None = None,
         seq: str = '',
         at_line_start: bool = False,
         at_whitespace_end: bool = False,
@@ -2274,7 +2274,7 @@ class JEditColorizer(BaseColorizer):
         return -len(word)  # An important new optimization.
 
     # @+node:ekr.20110605121601.18615: *4* jedit.match_line
-    def match_line(self, s: str, i: int, *, kind: str = None) -> int:
+    def match_line(self, s: str, i: int, *, kind: str | None = None) -> int:
         """Match the rest of the line."""
         j = g.skip_to_end_of_line(s, i)
         self.colorRangeWithTag(s, i, j, kind)
@@ -3338,7 +3338,7 @@ if Qsci:
     class NullScintillaLexer(Qsci.QsciLexerCustom):
         """A do-nothing colorizer for Scintilla."""
 
-        def __init__(self, c: Cmdr, parent: QWidget = None) -> None:
+        def __init__(self, c: Cmdr, parent: QWidget | None = None) -> None:
             super().__init__(parent)  # Init the pase class
             self.leo_c = c
             self.configure_lexer()
@@ -3384,7 +3384,7 @@ class PygmentsColorizer(JEditColorizer):
         # State unique to this class...
         self.color_enabled = self.enabled
         self.getDefaultFormat: Callable
-        self.old_v: VNode = None
+        self.old_v: VNode | None = None
         # Monkey-patch g.isValidLanguage.
         g.isValidLanguage = self.pygments_isValidLanguage
         # Init common data...
@@ -3678,7 +3678,7 @@ class QScintillaColorizer(BaseColorizer):
         self.error = False  # Set if there is an error in jeditColorizer.recolor
         self.flag = True  # Per-node enable/disable flag.
         self.highlighter = None
-        self.lexer: Lexer = None  # Set in changeLexer.
+        self.lexer: Lexer | None = None  # Set in changeLexer.
         widget.leo_colorizer = self
 
         # Define/configure various lexers.

--- a/leo/core/leoCompare.py
+++ b/leo/core/leoCompare.py
@@ -30,7 +30,7 @@ class BaseLeoCompare:
 
     def __init__(
         self,  # Keyword arguments are much convenient and more clear for scripts.
-        commands: Cmdr = None,
+        commands: Cmdr | None = None,
         appendOutput: bool = False,
         ignoreBlankLines: bool = True,
         ignoreFirstLine1: bool = False,
@@ -45,7 +45,7 @@ class BaseLeoCompare:
         printMatches: bool = False,
         printMismatches: bool = True,
         printTrailingMismatches: bool = False,
-        outputFileName: str = None,
+        outputFileName: str | None = None,
     ) -> None:
         # It is more convenient for the LeoComparePanel to set these directly.
         self.c = commands
@@ -68,7 +68,7 @@ class BaseLeoCompare:
         self.fileName1 = None
         self.fileName2 = None
         # Open files...
-        self.outputFile: BufferedWriter = None
+        self.outputFile: BufferedWriter | None = None
 
     # @+node:ekr.20031218072017.3635: *3* compare_directories (entry)
     # We ignore the filename portion of path1 and path2 if it exists.
@@ -493,10 +493,10 @@ class CompareLeoOutlines:
     def __init__(self, c: Cmdr) -> None:
         """Ctor for the LeoOutlineCompare class."""
         self.c = c
-        self.file_node: Position = None
-        self.root: Position = None
-        self.path1: str = None
-        self.path2: str = None
+        self.file_node: Position | None = None
+        self.root: Position | None = None
+        self.path1: str | None = None
+        self.path2: str | None = None
 
     # @+others
     # @+node:ekr.20180211170333.2: *3* loc.diff_list_of_files (entry)

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -72,7 +72,7 @@ class ExternalFilesController:
 
     # @+others
     # @+node:ekr.20150404083533.1: *3* efc.ctor
-    def __init__(self, c: Cmdr = None) -> None:
+    def __init__(self, c: Cmdr | None = None) -> None:
         """Ctor for ExternalFiles class."""
         self.checksum_d: dict[str, str] = {}  # Keys are full paths, values are file checksums.
         # For efc.on_idle.
@@ -546,7 +546,7 @@ class ExternalFilesController:
     # @+node:ekr.20150405110219.1: *3* efc.utilities
 
     # @+node:ekr.20150405200212.1: *4* efc.ask
-    def ask(self, c: Cmdr, path: str, p: Position = None) -> str:
+    def ask(self, c: Cmdr, path: str, p: Position | None = None) -> str:
         """
         Ask user whether to overwrite an @<file> tree.
 
@@ -678,7 +678,7 @@ class ExternalFilesController:
         return f"{s1} {s2}"
 
     # @+node:tbrown.20150904102518.1: *4* efc.set_time
-    def set_time(self, path: str, new_time: float = None) -> None:
+    def set_time(self, path: str, new_time: float | None = None) -> None:
         """
         Implements c.setTimeStamp.
 

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -218,7 +218,7 @@ class FastRead:
         fc.descendentMarksList = marked
 
     # @+node:ekr.20180606041211.1: *4* fast.resolveUa
-    def resolveUa(self, attr: str, val: Value, kind: str = None) -> Value:
+    def resolveUa(self, attr: str, val: Value, kind: str | None = None) -> Value:
         # Kind is for unit testing.
         """Parse an unknown attribute in a <v> or <t> element."""
         try:
@@ -640,15 +640,15 @@ class FileCommands:
         self.descendentMarksList: list[str] = []  # List of gnx's.
         self.descendentTnodeUaDictList: list[Value] = []
         self.descendentVnodeUaDictList: list[Value] = []
-        self.currentVnode: VNode = None
+        self.currentVnode: VNode | None = None
         # For writing...
         self.read_only = False
-        self.rootPosition: Position = None
-        self.outputFile: io.StringIO = None
+        self.rootPosition: Position | None = None
+        self.outputFile: io.StringIO | None = None
         self.usingClipboard = False
-        self.currentPosition: Position = None
+        self.currentPosition: Position | None = None
         # New in 3.12...
-        self.copiedTree: Position = None
+        self.copiedTree: Position | None = None
         # fc.gnxDict is never re-inited.
         self.gnxDict: dict[str, VNode] = {}  # Keys are gnx strings.
         self.vnodesDict: dict[str, bool] = {}  # keys are gnx strings.
@@ -656,7 +656,7 @@ class FileCommands:
     # @+node:ekr.20210316042224.1: *3* fc: Commands
     # @+node:ekr.20031218072017.2012: *4* write-at-file-nodes
     @cmd('write-at-file-nodes')
-    def writeAtFileNodes(self, event: LeoKeyEvent = None) -> None:
+    def writeAtFileNodes(self, event: LeoKeyEvent | None = None) -> None:
         """Write all @file nodes in the selected outline."""
         c = self.c
         c.endEditing()
@@ -666,7 +666,7 @@ class FileCommands:
 
     # @+node:ekr.20031218072017.1666: *4* write-dirty-at-file-nodes
     @cmd('write-dirty-at-file-nodes')
-    def writeDirtyAtFileNodes(self, event: LeoKeyEvent = None) -> None:
+    def writeDirtyAtFileNodes(self, event: LeoKeyEvent | None = None) -> None:
         """Write all changed @file Nodes."""
         c = self.c
         c.endEditing()
@@ -676,7 +676,7 @@ class FileCommands:
 
     # @+node:ekr.20031218072017.2013: *4* write-missing-at-file-nodes
     @cmd('write-missing-at-file-nodes')
-    def writeMissingAtFileNodes(self, event: LeoKeyEvent = None) -> None:
+    def writeMissingAtFileNodes(self, event: LeoKeyEvent | None = None) -> None:
         """Write all @file nodes for which the corresponding external file does not exist."""
         c = self.c
         c.endEditing()
@@ -684,7 +684,7 @@ class FileCommands:
 
     # @+node:ekr.20031218072017.3050: *4* write-outline-only
     @cmd('write-outline-only')
-    def writeOutlineOnly(self, event: LeoKeyEvent = None) -> None:
+    def writeOutlineOnly(self, event: LeoKeyEvent | None = None) -> None:
         """Write the entire outline without writing any derived files."""
         c = self.c
         c.endEditing()
@@ -692,7 +692,7 @@ class FileCommands:
 
     # @+node:ekr.20230406053535.1: *4* write-zip-archive
     @cmd('write-zip-archive')
-    def writeZipArchive(self, event: LeoKeyEvent = None) -> None:
+    def writeZipArchive(self, event: LeoKeyEvent | None = None) -> None:
         """
         Write a .zip file containing this .leo file and all external files.
 
@@ -1194,7 +1194,7 @@ class FileCommands:
         return rootChildren[0]
 
     # @+node:vitalije.20170815162307.1: *6* fc.initNewDb
-    def initNewDb(self, conn: Conn, path: str = None) -> VNode:
+    def initNewDb(self, conn: Conn, path: str | None = None) -> VNode:
         """Initializes tables and returns None"""
         c, fc = self.c, self
         v = leoNodes.VNode(context=c)
@@ -1253,7 +1253,7 @@ class FileCommands:
     # Pre Leo 4.5 Only @thin vnodes had the descendentTnodeUnknownAttributes field.
     # New in Leo 4.5: @thin & @shadow vnodes have descendentVnodeUnknownAttributes field.
 
-    def getDescendentUnknownAttributes(self, s: str, v: VNode = None) -> Value:
+    def getDescendentUnknownAttributes(self, s: str, v: VNode | None = None) -> Value:
         """Unhexlify and unpickle t/v.descendentUnknownAttribute field."""
         try:
             # Changed in version 3.2: Accept only bytestring or bytearray objects as input.
@@ -1607,7 +1607,7 @@ class FileCommands:
         )
 
     # @+node:ekr.20031218072017.1573: *5* fc.outline_to_clipboard_string
-    def outline_to_clipboard_string(self, p: Position = None) -> str:
+    def outline_to_clipboard_string(self, p: Position | None = None) -> str:
         """
         Return a string suitable for pasting to the clipboard.
         """
@@ -1639,7 +1639,7 @@ class FileCommands:
         return s
 
     # @+node:felix.20230326001957.1: *5* fc.outline_to_clipboard_json_string
-    def outline_to_clipboard_json_string(self, p: Position = None) -> str:
+    def outline_to_clipboard_json_string(self, p: Position | None = None) -> str:
         """
         Return a JSON string suitable for pasting to the clipboard.
         """
@@ -1718,7 +1718,7 @@ class FileCommands:
             return False
 
     # @+node:ekr.20210316095706.1: *6* fc.leojs_outline_dict
-    def leojs_outline_dict(self, p: Position = None) -> dict[str, Value]:
+    def leojs_outline_dict(self, p: Position | None = None) -> dict[str, Value]:
         """Return a dict representing the outline."""
         c = self.c
         uas = {}
@@ -2210,7 +2210,7 @@ class FileCommands:
         return ''.join(attrs)
 
     # @+node:ekr.20031218072017.1579: *5* fc.put_v_elements & helper
-    def put_v_elements(self, p: Position = None) -> None:
+    def put_v_elements(self, p: Position | None = None) -> None:
         """Puts all <v> elements in the order in which they appear in the outline."""
         c = self.c
         c.clearAllVisited()

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7340,7 +7340,7 @@ def os_startfile(fname: str) -> None:
         except ImportError:
             os.system(f"open {quoted_fname}")
     else:
-        ree: io.FileIO = None
+        ree: io.FileIO | None = None
         try:
             wre = tempfile.NamedTemporaryFile()
             ree = io.open(wre.name, 'rb', buffering=0)

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -160,9 +160,9 @@ class LeoImportCommands:
         self.c = c
         self.encoding = 'utf-8'
         self.errors = 0
-        self.fileName: str = None  # The original file name, say x.cpp
-        self.fileType: str = None  # ".py", ".c", etc.
-        self.methodName: str = None  # x, as in < < x methods > > =
+        self.fileName: str | None = None  # The original file name, say x.cpp
+        self.fileType: str | None = None  # ".py", ".c", etc.
+        self.methodName: str | None = None  # x, as in < < x methods > > =
         self.output_newline: str = g.getOutputNewline(c=c)  # Value of @bool output_newline
         self.treeType = "@file"  # None or "@file"
         self.verbose = True  # Leo 6.6
@@ -585,8 +585,8 @@ class LeoImportCommands:
     def createOutline(
         self,
         parent: Position,
-        ext: str = None,
-        s: str = None,
+        ext: str | None = None,
+        s: str | None = None,
         treeType: str = '@file',
     ) -> Position | None:
         """
@@ -735,7 +735,7 @@ class LeoImportCommands:
     # @+node:ekr.20031218072017.1810: *4* ic.importDerivedFiles
     def importDerivedFiles(
         self,
-        parent: Position = None,
+        parent: Position | None = None,
         paths: list[str] = None,
         command: str = 'Import',
     ) -> Position | None:
@@ -780,7 +780,7 @@ class LeoImportCommands:
     def importFilesCommand(
         self,
         files: list[str] = None,
-        parent: Position = None,
+        parent: Position | None = None,
         shortFn: bool = False,
         treeType: str = '@file',
         verbose: bool = True,  # Legacy value.
@@ -1394,7 +1394,7 @@ class LeoImportCommands:
         return s
 
     # @+node:ekr.20031218072017.1463: *4* ic.setEncoding (deprecated)
-    def setEncoding(self, p: Position = None, default: str = None) -> None:
+    def setEncoding(self, p: Position | None = None, default: str | None = None) -> None:
         g.deprecated()
         c = self.c
         self.encoding = c.getEncoding(p)
@@ -2061,7 +2061,7 @@ class TabImporter:
     def __init__(self, c: Cmdr, separate: bool = True) -> None:
         """Ctor for the TabImporter class."""
         self.c = c
-        self.root: Position = None
+        self.root: Position | None = None
         self.separate = separate
         self.stack: list[tuple[int, Position]] = []
 
@@ -2138,7 +2138,7 @@ class TabImporter:
             self.import_files(names)
 
     # @+node:ekr.20161006071801.5: *3* tabbed.scan
-    def scan(self, s1: str, fn: str = None, root: Position = None) -> Position:
+    def scan(self, s1: str, fn: str | None = None, root: Position | None = None) -> Position:
         """Create the outline corresponding to s1."""
         c = self.c
         # self.root can be None if we are called from a script or unit test.

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -56,7 +56,7 @@ def _sphinx_build() -> str | None:
 # @+node:ekr.20191006153522.1: ** adoc, pandoc & sphinx commands
 # @+node:ekr.20190515070742.22: *3* @g.command: 'adoc' & 'adoc-with-preview')
 @g.command('adoc')
-def adoc_command(event: LeoKeyEvent = None, verbose: bool = True) -> File_List:
+def adoc_command(event: LeoKeyEvent | None = None, verbose: bool = True) -> File_List:
     # @+<< adoc command docstring >>
     # @+node:ekr.20190515115100.1: *4* << adoc command docstring >>
     """
@@ -117,7 +117,7 @@ def adoc_command(event: LeoKeyEvent = None, verbose: bool = True) -> File_List:
 
 
 @g.command('adoc-with-preview')
-def adoc_with_preview_command(event: LeoKeyEvent = None, verbose: bool = True) -> File_List:
+def adoc_with_preview_command(event: LeoKeyEvent | None = None, verbose: bool = True) -> File_List:
     """Run the adoc command, then show the result in the browser."""
     c = event and event.get('c')
     if not c:
@@ -179,7 +179,7 @@ def pandoc_command(event: LeoKeyEvent, verbose: bool = True) -> File_List:
 
 @g.command('pandoc-with-preview')
 def pandoc_with_preview_command(
-    event: LeoKeyEvent = None,
+    event: LeoKeyEvent | None = None,
     verbose: bool = True,
 ) -> File_List:
     """Run the pandoc command, then show the result in the browser."""
@@ -243,7 +243,7 @@ def sphinx_command(event: LeoKeyEvent, verbose: bool = True) -> File_List:
 
 @g.command('sphinx-with-preview')
 def sphinx_with_preview_command(
-    event: LeoKeyEvent = None,
+    event: LeoKeyEvent | None = None,
     verbose: bool = True,
 ) -> File_List:
     """Run the sphinx command, then show the result in the browser."""
@@ -259,7 +259,7 @@ class MarkupCommands:
 
     def __init__(self, c: Cmdr) -> None:
         self.c = c
-        self.kind: str = None  # 'adoc' or 'pandoc'
+        self.kind: str | None = None  # 'adoc' or 'pandoc'
         self.level_offset = 0
         self.root_level = 0
         self.reload_settings()
@@ -556,7 +556,7 @@ class MarkupCommands:
     # @+node:ekr.20191006155051.1: *3* markup.commands
     def adoc_command(
         self,
-        event: LeoKeyEvent = None,
+        event: LeoKeyEvent | None = None,
         preview: bool = False,
         verbose: bool = True,
     ) -> File_List:
@@ -568,7 +568,7 @@ class MarkupCommands:
 
     def pandoc_command(
         self,
-        event: LeoKeyEvent = None,
+        event: LeoKeyEvent | None = None,
         preview: bool = False,
         verbose: bool = True,
     ) -> File_List:
@@ -580,7 +580,7 @@ class MarkupCommands:
 
     def sphinx_command(
         self,
-        event: LeoKeyEvent = None,
+        event: LeoKeyEvent | None = None,
         preview: bool = False,
         verbose: bool = True,
     ) -> File_List:

--- a/leo/core/leoPersistence.py
+++ b/leo/core/leoPersistence.py
@@ -55,7 +55,7 @@ class PersistenceDataController:
     def __init__(self, c: Cmdr) -> None:
         """Ctor for persistenceController class."""
         self.c = c
-        self.at_persistence: Position = None  # The position of the @position node.
+        self.at_persistence: Position | None = None  # The position of the @position node.
 
     # @+node:ekr.20140711111623.17793: *3* pd.Entry points
     # @+node:ekr.20140718153519.17731: *4* pd.clean

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -65,7 +65,7 @@ class CommandChainDispatcher:
 
     """
 
-    def __init__(self, commands: list = None) -> None:
+    def __init__(self, commands: list | None = None) -> None:
         if commands is None:
             self.chain = []
         else:
@@ -253,7 +253,7 @@ class BaseLeoPlugin:
 
     # @+node:ekr.20100908125007.6014: *3* BaseLeoPlugin.setMenuItem
     def setMenuItem(
-        self, menu: LeoQtMenu, commandName: str = None, handler: Callable = None
+        self, menu: LeoQtMenu, commandName: str | None = None, handler: Callable | None = None
     ) -> None:
         """Create a menu item in 'menu' using text 'commandName' calling handler 'handler'
         if commandName and handler are none, use the most recently defined values
@@ -271,7 +271,12 @@ class BaseLeoPlugin:
         self.c.frame.menu.createMenuItemsFromTable(menu, table)
 
     # @+node:ekr.20100908125007.6015: *3* BaseLeoPlugin.setButton
-    def setButton(self, buttonText: str = None, commandName: str = None, color: str = None) -> None:
+    def setButton(
+        self,
+        buttonText: str | None = None,
+        commandName: str | None = None,
+        color: str | None = None,
+    ) -> None:
         """Associate an existing command with a 'button'"""
         if buttonText is None:
             buttonText = self.commandName

--- a/leo/core/leoPrinting.py
+++ b/leo/core/leoPrinting.py
@@ -78,7 +78,7 @@ class PrintingController:
         return doc
 
     # @+node:ekr.20150419124739.9: *4* pr.document
-    def document(self, text: str, head: str = None) -> QtGui.QTextDocument:
+    def document(self, text: str, head: str | None = None) -> QtGui.QTextDocument:
         """Create a Qt document."""
         doc = QtGui.QTextDocument()
         doc.setDefaultStyleSheet(self.stylesheet)
@@ -127,14 +127,14 @@ class PrintingController:
     # @+node:ekr.20150420081215.1: *3* pr.Preview
     # @+node:ekr.20150419124739.21: *4* pr.preview_body
     @cmd('preview-body')
-    def preview_body(self, event: LeoKeyEvent = None) -> None:
+    def preview_body(self, event: LeoKeyEvent | None = None) -> None:
         """Preview the body of the selected node."""
         doc = self.document(self.c.p.b)
         self.preview_doc(doc)
 
     # @+node:ekr.20150419124739.19: *4* pr.preview_html
     @cmd('preview-html')
-    def preview_html(self, event: LeoKeyEvent = None) -> None:
+    def preview_html(self, event: LeoKeyEvent | None = None) -> None:
         """
         Preview the body of the selected text as html. The body must be valid
         html, including <html> and <body> elements.
@@ -144,14 +144,14 @@ class PrintingController:
 
     # @+node:peckj.20150421084706.1: *4* pr.preview_expanded_body
     @cmd('preview-expanded-body')
-    def preview_expanded_body(self, event: LeoKeyEvent = None) -> None:
+    def preview_expanded_body(self, event: LeoKeyEvent | None = None) -> None:
         """Preview the selected node's body, expanded"""
         doc = self.document(self.expand(self.c.p))
         self.preview_doc(doc)
 
     # @+node:peckj.20150421084719.1: *4* pr.preview_expanded_html
     @cmd('preview-expanded-html')
-    def preview_expanded_html(self, event: LeoKeyEvent = None) -> None:
+    def preview_expanded_html(self, event: LeoKeyEvent | None = None) -> None:
         """
         Preview all the expanded bodies of the selected node as html. The
         expanded text must be valid html, including <html> and <body> elements.
@@ -161,7 +161,7 @@ class PrintingController:
 
     # @+node:ekr.20150419124739.31: *4* pr.preview_marked_bodies
     @cmd('preview-marked-bodies')
-    def preview_marked_bodies(self, event: LeoKeyEvent = None) -> None:
+    def preview_marked_bodies(self, event: LeoKeyEvent | None = None) -> None:
         """Preview the bodies of the marked nodes."""
         nodes = [p.v for p in self.c.all_positions() if p.isMarked()]
         doc = self.complex_document(nodes)
@@ -169,7 +169,7 @@ class PrintingController:
 
     # @+node:ekr.20150420081906.1: *4* pr.preview_marked_html
     @cmd('preview-marked-html')
-    def preview_marked_html(self, event: LeoKeyEvent = None) -> None:
+    def preview_marked_html(self, event: LeoKeyEvent | None = None) -> None:
         """
         Preview the concatenated bodies of the marked nodes. The concatenated
         bodies must be valid html, including <html> and <body> elements.
@@ -181,7 +181,7 @@ class PrintingController:
 
     # @+node:ekr.20150419124739.33: *4* pr.preview_marked_nodes
     @cmd('preview-marked-nodes')
-    def preview_marked_nodes(self, event: LeoKeyEvent = None) -> None:
+    def preview_marked_nodes(self, event: LeoKeyEvent | None = None) -> None:
         """Preview the marked nodes."""
         nodes = [p.v for p in self.c.all_positions() if p.isMarked()]
         doc = self.complex_document(nodes, heads=True)
@@ -189,7 +189,7 @@ class PrintingController:
 
     # @+node:ekr.20150419124739.23: *4* pr.preview_node
     @cmd('preview-node')
-    def preview_node(self, event: LeoKeyEvent = None) -> None:
+    def preview_node(self, event: LeoKeyEvent | None = None) -> None:
         """Preview the selected node."""
         p = self.c.p
         doc = self.document(p.b, head=p.h)
@@ -197,14 +197,14 @@ class PrintingController:
 
     # @+node:ekr.20150419124739.26: *4* pr.preview_tree_bodies
     @cmd('preview-tree-bodies')
-    def preview_tree_bodies(self, event: LeoKeyEvent = None) -> None:
+    def preview_tree_bodies(self, event: LeoKeyEvent | None = None) -> None:
         """Preview the bodies in the selected tree."""
         doc = self.document(self.getBodies(self.c.p))
         self.preview_doc(doc)
 
     # @+node:ekr.20150419124739.28: *4* pr.preview_tree_nodes
     @cmd('preview-tree-nodes')
-    def preview_tree_nodes(self, event: LeoKeyEvent = None) -> None:
+    def preview_tree_nodes(self, event: LeoKeyEvent | None = None) -> None:
         """Preview the entire tree."""
         p = self.c.p
         doc = self.document(self.getNodes(p), head=p.h)
@@ -212,7 +212,7 @@ class PrintingController:
 
     # @+node:ekr.20150420081923.1: *4* pr_preview_tree_html
     @cmd('preview-tree-html')
-    def preview_tree_html(self, event: LeoKeyEvent = None) -> None:
+    def preview_tree_html(self, event: LeoKeyEvent | None = None) -> None:
         """
         Preview all the bodies of the selected node as html. The concatenated
         bodies must valid html, including <html> and <body> elements.
@@ -223,14 +223,14 @@ class PrintingController:
     # @+node:ekr.20150420073128.1: *3* pr.Print
     # @+node:ekr.20150419124739.20: *4* pr.print_body
     @cmd('print-body')
-    def print_body(self, event: LeoKeyEvent = None) -> None:
+    def print_body(self, event: LeoKeyEvent | None = None) -> None:
         """Print the selected node's body"""
         doc = self.document(self.c.p.b)
         self.print_doc(doc)
 
     # @+node:ekr.20150419124739.18: *4* pr.print_html
     @cmd('print-html')
-    def print_html(self, event: LeoKeyEvent = None) -> None:
+    def print_html(self, event: LeoKeyEvent | None = None) -> None:
         """
         Print the body of the selected text as html. The body must be valid
         html, including <html> and <body> elements.
@@ -240,14 +240,14 @@ class PrintingController:
 
     # @+node:peckj.20150421084548.1: *4* pr.print_expanded_body
     @cmd('print-expanded-body')
-    def print_expanded_body(self, event: LeoKeyEvent = None) -> None:
+    def print_expanded_body(self, event: LeoKeyEvent | None = None) -> None:
         """Print the selected node's body, expanded"""
         doc = self.document(self.expand(self.c.p))
         self.print_doc(doc)
 
     # @+node:peckj.20150421084636.1: *4* pr.print_expanded_html
     @cmd('print-expanded-html')
-    def print_expanded_html(self, event: LeoKeyEvent = None) -> None:
+    def print_expanded_html(self, event: LeoKeyEvent | None = None) -> None:
         """
         Preview all the expanded bodies of the selected node as html. The
         expanded text must be valid html, including <html> and <body> elements.
@@ -257,7 +257,7 @@ class PrintingController:
 
     # @+node:ekr.20150419124739.30: *4* pr.print_marked_bodies
     @cmd('print-marked-bodies')
-    def print_marked_bodies(self, event: LeoKeyEvent = None) -> None:
+    def print_marked_bodies(self, event: LeoKeyEvent | None = None) -> None:
         """Print the body text of marked nodes."""
         nodes = [p.v for p in self.c.all_positions() if p.isMarked()]
         doc = self.complex_document(nodes)
@@ -265,7 +265,7 @@ class PrintingController:
 
     # @+node:ekr.20150420085054.1: *4* pr.print_marked_html
     @cmd('print-marked-html')
-    def print_marked_html(self, event: LeoKeyEvent = None) -> None:
+    def print_marked_html(self, event: LeoKeyEvent | None = None) -> None:
         """
         Print the concatenated bodies of the marked nodes. The concatenated
         bodies must be valid html, including <html> and <body> elements.
@@ -277,7 +277,7 @@ class PrintingController:
 
     # @+node:ekr.20150419124739.32: *4* pr.print_marked_nodes
     @cmd('print-marked-nodes')
-    def print_marked_nodes(self, event: LeoKeyEvent = None) -> None:
+    def print_marked_nodes(self, event: LeoKeyEvent | None = None) -> None:
         """Print all the marked nodes"""
         nodes = [p.v for p in self.c.all_positions() if p.isMarked()]
         doc = self.complex_document(nodes, heads=True)
@@ -285,21 +285,21 @@ class PrintingController:
 
     # @+node:ekr.20150419124739.22: *4* pr.print_node
     @cmd('print-node')
-    def print_node(self, event: LeoKeyEvent = None) -> None:
+    def print_node(self, event: LeoKeyEvent | None = None) -> None:
         """Print the selected node"""
         doc = self.document(self.c.p.b, head=self.c.p.h)
         self.print_doc(doc)
 
     # @+node:ekr.20150419124739.25: *4* pr.print_tree_bodies
     @cmd('print-tree-bodies')
-    def print_tree_bodies(self, event: LeoKeyEvent = None) -> None:
+    def print_tree_bodies(self, event: LeoKeyEvent | None = None) -> None:
         """Print all the bodies in the selected tree."""
         doc = self.document(self.getBodies(self.c.p))
         self.print_doc(doc)
 
     # @+node:ekr.20150420084948.1: *4* pr.print_tree_html
     @cmd('print-tree-html')
-    def print_tree_html(self, event: LeoKeyEvent = None) -> None:
+    def print_tree_html(self, event: LeoKeyEvent | None = None) -> None:
         """
         Print all the bodies of the selected node as html. The concatenated
         bodies must valid html, including <html> and <body> elements.
@@ -309,7 +309,7 @@ class PrintingController:
 
     # @+node:ekr.20150419124739.27: *4* pr.print_tree_nodes
     @cmd('print-tree-nodes')
-    def print_tree_nodes(self, event: LeoKeyEvent = None) -> None:
+    def print_tree_nodes(self, event: LeoKeyEvent | None = None) -> None:
         """Print all the nodes of the selected tree."""
         doc = self.document(self.getNodes(self.c.p), head=self.c.p.h)
         self.print_doc(doc)

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -88,13 +88,13 @@ class RstCommands:
         self.encoding = 'utf-8'  # From any @encoding directive.
         self.path = ''  # The path from any @path directive.
         self.result_list: list[str] = []  # The intermediate results.
-        self.root: Position = None  # The @rst node being processed.
+        self.root: Position | None = None  # The @rst node being processed.
 
         # Default settings.
         self.default_underline_characters = '#=+*^~-:><'
         self.remove_leo_directives = False  # For compatibility with legacy operation.
-        self.user_filter_b: Callable = None
-        self.user_filter_h: Callable = None
+        self.user_filter_b: Callable | None = None
+        self.user_filter_h: Callable | None = None
 
         # Complete the init.
         self.reloadSettings()
@@ -140,7 +140,7 @@ class RstCommands:
     # @+node:ekr.20210403150303.1: *4* rst.rst-convert-legacy-outline
     @cmd('rst-convert-legacy-outline')
     @cmd('convert-legacy-rst-outline')
-    def convert_legacy_outline(self, event: LeoKeyEvent = None) -> None:
+    def convert_legacy_outline(self, event: LeoKeyEvent | None = None) -> None:
         """
         Convert @rst-preformat nodes and `@ @rst-options` doc parts.
         """
@@ -179,7 +179,7 @@ class RstCommands:
 
     # @+node:ekr.20090511055302.5793: *4* rst.rst3 command & helpers
     @cmd('rst3')
-    def rst3(self, event: LeoKeyEvent = None) -> int:
+    def rst3(self, event: LeoKeyEvent | None = None) -> int:
         """Write all @rst nodes."""
         t1 = time.time()
         self.n_intermediate = self.n_docutils = 0
@@ -559,7 +559,7 @@ class RstCommands:
         return result
 
     # @+node:ekr.20090502071837.66: *6* rst.handleMissingStyleSheetArgs
-    def handleMissingStyleSheetArgs(self, s: str = None) -> dict[str, str]:
+    def handleMissingStyleSheetArgs(self, s: str | None = None) -> dict[str, str]:
         """
         Parse the publish_argv_for_missing_stylesheets option,
         returning a dict containing the parsed args.

--- a/leo/core/leoShadow.py
+++ b/leo/core/leoShadow.py
@@ -81,9 +81,9 @@ class ShadowController:
         self.encoding: str = c.config.default_derived_file_encoding
         self.errors = 0
         self.results: list[str] = []
-        self.shadow_subdir: str = None
-        self.shadow_prefix: str = None
-        self.shadow_in_home_dir: bool = None
+        self.shadow_subdir: str | None = None
+        self.shadow_prefix: str | None = None
+        self.shadow_in_home_dir: bool | None = None
         # Support for goto-line.
         self.reloadSettings()
 
@@ -211,7 +211,7 @@ class ShadowController:
         new_public_lines: list[str],
         old_private_lines: list[str],
         marker: Marker,
-        p: Position = None,
+        p: Position | None = None,
     ) -> list[str]:
         # @+<< docstring >>
         # @+node:ekr.20150207044400.9: *5*  << docstring >>

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -77,7 +77,7 @@ class Undoer:
     # @+node:ekr.20031218072017.3606: *4* u.__init__
     def __init__(self, c: Cmdr) -> None:
         self.c = c
-        self.p: Position = None  # The position/node being operated upon for undo and redo.
+        self.p: Position | None = None  # The position/node being operated upon for undo and redo.
         self.granularity = None  # Set in reloadSettings.
         self.max_undo_stack_size = c.config.getInt('max-undo-stack-size') or 0
         # State ivars...
@@ -100,11 +100,11 @@ class Undoer:
         self.afterTree = None
         self.beforeTree = None
         self.children = None
-        self.deleteMarkedNodesData: g.Bunch = None
+        self.deleteMarkedNodesData: g.Bunch | None = None
         self.followingSibs: list[VNode] = None
         self.headlines: dict[str, tuple[str, str]]
-        self.inHead: bool = None
-        self.kind: str = None
+        self.inHead: bool | None = None
+        self.kind: str | None = None
         self.newBack = None
         self.newBody = None
         self.newChildren = None
@@ -979,10 +979,10 @@ class Undoer:
         undo_type: str,
         oldText: str,
         newText: str,
-        newInsert: int = None,
+        newInsert: int | None = None,
         oldSel: tuple[int, int] = None,
         newSel: tuple[int, int] = None,
-        oldYview: int = None,
+        oldYview: int | None = None,
     ) -> None:
         """
         Save enough information to undo or redo a typing operation efficiently,
@@ -1399,7 +1399,7 @@ class Undoer:
 
     # @+node:ekr.20031218072017.2030: *3* u.redo
     @cmd('redo')
-    def redo(self, event: LeoKeyEvent = None) -> None:
+    def redo(self, event: LeoKeyEvent | None = None) -> None:
         """Redo the operation undone by the last undo."""
         c, u = self.c, self
         if not c.p:
@@ -1796,7 +1796,7 @@ class Undoer:
 
     # @+node:ekr.20031218072017.2039: *3* u.undo
     @cmd('undo')
-    def undo(self, event: LeoKeyEvent = None) -> None:
+    def undo(self, event: LeoKeyEvent | None = None) -> None:
         """Undo the operation described by the undo parameters."""
         c, u = self.c, self
         if not c.p:
@@ -2189,7 +2189,7 @@ class Undoer:
         oldNewlines: list[str],
         newNewlines: list[str],  # Number of trailing newlines.
         tag: str = "undo",  # "undo" or "redo"
-        undoType: str = None,
+        undoType: str | None = None,
     ) -> None:
         """Handle text undo and redo: converts _new_ text into _old_ text."""
         # newNewlines is unused, but it has symmetry.

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -23,15 +23,15 @@ from __future__ import annotations
 from collections.abc import Callable
 import os
 import string
-from typing import Any, TYPE_CHECKING
+from typing import cast, Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core.leoGui import LeoKeyEvent
+from leo.plugins.qt_text import QTextMixin
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import QEvent
     from leo.core.leoQt import QtWidgets
-    from leo.plugins.qt_text import QTextMixin
 
     QWidget = QtWidgets.QWidget
     KWargs = Any
@@ -101,7 +101,7 @@ class VimCommands:
         """The ctor for the VimCommands class."""
         self.c = c
         self.k = c.k
-        self.w: QTextMixin = None
+        self.w = cast(QTextMixin, None)
         # Toggled by :toggle-vim-trace.
         self.trace_flag = 'keys' in g.app.debug
         self.init_constant_ivars()
@@ -443,40 +443,40 @@ class VimCommands:
     def init_state_ivars(self) -> None:
         """Init all ivars related to command state."""
         self.ch = None  # The incoming character.
-        self.command_i: int = None  # The offset into the text at the start of a command.
+        self.command_i: int | None = None  # The offset into the text at the start of a command.
         self.command_list: list[VimEvent] = []  # The list of all characters seen in this command.
-        self.command_n: int = None  # The repeat count in effect at the start of a command.
-        self.command_w: QTextMixin = None  # The widget in effect at the start of a command.
-        self.event: QEvent = None  # The event for the current key.
+        self.command_n: int | None = None  # The repeat count in effect at the start of a command.
+        self.command_w = cast(QTextMixin, None)  # The widget in effect at the start of a command.
+        self.event: QEvent | None = None  # The event for the current key.
         self.extend = False  # True: extending selection.
         self.handler: Callable = self.do_normal_mode  # Use the handler for normal mode.
         self.in_command = False  # True: we have seen some command characters.
         self.in_motion = False  # True if parsing an *inner* motion, the 2j in d2j.
         # The callback handler to execute after executing an inner motion.
-        self.motion_func: Callable = None
-        self.motion_i: int = None  # The offset into the text at the start of a motion.
+        self.motion_func: Callable | None = None
+        self.motion_i: int | None = None  # The offset into the text at the start of a motion.
         self.n1 = 1  # The first repeat count.
         self.n = 1  # The second repeat count.
         self.n1_seen = False  # True if self.n1 has been set.
-        self.next_func: Callable = None  # The continuation of a multi-character command.
-        self.old_sel: tuple = None  # The selection range at the start of a command.
+        self.next_func: Callable | None = None  # The continuation of a multi-character command.
+        self.old_sel: tuple | None = None  # The selection range at the start of a command.
         self.repeat_list: list[str] = []  # The characters of the current repeat count.
         # The value returned by do_key().
         # Handlers set this to False to tell k.masterKeyHandler to handle the key.
         self.return_value = True
         self.state = 'normal'  # in ('normal','insert','visual',)
-        self.stroke: Stroke = None  # The incoming stroke.
+        self.stroke: Stroke | None = None  # The incoming stroke.
         self.visual_line_flag = False  # True: in visual-line state.
-        self.vis_mode_i: int = None  # The insertion point at the start of visual mode.
+        self.vis_mode_i: int | None = None  # The insertion point at the start of visual mode.
         # The widget in effect at the start of visual mode.
-        self.vis_mode_w: QTextMixin = None
+        self.vis_mode_w = cast(QTextMixin, None)
 
     # @+node:ekr.20140803220119.18107: *5* vc.init_persistent_ivars
     def init_persistent_ivars(self) -> None:
         """Init ivars that are never re-inited."""
         c = self.c
         # The widget that has focus when a ':' command begins.  May be None.
-        self.colon_w: QTextMixin = None
+        self.colon_w = cast(QTextMixin, None)
         # True: allow f,F,h,l,t,T,x to cross line boundaries.
         self.cross_lines = c.config.getBool('vim-crosses-lines', default=True)
         self.register_d: dict[str, str] = {}  # Keys are letters; values are strings.
@@ -503,7 +503,7 @@ class VimCommands:
 
     # @+node:ekr.20140803220119.18097: *4* direct acceptance methods
     # @+node:ekr.20140802225657.18031: *5* vc.accept
-    def accept(self, add_to_dot: bool = True, handler: Callable = None) -> None:
+    def accept(self, add_to_dot: bool = True, handler: Callable | None = None) -> None:
         """
         Accept the present stroke.
         Optionally, this can set the dot or change self.handler.
@@ -536,7 +536,7 @@ class VimCommands:
         add_to_dot: bool = True,
         return_value: bool = True,
         set_dot: bool = True,
-        stroke: Stroke = None,
+        stroke: Stroke | None = None,
     ) -> None:
         """Complete a command, preserving text and optionally updating the dot."""
         self.do_trace()
@@ -628,7 +628,7 @@ class VimCommands:
 
     # @+node:ekr.20140802225657.18034: *4* indirect acceptance methods
     # @+node:ekr.20140222064735.16709: *5* vc.begin_insert_mode
-    def begin_insert_mode(self, i: int = None, w: QTextMixin = None) -> None:
+    def begin_insert_mode(self, i: int | None = None, w: QTextMixin | None = None) -> None:
         """Common code for beginning insert mode."""
         self.do_trace()
         # c = self.c
@@ -2077,7 +2077,7 @@ class VimCommands:
 
         # @+others
         # @+node:ekr.20140820063930.18321: *5* Substitution.__call__ (:%s & :s)
-        def __call__(self, event: QEvent = None) -> None:
+        def __call__(self, event: QEvent | None = None) -> None:
             """Handle the :s and :%s commands. Neither command affects the dot."""
             vc = self.vc
             c, w = vc.c, vc.w
@@ -2148,16 +2148,16 @@ class VimCommands:
 
     # @+node:ekr.20150509050905.1: *4* vc.e_command & tabnew_command
     @cmd(':e')
-    def e_command(self, event: LeoKeyEvent = None) -> None:
+    def e_command(self, event: LeoKeyEvent | None = None) -> None:
         self.Tabnew(self)
 
     @cmd(':tabnew')
-    def tabnew_command(self, event: LeoKeyEvent = None) -> None:
+    def tabnew_command(self, event: LeoKeyEvent | None = None) -> None:
         self.Tabnew(self)
 
     # @+node:ekr.20140815160132.18824: *4* vc.print_dot (:print-dot)
     @cmd(':print-dot')
-    def print_dot(self, event: LeoKeyEvent = None) -> None:
+    def print_dot(self, event: LeoKeyEvent | None = None) -> None:
         """Print the dot."""
         aList = [z.stroke if isinstance(z, VimEvent) else z for z in self.dot_list]
         aList = [show_stroke(self.c.k.stroke2char(z)) for z in aList]
@@ -2171,12 +2171,12 @@ class VimCommands:
 
     # @+node:ekr.20140815160132.18825: *4* vc.q/qa_command & quit_now (:q & q! & :qa)
     @cmd(':q')
-    def q_command(self, event: LeoKeyEvent = None) -> None:
+    def q_command(self, event: LeoKeyEvent | None = None) -> None:
         """Quit the present Leo outline, prompting for saves."""
         g.app.closeLeoWindow(self.c.frame, new_c=None)
 
     @cmd(':qa')
-    def qa_command(self, event: LeoKeyEvent = None) -> None:
+    def qa_command(self, event: LeoKeyEvent | None = None) -> None:
         """Quit only if there are no unsaved changes."""
         for c in g.app.commanders():
             if c.isChanged():
@@ -2184,33 +2184,33 @@ class VimCommands:
         g.app.onQuit(event)
 
     @cmd(':q!')
-    def quit_now(self, event: LeoKeyEvent = None) -> None:
+    def quit_now(self, event: LeoKeyEvent | None = None) -> None:
         """Quit immediately."""
         g.app.forceShutdown()
 
     # @+node:ekr.20150509050918.1: *4* vc.r_command
     @cmd(':r')
-    def r_command(self, event: LeoKeyEvent = None) -> None:
+    def r_command(self, event: LeoKeyEvent | None = None) -> None:
         self.LoadFileAtCursor(self)
 
     # @+node:ekr.20140815160132.18826: *4* vc.revert (:e!)
     @cmd(':e!')
-    def revert(self, event: LeoKeyEvent = None) -> None:
+    def revert(self, event: LeoKeyEvent | None = None) -> None:
         """Revert all changes to a .leo file, prompting if there have been changes."""
         self.c.revert()
 
     # @+node:ekr.20150509050755.1: *4* vc.s_command & percent_s_command
     @cmd(':%s')
-    def percent_s_command(self, event: LeoKeyEvent = None) -> None:
+    def percent_s_command(self, event: LeoKeyEvent | None = None) -> None:
         self.Substitution(self, all_lines=True)
 
     @cmd(':s')
-    def s_command(self, event: LeoKeyEvent = None) -> None:
+    def s_command(self, event: LeoKeyEvent | None = None) -> None:
         self.Substitution(self, all_lines=False)
 
     # @+node:ekr.20140815160132.18827: *4* vc.shell_command (:!)
     @cmd(':!')
-    def shell_command(self, event: LeoKeyEvent = None) -> None:
+    def shell_command(self, event: LeoKeyEvent | None = None) -> None:
         """Execute a shell command."""
         c, k = self.c, self.c.k
         if k.functionTail:
@@ -2223,7 +2223,7 @@ class VimCommands:
 
     # @+node:ekr.20140815160132.18830: *4* vc.toggle_vim_mode
     @cmd(':toggle-vim-mode')
-    def toggle_vim_mode(self, event: LeoKeyEvent = None) -> None:
+    def toggle_vim_mode(self, event: LeoKeyEvent | None = None) -> None:
         """toggle vim-mode."""
         c = self.c
         c.vim_mode = not c.vim_mode
@@ -2243,7 +2243,7 @@ class VimCommands:
 
     # @+node:ekr.20140909140052.18128: *4* vc.toggle_vim_trace
     @cmd(':toggle-vim-trace')
-    def toggle_vim_trace(self, event: LeoKeyEvent = None) -> None:
+    def toggle_vim_trace(self, event: LeoKeyEvent | None = None) -> None:
         """toggle vim tracing."""
         self.trace_flag = not self.trace_flag
         val = 'On' if self.trace_flag else 'Off'
@@ -2251,7 +2251,7 @@ class VimCommands:
 
     # @+node:ekr.20140815160132.18831: *4* vc.toggle_vim_trainer_mode
     @cmd(':toggle-vim-trainer-mode')
-    def toggle_vim_trainer_mode(self, event: LeoKeyEvent = None) -> None:
+    def toggle_vim_trainer_mode(self, event: LeoKeyEvent | None = None) -> None:
         """toggle vim-trainer mode."""
         self.trainer = not self.trainer
         val = 'on' if self.trainer else 'off'
@@ -2259,19 +2259,19 @@ class VimCommands:
 
     # @+node:ekr.20140815160132.18832: *4* w/xa/wq_command (:w & :xa & wq)
     @cmd(':w')
-    def w_command(self, event: LeoKeyEvent = None) -> None:
+    def w_command(self, event: LeoKeyEvent | None = None) -> None:
         """Save the .leo file."""
         self.c.save()
 
     @cmd(':xa')
-    def xa_command(self, event: LeoKeyEvent = None) -> None:  # same as :xa
+    def xa_command(self, event: LeoKeyEvent | None = None) -> None:  # same as :xa
         """Save all open files and keep working."""
         for c in g.app.commanders():
             if c.isChanged():
                 c.save()
 
     @cmd(':wq')
-    def wq_command(self, event: LeoKeyEvent = None) -> None:
+    def wq_command(self, event: LeoKeyEvent | None = None) -> None:
         """Save all open files and exit."""
         for c in g.app.commanders():
             c.save()
@@ -2384,7 +2384,7 @@ class VimCommands:
 
     # @+node:ekr.20140222064735.16682: *3* vc.Utilities
     # @+node:ekr.20140802183521.17998: *4* vc.add_to_dot
-    def add_to_dot(self, stroke: Stroke = None) -> None:
+    def add_to_dot(self, stroke: Stroke | None = None) -> None:
         """
         Add a new VimEvent to self.command_list.
         Never change self.command_list if self.in_dot is True
@@ -2406,7 +2406,7 @@ class VimCommands:
             self.dot_list = self.command_list[:]
 
     # @+node:ekr.20140810214537.18241: *4* vc.do
-    def do(self, o: Any, event: LeoKeyEvent = None) -> None:
+    def do(self, o: Any, event: LeoKeyEvent | None = None) -> None:
         """Do one or more Leo commands by name."""
         if not event:
             event = self.event
@@ -2447,7 +2447,7 @@ class VimCommands:
         """Return True if stroke is a plain key."""
         return self.k.isPlainKey(stroke)
 
-    def is_text_wrapper(self, w: QTextMixin = None) -> bool:
+    def is_text_wrapper(self, w: QTextMixin | None = None) -> bool:
         """Return True if w is a text widget."""
         return self.is_body(w) or self.is_head(w) or g.isTextWrapper(w)
 
@@ -2511,9 +2511,9 @@ class VimCommands:
     # @+node:ekr.20140804123147.18929: *4* vc.set_border & helper
     def set_border(
         self,
-        kind: str = None,
-        w: QTextMixin = None,
-        activeFlag: bool = None,
+        kind: str | None = None,
+        w: QTextMixin | None = None,
+        activeFlag: bool | None = None,
     ) -> None:
         """
         Set the border color of self.w, depending on state.

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -198,7 +198,7 @@ class FreeLayoutController:
         c.redraw()
 
     # @+node:ekr.20160424035257.1: *3* flc.get_main_splitter
-    def get_main_splitter(self, w: QTextMixin = None) -> NestedSplitter | None:
+    def get_main_splitter(self, w: QTextMixin | None = None) -> NestedSplitter | None:
         """
         Return the main splitter.
 

--- a/leo/plugins/pane_commands.py
+++ b/leo/plugins/pane_commands.py
@@ -31,7 +31,7 @@ def init() -> bool:
 
 # @+node:ekr.20221020063528.1: ** bottom of-pane
 @g.command('bottom-of-pane')
-def bottomOfPane(event: LeoKeyEvent = None) -> None:
+def bottomOfPane(event: LeoKeyEvent | None = None) -> None:
     """move the text cursor to the last character visible in the body pane"""
     c: Cmdr = event.c if event else None
     if not c:
@@ -62,7 +62,7 @@ def bottomOfPane(event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20221020063441.1: ** top-of-pane
 @g.command('top-of-pane')
-def topOfPane(event: LeoKeyEvent = None) -> None:
+def topOfPane(event: LeoKeyEvent | None = None) -> None:
     """move the text cursor to the first character visible in the body pane"""
     c: Cmdr = event.c if event else None
     if not c:

--- a/leo/plugins/qt_commands.py
+++ b/leo/plugins/qt_commands.py
@@ -133,7 +133,7 @@ def showColorNames(event: LeoKeyEvent) -> None:
 
 # @+node:ekr.20170324142416.1: ** qt: show-color-wheel
 @g.command('show-color-wheel')
-def showColorWheel(self: Any, event: LeoKeyEvent = None) -> None:
+def showColorWheel(self: Any, event: LeoKeyEvent | None = None) -> None:
     """Show a Qt color dialog."""
     c, p = self.c, self.c.p
     picker = QtWidgets.QColorDialog()
@@ -162,7 +162,7 @@ def showColorWheel(self: Any, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20170324143944.3: ** qt: show-fonts
 @g.command('show-fonts')
-def showFonts(self: Any, event: LeoKeyEvent = None) -> None:
+def showFonts(self: Any, event: LeoKeyEvent | None = None) -> None:
     """Open a tab in the log pane showing a font picker."""
     c, p = self.c, self.c.p
     picker = QtWidgets.QFontDialog()
@@ -205,7 +205,7 @@ def showFonts(self: Any, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20140918124632.17893: ** qt: show-style-sheet
 @g.command('show-style-sheet')
-def print_style_sheet(event: LeoKeyEvent = None) -> None:
+def print_style_sheet(event: LeoKeyEvent | None = None) -> None:
     """show-style-sheet command."""
     c: Cmdr = event.get('c')
     if c:

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -134,20 +134,20 @@ class DynamicWindow(QtWidgets.QMainWindow):
     # @+others
     # @+node:ekr.20240730052903.1: *3*  dw: Birth
     # @+node:ekr.20110605121601.18138: *4* dw.ctor
-    def __init__(self, c: Cmdr, parent: QWidget = None) -> None:
+    def __init__(self, c: Cmdr, parent: QWidget | None = None) -> None:
         """Ctor for the DynamicWindow class.  The main window is c.frame.top"""
         # Called from LeoQtFrame.finishCreate.
         # parent is a LeoTabbedTopLevel.
         super().__init__(parent)
         self.leo_c = c
-        self.leo_body_frame: QWidget = None
-        self.leo_master: LeoTabbedTopLevel = None  # Set in construct.
-        self.leo_menubar: QWidget = None  # Set in createMenuBar.
-        self.leo_statusBar: QtWidgets.QStatusBar = None
-        self.layout_name: str = None
-        self.old_layout_name: str = None
-        self.verticalLayout: QBoxLayout = None
-        self.vr_parent_frame: QWidget = None
+        self.leo_body_frame: QWidget | None = None
+        self.leo_master: LeoTabbedTopLevel | None = None  # Set in construct.
+        self.leo_menubar: QWidget | None = None  # Set in createMenuBar.
+        self.leo_statusBar: QtWidgets.QStatusBar | None = None
+        self.layout_name: str | None = None
+        self.old_layout_name: str | None = None
+        self.verticalLayout: QBoxLayout | None = None
+        self.vr_parent_frame: QWidget | None = None
         c._style_deltas = defaultdict(lambda: 0)  # for adjusting styles dynamically
         self.layout_cache = LayoutCacheWidget(c, self)
         self.reloadSettings()
@@ -189,7 +189,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
                 self.iconBar.hide()
 
     # @+node:ekr.20110605121601.18139: *3* dw.construct & helpers
-    def construct(self, master: LeoTabbedTopLevel = None) -> None:
+    def construct(self, master: LeoTabbedTopLevel | None = None) -> None:
         """Factor 'heavy duty' code out from the DynamicWindow ctor"""
         c = self.leo_c
         self.leo_master = master
@@ -616,11 +616,11 @@ class DynamicWindow(QtWidgets.QMainWindow):
         self,
         parent: QWidget,
         name: str,
-        hPolicy: Policy = None,
-        vPolicy: Policy = None,
+        hPolicy: Policy | None = None,
+        vPolicy: Policy | None = None,
         lineWidth: int = 1,
-        shadow: Shadow = None,
-        shape: Shape = None,
+        shadow: Shadow | None = None,
+        shape: Shape | None = None,
     ) -> QWidget:
         """Create a Qt Frame."""
         if shadow is None:
@@ -697,8 +697,8 @@ class DynamicWindow(QtWidgets.QMainWindow):
         parent: QWidget,
         name: str,
         lineWidth: int = 1,
-        hPolicy: Policy = None,
-        vPolicy: Policy = None,
+        hPolicy: Policy | None = None,
+        vPolicy: Policy | None = None,
     ) -> QWidget:  # QtWidgets.QStackedWidget
         w = QtWidgets.QStackedWidget(parent)
         self.set_widget_size_policy(w, kind1=hPolicy, kind2=vPolicy)
@@ -712,8 +712,8 @@ class DynamicWindow(QtWidgets.QMainWindow):
         self,
         parent: QWidget,
         name: str,
-        hPolicy: Policy = None,
-        vPolicy: Policy = None,
+        hPolicy: Policy | None = None,
+        vPolicy: Policy | None = None,
     ) -> QWidget:
         w = QtWidgets.QTabWidget(parent)
         # tb = w.tabBar()
@@ -728,8 +728,8 @@ class DynamicWindow(QtWidgets.QMainWindow):
         parent: QWidget,
         name: str,
         lineWidth: int = 0,
-        shadow: Shadow = None,
-        shape: Shape = None,
+        shadow: Shadow | None = None,
+        shape: Shape | None = None,
     ) -> QWidget | Qsci.QsciScintilla:
         # Create a text widget.
         c = self.leo_c
@@ -1083,7 +1083,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         self.findScrollArea.setWidget(self.findTab)
 
     # @+node:ekr.20110605121601.18212: *4* dw.packLabel
-    def packLabel(self, w: QWidget, n: int = None) -> None:
+    def packLabel(self, w: QWidget, n: int | None = None) -> None:
         """
         Pack w into the body frame's QVGridLayout.
 
@@ -1132,7 +1132,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
 
     # @+node:ekr.20110605121601.18170: *4* dw.set_widget_size_policy
     def set_widget_size_policy(
-        self, widget: QWidget, kind1: Policy = None, kind2: Policy = None
+        self, widget: QWidget, kind1: Policy | None = None, kind2: Policy | None = None
     ) -> None:
         if kind1 is None:
             kind1 = Policy.Ignored
@@ -1202,8 +1202,8 @@ class FindTabManager:
         self.c = c
         self.entry_focus = None  # The widget that had focus before find-pane entered.
         # Find/change text boxes.
-        self.find_findbox: QWidget = None
-        self.find_replacebox: QWidget = None
+        self.find_findbox: QWidget | None = None
+        self.find_replacebox: QWidget | None = None
         # Check boxes.
         self.check_box_ignore_case = None
         self.check_box_mark_changes = None
@@ -1617,7 +1617,7 @@ class LeoBaseTabWidget(QtWidgets.QTabWidget):
                     self.setTabText(i, title)
 
     # @+node:ekr.20131115120119.17396: *3* qt_base_tab.setTabName
-    def setTabName(self, c: Cmdr, fileName: str, tooltip: str = None) -> None:
+    def setTabName(self, c: Cmdr, fileName: str, tooltip: str | None = None) -> None:
         """Set the tab name and optional tooltip for c's tab to fileName."""
         # Find the tab corresponding to c.
         dw = c.frame.top  # A DynamicWindow
@@ -1656,9 +1656,9 @@ class LeoQtBody(leoFrame.LeoBody):
         super().__init__(frame)
         c = self.c
         assert c.frame == frame and frame.c == c
-        self.colorizer: BaseColorizer = None
-        self.wrapper: QtWrapper = None
-        self.widget: QWidget = None
+        self.colorizer: BaseColorizer | None = None
+        self.wrapper: QtWrapper | None = None
+        self.widget: QWidget | None = None
         self.reloadSettings()
         self.set_widget()  # Sets self.widget and self.wrapper.
         self.setWrap(c.p)
@@ -1789,15 +1789,15 @@ class LeoQtFrame(leoFrame.LeoFrame):
         leoFrame.LeoFrame.instances += 1  # Increment the class var.
 
         # Official ivars for objects.
-        self.bar1: LeoQtFrame = None
-        self.bar2: LeoQtFrame = None
-        self.body: LeoQtBody = None
-        self.iconBar: QtIconBarClass = None
-        self.iconFrame: QtIconBarClass = None
-        self.log: LeoQtLog = None
-        self.statusLine: QtStatusLineClass = None
-        self.tree: LeoQtTree = None
-        self.top: DynamicWindow = None
+        self.bar1: LeoQtFrame | None = None
+        self.bar2: LeoQtFrame | None = None
+        self.body: LeoQtBody | None = None
+        self.iconBar: QtIconBarClass | None = None
+        self.iconFrame: QtIconBarClass | None = None
+        self.log: LeoQtLog | None = None
+        self.statusLine: QtStatusLineClass | None = None
+        self.tree: LeoQtTree | None = None
+        self.top: DynamicWindow | None = None
 
         # Status ivars...
         self.title = title
@@ -1960,10 +1960,10 @@ class LeoQtFrame(leoFrame.LeoFrame):
         pass
 
     # @+node:ekr.20110605121601.18280: *4* LeoQtFrame.forceWrap & setWrap
-    def forceWrap(self, p: Position = None) -> None:
+    def forceWrap(self, p: Position | None = None) -> None:
         self.c.frame.body.forceWrap(p)
 
-    def setWrap(self, p: Position = None) -> None:
+    def setWrap(self, p: Position | None = None) -> None:
         self.c.frame.body.setWrap(p)
 
     # @+node:ekr.20110605121601.18281: *4* LeoQtFrame.reconfigurePanes
@@ -2041,21 +2041,21 @@ class LeoQtFrame(leoFrame.LeoFrame):
             g.app.closeLeoWindow(self)
 
     # @+node:ekr.20110605121601.18287: *4* LeoQtFrame.OnControlKeyUp/Down
-    def OnControlKeyDown(self, event: QEvent = None) -> None:
+    def OnControlKeyDown(self, event: QEvent | None = None) -> None:
         self.controlKeyIsDown = True
 
-    def OnControlKeyUp(self, event: QEvent = None) -> None:
+    def OnControlKeyUp(self, event: QEvent | None = None) -> None:
         self.controlKeyIsDown = False
 
     # @+node:ekr.20110605121601.18290: *4* LeoQtFrame.OnActivateTree
-    def OnActivateTree(self, event: QEvent = None) -> None:
+    def OnActivateTree(self, event: QEvent | None = None) -> None:
         pass
 
     # @+node:ekr.20110605121601.18293: *3* LeoQtFrame: Gui-dependent commands
     # @+node:ekr.20110605121601.18301: *4* LeoQtFrame.Window Menu...
     # @+node:ekr.20110605121601.18302: *5* LeoQtFrame.toggleActivePane
     @frame_cmd('toggle-active-pane')
-    def toggleActivePane(self, event: LeoKeyEvent = None) -> None:
+    def toggleActivePane(self, event: LeoKeyEvent | None = None) -> None:
         """Toggle the focus between the outline and body panes."""
         frame = self
         c = frame.c
@@ -2069,20 +2069,20 @@ class LeoQtFrame(leoFrame.LeoFrame):
 
     # @+node:ekr.20110605121601.18304: *5* LeoQtFrame.equalSizedPanes
     @frame_cmd('equal-sized-panes')
-    def equalSizedPanes(self, event: LeoKeyEvent = None) -> None:
+    def equalSizedPanes(self, event: LeoKeyEvent | None = None) -> None:
         """Make the outline and body panes have the same size."""
         self.resizePanesToRatio(0.5, self.compute_secondary_ratio())
 
     # @+node:ekr.20250422154709.1: *5* LeoQtFrame.contract/expandMainSplitter
     @frame_cmd('contract-main-splitter')
-    def contractMainSplitter(self, event: LeoKeyEvent = None) -> None:
+    def contractMainSplitter(self, event: LeoKeyEvent | None = None) -> None:
         """
         Contract the main splitter's first widget, expanding the main splitter's second widget.
         """
         self.resize_main_splitter(-40)
 
     @frame_cmd('expand-main-splitter')
-    def expandMainSplitter(self, event: LeoKeyEvent = None) -> None:
+    def expandMainSplitter(self, event: LeoKeyEvent | None = None) -> None:
         """
         Expand the main splitter's first widget, contracting the main splitter's second widget.
         """
@@ -2103,13 +2103,13 @@ class LeoQtFrame(leoFrame.LeoFrame):
             splitter.setSizes(sizes)
 
     # @+node:ekr.20110605121601.18305: *5* LeoQtFrame.hideLogWindow
-    def hideLogWindow(self, event: LeoKeyEvent = None) -> None:
+    def hideLogWindow(self, event: LeoKeyEvent | None = None) -> None:
         """Hide the log pane."""
         self.divideLeoSplitter2(0.99)
 
     # @+node:ekr.20110605121601.18306: *5* LeoQtFrame.minimizeAll
     @frame_cmd('minimize-all')
-    def minimizeAll(self, event: LeoKeyEvent = None) -> None:
+    def minimizeAll(self, event: LeoKeyEvent | None = None) -> None:
         """Minimize all Leo's windows."""
         for frame in g.app.windowList:
             self.minimize(frame)
@@ -2125,7 +2125,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
 
     # @+node:ekr.20110605121601.18307: *5* LeoQtFrame.toggleSplitDirection
     @frame_cmd('toggle-split-direction')
-    def toggleSplitDirection(self, event: LeoKeyEvent = None) -> None:
+    def toggleSplitDirection(self, event: LeoKeyEvent | None = None) -> None:
         """
         Toggle the split direction in the present Leo window.
         """
@@ -2141,7 +2141,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
 
     # @+node:ekr.20110605121601.18308: *5* LeoQtFrame.resizeToScreen
     @frame_cmd('resize-to-screen')
-    def resizeToScreen(self, event: LeoKeyEvent = None) -> None:
+    def resizeToScreen(self, event: LeoKeyEvent | None = None) -> None:
         """Resize the Leo window so it fill the entire screen."""
         frame = self
         # This unit test will fail when run externally.
@@ -2254,10 +2254,10 @@ class LeoQtLog(leoFrame.LeoLog):
         self.contentsDict: dict[str, LeoQTextBrowser] = {}  # Keys: tab names.
         self.eventFilters: list = []  # To make filters work!
         self.qtFrameDict: dict[str, QTabWidget] = {}
-        self.logCtrl: Any = None  # A Union.
+        self.logCtrl: Any | None = None  # A Union.
         self.logDict: dict[str, LeoQTextBrowser] = {}  # Keys: tab names.
-        self.logWidget: LeoLog = None
-        self.menu: qt_text.LeoQTextBrowser = None
+        self.logWidget: LeoLog | None = None
+        self.menu: qt_text.LeoQTextBrowser | None = None
         self.tabWidget: QWidget = c.frame.top.tabWidget
         tw = self.tabWidget
 
@@ -2316,7 +2316,7 @@ class LeoQtLog(leoFrame.LeoLog):
     # @+node:ekr.20150717102728.1: *3* LeoQtLog.clear-log & dump-log
     @log_cmd('clear-log')
     @log_cmd('log-clear')
-    def clearLog(self, event: LeoKeyEvent = None) -> None:
+    def clearLog(self, event: LeoKeyEvent | None = None) -> None:
         """Clear the log pane."""
         # self.logCtrl may be either a wrapper or a widget.
         w = self.logCtrl.widget
@@ -2325,7 +2325,7 @@ class LeoQtLog(leoFrame.LeoLog):
 
     @log_cmd('dump-log')
     @log_cmd('log-dump')
-    def dumpLog(self, event: LeoKeyEvent = None) -> None:
+    def dumpLog(self, event: LeoKeyEvent | None = None) -> None:
         """Clear the log pane."""
         # self.logCtrl may be either a wrapper or a widget.
         w = self.logCtrl.widget
@@ -2386,7 +2386,7 @@ class LeoQtLog(leoFrame.LeoLog):
                 g.es(key3, val3, tabName='Fonts')
 
     # @+node:ekr.20110605121601.18339: *3* LeoQtLog.hideFontTab
-    def hideFontTab(self, event: LeoKeyEvent = None) -> None:
+    def hideFontTab(self, event: LeoKeyEvent | None = None) -> None:
         c = self.c
         c.frame.log.selectTab('Log')
         c.bodyWantsFocus()
@@ -2430,10 +2430,10 @@ class LeoQtLog(leoFrame.LeoLog):
     def put(
         self,
         s: str,
-        color: str = None,
+        color: str | None = None,
         tabName: str = 'Log',
         from_redirect: bool = False,
-        nodeLink: str = None,
+        nodeLink: str | None = None,
     ) -> None:
         """
         Put s to the Qt Log widget, converting to html.
@@ -2554,7 +2554,7 @@ class LeoQtLog(leoFrame.LeoLog):
         self,
         tabName: str,
         createText: bool = True,
-        widget: QWidget = None,
+        widget: QWidget | None = None,
         wrap: str = 'none',
     ) -> QWidget:  # Widget or LeoQTextBrowser.
         """
@@ -2623,7 +2623,7 @@ class LeoQtLog(leoFrame.LeoLog):
         self.selectTab('Log')
 
     # @+node:ekr.20111122080923.10185: *4* LeoQtLog.orderedTabNames
-    def orderedTabNames(self, LeoLog: str = None) -> list[str]:  # Unused: LeoLog
+    def orderedTabNames(self, LeoLog: str | None = None) -> list[str]:  # Unused: LeoLog
         """Return a list of tab names in the order in which they appear in the QTabbedWidget."""
         w = self.tabWidget
         return [w.tabText(i) for i in range(w.count())]
@@ -2736,9 +2736,9 @@ class LeoQtMenu(leoMenu.LeoMenu):
         self,
         menu: QMenu,
         accelerator: str = '',
-        command: Callable = None,
-        commandName: str = None,
-        label: str = None,
+        command: Callable | None = None,
+        commandName: str | None = None,
+        label: str | None = None,
         underline: int = 0,
     ) -> None:
         """Wrapper for the Tkinter add_command menu method."""
@@ -2799,7 +2799,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
         position: int,
         label: str,
         command: Callable,
-        underline: int = None,
+        underline: int | None = None,
     ) -> None:
         menu = self.getMenu(menuName)
         if menu and label:
@@ -3503,14 +3503,14 @@ class LeoQtSpellTab:
         self.handler.add()
 
     # @+node:ekr.20110605121601.18391: *4* LeoQtSpellTab.onChangeButton & onChangeThenFindButton
-    def onChangeButton(self, event: QEvent = None) -> None:
+    def onChangeButton(self, event: QEvent | None = None) -> None:
         """Handle a click in the Change button in the Spell tab."""
         state = self.updateButtons()
         if state:
             self.handler.change()
         self.updateButtons()
 
-    def onChangeThenFindButton(self, event: QEvent = None) -> None:
+    def onChangeThenFindButton(self, event: QEvent | None = None) -> None:
         """Handle a click in the "Change, Find" button in the Spell tab."""
         state = self.updateButtons()
         if state:
@@ -3534,17 +3534,17 @@ class LeoQtSpellTab:
         self.handler.hide()
 
     # @+node:ekr.20110605121601.18394: *4* LeoQtSpellTab.onIgnoreButton
-    def onIgnoreButton(self, event: QEvent = None) -> None:
+    def onIgnoreButton(self, event: QEvent | None = None) -> None:
         """Handle a click in the Ignore button in the Check Spelling dialog."""
         self.handler.ignore()
 
     # @+node:ekr.20110605121601.18395: *4* LeoQtSpellTab.onMap
-    def onMap(self, event: QEvent = None) -> None:
+    def onMap(self, event: QEvent | None = None) -> None:
         """Respond to a Tk <Map> event."""
         self.update(show=False, fill=False)
 
     # @+node:ekr.20110605121601.18396: *4* LeoQtSpellTab.onSelectListBox
-    def onSelectListBox(self, event: QEvent = None) -> None:
+    def onSelectListBox(self, event: QEvent | None = None) -> None:
         """Respond to a click in the selection listBox."""
         c = self.c
         self.updateButtons()
@@ -3556,7 +3556,7 @@ class LeoQtSpellTab:
         self.c.frame.log.selectTab('Spell')
 
     # @+node:ekr.20110605121601.18399: *4* LeoQtSpellTab.fillbox
-    def fillbox(self, alts: list[str], word: str = None) -> None:
+    def fillbox(self, alts: list[str], word: str | None = None) -> None:
         """Update the suggestions listBox in the Check Spelling dialog."""
         self.suggestions = alts
         if not word:
@@ -3627,7 +3627,7 @@ class LeoQtTreeTab:
         self.iconBar = iconBar
         self.lockout = False  # True: do not redraw.
         self.tabNames: list[str] = []  # The list of tab names. Changes when tabs are renamed.
-        self.w: QComboBox = None
+        self.w: QComboBox | None = None
         # self.reloadSettings()
         self.createControl()
 
@@ -3767,7 +3767,7 @@ class QtIconBarClass:
     # @+node:ekr.20110605121601.18264: *3*  QtIconBar.do-nothings
     # These *are* called from Leo's core.
 
-    def addRow(self, height: int = None) -> None:
+    def addRow(self, height: int | None = None) -> None:
         pass
 
     def getNewFrame(self) -> None:
@@ -3798,7 +3798,7 @@ class QtIconBarClass:
         class leoIconBarButton(QtWidgets.QWidgetAction):
             def __init__(self, parent: QWidget, text: str, toolbar: QtIconBarClass) -> None:
                 super().__init__(parent)
-                self.button: QtWidgets.QPushButton = None
+                self.button: QtWidgets.QPushButton | None = None
                 self.text_val = text  # self.text is a method!
                 self.toolbar = toolbar
 
@@ -3945,8 +3945,8 @@ class QtIconBarClass:
         rclicks: RClicks,
         controller: ScriptingController,
         top_level: bool = True,
-        button: QWidget = None,
-        script: str = None,
+        button: QWidget | None = None,
+        script: str | None = None,
     ) -> None:
         c = controller.c
         top_offset = -2  # insert before the remove button and goto script items
@@ -4127,11 +4127,11 @@ class QtStatusLineClass:
     def get(self) -> str:
         return self.textWidget2.text()
 
-    def put(self, s: str, bg: str = None, fg: str = None) -> None:
+    def put(self, s: str, bg: str | None = None, fg: str | None = None) -> None:
         """Put the UNL area."""
         self.put_helper(s, self.textWidget2, bg, fg)
 
-    def put1(self, s: str, bg: str = None, fg: str = None) -> None:
+    def put1(self, s: str, bg: str | None = None, fg: str | None = None) -> None:
         """Put the status area"""
         self.put_helper(s, self.textWidget1, bg, fg)
 
@@ -4139,7 +4139,7 @@ class QtStatusLineClass:
     # Keys are widgets, values are stylesheets.
     styleSheetCache: dict[QWidget, str] = {}
 
-    def put_helper(self, s: str, w: QWidget, bg: str = None, fg: str = None) -> None:
+    def put_helper(self, s: str, w: QWidget, bg: str | None = None, fg: str | None = None) -> None:
         """Put string s in the indicated widget, with proper colors."""
         c = self.c
         bg = bg or c.config.getColor('status-bg') or 'white'
@@ -4266,7 +4266,7 @@ class QtStatusLineClass:
             self.put1(f"fline: {fline:2} line: {row:2d} col: {col:2} fcol: {fcol:2}")
 
     # @+node:ekr.20220911120019.1: *3* QtStatusLineClass: do-nothings
-    def disable(self, background: str = None) -> None:
+    def disable(self, background: str | None = None) -> None:
         pass
 
     def enable(self, background: str = "white") -> None:
@@ -4285,7 +4285,7 @@ class QtStatusLineClass:
 class QtTabBarWrapper(QtWidgets.QTabBar):
     # @+others
     # @+node:peckj.20140516114832.10108: *3* QtTabBarWrapper.__init__
-    def __init__(self, parent: QWidget = None) -> None:
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setMovable(True)
 
@@ -4316,7 +4316,7 @@ class TabbedFrameFactory:
         # Workaround a problem setting the window title when tabs are shown.
         self.alwaysShowTabs = True
         self.leoFrames: dict[QWidget, QWidget] = {}
-        self.masterFrame: LeoTabbedTopLevel = None
+        self.masterFrame: LeoTabbedTopLevel | None = None
         self.createTabCommands()
 
     # @+node:ekr.20110605121601.18466: *3* TabbedFrameFactory.createFrame

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -109,7 +109,7 @@ class LeoQtGui(leoGui.LeoGui):
         self.active = True
         self.consoleOnly = False  # Console is separate from the log.
         self.iconimages: dict[str, QIcon] = {}  # Keys are paths, values are Icons.
-        self.globalFindDialog: QDialog = None
+        self.globalFindDialog: QDialog | None = None
         self.idleTimeClass = qt_idle_time.IdleTime
         self.mGuiName = 'qt'
         self.show_tips_flag = False  # #2390: Can't be inited in reload_settings.
@@ -287,7 +287,7 @@ class LeoQtGui(leoGui.LeoGui):
             return None
 
     # @+node:ekr.20110605121601.18511: *3* LeoQtGui.getFullVersion
-    def getFullVersion(self, c: Cmdr = None) -> str:
+    def getFullVersion(self, c: Cmdr | None = None) -> str:
         """Return the PyQt version (for signon)"""
         try:
             qtLevel = f"version {QtCore.qVersion()}"
@@ -300,12 +300,12 @@ class LeoQtGui(leoGui.LeoGui):
     def makeScriptButton(
         self,
         c: Cmdr,
-        args: Any = None,
-        p: Position = None,  # A node containing the script.
-        script: str = None,  # The script itself.
-        buttonText: str = None,
+        args: Any | None = None,
+        p: Position | None = None,  # A node containing the script.
+        script: str | None = None,  # The script itself.
+        buttonText: str | None = None,
         balloonText: str = 'Script Button',
-        shortcut: str = None,
+        shortcut: str | None = None,
         bg: str = 'LightSteelBlue1',
         define_g: bool = True,
         define_name: str = '__main__',
@@ -327,14 +327,14 @@ class LeoQtGui(leoGui.LeoGui):
         # @+<< define the callbacks for b >>
         # @+node:ekr.20110605121601.18530: *4* << define the callbacks for b >>
         def deleteButtonCallback(
-            event: LeoKeyEvent = None, b: QPushButton = b, c: Cmdr = c
+            event: LeoKeyEvent | None = None, b: QPushButton = b, c: Cmdr = c
         ) -> None:
             if b:
                 b.pack_forget()
             c.bodyWantsFocus()
 
         def executeScriptCallback(
-            event: LeoKeyEvent = None,
+            event: LeoKeyEvent | None = None,
             b: QPushButton = b,
             c: Cmdr = c,
             buttonText: str = buttonText,
@@ -463,7 +463,7 @@ class LeoQtGui(leoGui.LeoGui):
 
     # @+node:ekr.20180117053546.1: *3* LeoQtGui.show_tips & helpers
     @g.command('show-tips')
-    def show_next_tip(self, event: LeoKeyEvent = None) -> None:
+    def show_next_tip(self, event: LeoKeyEvent | None = None) -> None:
         c = g.app.log and g.app.log.c
         if c:
             g.app.gui.show_tips(c)
@@ -730,8 +730,8 @@ class LeoQtGui(leoGui.LeoGui):
         c: Cmdr,
         title: str,
         message: str = 'Select Date/Time',
-        init: datetime.datetime = None,
-        step_min: dict = None,
+        init: datetime.datetime | None = None,
+        step_min: dict | None = None,
     ) -> datetime.datetime | None:
         """Create and run a qt date/time selection dialog.
 
@@ -760,9 +760,9 @@ class LeoQtGui(leoGui.LeoGui):
 
             def __init__(
                 self,
-                parent: QWidget = None,
-                init: datetime.datetime = None,
-                step_min: dict = None,
+                parent: QWidget | None = None,
+                init: datetime.datetime | None = None,
+                step_min: dict | None = None,
             ) -> None:
                 if step_min is None:
                     step_min = {}
@@ -781,10 +781,10 @@ class LeoQtGui(leoGui.LeoGui):
         class Calendar(QtWidgets.QDialog):
             def __init__(
                 self,
-                parent: QWidget = None,
+                parent: QWidget | None = None,
                 message: str = 'Select Date/Time',
-                init: datetime.datetime = None,
-                step_min: dict = None,
+                init: datetime.datetime | None = None,
+                step_min: dict | None = None,
             ) -> None:
                 if step_min is None:
                     step_min = {}
@@ -837,8 +837,8 @@ class LeoQtGui(leoGui.LeoGui):
         c: Cmdr,
         title: str,
         message: str,
-        cancelButtonText: str = None,
-        okButtonText: str = None,
+        cancelButtonText: str | None = None,
+        okButtonText: str | None = None,
     ) -> int | None:
         """Create and run askOkCancelNumber dialog ."""
         if g.unitTesting:
@@ -875,8 +875,8 @@ class LeoQtGui(leoGui.LeoGui):
         c: Cmdr,
         title: str,
         message: str,
-        cancelButtonText: str = None,
-        okButtonText: str = None,
+        cancelButtonText: str | None = None,
+        okButtonText: str | None = None,
         default: str = "",
         wide: bool = False,
     ) -> str | None:
@@ -910,7 +910,9 @@ class LeoQtGui(leoGui.LeoGui):
         return str(dialog.textValue()) if ok else None
 
     # @+node:ekr.20110605121601.18495: *4* LeoQtGui.runAskOkDialog
-    def runAskOkDialog(self, c: Cmdr, title: str, message: str = None, text: str = "Ok") -> None:
+    def runAskOkDialog(
+        self, c: Cmdr, title: str, message: str | None = None, text: str = "Ok"
+    ) -> None:
         """Create and run a qt askOK dialog ."""
         if g.unitTesting:
             return
@@ -940,12 +942,12 @@ class LeoQtGui(leoGui.LeoGui):
         self,
         c: Cmdr,
         title: str,
-        message: str = None,
+        message: str | None = None,
         yesMessage: str = "&Yes",
         noMessage: str = "&No",
-        yesToAllMessage: str = None,
+        yesToAllMessage: str | None = None,
         defaultButton: str = "Yes",
-        cancelMessage: str = None,
+        cancelMessage: str | None = None,
     ) -> str:
         """
         Create and run an askYesNo dialog.
@@ -1001,7 +1003,7 @@ class LeoQtGui(leoGui.LeoGui):
         self,
         c: Cmdr,
         title: str,
-        message: str = None,
+        message: str | None = None,
         yes_all: bool = False,
         no_all: bool = False,
     ) -> str:
@@ -1083,7 +1085,7 @@ class LeoQtGui(leoGui.LeoGui):
         *,
         filetypes: list[tuple[str, str]],
         defaultextension: str = '',  # Not used
-        startpath: str = None,
+        startpath: str | None = None,
     ) -> str:
         """
         Create and run an Qt open file dialog.
@@ -1129,7 +1131,7 @@ class LeoQtGui(leoGui.LeoGui):
         *,
         filetypes: list[tuple[str, str]],
         defaultextension: str = '',  # Not used.
-        startpath: str = None,
+        startpath: str | None = None,
     ) -> list[str]:
         """
         Create and run an Qt open file dialog.
@@ -1172,8 +1174,8 @@ class LeoQtGui(leoGui.LeoGui):
     def runPropertiesDialog(
         self,
         title: str = 'Properties',
-        data: Any = None,
-        callback: Callable = None,
+        data: Any | None = None,
+        callback: Callable | None = None,
         buttons: list[str] = None,
     ) -> tuple[str, dict]:
         """Display a modal TkPropertiesDialog"""
@@ -1233,7 +1235,7 @@ class LeoQtGui(leoGui.LeoGui):
         title: str = 'Message',
         label: str = '',
         msg: str = '',
-        c: Cmdr = None,
+        c: Cmdr | None = None,
         **keys: Any,
     ) -> None:
         if g.unitTesting:
@@ -1417,7 +1419,7 @@ class LeoQtGui(leoGui.LeoGui):
                 c.bodyWantsFocusNow()
 
     # @+node:ekr.20190601054958.1: *4* LeoQtGui.get_focus
-    def get_focus(self, c: Cmdr = None, raw: bool = False, at_idle: bool = False) -> QWidget:
+    def get_focus(self, c: Cmdr | None = None, raw: bool = False, at_idle: bool = False) -> QWidget:
         """Returns the widget that has focus."""
         trace = 'focus' in g.app.debug and not at_idle
         w = QtWidgets.QApplication.focusWidget()
@@ -1704,11 +1706,11 @@ class LeoQtGui(leoGui.LeoGui):
         self,
         parent: QWidget,
         name: str,
-        hPolicy: Policy = None,
-        vPolicy: Policy = None,
+        hPolicy: Policy | None = None,
+        vPolicy: Policy | None = None,
         lineWidth: int = 1,
-        shadow: Shadow = None,
-        shape: Shape = None,
+        shadow: Shadow | None = None,
+        shape: Shape | None = None,
     ) -> QFrame:
         """Create a Qt Frame."""
         if shadow is None:
@@ -1765,8 +1767,8 @@ class LeoQtGui(leoGui.LeoGui):
         self,
         parent: QWidget,
         name: str,
-        hPolicy: Policy = None,
-        vPolicy: Policy = None,
+        hPolicy: Policy | None = None,
+        vPolicy: Policy | None = None,
     ) -> QTabWidget:
         w = QtWidgets.QTabWidget(parent)
         self.setSizePolicy(w, kind1=hPolicy, kind2=vPolicy)
@@ -1774,7 +1776,9 @@ class LeoQtGui(leoGui.LeoGui):
         return w
 
     # @+node:ekr.20190819091214.1: *4* LeoQtGui.setSizePolicy
-    def setSizePolicy(self, widget: QWidget, kind1: Policy = None, kind2: Policy = None) -> None:
+    def setSizePolicy(
+        self, widget: QWidget, kind1: Policy | None = None, kind2: Policy | None = None
+    ) -> None:
         if kind1 is None:
             kind1 = Policy.Ignored
         if kind2 is None:
@@ -1874,7 +1878,7 @@ class StyleSheetManager:
         # g.es("https://leo-editor.github.io/leo-editor/tutorial-basics.html#configuring-leo")
 
     # @+node:ekr.20170222051716.1: *3*  StyleSheetManager.reload_settings
-    def reload_settings(self, sheet: str = None) -> None:
+    def reload_settings(self, sheet: str | None = None) -> None:
         """
         Recompute and apply the stylesheet.
         Called automatically by the reload-settings commands.
@@ -1995,7 +1999,9 @@ class StyleSheetManager:
         print(f"style sheet for: {w}...\n\n{sheet}")
 
     # @+node:ekr.20110605121601.18175: *4* StyleSheetManager.set_style_sheets
-    def set_style_sheets(self, all: bool = True, top: QWidget = None, w: QWidget = None) -> None:
+    def set_style_sheets(
+        self, all: bool = True, top: QWidget | None = None, w: QWidget | None = None
+    ) -> None:
         """Set the master style sheet for all widgets using config settings."""
         c = self.c
         if top is None:
@@ -2033,7 +2039,7 @@ class StyleSheetManager:
     # @+node:ekr.20140915062551.19510: *4* StyleSheetManager.expand_css_constants & helpers
     css_warning_given = False  # For do_pass.
 
-    def expand_css_constants(self, sheet: str, settingsDict: g.SettingsDict = None) -> str:
+    def expand_css_constants(self, sheet: str, settingsDict: g.SettingsDict | None = None) -> str:
         """Expand @ settings into their corresponding constants."""
         c = self.c
         trace = 'zoom' in g.app.debug
@@ -2305,7 +2311,7 @@ class StyleSheetManager:
 
     # @+node:ekr.20180316092116.1: *3* StyleSheetManager: Widgets
     # @+node:ekr.20140913054442.19390: *4* StyleSheetManager.get_master_widget
-    def get_master_widget(self, top: QWidget = None) -> QWidget:
+    def get_master_widget(self, top: QWidget | None = None) -> QWidget:
         """
         Carefully return the master widget.
         c.frame.top is a DynamicWindow.

--- a/leo/plugins/qt_idle_time.py
+++ b/leo/plugins/qt_idle_time.py
@@ -52,12 +52,12 @@ class IdleTime:
 
     # @+others
     # @+node:ekr.20140825042850.18406: *3* IdleTime.__init__
-    def __init__(self, handler: Callable, delay: int = 500, tag: str = None) -> None:
+    def __init__(self, handler: Callable, delay: int = 500, tag: str | None = None) -> None:
         """ctor for IdleTime class."""
         # For use by handlers...
         self.count = 0  # The number of times handler has been called.
-        self.starting_time: float = None  # Time that the timer started.
-        self.time: float = None  # Time that the handle is called.
+        self.starting_time: float | None = None  # Time that the timer started.
+        self.time: float | None = None  # Time that the handle is called.
         self.tag: str = tag  # For debugging.
 
         # For the IdleTime class...

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -486,7 +486,7 @@ class LayoutCacheWidget(QWidget):
         super().__init__(parent)
         self.c = c
         self.setObjectName('leo-layout-cache')
-        self.layout_dict: Dict = None
+        self.layout_dict: Dict | None = None
 
         # maps splitter objectNames to their splitter object.
         self.created_splitter_dict: Dict[str, QWidget] = {}
@@ -606,7 +606,7 @@ class LayoutCacheWidget(QWidget):
     # @+node:tom.20240923194438.4: *4* LCW.find_widget_in_children
     def find_widget_in_children(self, name: str) -> QWidget | None:
         """Return a child widget with the given objectName."""
-        w: QWidget = None
+        w: QWidget | None = None
         for kid in self.children():
             if kid.objectName() == name:
                 w = kid  # type: ignore [assignment]
@@ -657,7 +657,7 @@ class LayoutCacheWidget(QWidget):
                 return
 
     # @+node:tom.20240923194438.6: *4* LCW.restoreFromLayout
-    def restoreFromLayout(self, layout: Dict = None) -> None:
+    def restoreFromLayout(self, layout: Dict | None = None) -> None:
         self.layout_dict = layout
         if layout is None:
             layout = FALLBACK_LAYOUT

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -40,7 +40,7 @@ QFontMetrics = QtGui.QFontMetrics
 # @+node:ekr.20191001084541.1: **  zoom commands
 # @+node:tbrown.20130411145310.18857: *3* @g.command('zoom-in')
 @g.command("zoom-in")
-def zoom_in(event: LeoKeyEvent = None, delta: int = 1) -> None:
+def zoom_in(event: LeoKeyEvent | None = None, delta: int = 1) -> None:
     """increase body font size by one
 
     @font-size-body must be present in the stylesheet
@@ -50,7 +50,7 @@ def zoom_in(event: LeoKeyEvent = None, delta: int = 1) -> None:
 
 # @+node:ekr.20191001084646.1: *3* @g.command('zoom-out')
 @g.command("zoom-out")
-def zoom_out(event: LeoKeyEvent = None) -> None:
+def zoom_out(event: LeoKeyEvent | None = None) -> None:
     """decrease body font size by one
 
     @font-size-body must be present in the stylesheet
@@ -113,7 +113,7 @@ Valid values are standard css color names like `lightgrey`, and css rgb values l
 
 
 @g.command('help-for-highlight-current-line')
-def helpForLineHighlight(self: Any, event: LeoKeyEvent = None) -> None:
+def helpForLineHighlight(self: Any, event: LeoKeyEvent | None = None) -> None:
     """Displays Settings used by current line highlighter."""
     self.c.putHelpFor(hilite_doc)
 
@@ -154,15 +154,15 @@ class QTextMixin:
 
     # @+others
     # @+node:ekr.20140901062324.18732: *3* QTextMixin.ctor & helper
-    def __init__(self, c: Cmdr = None) -> None:
+    def __init__(self, c: Cmdr | None = None) -> None:
         """Ctor for QTextMixin class"""
         self.c = c
         self.enabled = True
         self.tags: dict[str, str] = {}
         self.permanent = True  # False if selecting the minibuffer will make the widget go away.
         self.useScintilla = False  # This is used!
-        self.virtualInsertPoint: int = None
-        self.widget: Any = None  # 'Any' is correct for the QTextMixin class.
+        self.virtualInsertPoint: int | None = None
+        self.widget: Any | None = None  # 'Any' is correct for the QTextMixin class.
         if c:
             self.injectIvars(c)
 
@@ -184,7 +184,7 @@ class QTextMixin:
     # @+node:ekr.20140901122110.18733: *3* QTextMixin.Event handlers
     # These are independent of the kind of Qt widget.
     # @+node:ekr.20140901062324.18716: *4* QTextMixin.onCursorPositionChanged
-    def onCursorPositionChanged(self, event: QEvent = None) -> None:
+    def onCursorPositionChanged(self, event: QEvent | None = None) -> None:
         c = self.c
         name = c.widget_name(self)
         # Apparently, this does not cause problems
@@ -234,7 +234,7 @@ class QTextMixin:
         self.setInsertPoint(len(s2))
 
     # @+node:ekr.20140901141402.18706: *5* QTextMixin.delete
-    def delete(self, i: int, j: int = None) -> None:
+    def delete(self, i: int, j: int | None = None) -> None:
         if j is None:
             j = i + 1
         # This allows subclasses to use this base class method.
@@ -251,7 +251,7 @@ class QTextMixin:
         self.delete(i, j)
 
     # @+node:ekr.20110605121601.18102: *5* QTextMixin.get
-    def get(self, i: int, j: int = None) -> str:
+    def get(self, i: int, j: int | None = None) -> str:
         # 2012/04/12: fix the following two bugs by using the vanilla code:
         # https://bugs.launchpad.net/leo-editor/+bug/979142
         # https://bugs.launchpad.net/leo-editor/+bug/971166
@@ -323,7 +323,7 @@ class QLineEditWrapper(QTextMixin):
 
     # @+others
     # @+node:ekr.20110605121601.18060: *3* QLineEditWrapper.__init__ & __repr__
-    def __init__(self, widget: QLineEdit, name: str, c: Cmdr = None) -> None:
+    def __init__(self, widget: QLineEdit, name: str, c: Cmdr | None = None) -> None:
         """Ctor for QLineEditWrapper class."""
         super().__init__(c)
         self.widget = widget
@@ -418,7 +418,7 @@ class QLineEditWrapper(QTextMixin):
             g.app.gui.set_focus(self.c, self.widget)
 
     # @+node:ekr.20110605121601.18129: *4* QLineEditWrapper.setInsertPoint
-    def setInsertPoint(self, i: int, s: str = None) -> None:
+    def setInsertPoint(self, i: int, s: str | None = None) -> None:
         """QHeadlineWrapper."""
         if not self.check():
             return
@@ -429,7 +429,9 @@ class QLineEditWrapper(QTextMixin):
         w.setCursorPosition(i)
 
     # @+node:ekr.20110605121601.18130: *4* QLineEditWrapper.setSelectionRange
-    def setSelectionRange(self, i: int, j: int, insert: int | None = None, s: str = None) -> None:
+    def setSelectionRange(
+        self, i: int, j: int, insert: int | None = None, s: str | None = None
+    ) -> None:
         """QHeadlineWrapper."""
         if not self.check():
             return
@@ -975,7 +977,7 @@ if QtWidgets:
         # @+node:ekr.20201204172235.1: *3* LeoQTextBrowser.paintEvent
         leo_cursor_width = 0
 
-        leo_vim_mode: bool = None
+        leo_vim_mode: bool | None = None
 
         def paintEvent(self, event: QPaintEvent) -> None:
             """
@@ -1318,7 +1320,9 @@ class QMinibufferWrapper(QLineEditWrapper):
         # level sheet will get pushed down quite frequently.
         self.widget.setStyleSheet(self.c.frame.top.styleSheet())
 
-    def setSelectionRange(self, i: int, j: int, insert: int = None, s: str = None) -> None:
+    def setSelectionRange(
+        self, i: int, j: int, insert: int | None = None, s: str | None = None
+    ) -> None:
         QLineEditWrapper.setSelectionRange(self, i, j, insert, s)
         insert = j if insert is None else insert
         if self.widget:
@@ -1338,7 +1342,7 @@ class QScintillaWrapper(QTextMixin):
 
     # @+others
     # @+node:ekr.20110605121601.18105: *3* QScintillaWrapper.ctor
-    def __init__(self, widget: QWidget, c: Cmdr, name: str = None) -> None:
+    def __init__(self, widget: QWidget, c: Cmdr, name: str | None = None) -> None:
         """Ctor for the QScintillaWrapper class."""
         super().__init__(c)
         self.baseClassName = 'QScintillaWrapper'
@@ -1369,7 +1373,7 @@ class QScintillaWrapper(QTextMixin):
 
     # @+node:ekr.20110605121601.18107: *3* QScintillaWrapper.WidgetAPI
     # @+node:ekr.20140901062324.18593: *4* QScintillaWrapper.delete
-    def delete(self, i: int, j: int = None) -> None:
+    def delete(self, i: int, j: int | None = None) -> None:
         """Delete s[i:j]"""
         w = self.widget
         if j is None:
@@ -1438,7 +1442,7 @@ class QScintillaWrapper(QTextMixin):
             addFlashCallback()
 
     # @+node:ekr.20140901062324.18595: *4* QScintillaWrapper.get
-    def get(self, i: int, j: int = None) -> str:
+    def get(self, i: int, j: int | None = None) -> str:
         # Fix the following two bugs by using vanilla code:
         # https://bugs.launchpad.net/leo-editor/+bug/979142
         # https://bugs.launchpad.net/leo-editor/+bug/971166
@@ -1551,7 +1555,7 @@ class QScintillaWrapper(QTextMixin):
         # w.update()
 
     # @+node:ekr.20110605121601.18114: *4* QScintillaWrapper.setInsertPoint
-    def setInsertPoint(self, i: int, s: str = None) -> None:
+    def setInsertPoint(self, i: int, s: str | None = None) -> None:
         """Set the insertion point in a QsciScintilla widget."""
         w = self.widget
         # w.SendScintilla(w.SCI_SETCURRENTPOS,i)
@@ -1559,7 +1563,9 @@ class QScintillaWrapper(QTextMixin):
         w.SendScintilla(w.SCI_SETSEL, i, i)
 
     # @+node:ekr.20110605121601.18115: *4* QScintillaWrapper.setSelectionRange
-    def setSelectionRange(self, i: int, j: int, insert: int = None, s: str = None) -> None:
+    def setSelectionRange(
+        self, i: int, j: int, insert: int | None = None, s: str | None = None
+    ) -> None:
         """Set the selection range in a QsciScintilla widget."""
         w = self.widget
         if insert is None:
@@ -1655,7 +1661,7 @@ class QTextEditWrapper(QTextMixin):
     # @+node:ekr.20110605121601.18078: *3* QTextEditWrapper: High-level interface
     # These are all widget-dependent
     # @+node:ekr.20110605121601.18079: *4* QTextEditWrapper.delete (avoid call to setAllText)
-    def delete(self, i: int, j: int = None) -> None:
+    def delete(self, i: int, j: int | None = None) -> None:
         """QTextEditWrapper."""
         w = self.widget
         if j is None:
@@ -1952,7 +1958,7 @@ class QTextEditWrapper(QTextMixin):
         self.setSelectionRange(i=i, j=i, insert=i)
 
     # @+node:ekr.20110605121601.18096: *4* QTextEditWrapper.setSelectionRange
-    def setSelectionRange(self, i: int, j: int, insert: int = None) -> None:
+    def setSelectionRange(self, i: int, j: int, insert: int | None = None) -> None:
         """Set the selection range and the insert point."""
         c = self.c
         # Part 1

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -164,7 +164,7 @@ class LeoQtTree(leoFrame.LeoTree):
         w.clear()
 
     # @+node:ekr.20110605121601.17873: *4* LeoQtTree.redraw_tree & helpers
-    def redraw_tree(self, p: Position = None) -> Position:
+    def redraw_tree(self, p: Position | None = None) -> Position:
         """
         Redraw all visible nodes of the tree.
         Preserve the vertical scrolling unless scroll is True.
@@ -238,7 +238,7 @@ class LeoQtTree(leoFrame.LeoTree):
             If cmd is not a replacement command returns (None, None)
             """
             # 's' is string when 'cmd' is recognized and is None otherwise
-            s: str = None
+            s: str | None = None
             if cmd == 'REPLACE':
                 try:
                     s = pattern.sub(arg, text)
@@ -275,7 +275,7 @@ class LeoQtTree(leoFrame.LeoTree):
             Returns (None, param) if 'cmd' is not a style option.
             """
             param = c.styleSheetManager.expand_css_constants(arg).split()[0]
-            modifier: Callable = None
+            modifier: Callable | None = None
 
             if cmd == 'ICON':
 
@@ -484,7 +484,7 @@ class LeoQtTree(leoFrame.LeoTree):
             g.trace(f"{c.shortFileName()} {t2 - t1:5.2f} sec.")
 
     # @+node:ekr.20110605121601.17877: *5* LeoQtTree.drawTree
-    def drawTree(self, p: Position, parent_item: QTreeWidgetItem = None) -> None:
+    def drawTree(self, p: Position, parent_item: QTreeWidgetItem | None = None) -> None:
         if g.app.gui.isNullGui:
             return
         # Draw the (visible) parent node.
@@ -558,7 +558,7 @@ class LeoQtTree(leoFrame.LeoTree):
     # @+node:ekr.20110605121601.17885: *3* LeoQtTree: Event handlers
     # @+node:ekr.20110605121601.17887: *4*  LeoQtTree: Click box event handlers
     # @+node:ekr.20110605121601.17888: *5* LeoQtTree.onClickBoxClick
-    def onClickBoxClick(self, event: LeoKeyEvent, p: Position = None) -> None:
+    def onClickBoxClick(self, event: LeoKeyEvent, p: Position | None = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -567,7 +567,7 @@ class LeoQtTree(leoFrame.LeoTree):
         c.outerUpdate()
 
     # @+node:ekr.20110605121601.17889: *5* LeoQtTree.onClickBoxRightClick
-    def onClickBoxRightClick(self, event: LeoKeyEvent, p: Position = None) -> None:
+    def onClickBoxRightClick(self, event: LeoKeyEvent, p: Position | None = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -576,7 +576,7 @@ class LeoQtTree(leoFrame.LeoTree):
         c.outerUpdate()
 
     # @+node:ekr.20110605121601.17890: *5* LeoQtTree.onPlusBoxRightClick
-    def onPlusBoxRightClick(self, event: LeoKeyEvent, p: Position = None) -> None:
+    def onPlusBoxRightClick(self, event: LeoKeyEvent, p: Position | None = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -586,7 +586,7 @@ class LeoQtTree(leoFrame.LeoTree):
     # @+node:ekr.20110605121601.17891: *4*  LeoQtTree: Icon box event handlers
     # For Qt, there seems to be no way to trigger these events.
     # @+node:ekr.20110605121601.17892: *5* LeoQtTree.onIconBoxClick
-    def onIconBoxClick(self, event: LeoKeyEvent, p: Position = None) -> None:
+    def onIconBoxClick(self, event: LeoKeyEvent, p: Position | None = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -595,7 +595,7 @@ class LeoQtTree(leoFrame.LeoTree):
         c.outerUpdate()
 
     # @+node:ekr.20110605121601.17893: *5* LeoQtTree.onIconBoxRightClick
-    def onIconBoxRightClick(self, event: LeoKeyEvent, p: Position = None) -> None:
+    def onIconBoxRightClick(self, event: LeoKeyEvent, p: Position | None = None) -> None:
         """Handle a right click in any outline widget."""
         if self.busy:
             return
@@ -605,7 +605,7 @@ class LeoQtTree(leoFrame.LeoTree):
         c.outerUpdate()
 
     # @+node:ekr.20110605121601.17894: *5* LeoQtTree.onIconBoxDoubleClick
-    def onIconBoxDoubleClick(self, event: LeoKeyEvent, p: Position = None) -> None:
+    def onIconBoxDoubleClick(self, event: LeoKeyEvent, p: Position | None = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -1149,7 +1149,7 @@ class LeoQtTree(leoFrame.LeoTree):
         self,
         p: Position,
         selectAll: bool = False,
-        selection: tuple = None,
+        selection: tuple | None = None,
     ) -> tuple[QLineEdit, QHeadlineWrapper]:
         """Start editing p's headline."""
         if self.busy:
@@ -1177,7 +1177,7 @@ class LeoQtTree(leoFrame.LeoTree):
         self,
         item: QTreeWidgetItem,
         selectAll: bool = False,
-        selection: tuple = None,
+        selection: tuple | None = None,
     ) -> tuple[QLineEdit, QHeadlineWrapper]:
         """Helper for qtree.editLabel."""
         c, vc = self.c, self.c.vimCommands


### PR DESCRIPTION
See #4766.

This PR changes *only* annotation syntax. It does *not* change:

- Default *values* for any var, arg, or kwarg!
- .mypy.ini. In particular, mypy does not require strict_optional for any more modules!

A later PR will:

- Change default values for (most, all?) strings from None to the empty string.
- Use pythonic tests instead of tests against None.
- Require the event arg for all commands and in various other places.
  Annotate event vars and args as `event: LeoKeyEvent`, without a default.

### Use correct syntax for all optional values

Replace `x: y = None` with `x: y | None = None` in:

- [x] leo/core.
- [x] leo/plugins.
- [x] all Qt gui modules.

### Other changes

- [x] Use casts in leoVim.py.