### PR TITLE
Fix line-number gutter not appearing

### DIFF
--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -836,7 +836,8 @@ class DynamicWindow(QtWidgets.QMainWindow):
         # Pack.
         vLayout = self.createVLayout(page2, 'bodyVLayout', spacing=0)
         grid = self.createGrid(bodyFrame, 'bodyGrid')
-        if innerGrid := self.createGrid(innerFrame, 'bodyInnerGrid'):
+        innerGrid = self.createGrid(innerFrame, 'bodyInnerGrid')
+        if self.use_gutter:
             lineWidget = qt_text.LeoLineTextWidget(c, body)
             vLayout.addWidget(lineWidget)
         else:

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -174,6 +174,20 @@ class TestQtGui(LeoUnitTest):
         ):
             assert issubclass(class_, QTextMixin), repr(class_)
 
+    # @+node:Sanjays2402.20260724103000.1: *3* TestQtGui.test_bug_4817
+    def test_bug_4817(self):
+        # https://github.com/leo-editor/leo-editor/issues/4817
+        top = self.c.frame.top
+        old_use_gutter = top.use_gutter
+        try:
+            top.use_gutter = True
+            parent = QtWidgets.QWidget()
+            pane = top.createBodyPane(parent)
+            gutter = pane.findChild(QtWidgets.QFrame, 'gutter')
+            assert gutter is not None
+        finally:
+            top.use_gutter = old_use_gutter
+
     # @+node:ekr.20210913120449.1: *3* TestQtGui.test_bug_2164
     def test_bug_2164(self):
         # show-invisibles crashes with PyQt6.


### PR DESCRIPTION
Closes #4817

The walrus conversion accidentally tested the new empty layout's truthiness instead of `self.use_gutter`, so Qt always took the no-gutter path. This restores the setting check and adds a Qt regression test for the enabled gutter.

Tested with `python -m unittest leo.unittests.plugins.test_gui.TestQtGui` (9 tests, 1 skipped).
