### PR TITLE
PR: check all calls to routines whose API has changed

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -972,7 +972,7 @@ def readFileIntoNode(self: Self, event: LeoKeyEvent | None = None) -> None:
     if isinstance(fileName, list):
         fileName = fileName[0]
     s, e = g.readFileIntoString(fileName)
-    if s is None:
+    if not s:
         return
     g.chdir(fileName)
     s = '@nocolor\n' + s

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -518,10 +518,10 @@ class EditFileCommandsClass(BaseEditCommandsClass):
         if not fn2:
             return
         s1, e = g.readFileIntoString(fn)
-        if s1 is None:
+        if not s1:
             return
         s2, e = g.readFileIntoString(fn2)
-        if s2 is None:
+        if not s2:
             return
         lines1, lines2 = g.splitLines(s1), g.splitLines(s2)
         aList = difflib.ndiff(lines1, lines2)

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3773,14 +3773,14 @@ class RecentFilesManager:
         return True
 
     # @+node:ekr.20120225072226.10285: *3* rf.sanitize
-    def sanitize(self, name: str) -> str | None:
+    def sanitize(self, name: str) -> str:
         """Return a sanitized file name."""
         if name is None:
             return None
         name = name.lower()
         for ch in ('-', '_', ' ', '\n'):
             name = name.replace(ch, '')
-        return name or None
+        return name or ''
 
     # @+node:ekr.20120215072959.12478: *3* rf.setRecentFiles
     def setRecentFiles(self, files: list[str]) -> None:

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -382,7 +382,7 @@ class AtFile:
             # Sets at.encoding, regularizes whitespace and calls at.initReadLines.
             s = at.readFileToUnicode(fn)
             # #1466.
-            if s is None:  # pragma: no cover
+            if not s:  # pragma: no cover
                 # The error has been given.
                 return None, None
             at.warnOnReadOnlyFile(fn)
@@ -1044,7 +1044,7 @@ class AtFile:
         return valid, new_df, start, end, isThin
 
     # @+node:ekr.20130911110233.11284: *5* at.readFileToUnicode & helpers
-    def readFileToUnicode(self, fileName: str) -> str | None:  # pragma: no cover
+    def readFileToUnicode(self, fileName: str) -> str:  # pragma: no cover
         """
         Carefully sets at.encoding, then uses at.encoding to convert the file
         to a unicode string.
@@ -1057,11 +1057,10 @@ class AtFile:
         Returns the string, or None on failure.
         """
         at = self
-        s: str
         s_bytes = at.openFileHelper(fileName)  # Catches all exceptions.
         # #1798.
         if not s_bytes:
-            return None  # Not ''.
+            return ''
         e, s_bytes = g.stripBOM(s_bytes)
         if e:
             # The BOM determines the encoding unambiguously.

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3296,17 +3296,6 @@ class AtFile:
 
     # @+node:ekr.20050104131929: *4* at.file operations...
     # Error checking versions of corresponding functions in Python's os module.
-    # @+node:ekr.20050104131820: *5* at.chmod
-    def chmod(self, fileName: str, mode: int) -> None:  # pragma: no cover
-        # Do _not_ call self.error here.
-        if mode is None:
-            return
-        try:
-            os.chmod(fileName, mode)
-        except Exception:
-            g.es("exception in os.chmod", fileName)
-            g.es_exception()
-
     # @+node:ekr.20050104132018: *5* at.remove
     def remove(self, fileName: str) -> bool:  # pragma: no cover
         if not fileName:

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -408,7 +408,7 @@ class AtFile:
         return shadow_fn
 
     # @+node:ekr.20041005105605.21: *5* at.read & helpers
-    def read(self, root: Position, fromString: str | None = None) -> bool:
+    def read(self, root: Position, fromString: str = '') -> bool:
         """Read an @thin or @file tree."""
         at, c = self, self.c
         fileName = c.fullPath(root)
@@ -425,7 +425,7 @@ class AtFile:
 
         # Open the file.
         fileName, file_s = at.openFileForReading(fromString=fromString)
-        if file_s is None:  # #1798:
+        if not file_s:  # #1798:
             return False  # pragma: no cover
 
         # Set the time stamp.

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -325,10 +325,10 @@ class AtFile:
             g.red(f"file not found: {fn}")
             return
         s, e = g.readFileIntoString(fn)
-        if s is None:
+        if not s:
             g.red(f"empty file: {fn}")
             return
-        #
+
         # Create a dummy, unconnected, VNode as the root.
         root_v = leoNodes.VNode(context=c)
         root = leoNodes.Position(root_v)

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3334,9 +3334,7 @@ class AtFile:
         p.v.tempAttributes['read-path'] = d
 
     # @+node:ekr.20090712050729.6017: *4* at.promptForDangerousWrite
-    def promptForDangerousWrite(
-        self, fileName: str, message: str | None = None
-    ) -> bool:  # pragma: no cover
+    def promptForDangerousWrite(self, fileName: str, message: str = '') -> bool:
         """Raise a dialog asking the user whether to overwrite an existing file."""
         at, c, root = self, self.c, self.root
         if at.cancelFlag:
@@ -3357,7 +3355,7 @@ class AtFile:
                     root.h = h
                     c.redraw()
                     return False
