### PR TITLE
PR Add more defaults for LeoKeyEvent

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -71,7 +71,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
         self.w = cast(QTextMixin, None)
 
     # @+node:ekr.20150514043850.11: *3* abbrev.expandAbbrev & helpers (entry point)
-    def expandAbbrev(self, event: LeoKeyEvent, stroke: g.KeyStroke) -> bool:
+    def expandAbbrev(self, event: LeoKeyEvent | None, stroke: g.KeyStroke) -> bool:
         """
         Not a command.  Expand abbreviations..
 
@@ -119,7 +119,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20260516063712.1: *4* abbrev: startup
     # @+node:ekr.20161121111502.1: *5* abbrev.get_ch
-    def get_ch(self, event: LeoKeyEvent, stroke: g.KeyStroke) -> str:
+    def get_ch(self, event: LeoKeyEvent | None, stroke: g.KeyStroke) -> str:
         """Return the ch from the stroke or event."""
         event_ch = event.char or '' if event else ''
         assert g.isStrokeOrNone(stroke), stroke

--- a/leo/commands/bufferCommands.py
+++ b/leo/commands/bufferCommands.py
@@ -229,7 +229,7 @@ class BufferCommandsClass(BaseEditCommandsClass):
         return None
 
     # @+node:ekr.20150514045829.17: *4* getBufferName
-    def getBufferName(self, event: LeoKeyEvent, finisher: Callable) -> None:
+    def getBufferName(self, event: LeoKeyEvent | None, finisher: Callable) -> None:
         """Get a buffer name into k.arg and call k.setState(kind,n,handler)."""
         k = self.c.k
         self.computeData()

--- a/leo/commands/controlCommands.py
+++ b/leo/commands/controlCommands.py
@@ -34,7 +34,7 @@ class ControlCommandsClass(BaseEditCommandsClass):
 
     # @+others
     # @+node:ekr.20150514063305.91: *3* executeSubprocess
-    def executeSubprocess(self, event: LeoKeyEvent, command: str) -> None:
+    def executeSubprocess(self, event: LeoKeyEvent | None, command: str) -> None:
         """Execute a command in a separate process."""
         trace = False
         k = self.c.k

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -653,7 +653,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Convert tabs to 4 spaces in the selected text."""
         self.tabifyHelper(event, which='untabify')
 
-    def tabifyHelper(self, event: LeoKeyEvent, which: str) -> None:
+    def tabifyHelper(self, event: LeoKeyEvent | None, which: str) -> None:
         c = self.c
         w = event.w if event else c.frame.body.wrapper
         if not g.isTextWrapper(w):
@@ -691,7 +691,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self.capitalizeHelper(event, 'up', 'upcase-word')
 
     # @+node:ekr.20150514063305.194: *4* ec.capitalizeHelper
-    def capitalizeHelper(self, event: LeoKeyEvent, which: str, undoType: str) -> None:
+    def capitalizeHelper(self, event: LeoKeyEvent | None, which: str, undoType: str) -> None:
         c = self.c
         w = event.w if event else c.frame.body.wrapper
         if not g.isTextWrapper(w):
@@ -1039,7 +1039,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self.findCharacterHelper(event, backward=False, extend=True)
 
     # @+node:ekr.20150514063305.222: *5* ec.findCharacterHelper
-    def findCharacterHelper(self, event: LeoKeyEvent, backward: bool, extend: bool) -> None:
+    def findCharacterHelper(self, event: LeoKeyEvent | None, backward: bool, extend: bool) -> None:
         """Put the cursor at the next occurrence of a character on a line."""
         c, k = self.c, self.c.k
         self.w = event.w if event else c.frame.body.wrapper
@@ -1091,7 +1091,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self.findWordHelper(event, oneLine=True)
 
     # @+node:ekr.20150514063305.224: *5* ec.findWordHelper
-    def findWordHelper(self, event: LeoKeyEvent, oneLine: bool) -> None:
+    def findWordHelper(self, event: LeoKeyEvent | None, oneLine: bool) -> None:
         c, k = self.c, self.c.k
         self.w = event.w if event else c.frame.body.wrapper
         if self.w:
