### PR TITLE
PR fixes #4807: g.readFileIntoString should return None

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -289,7 +289,7 @@ def import_txt_file(self: Self, fn: str) -> None:
     p = c.p.insertAfter()
     p.h = f"@edit {c.relativeDirectory(fn)}"
     s, e = g.readFileIntoString(fn, kind='@edit')
-    p.b = s
+    p.b = s or ''
     u.afterInsertNode(p, 'Import', undoData)
     c.setChanged()
     c.redraw(p)
@@ -972,7 +972,7 @@ def readFileIntoNode(self: Self, event: LeoKeyEvent | None = None) -> None:
     if isinstance(fileName, list):
         fileName = fileName[0]
     s, e = g.readFileIntoString(fileName)
-    if not s:
+    if s is None:
         return
     g.chdir(fileName)
     s = '@nocolor\n' + s

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -518,10 +518,10 @@ class EditFileCommandsClass(BaseEditCommandsClass):
         if not fn2:
             return
         s1, e = g.readFileIntoString(fn)
-        if not s1:
+        if s1 is None:
             return
         s2, e = g.readFileIntoString(fn2)
-        if not s2:
+        if s2 is None:
             return
         lines1, lines2 = g.splitLines(s1), g.splitLines(s2)
         aList = difflib.ndiff(lines1, lines2)
@@ -586,7 +586,7 @@ class EditFileCommandsClass(BaseEditCommandsClass):
         if not fn:
             return
         s, e = g.readFileIntoString(fn)
-        if s:
+        if s is not None:
             self.beginCommand(w, undoType='insert-file')
             i = w.getInsertPoint()
             w.insert(i, s)

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2847,7 +2847,7 @@ class LoadManager:
             # #1090: use cwd, not g.app.loadDir, to find scripts.
             path = g.finalize_join(os.getcwd(), fn)
             script, e = g.readFileIntoString(path, kind='script:', verbose=False)
-            if not script:
+            if script is None:
                 arg = m.group(0)
                 utils.option_error(arg, f"Script not found: {m.group(1)!r}")
             return script

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -326,7 +326,7 @@ class AtFile:
             return
         s, e = g.readFileIntoString(fn)
         if not s:
-            g.red(f"empty file: {fn}")
+            # g.red(f"empty file: {fn}")
             return
 
         # Create a dummy, unconnected, VNode as the root.
@@ -673,7 +673,7 @@ class AtFile:
         # Remember the full fileName.
         at.rememberReadPath(fn, p)
         s, e = g.readFileIntoString(fn, kind='@edit')
-        if not s:
+        if s is None:
             return
         encoding = e or 'utf-8'
         # Delete all children.
@@ -837,7 +837,7 @@ class AtFile:
         # Fix bug 889175: Remember the full fileName.
         at.rememberReadPath(fn, p)
         s, e = g.readFileIntoString(fn, kind='@edit')
-        if not s:
+        if s is None:
             return
         encoding = e or 'utf-8'
         # Delete all children.

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -279,7 +279,7 @@ class ExternalFilesController:
         c, p = ef.c, ef.p.copy()
         g.blue(f"updated {p.h}")
         s, e = g.readFileIntoString(ef.path)
-        p.b = s
+        p.b = s or ''
         if c.config.getBool('open-with-goto-node-on-update'):
             c.selectPosition(p)
         if c.config.getBool('open-with-save-on-update'):

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -4050,7 +4050,7 @@ def readFileIntoString(
     encoding: str = 'utf-8',  # BOM may override this.
     kind: str = '',  # @file, @edit, ...
     verbose: bool = True,
-) -> tuple[str, str]:
+) -> tuple[str | None, str]:
     """
     Return the contents of the file whose full path is fileName.
 
@@ -4062,7 +4062,7 @@ def readFileIntoString(
     - The encoding given by the 'encoding' keyword arg.
     - None, which typically means 'utf-8'.
     """
