### PR TITLE
Make @auto-md nodes respect @noheader

### DIFF
--- a/leo/plugins/importers/markdown.py
+++ b/leo/plugins/importers/markdown.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 from leo.core import leoGlobals as g
 from leo.plugins.importers.base_importer import Importer
 
@@ -42,6 +43,9 @@ class Markdown_Importer(Importer):
             level, name = self.is_hash(line)
             if skip > 0:
                 skip -= 1
+            elif not in_code and (marker := self.is_noheader_marker(line)) is not None:
+                marker_level, marker_name = marker
+                self.make_noheader_node(marker_level, marker_name)
             elif not in_code and self.lookahead_underline(i):
                 level = 1 if lines[i + 1].startswith('=') else 2
                 self.make_markdown_node(level, line)
@@ -81,6 +85,19 @@ class Markdown_Importer(Importer):
                 return level, name
         return None, None
 
+    # @+node:axk.20260709133000.2: *4* md_i.is_noheader_marker
+    md_noheader_pattern = re.compile(
+        r'^\s*<!--\s*leo-noheader level=(\d+)\s+headline=(.*?)\s*-->\s*\n?$'
+    )
+
+    def is_noheader_marker(self, line: str) -> tuple[int, str] | None:
+        """Return level, name if line is a Leo noheader marker."""
+        if m := self.md_noheader_pattern.match(line):
+            level = int(m.group(1))
+            name = unquote(m.group(2))
+            return level, name
+        return None
+
     # @+node:ekr.20230528170618.3: *4* md_i.is_underline
     md_pattern_table = (
         re.compile(r'^(=+)\n'),
@@ -116,6 +133,13 @@ class Markdown_Importer(Importer):
         child.h = '!Declarations'
         lines_dict[child.v] = [line]
         self.stack.append(child)
+
+    # @+node:axk.20260709133000.3: *4* md_i.make_noheader_node
+    def make_noheader_node(self, level: int, name: str) -> Position:
+        """Create a node represented by a Leo noheader HTML comment."""
+        child = self.make_markdown_node(level, name)
+        self.lines_dict[child.v].append('@noheader\n')
+        return child
 
     # @+node:ekr.20230528170618.6: *4* md_i.make_markdown_node
     def make_markdown_node(self, level: int, name: str) -> Position:

--- a/leo/plugins/writers/markdown.py
+++ b/leo/plugins/writers/markdown.py
@@ -3,6 +3,7 @@
 """The @auto write code for markdown."""
 
 import re
+from urllib.parse import quote
 from leo.core import leoGlobals as g
 from leo.core.leoNodes import Position
 import leo.plugins.writers.basewriter as basewriter
@@ -14,6 +15,23 @@ class MarkdownWriter(basewriter.BaseWriter):
     """The writer class for markdown files."""
 
     # @+others
+    # @+node:axk.20260709120000.1: *3* mdw.has_noheader
+    def has_noheader(self, p: Position) -> bool:
+        """Return True if p contains a local @noheader directive."""
+        for line in [p.h, *g.splitLines(p.b)]:
+            if g.isDirective(line):
+                if m := g.g_is_directive_pattern.match(line):
+                    if m.group(1) == 'noheader':
+                        return True
+        return False
+
+    # @+node:axk.20260709133000.1: *3* mdw.noheader_marker
+    def noheader_marker(self, p: Position) -> str:
+        """Return the HTML comment marker for a hidden markdown node."""
+        level = p.level() - self.root.level()
+        headline = quote(p.h, safe='')
+        return f"<!-- leo-noheader level={level} headline={headline} -->"
+
     # @+node:ekr.20140726091031.18076: *3* mdw.write
     def write(self, root: Position) -> None:
         """Write all the *descendants* of an @auto-markdown node."""
@@ -26,6 +44,8 @@ class MarkdownWriter(basewriter.BaseWriter):
                 # skip this 'placeholder level X' node
                 pass
             else:
+                if self.has_noheader(p):
+                    self.put(self.noheader_marker(p))
                 self.write_headline(p)
                 lines = p.b.splitlines(False)
                 for s in lines:
@@ -51,7 +71,7 @@ class MarkdownWriter(basewriter.BaseWriter):
         """
         level = p.level() - self.root.level()
         assert level > 0, p.h
-        if p.h == '!Declarations' or self.placeholder_regex.match(p.h):
+        if p.h == '!Declarations' or self.placeholder_regex.match(p.h) or self.has_noheader(p):
             pass
         else:
             # Leo 6.6.4: preserve spacing.

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -2260,6 +2260,47 @@ class TestMarkdown(BaseTestImporter):
         )  # fmt: skip
         self.new_run_test(s, expected_results)  # check=False)
 
+    # @+node:axk.20260709133000.4: *3* TestMarkdown.test_markdown_importer_noheader_marker
+    def test_markdown_importer_noheader_marker(self):
+        s = """
+            <!-- leo-noheader level=1 headline=First%20hidden -->
+            First body
+            <!-- leo-noheader level=1 headline=Second%20hidden -->
+            Second body
+            ## Visible child
+            Child body
+            # Visible sibling
+            Sibling body
+        """
+        expected_results = (
+            (
+                0, '',  # Ignore the first headline.
+                '@language md\n'
+                '@tabwidth -4\n'
+            ),
+            (
+                1, 'First hidden',
+                '@noheader\n'
+                'First body\n'
+            ),
+            (
+                1, 'Second hidden',
+                '@noheader\n'
+                'Second body\n'
+            ),
+            (
+                2, 'Visible child',
+                'Child body\n'
+            ),
+            (
+                1, 'Visible sibling',
+                'Sibling body\n'
+            ),
+        )  # fmt: skip
+        p = self.run_test(s)
+        self.check_outline(p, expected_results)
+        self.check_round_trip(p, self.prep(s))
+
     # @+node:ekr.20210904065459.112: *3* TestMarkdown.test_markdown_importer_implicit_section
     def test_markdown_importer_implicit_section(self):
 

--- a/leo/unittests/plugins/test_writers.py
+++ b/leo/unittests/plugins/test_writers.py
@@ -157,7 +157,7 @@ class TestMDWriter(BaseTestWriter):
 
     # @+node:axk.20260709120000.3: *3* TestMDWriter.test_markdown_noheader_leaf
     def test_markdown_noheader_leaf(self):
-        c, root = self.c, self.c.p
+        root = self.c.p
         hidden = root.insertAsLastChild()
         hidden.h = 'Hidden leaf'
         hidden.b = '@noheader\nLeaf body\n'
@@ -177,7 +177,7 @@ class TestMDWriter(BaseTestWriter):
 
     # @+node:axk.20260709120000.4: *3* TestMDWriter.test_markdown_noheader_intermediate
     def test_markdown_noheader_intermediate(self):
-        c, root = self.c, self.c.p
+        root = self.c.p
         hidden = root.insertAsLastChild()
         hidden.h = 'Hidden parent'
         hidden.b = '@noheader\nParent body\n'

--- a/leo/unittests/plugins/test_writers.py
+++ b/leo/unittests/plugins/test_writers.py
@@ -69,6 +69,12 @@ class TestMDWriter(BaseTestWriter):
     """Test Cases for the markdown writer plugin."""
 
     # @+others
+    # @+node:axk.20260709120000.2: *3* TestMDWriter.render_markdown
+    def render_markdown(self, root):
+        writer = MarkdownWriter(self.c)
+        writer.write(root)
+        return ''.join(self.c.atFileCommands.outputList)
+
     # @+node:ekr.20231219151402.1: *3* TestMDWriter.test_markdown_sections
     def test_markdown_sections(self):
         c, root = self.c, self.c.p
@@ -148,6 +154,52 @@ class TestMDWriter(BaseTestWriter):
             g.printObj(contents, tag='contents')
             g.printObj(results_s, tag='results_s')
         self.assertEqual(results_s, contents)
+
+    # @+node:axk.20260709120000.3: *3* TestMDWriter.test_markdown_noheader_leaf
+    def test_markdown_noheader_leaf(self):
+        c, root = self.c, self.c.p
+        hidden = root.insertAsLastChild()
+        hidden.h = 'Hidden leaf'
+        hidden.b = '@noheader\nLeaf body\n'
+        visible = root.insertAsLastChild()
+        visible.h = 'Visible sibling'
+        visible.b = 'Visible body\n'
+
+        results_s = self.render_markdown(root)
+        self.assertEqual(
+            results_s,
+            '<!-- leo-noheader level=1 headline=Hidden%20leaf -->\n'
+            'Leaf body\n'
+            '# Visible sibling\n'
+            'Visible body\n',
+        )
+        self.assertNotIn('@noheader', results_s)
+
+    # @+node:axk.20260709120000.4: *3* TestMDWriter.test_markdown_noheader_intermediate
+    def test_markdown_noheader_intermediate(self):
+        c, root = self.c, self.c.p
+        hidden = root.insertAsLastChild()
+        hidden.h = 'Hidden parent'
+        hidden.b = '@noheader\nParent body\n'
+        child = hidden.insertAsLastChild()
+        child.h = 'Visible child'
+        child.b = 'Child body\n'
+        sibling = root.insertAsLastChild()
+        sibling.h = 'Visible sibling'
+        sibling.b = 'Sibling body\n'
+
+        results_s = self.render_markdown(root)
+        self.assertEqual(
+            results_s,
+            '<!-- leo-noheader level=1 headline=Hidden%20parent -->\n'
+            'Parent body\n'
+            '## Visible child\n'
+            'Child body\n'
+            '# Visible sibling\n'
+            'Sibling body\n',
+        )
+        self.assertNotIn('# Hidden parent\n', results_s)
+        self.assertNotIn('@noheader', results_s)
 
     # @+node:ekr.20231227225308.1: *3* TestMDWriter.test_placeholders
     def test_markdown_placeholders(self):


### PR DESCRIPTION
## Summary

Fix `@auto-md` / `@auto-markdown` handling of `@noheader` nodes - Issue #4787 

This change teaches the Markdown writer to suppress a node's generated Markdown heading when the node contains `@noheader`, while still writing the node body and preserving descendant heading depth.

To make this round-trip through Markdown import/export, the writer now emits a Leo-specific HTML comment marker for hidden nodes:

```md
<!-- leo-noheader level=... headline=... -->
```

The Markdown importer recognizes that marker, recreates the hidden node, and restores `@noheader` in the imported Leo body text.

## Notes

- Initial implementation did not have hidden nodes marker, but I added it specifically so that two-way binding is preserved.

## What Changed

- Added local `@noheader` detection in the Markdown writer
- Added Leo-specific HTML comment markers for hidden Markdown nodes.
- Updated the Markdown importer to recognize those markers and recreate hidden nodes with `@noheader`.
- Added focused writer and importer tests covering:
  - hidden leaf nodes
  - hidden intermediate nodes with visible children
  - sibling hidden nodes
  - importer round-trip for the new HTML comment marker

## Issue / Branch

- Issue: `Fixes #4787`
- Target branch: `devel`

## LLM Disclosure

Codex/GPT 5.4 was used to help design, implement, and test the Markdown importer/writer changes. All code and test changes were reviewed and verified locally before submission. Contribution time: ~1.5h.