@@ -1689,7 +1689,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self.addRemoveHelper(event, ch='\t', add=False, undoType='remove-tab-from-lines')
 
     # @+node:ekr.20150514063305.252: *5* ec.addRemoveHelper
-    def addRemoveHelper(self, event: LeoKeyEvent, ch: str, add: bool, undoType: str) -> None:
+    def addRemoveHelper(self, event: LeoKeyEvent | None, ch: str, add: bool, undoType: str) -> None:
         c = self.c
         w = event.w if event else c.frame.body.wrapper
         if not g.isTextWrapper(w):
@@ -1884,7 +1884,9 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Delete the word in front of the cursor, treating whitespace and symbols smartly."""
         self.deleteWordHelper(event, forward=False, smart=True)
 
-    def deleteWordHelper(self, event: LeoKeyEvent, forward: bool, smart: bool = False) -> None:
+    def deleteWordHelper(
+        self, event: LeoKeyEvent | None, forward: bool, smart: bool = False
+    ) -> None:
         c = self.c
         w = event.w if event else c.frame.body.wrapper
         if not g.isTextWrapper(w):
@@ -2216,7 +2218,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self,
         action: str,
         ch: str,
-        event: LeoKeyEvent,
+        event: LeoKeyEvent | None,
         inBrackets: bool,
         oldSel: tuple[int, int],
         stroke: g.KeyStroke,
@@ -2417,7 +2419,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.277: *5* ec.updateTab & helper
     def updateTab(
         self,
-        event: LeoKeyEvent,
+        event: LeoKeyEvent | None,
         p: Position,
         w: QTextMixin,
         smartTab: bool = True,
@@ -2587,7 +2589,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         c.frame.updateStatusLine()
 
     # @+node:ekr.20150514063305.288: *5* ec.moveToHelper
-    def moveToHelper(self, event: LeoKeyEvent, spot: int, extend: bool) -> None:
+    def moveToHelper(self, event: LeoKeyEvent | None, spot: int, extend: bool) -> None:
         """
         Common helper method for commands the move the cursor
         in a way that can be described by a Tk Text expression.
@@ -2607,7 +2609,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self.extendHelper(w, extend, spot, upOrDown=False)
 
     # @+node:ekr.20150514063305.305: *5* ec.moveWithinLineHelper
-    def moveWithinLineHelper(self, event: LeoKeyEvent, spot: str, extend: bool) -> None:
+    def moveWithinLineHelper(self, event: LeoKeyEvent | None, spot: str, extend: bool) -> None:
         c = self.c
         w = event.w if event else c.frame.body.wrapper
         if not g.isTextWrapper(w):