-    fail = '', ''
+    fail = None, ''
     if not fileName:
         if verbose:
             g.trace('no fileName arg given')

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -467,7 +467,7 @@ class LeoImportCommands:
             g.setGlobalOpenDir(fileName)
             path, self.fileName = g.os_path_split(fileName)
             s, e = g.readFileIntoString(fileName, self.encoding)
-            if not s:
+            if s is None:
                 continue  # PR #4801.
             if e:
                 self.encoding = e
@@ -660,7 +660,7 @@ class LeoImportCommands:
         if not s:
             # Set the kind for error messages in readFileIntoString.
             s, e = g.readFileIntoString(fileName, encoding=self.encoding)
-            if not s:
+            if s is None:
                 return None, None
             if e:
                 self.encoding = e
@@ -968,7 +968,7 @@ class LeoImportCommands:
         lb = "@<" if theType == "cweb" else "<<"
         rb = "@>" if theType == "cweb" else ">>"
         s, e = g.readFileIntoString(fileName)
-        if not s:
+        if s is None:
             return
         # @+<< Create a symbol table of all section names >>
         # @+node:ekr.20031218072017.3232: *6* << Create a symbol table of all section names >>
@@ -1557,7 +1557,7 @@ class MORE_Importer:
         ic.encoding = c.getEncoding(c.p)
         g.setGlobalOpenDir(fileName)
         s, _e = g.readFileIntoString(fileName)
-        if not s:
+        if s is None:
             return None
         s = s.replace('\r', '')  # Fixes bug 626101.
         lines = g.splitLines(s)
@@ -1798,7 +1798,7 @@ class RecursiveImportController:
             path = c.relativeDirectory(path)
             p.v.h = '@edit ' + path.replace('\\', '/')
             s, e = g.readFileIntoString(path, kind=self.kind)
-            p.v.b = s
+            p.v.b = s or ''
             return
         # #1484: Use this for @auto as well.
         c.importCommands.importFilesCommand(

--- a/leo/core/leoShadow.py
+++ b/leo/core/leoShadow.py
@@ -147,7 +147,7 @@ class ShadowController:
         if exists := g.os_path_exists(fileName):
             # Read the file.  Return if it is the same.
             s2, e = g.readFileIntoString(fileName)
-            if not s2:
+            if s2 is None:
                 return False
             if s == s2:
                 report = c.config.getBool('report-unchanged-files', default=True)

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -1762,7 +1762,7 @@ class LeoServer:
                 fileName = param.get("name")
                 if fileName:
                     s, e = g.readFileIntoString(fileName)
-                    if not s:
+                    if s is None:
                         return None
                     g.chdir(fileName)
                     s = '@nocolor\n' + s

--- a/leo/plugins/bibtex.py
+++ b/leo/plugins/bibtex.py
@@ -184,7 +184,7 @@ def readBibTexFileIntoTree(c, fn, p):
     root = p.copy()
     g.es('reading:', fn)
     s, _e = g.readFileIntoString(fn)
-    if not s.strip():
+    if s is None:
         return
     aList: list[tuple] = []  # A list of tuples (h, b).
     strings: list[str] = []

--- a/leo/unittests/misc_tests/test_syntax.py
+++ b/leo/unittests/misc_tests/test_syntax.py
@@ -58,7 +58,7 @@ class TestSyntax(LeoUnitTest):
                     n += 1
                     fn = g.shortFileName(z)
                     s, e = g.readFileIntoString(z)
-                    self.assertTrue(self.check_syntax(fn, s), msg=fn)
+                    self.assertTrue(self.check_syntax(fn, s or ''), msg=fn)
 
     # @-others
 


### PR DESCRIPTION
See #4807.

- [x] Change g.readFileIntoString. Its return type is now `tuple[str | None, str]`.
- [x] Convert truthy tests to tests on None.
- [x] Change assignments from `x = s` to `x = s or ''`.