### PR TITLE
docs: fix typo in pyproject.toml dependencies comment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,7 +279,7 @@ readme = "README.md"
 # Yes, we must duplicate requirements.txt.
 #@+<< pyproject.toml: dependencies >>
 #@+node:ekr.20240713074535.1: ** << pyproject.toml: dependencies >>
-# Warning: these dependencies should match those in pyproject.toml.
+# Warning: these dependencies should match those in requirements.txt.
 
 dependencies = [
 


### PR DESCRIPTION
## Description
This PR fixes a small typo in the dependencies comment within .

## Motivation
The comment under  in  read:
`# Warning: these dependencies should match those in pyproject.toml.`
Because it was copied from `requirements.txt`, inside `pyproject.toml` it should refer to `requirements.txt`. Updating this comment prevents confusion for maintainers and build script authors.