-        if message is None:
+        if not message:
             message = (
                 f"{g.splitLongFileName(fileName)}\n"
                 f"{g.tr('already exists.')}\n"

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -674,9 +674,9 @@ class AtFile:
         # Remember the full fileName.
         at.rememberReadPath(fn, p)
         s, e = g.readFileIntoString(fn, kind='@edit')
-        if s is None:
+        if not s:
             return
-        encoding = 'utf-8' if e is None else e
+        encoding = e or 'utf-8'
         # Delete all children.
         while p.hasChildren():
             p.firstChild().doDelete()
@@ -838,9 +838,9 @@ class AtFile:
         # Fix bug 889175: Remember the full fileName.
         at.rememberReadPath(fn, p)
         s, e = g.readFileIntoString(fn, kind='@edit')
-        if s is None:
+        if not s:
             return
-        encoding = 'utf-8' if e is None else e
+        encoding = e or 'utf-8'
         # Delete all children.
         while p.hasChildren():
             p.firstChild().doDelete()
@@ -1654,7 +1654,7 @@ class AtFile:
             if c.persistenceController:
                 c.persistenceController.update_before_write_foreign_file(root)
             contents = at.writeAtAutoContents(fileName, root)
-            if contents is None:
+            if not contents:
                 g.es("not written:", fileName)
                 at.addToOrphanList(root)
                 return False

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -453,8 +453,7 @@ class AtFile:
         """
         at, c = self, self.c
         # Find the unvisited nodes.
-        aList = [z for z in root.subtree() if not z.isVisited()]
-        if aList:
+        if aList := [z for z in root.subtree() if not z.isVisited()]:
             at.c.deletePositionsInList(aList)
             c.redraw()
 
@@ -1703,8 +1702,7 @@ class AtFile:
         """A factory returning a writer function for the given file extension."""
         at = self
         d = g.app.writersDispatchDict
-        aClass = d.get(ext)
-        if aClass:
+        if aClass := d.get(ext):
 
             def writer_for_ext_cb(root: Position) -> str | None:
                 try:

--- a/leo/core/leoBackground.py
+++ b/leo/core/leoBackground.py
@@ -141,9 +141,9 @@ class BackgroundProcessManager:
         self.pid = None
 
     # @+node:ekr.20161026193609.3: *3* bpm.kill
-    def kill(self, kind: str | None = None) -> None:
+    def kill(self, kind: str = '') -> None:
         """Kill the presently running process, if any."""
-        if kind is None:
+        if not kind:
             kind = 'all'
         if kind == 'all':
             self.process_queue = []

--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -92,7 +92,7 @@ class GlobalCacher:
             if trace:
                 print('path for g.app.db:', repr(path))
             self.db = SqlitePickleShare(path)
-            if trace and self.db is not None:
+            if trace and self.db:
                 self.dump(tag='Startup')
         except Exception:
             if trace:
@@ -265,7 +265,7 @@ class SqlitePickleShare:
         """
 
     # @+node:vitalije.20170716201700.13: *4* _listdir
-    def _listdir(self, s: str, pattern: str | None = None) -> list[str]:
+    def _listdir(self, s: str, pattern: str = '') -> list[str]:
         """D.listdir() -> List of items in this directory.
 
         Use D.files() or D.dirs() instead if you want a listing
@@ -277,7 +277,7 @@ class SqlitePickleShare:
         items whose names match the given pattern.
         """
         names = os.listdir(s)
-        if pattern is not None:
+        if pattern:
             names = fnmatch.filter(names, pattern)
         return [join(s, child) for child in names]
 
@@ -328,10 +328,10 @@ class SqlitePickleShare:
     # @+node:vitalije.20170716201700.19: *3* keys (SqlitePickleShare)
     # Called by clear, and during unit testing.
 
-    def keys(self, globpat: str | None = None) -> Generator:
+    def keys(self, globpat: str = '') -> Generator:
         """Return all keys in DB, or all keys matching a glob"""
         args: tuple
-        if globpat is None:
+        if not globpat:
             sql = 'select key from cachevalues;'
             args = tuple()
         else:
@@ -383,8 +383,8 @@ class SqlitePickleShare:
 def dump_cache(db: dict | SqlitePickleShare, tag: str) -> None:
     """Dump the given cache."""
     print(f'\n===== {tag} =====\n')
-    if db is None:
-        print('db is None!')
+    if not db:
+        print('No db!')
         return
     # Create a dict, sorted by file prefixes.
     d: dict[str, Any] = {}

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -294,7 +294,7 @@ class ChapterController:
             if binding:
                 binding = binding.strip()
         else:
-            chapterName = binding = None
+            chapterName = binding = ''
         return chapterName, binding
 
     # @+node:ekr.20160414183716.1: *4* cc.sanitize

--- a/leo/core/leoColor.py
+++ b/leo/core/leoColor.py
@@ -775,10 +775,10 @@ getRGB = getColorRGB
 
 
 # @+node:bob.20080115072302: *3* function: leoColor.getCairo / getColorCairo
-def getColorCairo(name: str, default: str | None = None) -> tuple[float, float, float] | None:
+def getColorCairo(name: str, default: str = '') -> tuple[float, float, float] | None:
     """Convert a named color into a cairo color tuple."""
     color = getColorRGB(name, default)
-    if color is None:
+    if not color:
         return None
     try:
         r, g, b = color

--- a/leo/core/leoColor.py
+++ b/leo/core/leoColor.py
@@ -761,7 +761,7 @@ get = getColor
 
 
 # @+node:bob.20080115070511.4: *3* function: leoColor.getRGB / getColorRGB
-def getColorRGB(name: str, default: str | None = None) -> tuple[int, int, int]:
+def getColorRGB(name: str, default: str | None = None) -> tuple[int, int, int] | None:
     """Convert a named color into an (r, g, b) tuple."""
     s = getColor(name, default)
     try:

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -372,8 +372,7 @@ class BaseColorizer:
 
     def normalize(self, s: str) -> str:
         """Return the normalized value of s."""
-        cached = self._normalize_cache.get(s)
-        if cached:
+        if cached := self._normalize_cache.get(s):
             return cached
         t = s[1:] if s.startswith('@') else s
         t = t.replace(' ', '').replace('-', '').replace('_', '').lower().strip()

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -373,7 +373,7 @@ class BaseColorizer:
     def normalize(self, s: str) -> str:
         """Return the normalized value of s."""
         cached = self._normalize_cache.get(s)
-        if cached is not None:
+        if cached:
             return cached
         t = s[1:] if s.startswith('@') else s
         t = t.replace(' ', '').replace('-', '').replace('_', '').lower().strip()
@@ -3653,7 +3653,7 @@ class PygmentsColorizer(JEditColorizer):
             self.old_v = p.v  # Fix a major performance bug.
             self.init()
             assert self.language
-        if s is not None:
+        if s:
             # For pygments, we *must* call for all lines.
             self.pygmentsMainLoop(s)
 

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2952,7 +2952,7 @@ class Commands:
         else:
             format = c.config.getString("headline-time-format-string")
             gmt = c.config.getBool("headline-gmt-time")
-        if format is None:
+        if not format:
             format = default_format
         try:
             # import time
@@ -3226,7 +3226,7 @@ class Commands:
         for d in aList:
             # Look for @path directives.
             path = d.get('path')
-            if path is not None:  # retain empty paths for warnings.
+            if path:  # retain empty paths for warnings.
                 # Convert "path" or <path> to path.
                 path = g.stripPathCruft(path)
                 if path:
@@ -4059,7 +4059,7 @@ class Commands:
         t1 = time.process_time()
 
         # Using the Qt gui will likely overwhelm Leo!
-        if gui is None:
+        if not gui:
             gui = g.app.nullGui
 
         # The main loop.
@@ -4606,7 +4606,7 @@ class Commands:
         deltaTime = c.config.getFloat('outline-nav-extend-delay')
         if deltaTime in (None, 0.0):
             return False
-        if c.navTime is None:
+        if not c.navTime:
             return False  # mypy.
         return time.time() - c.navTime < deltaTime
 

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3225,11 +3225,9 @@ class Commands:
         paths = []
         for d in aList:
             # Look for @path directives.
-            path = d.get('path')
-            if path:  # retain empty paths for warnings.
+            if path := d.get('path'):
                 # Convert "path" or <path> to path.
-                path = g.stripPathCruft(path)
-                if path:
+                if path := g.stripPathCruft(path):
                     paths.append(path)
 
         # Add absbase and reverse the list.

--- a/leo/core/leoCompare.py
+++ b/leo/core/leoCompare.py
@@ -242,21 +242,21 @@ class BaseLeoCompare:
             if not sentinelComment2:
                 self.show("no @+leo line for " + name2)
         if self.ignoreFirstLine1:
-            if s1 is None:
+            if not s1:
                 g.readlineForceUnixNewline(f1)
                 lines1 += 1
             s1 = None
         if self.ignoreFirstLine2:
-            if s2 is None:
+            if not s2:
                 g.readlineForceUnixNewline(f2)
                 lines2 += 1
             s2 = None
         # @-<< handle opening lines >>
         while 1:
-            if s1 is None:
+            if not s1:
                 s1 = g.readlineForceUnixNewline(f1)
                 lines1 += 1
-            if s2 is None:
+            if not s2:
                 s2 = g.readlineForceUnixNewline(f2)
                 lines2 += 1
             # @+<< ignore blank lines and/or sentinels >>
@@ -413,7 +413,7 @@ class BaseLeoCompare:
 
     # @+node:ekr.20031218072017.1144: *4* compare.openOutputFile
     def openOutputFile(self) -> bool:  # Bug fix: return a bool.
-        if self.outputFileName is None:
+        if not self.outputFileName:
             return False
         theDir, name = g.os_path_split(self.outputFileName)
         if not theDir:

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1203,11 +1203,7 @@ class ActiveSettingsOutline:
                 self.add(p)
 
     # @+node:ekr.20190905091614.12: *3* aso.add
-    def add(
-        self,
-        p: Position,
-        h: str | None = None,  # Don't change this.
-    ) -> None:
+    def add(self, p: Position, h: str = '') -> None:
         """
         Add a node for p.
 

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -493,7 +493,7 @@ class ParserBaseClass:
                 self.dumpMenuTree(val, level + 1, path=path + '/' + name)
 
     # @+node:tbrown.20080514180046.8: *5* pbc.patchMenuTree
-    def patchMenuTree(self, orig: list[Any], targetPath: str, path: str = '') -> Any | None:
+    def patchMenuTree(self, orig: list[Any], targetPath: str, path: str = '') -> Any:
         kind: str
         val: Any
         val2: Any
@@ -856,7 +856,7 @@ class ParserBaseClass:
         else:
             d[tag] = val
 
-    # @+node:ekr.20041120112043: *4* pbc.parseShortcutLine
+    # @+node:ekr.20041120112043: *4* pbc.parseShortcutLine (change?)
     def parseShortcutLine(self, kind: str, s: str) -> tuple[str | None, Any]:
         """Parse a shortcut line.  Valid forms:
 
@@ -1373,7 +1373,7 @@ class GlobalConfigManager:
         return False
 
     # @+node:ekr.20041117083141: *4* gcm.get & allies
-    def get(self, setting: str, kind: str) -> Any | None:
+    def get(self, setting: str, kind: str) -> Any:
         """Get the setting and make sure its type matches the expected type."""
         # It *is* valid to call this method: it returns the global settings.
         lm = g.app.loadManager
@@ -1391,7 +1391,7 @@ class GlobalConfigManager:
         setting: str,
         requestedType: str,
         warn: bool = True,
-    ) -> tuple[Any | None, bool]:
+    ) -> tuple[Any, bool]:
         """
         Look up the setting in d. If warn is True, warn if the requested type
         does not (loosely) match the actual type.
@@ -1608,7 +1608,7 @@ class GlobalConfigManager:
         return self.get(setting, "string") or ''
 
     # @+node:ekr.20171115062202.1: *3* gcm.valueInMyLeoSettings
-    def valueInMyLeoSettings(self, settingName: str) -> Any | None:
+    def valueInMyLeoSettings(self, settingName: str) -> Any:
         """Return the value of the setting, if any, in myLeoSettings.leo."""
         lm = g.app.loadManager
         d = lm.globalSettingsDict

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1234,7 +1234,7 @@ class FileCommands:
     # @+node:ekr.20060919133249: *4* fc: Read Utils
     # Methods common to both the sax and non-sax code.
     # @+node:ekr.20061006104837.1: *5* fc.archivedPositionToPosition
-    def archivedPositionToPosition(self, s: str) -> Position:
+    def archivedPositionToPosition(self, s: str) -> Position | None:
         """Convert an archived position (a string) to a position."""
         return self.c.archivedPositionToPosition(s)
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5813,7 +5813,7 @@ def getLine(s: str, i: int) -> tuple[int, int]:
 
 
 # @+node:ekr.20111114151846.9847: *4* g.toPythonIndex
-def toPythonIndex(s: str, index: str) -> int:
+def toPythonIndex(s: str, index: str | None) -> int:
     """
     Convert index to a Python int.
 
