### PR TITLE
PR: fix ruff lint errors on Linux

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4804,33 +4804,32 @@ class Commands:
     def add_command(
         self,
         menu: LeoQtMenu,
+        command: Callable,
+        *,  # 2026/07/29
         accelerator: str = '',  # Not used.
-        command: Callable | None = None,
         commandName: str = '',  # Not used.
         label: str = '',  # Not used.
         underline: int = 0,
     ) -> None:
         c = self
-        if command:
-            # Command is one of two callbacks defined in createMenuEntries.
+        assert command is not None  # 2026/07/29
+        # Command is one of two callbacks defined in createMenuEntries.
 
-            def add_commandCallback(c: Commands = c, command: Callable = command) -> Value:
-                val = command()
-                # Careful: func may destroy c.
-                if c.exists:
-                    c.outerUpdate()
-                return val
+        def add_commandCallback(c: Commands = c, command: Callable = command) -> Value:
+            val = command()
+            # Careful: func may destroy c.
+            if c.exists:
+                c.outerUpdate()
+            return val
 
-            menu.add_command(
-                menu,
-                accelerator=accelerator,
-                command=command,
-                commandName=commandName,
-                label=label,
-                underline=underline,
-            )
-        else:
-            g.trace('can not happen: no "command" arg')
+        menu.add_command(
+            menu,
+            accelerator=accelerator,
+            command=command,
+            commandName=commandName,
+            label=label,
+            underline=underline,
+        )
 
     # @+node:ekr.20171123203044.1: *5* c.Menu Enablers
     # @+node:ekr.20040131170659: *6* c.canClone

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4805,14 +4805,14 @@ class Commands:
         self,
         menu: LeoQtMenu,
         command: Callable,
-        *,  # 2026/07/29
+        *,  # PR #4826
         accelerator: str = '',  # Not used.
         commandName: str = '',  # Not used.
         label: str = '',  # Not used.
         underline: int = 0,
     ) -> None:
         c = self
-        assert command is not None  # 2026/07/29
+        assert command is not None  # PR #4826
         # Command is one of two callbacks defined in createMenuEntries.
 
         def add_commandCallback(c: Commands = c, command: Callable = command) -> Value:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7575,8 +7575,7 @@ def os_startfile(fname: str) -> None:
     elif sys.platform == 'darwin':
         # From Marc-Antoine Parent.
         try:
-            # Fix bug 1226358: File URL's are broken on MacOS:
-            # use fname, not quoted_fname, as the argument to subprocess.call.
+            # Use fname, not quoted_fname, as the argument to subprocess.call.
             subprocess.call(['open', fname])
         except OSError:
             pass  # There may be a spurious "Interrupted system call"
@@ -7602,7 +7601,7 @@ def os_startfile(fname: str) -> None:
                 (lambda ito: itPoll(fname, ree, subPopen, g, ito)),
                 delay=1000,
             )
-            assert itoPolldate  # 2026/07/29
+            assert itoPolldate  # PR #4826
             itoPoll.start()
             # Let the Leo-Editor process run
             # so that Leo-Editor is usable while the file is open.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7601,7 +7601,7 @@ def os_startfile(fname: str) -> None:
                 (lambda ito: itPoll(fname, ree, subPopen, g, ito)),
                 delay=1000,
             )
-            assert itoPolldate  # PR #4826
+            assert itoPoll is not None  # PR #4826
             itoPoll.start()
             # Let the Leo-Editor process run
             # so that Leo-Editor is usable while the file is open.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7602,6 +7602,7 @@ def os_startfile(fname: str) -> None:
                 (lambda ito: itPoll(fname, ree, subPopen, g, ito)),
                 delay=1000,
             )
+            assert itoPolldate  # 2026/07/29
             itoPoll.start()
             # Let the Leo-Editor process run
             # so that Leo-Editor is usable while the file is open.


### PR DESCRIPTION
These errors may have caused the ci.yml action to fail.