@@ -2648,7 +2650,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.317: *5* ec.moveWordHelper
     def moveWordHelper(
         self,
-        event: LeoKeyEvent,
+        event: LeoKeyEvent | None,
         extend: bool,
         forward: bool,
         end: bool = False,
@@ -2870,7 +2872,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self.moveUpOrDownHelper(event, 'up', extend=True)
 
     # @+node:ekr.20150514063305.293: *5* ec.moveUpOrDownHelper
-    def moveUpOrDownHelper(self, event: LeoKeyEvent, direction: str, extend: bool) -> None:
+    def moveUpOrDownHelper(self, event: LeoKeyEvent | None, direction: str, extend: bool) -> None:
         c = self.c
         w = event.w if event else c.frame.body.wrapper
         if not g.isTextWrapper(w):
@@ -2917,7 +2919,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self.moveToBufferHelper(event, 'end', extend=True)
 
     # @+node:ekr.20150514063305.295: *5* ec.moveToBufferHelper
-    def moveToBufferHelper(self, event: LeoKeyEvent, spot: str, extend: bool) -> None:
+    def moveToBufferHelper(self, event: LeoKeyEvent | None, spot: str, extend: bool) -> None:
         c = self.c
         w = event.w if event else c.frame.body.wrapper
         if not g.isTextWrapper(w):
@@ -2956,7 +2958,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self.moveToCharacterHelper(event, 'right', extend=True)
 
     # @+node:ekr.20150514063305.297: *5* ec.moveToCharacterHelper
-    def moveToCharacterHelper(self, event: LeoKeyEvent, spot: str, extend: bool) -> None:
+    def moveToCharacterHelper(self, event: LeoKeyEvent | None, spot: str, extend: bool) -> None:
         c = self.c
         w = event.w if event else c.frame.body.wrapper
         if not g.isTextWrapper(w):
@@ -2991,7 +2993,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Toggle extend mode, i.e., toggle whether cursor movement commands extend the selections."""
         self.extendModeHelper(event, not self.extendMode)
 
-    def extendModeHelper(self, event: LeoKeyEvent, val: bool) -> None:
+    def extendModeHelper(self, event: LeoKeyEvent | None, val: bool) -> None:
         c = self.c
         w = event.w if event else c.frame.body.wrapper
         if g.isTextWrapper(w):
@@ -3170,7 +3172,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self.movePastCloseHelper(event, extend=True)
 
     # @+node:ekr.20150514063305.304: *5* ec.movePastCloseHelper
-    def movePastCloseHelper(self, event: LeoKeyEvent, extend: bool) -> None:
+    def movePastCloseHelper(self, event: LeoKeyEvent | None, extend: bool) -> None:
         c = self.c
         w = event.w if event else c.frame.body.wrapper
         if not g.isTextWrapper(w):
@@ -3235,7 +3237,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.307: *5* ec.movePageHelper
     def movePageHelper(
-        self, event: LeoKeyEvent, kind: str, extend: bool
+        self, event: LeoKeyEvent | None, kind: str, extend: bool
     ) -> None:  # kind in back/forward.
         """Move the cursor up/down one page, possibly extending the selection."""
         c = self.c
@@ -3289,7 +3291,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self.forwardParagraphHelper(event, extend=True)
 
     # @+node:ekr.20150514063305.309: *5* ec.backwardParagraphHelper
-    def backwardParagraphHelper(self, event: LeoKeyEvent, extend: bool) -> None:
+    def backwardParagraphHelper(self, event: LeoKeyEvent | None, extend: bool) -> None:
         w = event.w if event else None
         if not g.isTextWrapper(w):
             return
@@ -3314,7 +3316,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self.moveToHelper(event, i, extend)
 
     # @+node:ekr.20150514063305.310: *5* ec.forwardParagraphHelper
-    def forwardParagraphHelper(self, event: LeoKeyEvent, extend: bool) -> None:
+    def forwardParagraphHelper(self, event: LeoKeyEvent | None, extend: bool) -> None:
         w = event.w if event else None
         if not g.isTextWrapper(w):
             return
@@ -3402,7 +3404,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self.forwardSentenceHelper(event, extend=True)
 
     # @+node:ekr.20150514063305.313: *5* ec.backSentenceHelper
-    def backSentenceHelper(self, event: LeoKeyEvent, extend: bool) -> None:
+    def backSentenceHelper(self, event: LeoKeyEvent | None, extend: bool) -> None:
         c = self.c
         w = event.w if event else None
         if not g.isTextWrapper(w):
@@ -3468,7 +3470,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             self.moveToHelper(event, i, extend)
 
     # @+node:ekr.20150514063305.314: *5* ec.forwardSentenceHelper
-    def forwardSentenceHelper(self, event: LeoKeyEvent, extend: bool) -> None:
+    def forwardSentenceHelper(self, event: LeoKeyEvent | None, extend: bool) -> None:
         c = self.c
         w = event.w if event else None
         if not g.isTextWrapper(w):
@@ -3890,7 +3892,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         self.scrollHelper(event, 'up', 'page')
 
     # @+node:ekr.20150514063305.336: *5* ec.scrollHelper
-    def scrollHelper(self, event: LeoKeyEvent, direction: str, distance: str) -> None:
+    def scrollHelper(self, event: LeoKeyEvent | None, direction: str, distance: str) -> None:
         """
         Scroll the present pane up or down one page
         kind is in ('up/down-half-page/line/page)

--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -174,7 +174,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20150514063305.419: *3* ec.killHelper
     def killHelper(
         self,
-        event: LeoKeyEvent,
+        event: LeoKeyEvent | None,
         frm: int,
         to: int,
         w: QTextMixin,
@@ -206,7 +206,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
     # @+node:ekr.20220121073752.1: *3* ec.killParagraphHelper
     def killParagraphHelper(
         self,
-        event: LeoKeyEvent,
+        event: LeoKeyEvent | None,
         frm: int,
         to: int,
         undoType: str | None = None,
@@ -358,7 +358,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         """Insert the first entry of the kill ring."""
         self.yankHelper(event, pop=True)
 
-    def yankHelper(self, event: LeoKeyEvent, pop: bool) -> None:
+    def yankHelper(self, event: LeoKeyEvent | None, pop: bool) -> None:
         """
         Helper for yank and yank-pop:
         pop = False: insert the first entry of the kill ring.

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2998,7 +2998,7 @@ class Commands:
 
     # @+node:ekr.20180503110307.1: *4* c.interactive*
     # @+node:ekr.20180504075937.1: *5* c.interactive
-    def interactive(self, callback: Callable, event: LeoKeyEvent, prompts: Sequence) -> None:
+    def interactive(self, callback: Callable, event: LeoKeyEvent | None, prompts: Sequence) -> None:
         # @+<< c.interactive docstring >>
         # @+node:ekr.20180503131222.1: *6* << c.interactive docstring >>
         """
@@ -3040,7 +3040,7 @@ class Commands:
     def interactive1(
         self,
         callback: Callable,
-        event: LeoKeyEvent,  # Used in the callback.
+        event: LeoKeyEvent | None,  # Used in the callback.
         prompts: Sequence,
     ) -> None:
         c, k = self, self.k
@@ -3059,7 +3059,7 @@ class Commands:
     def interactive2(
         self,
         callback: Callable,  # Used in the callback.
-        event: LeoKeyEvent,
+        event: LeoKeyEvent | None,
         prompts: Sequence,
     ) -> None:
         c, k = self, self.k
@@ -3084,7 +3084,7 @@ class Commands:
     def interactive3(
         self,
         callback: Callable,
-        event: LeoKeyEvent,  # Used in the callback.
+        event: LeoKeyEvent | None,  # Used in the callback.
         prompts: Sequence,
     ) -> None:
         c = self
@@ -3092,17 +3092,17 @@ class Commands:
         k = self.k
         prompt1, prompt2, prompt3 = prompts
 
-        def state1(event: LeoKeyEvent) -> None:
+        def state1(event: LeoKeyEvent | None = None) -> None:
             d['arg1'] = k.arg
             k.extendLabel(prompt2, select=False, protect=True)
             k.getNextArg(handler=state2)
 
-        def state2(event: LeoKeyEvent) -> None:
+        def state2(event: LeoKeyEvent | None = None) -> None:
             d['arg2'] = k.arg
             k.extendLabel(prompt3, select=False, protect=True)
             k.get1Arg(event, handler=state3)  # Restart.
 
-        def state3(event: LeoKeyEvent) -> None:
+        def state3(event: LeoKeyEvent | None = None) -> None:
             args = [d.get('arg1'), d.get('arg2'), k.arg]
             callback(args=args, c=c, event=event)
             k.clearState()

--- a/leo/core/leoCompare.py
+++ b/leo/core/leoCompare.py
@@ -749,7 +749,7 @@ def diffMarkedNodes(event: LeoKeyEvent | None = None) -> None:
 
 
 # @+node:ekr.20180213104627.1: *3* diff_leo_files_helper
-def diff_leo_files_helper(event: LeoKeyEvent, title: str, visible: bool) -> None:
+def diff_leo_files_helper(event: LeoKeyEvent | None, title: str, visible: bool) -> None:
     """Prompt for a list of Leo files to open."""
     c = event and event.get('c')
     if not c:

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1141,7 +1141,7 @@ class LeoFind:
         """Toggle the 'Whole Word' checkbox in the Find tab."""
         self.toggle_option(event, 'whole_word')
 
-    def toggle_option(self, event: LeoKeyEvent, checkbox_name: str) -> None:
+    def toggle_option(self, event: LeoKeyEvent | None, checkbox_name: str) -> None:
         c, finder = self.c, self.c.findCommands
         self.ftm.toggle_checkbox(checkbox_name)
         if self.minibuffer_mode:
@@ -3354,7 +3354,7 @@ class LeoFind:
     # @+node:ekr.20131117164142.16955: *5* find.start_incremental
     def start_incremental(
         self,
-        event: LeoKeyEvent,
+        event: LeoKeyEvent | None,
         commandName: str,
         forward: bool,
         ignoreCase: bool,
@@ -3513,7 +3513,7 @@ class LeoFind:
     # @+node:ekr.20131117164142.17007: *4* find.start_state_machine & helpers
     def start_state_machine(
         self,
-        event: LeoKeyEvent,
+        event: LeoKeyEvent | None,
         prefix: str,
         handler: Callable,
         escape_handler: Callable = None,

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1098,7 +1098,7 @@ class LeoTree:
         pass
 
     # @+node:ekr.20051026083544.2: *4* LeoTree.updateHead
-    def updateHead(self, event: LeoKeyEvent, w: QTextMixin) -> None:
+    def updateHead(self, event: LeoKeyEvent | None, w: QTextMixin) -> None:
         """
         Update a headline from an event.
 

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1220,7 +1220,7 @@ class FileNameChooser:
     # @+node:ekr.20140813052702.18200: *3* fnc.get_file_name (entry)
     def get_file_name(
         self,
-        event: LeoKeyEvent,
+        event: LeoKeyEvent | None,
         callback: Callable,
         filterExt: list[str],
         prompt: str,
@@ -1585,7 +1585,7 @@ class GetArg:
         self.after_get_arg_state = None
 
     # @+node:ekr.20140816165728.18955: *4* ga.do_char
-    def do_char(self, event: LeoKeyEvent, char: str) -> None:
+    def do_char(self, event: LeoKeyEvent | None, char: str) -> None:
         """Handle a non-special character."""
         k = self.k
         k.updateLabel(event)
@@ -1593,7 +1593,7 @@ class GetArg:
         self.reset_tab_cycling()
 
     # @+node:ekr.20140817110228.18316: *4* ga.do_end
-    def do_end(self, event: LeoKeyEvent, char: str, stroke: Stroke) -> None:
+    def do_end(self, event: LeoKeyEvent | None, char: str, stroke: Stroke) -> None:
         """A return or escape has been seen."""
         k = self.k
         if char == '\t' and char in k.getArgEscapes:
@@ -1619,7 +1619,7 @@ class GetArg:
     def do_state_zero(
         self,
         completion: bool,
-        event: LeoKeyEvent,
+        event: LeoKeyEvent | None,
         handler: Callable,
         oneCharacter: bool,
         returnKind: str,
@@ -3042,7 +3042,7 @@ class KeyHandlerClass:
 
     def get1Arg(
         self,
-        event: LeoKeyEvent,
+        event: LeoKeyEvent | None,
         handler: Callable,
         prefix: str = None,
         tabList: list[str] = None,
@@ -3645,7 +3645,7 @@ class KeyHandlerClass:
         return val
 
     # @+node:ekr.20061031131434.152: *6* k.handleMiniBindings
-    def handleMiniBindings(self, event: LeoKeyEvent, state: str, stroke: Stroke) -> bool:
+    def handleMiniBindings(self, event: LeoKeyEvent | None, state: str, stroke: Stroke) -> bool:
         """
         Find and execute commands bound to the event.
 
@@ -3688,7 +3688,7 @@ class KeyHandlerClass:
 
     # @+node:ekr.20180418114300.1: *7* k.handleMinibufferHelper
     def handleMinibufferHelper(
-        self, event: LeoKeyEvent, pane: str, state: str, stroke: Stroke
+        self, event: LeoKeyEvent | None, pane: str, state: str, stroke: Stroke
     ) -> str:
         """
         Execute a pane binding in the minibuffer.
@@ -3721,7 +3721,7 @@ class KeyHandlerClass:
         return 'found'
 
     # @+node:vitalije.20170708161511.1: *6* k.handleInputShortcut
-    def handleInputShortcut(self, event: LeoKeyEvent, stroke: Stroke) -> None:
+    def handleInputShortcut(self, event: LeoKeyEvent | None, stroke: Stroke) -> None:
         c, k, p, u = self.c, self, self.c.p, self.c.undoer
         k.clearState()
         if p.h.startswith(('@shortcuts', '@mode')):
@@ -4183,7 +4183,7 @@ class KeyHandlerClass:
             c.widgetWantsFocusNow(w)
 
     # @+node:ekr.20061031131434.160: *4* k.enterNamedMode
-    def enterNamedMode(self, event: LeoKeyEvent, commandName: str) -> None:
+    def enterNamedMode(self, event: LeoKeyEvent | None, commandName: str) -> None:
         c, k = self.c, self
         modeName = commandName[6:]
         c.inCommand = False  # Allow inner commands in the mode.
@@ -4254,7 +4254,7 @@ class KeyHandlerClass:
                     self.initMode(event, nextMode)  # Enter another mode.
 
     # @+node:ekr.20061031131434.163: *4* k.initMode
-    def initMode(self, event: LeoKeyEvent, modeName: str) -> None:
+    def initMode(self, event: LeoKeyEvent | None, modeName: str) -> None:
         c, k = self.c, self
         if not modeName:
             g.trace('oops: no modeName')

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -276,7 +276,7 @@ class MarkupCommands:
     # @+node:ekr.20191006153233.1: *3* markup.command_helper & helpers
     def command_helper(
         self,
-        event: LeoKeyEvent,
+        event: LeoKeyEvent | None,
         kind: str,
         preview: bool,
         verbose: bool,

--- a/leo/plugins/contextmenu.py
+++ b/leo/plugins/contextmenu.py
@@ -70,7 +70,7 @@ inited = False
 # @+node:ville.20090701224704.9805: *3* 'cm-external-editor'
 # cm is 'contextmenu' prefix
 @g.command('cm-external-editor')
-def cm_external_editor(event: LeoKeyEvent) -> None:
+def cm_external_editor(event: LeoKeyEvent | None = None) -> None:
     """Open node in external editor
 
     Set LEO_EDITOR/EDITOR environment variable to get the editor you want.
@@ -90,7 +90,7 @@ def cm_external_editor(event: LeoKeyEvent) -> None:
 
 # @+node:tbrown.20121123075838.19937: *3* 'context_menu_open'
 @g.command('context-menu-open')
-def context_menu_open(event: LeoKeyEvent) -> None:
+def context_menu_open(event: LeoKeyEvent | None = None) -> None:
     """Provide a command for key binding to open the context menu"""
     event.c.frame.tree.onContextMenu(QtCore.QPoint(0, 0))
 

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -415,7 +415,7 @@ class FreeLayoutController:
         self,
         splitter: QSplitter,
         handle: QSplitter,
-        event: LeoKeyEvent,
+        event: LeoKeyEvent | None,
         release: str,
         double: bool,
     ) -> None:
@@ -429,6 +429,8 @@ class FreeLayoutController:
         :param bool release: was it a Press or Release event
         :param bool double: was it a double click event
         """
+        if not event:
+            return
         if not release or event.button() != MouseButton.MiddleButton:
             return
         if splitter.root.zoomed:  # unzoom if *any* handle clicked

--- a/leo/plugins/freewin.py
+++ b/leo/plugins/freewin.py
@@ -536,7 +536,7 @@ def init() -> bool:
 
 # @+node:tom.20210527153848.1: ** z-commands
 @g.command('z-open-freewin')
-def open_z_window(event: LeoKeyEvent) -> None:
+def open_z_window(event: LeoKeyEvent | None = None) -> None:
     """Open or show editing window for the selected node."""
     if g.app.gui.guiName() != 'qt':
         return

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -3457,7 +3457,7 @@ class LeoQTreeWidget(QtWidgets.QTreeWidget):
 
     # @+node:ekr.20110605121601.18381: *3* LeoQTreeWidget: utils
     # @+node:ekr.20110605121601.18382: *4* LeoQTreeWidget.dump
-    def dump(self, ev: LeoKeyEvent, p: Position, tag: str) -> None:
+    def dump(self, ev: LeoKeyEvent | None, p: Position, tag: str) -> None:
         if ev:
             md = ev.mimeData()
             s = g.checkUnicode(md.text(), encoding='utf-8')

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -60,11 +60,11 @@ def zoom_out(event: LeoKeyEvent | None = None) -> None:
 
 
 # @+node:ekr.20191001084612.1: *3* zoom_helper
-def zoom_helper(event: LeoKeyEvent, delta: int) -> None:
+def zoom_helper(event: LeoKeyEvent | None, delta: int) -> None:
     """
     Common helper for zoom commands.
     """
-    c = event.get('c')
+    c = event.get('c') if event else None
     if not c:
         return
     if not c.config.getBool('allow-text-zoom', default=True):
@@ -936,7 +936,9 @@ if QtWidgets:
             sb.setSliderPosition(pos)
 
         # @+node:ekr.20110605121601.18019: *3* LeoQTextBrowser.leo_dumpButton
-        def leo_dumpButton(self, event: LeoKeyEvent, tag: str) -> str:
+        def leo_dumpButton(self, event: LeoKeyEvent | None, tag: str) -> str:
+            if not event:
+                return ''
             button = event.button()
             table = (
                 (MouseButton.NoButton,     'no button'),

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -405,14 +405,14 @@ def show_scrolled_message(tag: str, kw: Any) -> None:
 # @+node:ekr.20110320120020.14490: ** vr.Commands
 # @+node:ekr.20131213163822.16471: *3* g.command('preview')
 @g.command('preview')
-def preview(event: LeoKeyEvent) -> None:
+def preview(event: LeoKeyEvent | None = None) -> None:
     """A synonym for the vr-toggle command."""
     toggle_rendering_pane(event)
 
 
 # @+node:tbrown.20100318101414.5998: *3* g.command('vr')
 @g.command('vr')
-def viewrendered(event: LeoKeyEvent) -> Any | None:
+def viewrendered(event: LeoKeyEvent | None = None) -> Any | None:
     """Open render view for commander"""
     vr = getVr(event=event)
     if vr:
@@ -426,7 +426,7 @@ def viewrendered(event: LeoKeyEvent) -> Any | None:
 
 # @+node:ekr.20130413061407.10362: *3* g.command('vr-contract')
 @g.command('vr-contract')
-def contract_rendering_pane(event: LeoKeyEvent) -> None:
+def contract_rendering_pane(event: LeoKeyEvent | None = None) -> None:
     """Contract the rendering pane."""
     vr = getVr(event=event)
     if vr:
@@ -436,7 +436,7 @@ def contract_rendering_pane(event: LeoKeyEvent) -> None:
 
 # @+node:ekr.20130413061407.10361: *3* g.command('vr-expand')
 @g.command('vr-expand')
-def expand_rendering_pane(event: LeoKeyEvent) -> None:
+def expand_rendering_pane(event: LeoKeyEvent | None = None) -> None:
     """Expand the rendering pane."""
     vr = getVr(event=event)
     if vr:
@@ -446,7 +446,7 @@ def expand_rendering_pane(event: LeoKeyEvent) -> None:
 
 # @+node:ekr.20240507095853.1: *3* g.command('vr-fully-expand')
 @g.command('vr-fully-expand')
-def fully_expand_rendering_pane(event: LeoKeyEvent) -> None:
+def fully_expand_rendering_pane(event: LeoKeyEvent | None = None) -> None:
     """Expand the rendering pane."""
     vr = getVr(event=event)
     if vr:
@@ -456,7 +456,7 @@ def fully_expand_rendering_pane(event: LeoKeyEvent) -> None:
 
 # @+node:ekr.20110917103917.3639: *3* g.command('vr-hide')
 @g.command('vr-hide')
-def hide_rendering_pane(event: LeoKeyEvent) -> None:
+def hide_rendering_pane(event: LeoKeyEvent | None = None) -> None:
     """Close the rendering pane."""
     vr = getVr(event=event)
     if vr:
@@ -471,7 +471,7 @@ close_rendering_pane = hide_rendering_pane
 
 # @+node:ekr.20110321072702.14507: *3* g.command('vr-lock')
 @g.command('vr-lock')
-def lock_rendering_pane(event: LeoKeyEvent) -> None:
+def lock_rendering_pane(event: LeoKeyEvent | None = None) -> None:
     """Lock the rendering pane."""
     vr = getVr(event=event)
     if vr and not vr.locked:
@@ -480,7 +480,7 @@ def lock_rendering_pane(event: LeoKeyEvent) -> None:
 
 # @+node:ekr.20110320233639.5777: *3* g.command('vr-pause-play')
 @g.command('vr-pause-play-movie')
-def pause_play_movie(event: LeoKeyEvent) -> None:
+def pause_play_movie(event: LeoKeyEvent | None = None) -> None:
     """Pause or play a movie in the rendering pane."""
     vr = getVr(event=event)
     if vr:
@@ -493,7 +493,7 @@ def pause_play_movie(event: LeoKeyEvent) -> None:
 
 # @+node:ekr.20110317080650.14386: *3* g.command('vr-show')
 @g.command('vr-show')
-def show_rendering_pane(event: LeoKeyEvent) -> None:
+def show_rendering_pane(event: LeoKeyEvent | None = None) -> None:
     """Show the rendering pane."""
     vr = getVr(event=event)
     if vr:
@@ -506,7 +506,7 @@ def show_rendering_pane(event: LeoKeyEvent) -> None:
 # @+node:ekr.20131001100335.16606: *3* g.command('vr-toggle-visibility')
 @g.command('vr-toggle-visibility')
 @g.command('vr-toggle')  # Legacy
-def toggle_rendering_pane(event: LeoKeyEvent) -> None:
+def toggle_rendering_pane(event: LeoKeyEvent | None = None) -> None:
     """Toggle the visibility of the VR pane."""
     vr = getVr(event=event)
     if not vr:
@@ -524,7 +524,7 @@ def toggle_rendering_pane(event: LeoKeyEvent) -> None:
 
 # @+node:ekr.20240508082844.1: *3* g.command('vr-toggle-keep-open')
 @g.command('vr-toggle-keep-open')
-def toggle_keep_open(event: LeoKeyEvent) -> None:
+def toggle_keep_open(event: LeoKeyEvent | None = None) -> None:
     """Toggle the visibility of the VR pane."""
     vr = getVr(event=event)
     if vr:
@@ -536,7 +536,7 @@ def toggle_keep_open(event: LeoKeyEvent) -> None:
 
 # @+node:ekr.20130412180825.10345: *3* g.command('vr-unlock')
 @g.command('vr-unlock')
-def unlock_rendering_pane(event: LeoKeyEvent) -> None:
+def unlock_rendering_pane(event: LeoKeyEvent | None = None) -> None:
     """Pause or play a movie in the rendering pane."""
     vr = getVr(event=event)
     if vr and vr.locked:
@@ -545,7 +545,7 @@ def unlock_rendering_pane(event: LeoKeyEvent) -> None:
 
 # @+node:ekr.20110321151523.14464: *3* g.command('vr-update')
 @g.command('vr-update')
-def update_rendering_pane(event: LeoKeyEvent) -> None:
+def update_rendering_pane(event: LeoKeyEvent | None = None) -> None:
     """Update the rendering pane"""
     vr = getVr(event=event)
     if vr:


### PR DESCRIPTION
See #4766. This PR continues PR #4783. 

The following rules minimize semantic changes, ensuring that this PR changes as little as possible.

### Annotate commands

- [x] Use `event: LeoKeyEvent | None = None`  in all methods decorated with one of Leo's command decorators.

### Annotate helper methods

- [x] Use `event: LeoKeyEvent | None = None` where it would be syntactically correct to do so.
    - [x] Add guards as necessary to suppress mypy complaints.
- [x] Use `event: LeoKeyEvent | None` where a default would be syntactically incorrect.
    - Such annotations will never generate new mypy complaints about event being None!