@@ -6916,7 +6916,7 @@ def es_print_unique_message(message: str, *, color: str = 'error') -> bool:
 trace_unique_dict: dict[str, list[str]] = {}
 
 
-def traceUnique(value: object, *, n: int = 2, pad: int = 30) -> None:
+def traceUnique(value: object, *, n: int = 2, pad: int | None = None) -> None:
     """Print unique values associated with g.callers(n)."""
     if pad is None:
         pad = 30
@@ -7532,7 +7532,7 @@ def os_path_splitext(path: str) -> tuple[str, str]:
 # @+node:ekr.20090829140232.6036: *3* g.os_startfile
 def os_startfile(fname: str) -> None:
     # @+others
-    # @+node:bob.20170516112250.1: *4* stderr2log()
+    # @+node:bob.20170516112250.1: *4* g.stderr2log()
     def stderr2log(g: LeoGlobals, ree: io.FileIO, fname: str) -> None:
         """Display stderr output in the Leo-Editor log pane
 
@@ -7552,7 +7552,7 @@ def os_startfile(fname: str) -> None:
             else:
                 break
 
-    # @+node:bob.20170516112304.1: *4* itPoll()
+    # @+node:bob.20170516112304.1: *4* g.itPoll()
     def itPoll(
         fname: str,
         ree: io.FileIO,

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -8787,8 +8787,7 @@ def openUrlHelper(event: LeoKeyEvent | None = None, url: str = '') -> None:
     word = w.getSelectedText().strip()
     if not word:
         return
-    matches = c.findCommands.find_def(event)
-    if matches:
+    if c.findCommands.find_def(event):
         return
     # @+<< look for filename or import>>
     # @+node:tom.20230130102836.1: *5* << look for filename or import >>
@@ -8806,8 +8805,7 @@ def openUrlHelper(event: LeoKeyEvent | None = None, url: str = '') -> None:
         IMPORTSre = FROMre + '|' + IMPORTre
 
         m = re.match(IMPORTSre, s[i:], re.MULTILINE)
-        module = m and (m[2] or m[1])
-        if module:
+        if module := m and (m[2] or m[1]):
             filename = module + '.py'
             filename_w = module + '.pyw'
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -8834,7 +8834,6 @@ def openUrlHelper(
                 c.redraw(p)
                 break
     # @-<< look for filename or import>>
-    return
 
 
 # @+node:ekr.20170226093349.1: *3* g.unquoteUrl

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -8701,22 +8701,22 @@ def openUrlOnClick(
 def openUrlHelper(
     event: LeoKeyEvent | None = None,
     url: str | None = None,  # Don't change this.
-) -> str | None:  # Don't change this.
+) -> None:
     """Open the unl, url or gnx under the cursor.  Return it for unit testing."""
     if not event:
-        return None
+        return
     c, w = event.c, event.w
     if not c:
-        return None
+        return
     if not g.app.gui.isTextWrapper(w):
-        return None
+        return
     # Part 1: get the url.
     if url is None:
         s = w.getAllText()
         ins = w.getInsertPoint()
         i, j = w.getSelectionRange()
         if i != j:
-            return None  # So find doesn't open the url.
+            return  # So find doesn't open the url.
         row, col = g.convertPythonIndexToRowCol(s, ins)
         i, j = g.getLine(s, ins)
         line = s[i:j]
@@ -8735,7 +8735,7 @@ def openUrlHelper(
             if px:
                 c.selectPosition(px)
                 c.redraw()
-            return None
+            return
         # @-<< look for section ref >>
         url = unl = None
         # @+<< look for url >>
@@ -8756,7 +8756,7 @@ def openUrlHelper(
                 if match.start() <= col < match.end():
                     unl = match.group()
                     g.handleUnl(unl, c)
-                    return None
+                    return
             # @-<< look for unl >>
             if not unl:
                 # @+<< look for gnx >>
@@ -8770,13 +8770,13 @@ def openUrlHelper(
 
                 if target:
                     if c.p.gnx == target:
-                        return target
+                        return
                     for p in c.all_unique_positions():
                         if p.v.gnx == target:
                             c.selectPosition(p)
                             c.redraw()
-                            return target
-                    return None
+                            break
+                    return
                 # @-<< look for gnx >>
     elif not isinstance(url, str):
         url = url.toString()
@@ -8787,16 +8787,16 @@ def openUrlHelper(
         if not g.doHook("@url1", c=c, p=p, url=url):
             g.handleUrl(url, c=c, p=p)
         g.doHook("@url2", c=c, p=p)
-        return url
+        return
     # Part 3: call find-def.
     if not w.hasSelection():
         c.editCommands.extendToWord(event, select=True)
     word = w.getSelectedText().strip()
     if not word:
-        return None
+        return
     matches = c.findCommands.find_def(event)
     if matches:
-        return None
+        return
     # @+<< look for filename or import>>
     # @+node:tom.20230130102836.1: *5* << look for filename or import >>
     # Part 4: #2546: look for a file name.
@@ -8834,7 +8834,7 @@ def openUrlHelper(
                 c.redraw(p)
                 break
     # @-<< look for filename or import>>
-    return None
+    return
 
 
 # @+node:ekr.20170226093349.1: *3* g.unquoteUrl

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7546,8 +7546,7 @@ def os_startfile(fname: str) -> None:
         """
 
         while True:
-            emsg = ree.read().decode('utf-8')
-            if emsg:
+            if emsg := ree.read().decode('utf-8'):
                 g.es_print_error(f"xdg-open {fname} caused output to stderr:\n{emsg}")
             else:
                 break
@@ -8677,10 +8676,7 @@ def openUrl(p: Position) -> None:  # pragma: no cover
 
 
 # @+node:ekr.20110605121601.18135: *3* g.openUrlOnClick (open-url-under-cursor)
-def openUrlOnClick(
-    event: QMouseEvent,
-    url: str | None = None,  # Don't change this.
-) -> None:
+def openUrlOnClick(event: QMouseEvent, url: str = '') -> None:
     """Open the URL under the cursor.  Return it for unit testing."""
     from leo.core.leoGui import LeoKeyEvent
     from leo.plugins.qt_text import QTextEditWrapper
@@ -8698,10 +8694,7 @@ def openUrlOnClick(
 
 
 # @+node:ekr.20170216091704.1: *4* g.openUrlHelper
-def openUrlHelper(
-    event: LeoKeyEvent | None = None,
-    url: str | None = None,  # Don't change this.
-) -> None:
+def openUrlHelper(event: LeoKeyEvent | None = None, url: str = '') -> None:
     """Open the unl, url or gnx under the cursor.  Return it for unit testing."""
     if not event:
         return
@@ -8711,7 +8704,7 @@ def openUrlHelper(
     if not g.app.gui.isTextWrapper(w):
         return
     # Part 1: get the url.
-    if url is None:
+    if not url:
         s = w.getAllText()
         ins = w.getInsertPoint()
         i, j = w.getSelectionRange()
@@ -8737,7 +8730,7 @@ def openUrlHelper(
                 c.redraw()
             return
         # @-<< look for section ref >>
-        url = unl = None
+        url = unl = ''
         # @+<< look for url >>
         # @+node:tom.20220328141544.1: *5* << look for url  >>
         # Find the url on the line.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5758,7 +5758,7 @@ def convertRowColToPythonIndex(s: str, row: int, col: int, lines: list[str] | No
     """Convert zero-based row/col indices into a python index into string s."""
     if row < 0:
         return 0
-    if lines is None:
+    if not lines:
         lines = g.splitLines(s)
     if row >= len(lines):
         return len(s)
@@ -6732,7 +6732,7 @@ is_unique_class = isUniqueClass
 # @+node:ekr.20150127060254.5: *3* g.log_to_file
 def log_to_file(s: str, fn: str = '') -> None:
     """Write a message to ~/test/leo_log.txt."""
-    if fn is None:
+    if not fn:
         fn = g.finalize('~/test/leo_log.txt')
     if not s.endswith('\n'):
         s = s + '\n'

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7177,7 +7177,7 @@ init_zodb_failed: dict[str, bool] = {}  # Keys are paths, values are True.
 init_zodb_db: dict[str, Value] = {}  # Keys are paths, values are ZODB.DB instances.
 
 
-def init_zodb(pathToZodbStorage: str, verbose: bool = True) -> Value | None:
+def init_zodb(pathToZodbStorage: str, verbose: bool = True) -> Value:
     """
     Return an ZODB.DB instance from the given path.
     return None on any error.

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1947,7 +1947,7 @@ class RecursiveImportController:
             c.deletePositionsInList(aList)  # Don't redraw.
 
     # @+node:ekr.20230829043849.1: *3* ric_resolve_dir_arg
-    def resolve_dir_arg(self, arg: str) -> str | None:
+    def resolve_dir_arg(self, arg: str) -> str:
         """
         arg can be None or a path (relative or absolute) to a file or
         directory.
@@ -1975,7 +1975,7 @@ class RecursiveImportController:
         elif not os.path.isabs(arg):
             arg = os.path.join(outline_dir, arg)
         if not os.path.exists(arg):
-            return None
+            return ''
 
         # Final sanity checks.
         assert arg, repr(arg1)
@@ -1984,11 +1984,11 @@ class RecursiveImportController:
         return arg
 
     # @+node:ekr.20130823083943.12613: *3* ric.run
-    def run(self, dir_: str | None) -> None:
+    def run(self, dir_: str) -> None:
         """
         dir_ can be None, a directory contained in the outline's directory, or a single file.
 
-        Import all files in the dir_ directory, or the outline's directory if dir_ is None.
+        Import all files in the dir_ directory, or the outline's directory if dir_ is empty.
 
         Import all files whose extension matches self.theTypes in dir_.
         In fact, dir_ can be a path to a single file.
@@ -2003,7 +2003,7 @@ class RecursiveImportController:
         # Resolve dir_ to an absolute path.
         dir_1 = dir_
         dir_ = self.resolve_dir_arg(dir_)
-        if dir_ is None:
+        if not dir_:
             self.error(f"invalid 'dir_' argument: {dir_1!r}")
             return
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -98,7 +98,7 @@ class FreeMindImporter:
             htmltree = lxml.html.parse(path)
             root = htmltree.getroot()
             body = root.findall('body')[0]
-            if body is None:
+            if not body:
                 g.error(f"no body in: {sfn}")
             else:
                 root_p = c.lastTopLevel().insertAfter()
@@ -460,15 +460,15 @@ class LeoImportCommands:
         theFile.close()
 
     # @+node:ekr.20031218072017.3300: *4* ic.removeSentinelsCommand
-    def removeSentinelsCommand(self, paths: list[str], toString: bool = False) -> str | None:
+    def removeSentinelsCommand(self, paths: list[str]) -> None:
         c = self.c
         self.encoding = c.getEncoding(c.p)
         for fileName in paths:
             g.setGlobalOpenDir(fileName)
             path, self.fileName = g.os_path_split(fileName)
             s, e = g.readFileIntoString(fileName, self.encoding)
-            if s is None:
-                return None
+            if not s:
+                continue  # PR #4801.
             if e:
                 self.encoding = e
             # @+<< set delims from the header line >>
@@ -483,9 +483,8 @@ class LeoImportCommands:
             line = s[i:j]
             valid, junk, start_delim, end_delim, junk = at.parseLeoSentinel(line)
             if not valid:
-                if not toString:
-                    g.es("invalid @+leo sentinel in", fileName)
-                return None
+                g.es("invalid @+leo sentinel in", fileName)
+                return
             if end_delim:
                 line_delim = None
             else:
@@ -500,8 +499,6 @@ class LeoImportCommands:
             else:
                 head, ext2 = g.os_path_splitext(fileName)
                 newFileName = g.finalize_join(path, head + ext + ext2)  # 1341
-            if toString:
-                return s
             # @+<< Write s into newFileName >>
             # @+node:ekr.20031218072017.1149: *5* << Write s into newFileName >> (remove-sentinels)
             # Remove sentinels command.
@@ -514,7 +511,6 @@ class LeoImportCommands:
                 g.es("exception creating:", newFileName)
                 g.print_exception()
             # @-<< Write s into newFileName >>
-        return None
 
     # @+node:ekr.20031218072017.3303: *4* ic.removeSentinelLines
     # This does not handle @nonl properly, but that no longer matters.
@@ -583,15 +579,10 @@ class LeoImportCommands:
     # @+node:ekr.20031218072017.3209: *3* ic.Import
     # @+node:ekr.20031218072017.3210: *4* ic.createOutline & helpers
     def createOutline(
-        self,
-        parent: Position,
-        ext: str | None = None,
-        s: str | None = None,
-        treeType: str = '@file',
+        self, parent: Position, ext: str = '', s: str = '', treeType: str = '@file'
     ) -> Position | None:
         """
-        Create an outline by importing a file, reading the file with the
-        given encoding if string s is None.
+        Create an outline by importing a file.
 
         ext,        The file extension to be used, or None.
         fileName:   A string or None. The name of the file to be read.
@@ -607,7 +598,7 @@ class LeoImportCommands:
         # Init ivars.
         self.encoding = c.getEncoding(parent)
         ext, s = self.init_import(ext, fileName, s)
-        if s is None:
+        if not s:
             return None
 
         # Each importer file defines `do_import` at the top level.
@@ -669,7 +660,7 @@ class LeoImportCommands:
         if not s:
             # Set the kind for error messages in readFileIntoString.
             s, e = g.readFileIntoString(fileName, encoding=self.encoding)
-            if s is None:
+            if not s:
                 return None, None
             if e:
                 self.encoding = e
@@ -862,7 +853,7 @@ class LeoImportCommands:
     # @+node:ekr.20031218072017.3224: *4* ic.importWebCommand & helpers
     def importWebCommand(self, files: list[str], webType: str) -> None:
         c, current = self.c, self.c.p
-        if current is None:
+        if not current:
             return
         if not files:
             return
@@ -978,7 +969,7 @@ class LeoImportCommands:
         lb = "@<" if theType == "cweb" else "<<"
         rb = "@>" if theType == "cweb" else ">>"
         s, e = g.readFileIntoString(fileName)
-        if s is None:
+        if not s:
             return
         # @+<< Create a symbol table of all section names >>
         # @+node:ekr.20031218072017.3232: *6* << Create a symbol table of all section names >>
@@ -1567,7 +1558,7 @@ class MORE_Importer:
         ic.encoding = c.getEncoding(c.p)
         g.setGlobalOpenDir(fileName)
         s, _e = g.readFileIntoString(fileName)
-        if s is None:
+        if not s:
             return None
         s = s.replace('\r', '')  # Fixes bug 626101.
         lines = g.splitLines(s)

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -675,8 +675,7 @@ class LeoImportCommands:
         elif ext in ('.txt', '.text'):
             body += '@nocolor\n'
         else:
-            language = self.languageForExtension(ext)
-            if language:
+            if language := self.languageForExtension(ext):
                 body += f"@language {language}\n"
         self.setBodyString(p, body + s)
         for p in p.self_and_subtree():
@@ -1568,8 +1567,7 @@ class MORE_Importer:
             undoData = u.beforeInsertNode(c.p)
             root = last.insertAfter()
             root.h = fileName
-            p = self.import_lines(lines, root)
-            if p:
+            if p := self.import_lines(lines, root):
                 c.endEditing()
                 c.checkOutline()
                 p.setDirty()

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2314,7 +2314,7 @@ class VNode:
     # @+others
     # @+node:ekr.20031218072017.3342: *3* v.Birth & death
     # @+node:ekr.20031218072017.3344: *4* v.__init__
-    def __init__(self, context: Cmdr, gnx: str | None = None):
+    def __init__(self, context: Cmdr, gnx: str | None = None) -> None:
         """
         Ctor for the VNode class.
         To support ZODB, the code must set v._p_changed = True whenever

--- a/leo/core/leoPersistence.py
+++ b/leo/core/leoPersistence.py
@@ -526,7 +526,7 @@ class PersistenceDataController:
             return ''
 
     # @+node:ekr.20140713135856.17744: *5* pd.unpickle
-    def unpickle(self, s: str) -> Value | None:  # An actual uA.
+    def unpickle(self, s: str) -> Value:  # An actual uA.
         """Unhexlify and unpickle string s into p."""
         try:
             # Throws TypeError if s is not a hex string.

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -66,10 +66,7 @@ class CommandChainDispatcher:
     """
 
     def __init__(self, commands: list | None = None) -> None:
-        if commands is None:
-            self.chain = []
-        else:
-            self.chain = commands
+        self.chain = commands or []
 
     def __call__(self, *args: Args, **kw: KWargs) -> None:
         """Command chain is called just like normal func.
@@ -253,39 +250,34 @@ class BaseLeoPlugin:
 
     # @+node:ekr.20100908125007.6014: *3* BaseLeoPlugin.setMenuItem
     def setMenuItem(
-        self, menu: LeoQtMenu, commandName: str | None = None, handler: Callable | None = None
+        self, menu: LeoQtMenu, commandName: str = '', handler: Callable | None = None
     ) -> None:
         """Create a menu item in 'menu' using text 'commandName' calling handler 'handler'
         if commandName and handler are none, use the most recently defined values
         """
         # setMenuItem can create a command, or use a previously defined one.
-        if commandName is None:
+        if not commandName:
             commandName = self.commandName
         # make sure commandName is in the list of commandNames
         else:
             if commandName not in self.commandNames:
                 self.commandNames.append(commandName)
-        if handler is None:
+        if not handler:
             handler = self.handler
         table = ((commandName, None, handler),)
         self.c.frame.menu.createMenuItemsFromTable(menu, table)
 
     # @+node:ekr.20100908125007.6015: *3* BaseLeoPlugin.setButton
-    def setButton(
-        self,
-        buttonText: str | None = None,
-        commandName: str | None = None,
-        color: str | None = None,
-    ) -> None:
+    def setButton(self, buttonText: str = '', commandName: str = '', color: str = '') -> None:
         """Associate an existing command with a 'button'"""
-        if buttonText is None:
+        if not buttonText:
             buttonText = self.commandName
-        if commandName is None:
+        if not commandName:
             commandName = self.commandName
         else:
             if commandName not in self.commandNames:
                 raise NameError(f"setButton error, {commandName} is not a commandName")
-        if color is None:
+        if not color:
             color = 'grey'
         script = f"c.doCommandByName('{self.commandName}')"
         g.app.gui.makeScriptButton(

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -330,7 +330,7 @@ class LeoPluginsController:
                 g.doHook("idle", c=c)
 
     # @+node:ekr.20100908125007.6017: *4* plugins.doHandlersForTag & helper
-    def doHandlersForTag(self, tag: str, keywords: Keywords) -> Value | None:
+    def doHandlersForTag(self, tag: str, keywords: Keywords) -> Value:
         """
         Execute all handlers for a given tag, in alphabetical order.
         The caller, doHook, catches all exceptions.
@@ -351,7 +351,7 @@ class LeoPluginsController:
         return None
 
     # @+node:ekr.20100908125007.6016: *5* plugins.callTagHandler
-    def callTagHandler(self, bunch: g.Bunch, tag: str, keywords: Keywords) -> Value | None:
+    def callTagHandler(self, bunch: g.Bunch, tag: str, keywords: Keywords) -> Value:
         """Call the event handler."""
         handler, moduleName = bunch.fn, bunch.moduleName
         # Make sure the new commander exists.
@@ -373,7 +373,7 @@ class LeoPluginsController:
         return result
 
     # @+node:ekr.20100908125007.6018: *4* plugins.doPlugins (g.app.hookFunction)
-    def doPlugins(self, tag: str, keywords: Keywords) -> Value | None:
+    def doPlugins(self, tag: str, keywords: Keywords) -> Value:
         """The default g.app.hookFunction."""
         if g.app.killed:
             return None
@@ -553,7 +553,7 @@ class LeoPluginsController:
             return result
 
         # @+node:ekr.20180528162604.1: *5* function:finishImport
-        def finishImport(result: Value) -> Value | None:
+        def finishImport(result: Value) -> Value:
             """Handle last-minute checks."""
             if tag == 'unit-test-load':
                 return result  # Keep the result, but do no more.

--- a/leo/core/leoPymacs.py
+++ b/leo/core/leoPymacs.py
@@ -104,7 +104,7 @@ def init():
 
 
 # @+node:ekr.20061024075542.1: ** open (pymacs)
-def open(fileName=None) -> Any | None:
+def open(fileName=None) -> Any:
     # global g
     init()
     if g.unitTesting:

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -448,7 +448,7 @@ class RstCommands:
             return True
         if c and c.config and c.config.getBool('create-nonexistent-directories', default=False):
             theDir = c.expand_path_expression(theDir)
-            ok: str = g.makeAllNonExistentDirectories(theDir)
+            ok = g.makeAllNonExistentDirectories(theDir)
             if not ok:
                 g.error('did not create:', theDir)
             return bool(ok)

--- a/leo/core/leoShadow.py
+++ b/leo/core/leoShadow.py
@@ -144,8 +144,7 @@ class ShadowController:
         Return True if theFile was changed.
         """
         x, c = self, self.c
-        exists = g.os_path_exists(fileName)
-        if exists:
+        if exists := g.os_path_exists(fileName):
             # Read the file.  Return if it is the same.
             s2, e = g.readFileIntoString(fileName)
             if not s2:

--- a/leo/core/leoShadow.py
+++ b/leo/core/leoShadow.py
@@ -148,7 +148,7 @@ class ShadowController:
         if exists:
             # Read the file.  Return if it is the same.
             s2, e = g.readFileIntoString(fileName)
-            if s2 is None:
+            if not s2:
                 return False
             if s == s2:
                 report = c.config.getBool('report-unchanged-files', default=True)

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -1762,7 +1762,7 @@ class LeoServer:
                 fileName = param.get("name")
                 if fileName:
                     s, e = g.readFileIntoString(fileName)
-                    if s is None:
+                    if not s:
                         return None
                     g.chdir(fileName)
                     s = '@nocolor\n' + s

--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -32711,12 +32711,13 @@ def run():
 
 ### Changed string functions
 
-The functions listed below now return an empty string instead of None. Tests against None will no longer work as expected--the pythonic tests below must be used instead::
-
+The functions and methods listed below now return an empty string instead of None. Tests against None will no longer work as expected--the "truthy" tests below must be used instead::
 
     if s:
     if not s:
 
+
+- AtFile.readFileToUnicode.
 - g.findAtTabWidthDirectives.
 - g.findFirstAtLanguageDirective.
 - g.findLanguageDirectives.
@@ -32727,6 +32728,12 @@ The functions listed below now return an empty string instead of None. Tests aga
 - g.makeAllNonExistentDirectories.
 - g.stripBOM.
 - g.readFileIntoEncodedString.
+- RecentFilesManager.sanitize.
+- RecursiveImportController.resolve_dir_arg.
+
+The following methods now return an empty string instead of None:
+
+- SettingsDict.get_setting and SettingsDict.get_string_setting.
 
 ### Changed commander functions
 
@@ -32743,18 +32750,19 @@ The functions below may return None instead of a position:
 
 - g.findUnl, g.findGnx, and g.findAnyUnl.
 
-### Changed string methods
+### Deleted global functions and methods
 
-The following methods now return an empty string instead of None:
+- AtFile.chmod.
 
-- SettingsDict.get_setting and SettingsDict.get_string_setting.
+mypy revealed that the following functions  were impossible to use.
 
-### Deleted global functions
+- g.execute_shell_commands_with_options.
+- g.computeBaseDir.
+- g.computeCommands.
 
-- g.execute_shell_commands_with_options: mypy revealed that its options were impossibly complex.
-- g.computeBaseDir: not used, and can't be fixed.
-- g.computeCommands: not used, and can't be fixed.
-</t>
+### Other breaking changes
+
+- LeoImportCommands.removeSentinelsCommand: Remove unused ``toString`` kwarg.</t>
 <t tx="felix.20210825213137.1">Since a WebSocket server can receive events from clients, process them to update the
 application state, and synchronize the resulting state across clients, leoserver.py
 has the ability to listen and interact with more than one concurrent client, and have

--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -2464,6 +2464,8 @@
 </v>
 <v t="ekr.20260531063902.1"></v>
 <v t="ekr.20260531063735.1"></v>
+<v t="ekr.20260716061125.1"><vh>Leo 6.8.10 release notes</vh></v>
+<v t="ekr.20260716061137.1"><vh>Breaking changes to Leo's API</vh></v>
 </vnodes>
 <tnodes>
 <t tx="EKR.20040524104904.140">Leo stores options in **@settings trees**, outlines whose headline is ``@settings``. When opening a .leo file, Leo looks for ``@settings`` trees not only in the outline being opened but also in various ``leoSettings.leo`` files. This scheme allows for the following kinds of settings:
@@ -32704,6 +32706,55 @@ def run():
     if total_n == 0:
         g.es_print('No intermediate files changed', color='red')
     return total_n &gt; 0</t>
+<t tx="ekr.20260716061125.1"></t>
+<t tx="ekr.20260716061137.1">Leo 6.8.10 changes the values *returned* by several methods. As described below, in some cases these changes might break existing scripts or plugins.
+
+### Changed string functions
+
+The functions listed below now return an empty string instead of None. Tests against None will no longer work as expected--the pythonic tests below must be used instead::
+
+
+    if s:
+    if not s:
+
+- g.findAtTabWidthDirectives.
+- g.findFirstAtLanguageDirective.
+- g.findLanguageDirectives.
+- g.get_backup_directory.
+- g.gitHeadPath.
+- g.getUrlFromNode.
+- g.guessExternalEditor.
+- g.makeAllNonExistentDirectories.
+- g.stripBOM.
+- g.readFileIntoEncodedString.
+
+### Changed commander functions
+
+The functions below may return None instead of a commander:
+
+- g.openUNLFile and g.openUrlHelper.
+- g.handleUnl.
+
+*Note* g.openWithFileName now *always* returns a valid commander. This is *not* a breaking change.
+
+### Changed position functions
+
+The functions below may return None instead of a position:
+
+- g.findUnl, g.findGnx, and g.findAnyUnl.
+
+### Changed string methods
+
+The following methods now return an empty string instead of None:
+
+- SettingsDict.get_setting and SettingsDict.get_string_setting.
+
+### Deleted global functions
+
+- g.execute_shell_commands_with_options: mypy revealed that its options were impossibly complex.
+- g.computeBaseDir: not used, and can't be fixed.
+- g.computeCommands: not used, and can't be fixed.
+</t>
 <t tx="felix.20210825213137.1">Since a WebSocket server can receive events from clients, process them to update the
 application state, and synchronize the resulting state across clients, leoserver.py
 has the ability to listen and interact with more than one concurrent client, and have

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -188,15 +188,12 @@ class TestQtGui(LeoUnitTest):
     # @+node:ekr.20260423040149.1: *3* TestQtGui.test_bug_4626
     def test_bug_4626(self):
         # https://github.com/leo-editor/leo-editor/issues/4626
+        self.skipTest('Can hang depending clipboard contents')
+
         c, gui = self.c, g.app.gui
         k, log, qtApp = c.k, c.frame.log, gui.qtApp
         old_log = g.app.log
         old_clipboard_contents = gui.getTextFromClipboard()
-
-        # Leo sometimes hangs in this test depending on the contents of the clipboard.
-        if len(old_clipboard_contents) > 1000 or '\n' in old_clipboard_contents:
-            self.skipTest('Complex clipboard contents')
-
         try:
             # Part 1: Create the 'Completion' tab, and copy it's contents to the clipboard.
             # Force g.es to print to the log.


### PR DESCRIPTION
See #4800.

- [x] Use truthy tests where required by the breaking changes listed below. Where valid, such tests generalize Leo's API.
    A *lot* of diffs and cffs were involved in discovering the places where truthy tests were needed.
    This PR is a big step forward, but only time will tell whether more work is needed.
- [x] LeoDocs.leo: document all breaking changes to Leo's API.
- [x] Use walrus operator in a few changed methods.
    A separate PR will use the walrus operator in many other places.
- [x] TestQtGui.test_bug_4626: always skip this tests: it can still hang.

### Breaking changes to Leo's API

Leo 6.8.10 introduces many breaking changes to Leo's API. Few scripts and plugins will likely be affected by these changes: most of the changed routines are for Leo's internal use.

<details></summary>
<br>

Leo 6.8.10 changes the values *returned* by several methods. As described below, in some cases these changes might break existing scripts or plugins.

### Changed string functions

The functions and methods listed below now return an empty string instead of None. Tests against None will no longer work as expected--the "truthy" tests below must be used instead::

    if s:
    if not s:


- AtFile.readFileToUnicode.
- g.findAtTabWidthDirectives.
- g.findFirstAtLanguageDirective.
- g.findLanguageDirectives.
- g.get_backup_directory.
- g.gitHeadPath.
- g.getUrlFromNode.
- g.guessExternalEditor.
- g.makeAllNonExistentDirectories.
- g.stripBOM.
- g.readFileIntoEncodedString.
- RecentFilesManager.sanitize.
- RecursiveImportController.resolve_dir_arg.

The following methods now return an empty string instead of None:

- SettingsDict.get_setting and SettingsDict.get_string_setting.

### Changed functions that return an optional commander

The functions below may return None instead of a commander:

- g.openUNLFile and g.openUrlHelper.
- g.handleUnl.

*Note* g.openWithFileName now *always* returns a valid commander. This is *not* a breaking change.

### Changed functions that return an optional position.

The functions below may return None instead of a position:

- g.findUnl, g.findGnx, and g.findAnyUnl.

### Deleted global functions and methods

- AtFile.chmod.

mypy revealed that the following functions  were impossible to use:

- g.execute_shell_commands_with_options.
- g.computeBaseDir.
- g.computeCommands.

### Other breaking changes

- LeoImportCommands.removeSentinelsCommand: Remove unused `toString` kwarg.

</details>
