### PR TITLE
PR fixes #4828: fix deprecated datetime methods

### DIFF
--- a/leo/commands/commanderHelpCommands.py
+++ b/leo/commands/commanderHelpCommands.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:  # pragma: no cover
 def about(self: Self, event: LeoKeyEvent | None = None) -> None:
     """Bring up an About Leo Dialog."""
     c = self
-    import datetime
+    import datetime as dt
 
     # Don't use triple-quoted strings or continued strings here.
     # Doing so would add unwanted leading tabs.
@@ -34,7 +34,7 @@ def about(self: Self, event: LeoKeyEvent | None = None) -> None:
         'Copyright 1999-%s by Edward K. Ream\n'
         'All Rights Reserved\n'
         'Leo is distributed under the MIT License'
-    ) % datetime.date.today().year  # fmt: skip
+    ) % dt.datetime.now().year  # fmt: skip
     url = "https://leo-editor.github.io/leo-editor/"
     email = "edreamleo@gmail.com"
     g.app.gui.runAboutLeoDialog(c, version, theCopyright, url, email)

--- a/leo/commands/commanderHelpCommands.py
+++ b/leo/commands/commanderHelpCommands.py
@@ -34,7 +34,7 @@ def about(self: Self, event: LeoKeyEvent | None = None) -> None:
         'Copyright 1999-%s by Edward K. Ream\n'
         'All Rights Reserved\n'
         'Leo is distributed under the MIT License'
-    ) % dt.datetime.now().year  # fmt: skip
+    ) % dt.datetime.now(tz=dt.timezone.utc).year  # fmt: skip
     url = "https://leo-editor.github.io/leo-editor/"
     email = "edreamleo@gmail.com"
     g.app.gui.runAboutLeoDialog(c, version, theCopyright, url, email)

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import binascii
 from collections import defaultdict
 from collections.abc import Callable
-from datetime import datetime
+import datetime as dt
 import difflib
 import hashlib
 import io
@@ -698,9 +698,8 @@ class FileCommands:
             return
 
         # Compute the timestamp.
-        timestamp = datetime.now().timestamp()
-        time = datetime.fromtimestamp(timestamp)
-        time_s = time.strftime('%Y-%m-%d-%H-%M-%S')
+        today = dt.datetime.fromtimestamp(time.time(), tz=dt.timezone.utc)  # PR #4829
+        time_s = today.strftime('%Y-%m-%d-%H-%M-%S')
 
         # Compute archive_name.
         archive_name = None

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -698,7 +698,6 @@ class FileCommands:
             return
 
         # Compute the timestamp.
-        ### today = dt.datetime.fromtimestamp(time.time(), tz=dt.timezone.utc)  # PR #4829
         today = dt.datetime.now(tz=dt.timezone.utc)  # PR #4829
         time_s = today.strftime('%Y-%m-%d-%H-%M-%S')
 

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -698,7 +698,8 @@ class FileCommands:
             return
 
         # Compute the timestamp.
-        today = dt.datetime.fromtimestamp(time.time(), tz=dt.timezone.utc)  # PR #4829
+        ### today = dt.datetime.fromtimestamp(time.time(), tz=dt.timezone.utc)  # PR #4829
+        today = dt.datetime.now(tz=dt.timezone.utc)  # PR #4829
         time_s = today.strftime('%Y-%m-%d-%H-%M-%S')
 
         # Compute archive_name.

--- a/leo/plugins/QNCalendarWidget.py
+++ b/leo/plugins/QNCalendarWidget.py
@@ -12,7 +12,7 @@ Terry_N_Brown@yahoo.com, Tue Oct 15 09:53:38 2013
 """
 
 import sys
-import datetime
+import datetime as dt
 from leo.core import leoGlobals as g
 from leo.core.leoQt import QtCore, QtWidgets
 
@@ -45,9 +45,9 @@ class QNCalendarWidget(QtWidgets.QCalendarWidget):  # type:ignore
         self.calendars = []
 
         if year is None:
-            year = datetime.date.today().year
+            year = dt.datetime.now().year
         if month is None:
-            month = datetime.date.today().month
+            month = dt.datetime.now().month
 
         layout = QtWidgets.QGridLayout()
         while self.layout().count():

--- a/leo/plugins/QNCalendarWidget.py
+++ b/leo/plugins/QNCalendarWidget.py
@@ -44,10 +44,11 @@ class QNCalendarWidget(QtWidgets.QCalendarWidget):  # type:ignore
     def build(self, n=3, columns=3, year=None, month=None):
         self.calendars = []
 
+        now = dt.datetime.now(tz=dt.timezone.utc)  # PR #4829
         if year is None:
-            year = dt.datetime.now().year
+            year = now.year
         if month is None:
-            month = dt.datetime.now().month
+            month = now.month
 
         layout = QtWidgets.QGridLayout()
         while self.layout().count():

--- a/leo/plugins/datenodes.py
+++ b/leo/plugins/datenodes.py
@@ -172,7 +172,7 @@ class DateNodes:
     # @+node:gfunch.20041208074734: *3* insert_day_node
     def insert_day_node(self, event=None):
         c = self.c
-        today = dt.datetime.now()
+        today = dt.datetime.now(tz=dt.timezone.utc)
         day_fmt = self.settings["day_node_headline"]
         day_node = self._insert_day_node(self.c.p, today, day_fmt)
         c.selectPosition(day_node)
@@ -181,7 +181,7 @@ class DateNodes:
     # @+node:dcb.20060806183928: *3* insert_month_node
     def insert_month_node(self, event=None):
         c = self.c
-        today = dt.datetime.now()
+        today = dt.datetime.now(tz=dt.timezone.utc)
         day_fmt = self.settings["month_node_day_headline"]
         month_fmt = self.settings["month_node_month_headline"]
         omit_saturdays = self.settings["month_node_omit_saturdays"]
@@ -195,7 +195,7 @@ class DateNodes:
     # @+node:dcb.20060806184117: *3* insert_year_node
     def insert_year_node(self, event=None):
         c = self.c
-        today = dt.datetime.now()
+        today = dt.datetime.now(tz=dt.timezone.utc)
         day_fmt = self.settings["year_node_day_headline"]
         month_fmt = self.settings["year_node_month_headline"]
         year_fmt = self.settings["year_node_year_headline"]

--- a/leo/plugins/datenodes.py
+++ b/leo/plugins/datenodes.py
@@ -47,7 +47,7 @@ The following commands are available for use via the minibuffer or in
 # @+node:gfunch.20041207100416.3: ** << imports >>
 import calendar
 import codecs
-import datetime
+import datetime as dt
 from leo.core import leoGlobals as g
 # @-<< imports >>
 
@@ -136,7 +136,7 @@ class DateNodes:
         year, month = date.timetuple()[:2]
         first_day_of_month, num_days = calendar.monthrange(year, month)
         for day in range(1, num_days + 1):
-            day_date = datetime.date(year, month, day)
+            day_date = dt.date(year, month, day)
             isoweekday = day_date.isoweekday()
             if (isoweekday == 6 and omit_saturdays) or (isoweekday == 7 and omit_sundays):
                 continue
@@ -158,7 +158,7 @@ class DateNodes:
         year_node = self._insert_date_node(parent, date, year_fmt)
         year, month, day = date.timetuple()[:3]
         for month in range(1, 13):
-            month_date = datetime.date(year, month, day)
+            month_date = dt.date(year, month, day)
             self._insert_month_node(
                 parent=year_node,
                 date=month_date,
@@ -172,7 +172,7 @@ class DateNodes:
     # @+node:gfunch.20041208074734: *3* insert_day_node
     def insert_day_node(self, event=None):
         c = self.c
-        today = datetime.date.today()
+        today = dt.datetime.now()
         day_fmt = self.settings["day_node_headline"]
         day_node = self._insert_day_node(self.c.p, today, day_fmt)
         c.selectPosition(day_node)
@@ -181,7 +181,7 @@ class DateNodes:
     # @+node:dcb.20060806183928: *3* insert_month_node
     def insert_month_node(self, event=None):
         c = self.c
-        today = datetime.date.today()
+        today = dt.datetime.now()
         day_fmt = self.settings["month_node_day_headline"]
         month_fmt = self.settings["month_node_month_headline"]
         omit_saturdays = self.settings["month_node_omit_saturdays"]
@@ -195,7 +195,7 @@ class DateNodes:
     # @+node:dcb.20060806184117: *3* insert_year_node
     def insert_year_node(self, event=None):
         c = self.c
-        today = datetime.date.today()
+        today = dt.datetime.now()
         day_fmt = self.settings["year_node_day_headline"]
         month_fmt = self.settings["year_node_month_headline"]
         year_fmt = self.settings["year_node_year_headline"]

--- a/leo/plugins/history_tracer.py
+++ b/leo/plugins/history_tracer.py
@@ -31,7 +31,7 @@ Author: vitalije(at)kviziracija.net
 # @-<< docstring >>
 # @+<< imports: history_tracer.py >>
 # @+node:vitalije.20190928154420.3: ** << imports: history_tracer.py >>
-import datetime
+import datetime as dt
 import time
 import threading
 from urllib.request import urlopen
@@ -124,8 +124,8 @@ def save_snapshot(c):
 
 # @+node:vitalije.20190928160538.1: ** snap
 def snap(c):
-    dt = datetime.datetime.utcnow()
-    buf = [c.mFileName, '\n', dt.strftime('%Y-%m-%dT%H:%M:%S.000000'), '\n']
+    today = dt.datetime.now(tz=dt.timezone.utc)  # PR #4829
+    buf = [c.mFileName, '\n', today.strftime('%Y-%m-%dT%H:%M:%S.000000'), '\n']
     nbuf = {}
 
     def it(v, lev):

--- a/leo/plugins/leo_babel/tests/lib_test.py
+++ b/leo/plugins/leo_babel/tests/lib_test.py
@@ -9,8 +9,7 @@
 
 # @+<< imports >>
 # @+node:bob.20180205135704.1: ** << imports >>
-import datetime
-# import time
+import datetime as dt
 
 from leo.core import leoGlobals as leoG
 
@@ -172,9 +171,9 @@ class TestCmdr:
         self.testCnt = 0
         self.babelExecCnt = 0
 
-        fdR.write(
-            '||* Tests *|| {0}\n'.format(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%s'))
-        )
+        tz = dt.timezone.utc
+        now = dt.datetime.now(tz=tz)  # PR #4829
+        fdR.write('||* Tests *|| {0}\n'.format(now).strftime('%Y-%m-%d %H:%M:%s', tz=tz))
 
     # @-others
 

--- a/leo/plugins/leo_cloud.py
+++ b/leo/plugins/leo_cloud.py
@@ -83,7 +83,8 @@ import tempfile
 import threading
 from typing import Any
 from copy import deepcopy
-from datetime import date, datetime
+from datetime import date
+import datetime as dt
 from hashlib import sha1
 from leo.core import leoGlobals as g
 from leo.core.leoNodes import vnode
@@ -508,14 +509,14 @@ class LeoCloud:
                 read = True
             elif read_on_load == 'ask':
                 try:
-                    last_read = datetime.strptime(  # noqa
+                    last_read = dt.datetime.strptime(  # PR #4829
                         lc_v.u['_leo_cloud']['last_read'], "%Y-%m-%dT%H:%M:%S.%f"
-                    )
+                    ).replace(tzinfo=dt.timezone.utc)
                 except KeyError:
                     last_read = None
                 message = "Read cloud data '%s', overwriting local nodes?" % kwargs['ID']
                 if last_read:
-                    delta = datetime.now() - last_read
+                    delta = dt.datetime.now(tz=dt.timezone.utc) - last_read
                     message = "%s\n%s, %sh:%sm:%ss ago" % (
                         message,
                         last_read.strftime("%a %b %d %H:%M"),
@@ -584,7 +585,8 @@ class LeoCloud:
         # because we want the user to understand why the outline's changed,
         # so just ignore top node dirtiness in self.subtree_changed()
         self.c.setChanged()
-        p.v.u.setdefault('_leo_cloud', {})['last_read'] = datetime.now().isoformat()
+        tz = dt.timezone.utc
+        p.v.u.setdefault('_leo_cloud', {})['last_read'] = dt.datetime.now(tz=tz).isoformat()
 
     # @+node:ekr.20201012111338.34: *3* LeoCloud.recursive_hash
     @staticmethod
@@ -682,7 +684,7 @@ class LeoCloud:
     @staticmethod
     def _to_json_serial(obj):
         """JSON serializer for objects not serializable by default json code"""
-        if isinstance(obj, (datetime, date)):
+        if isinstance(obj, (dt.datetime, date)):
             return obj.isoformat()
         if isinstance(obj, set):
             return list(obj)
@@ -772,7 +774,8 @@ class LeoCloud:
         lc_io.put_subtree(lc_io.lc_id, p.v)
         g.es("Stored %s" % lc_io.lc_id)
         # writing counts as reading, last read time msg. confusing otherwise
-        p.v.u.setdefault('_leo_cloud', {})['last_read'] = datetime.now().isoformat()
+        tz = dt.timezone.utc
+        p.v.u.setdefault('_leo_cloud', {})['last_read'] = dt.datetime.now(tz=tz).isoformat()
 
     # @-others
 

--- a/leo/plugins/leo_cloud.py
+++ b/leo/plugins/leo_cloud.py
@@ -508,7 +508,7 @@ class LeoCloud:
                 read = True
             elif read_on_load == 'ask':
                 try:
-                    last_read = datetime.strptime(
+                    last_read = datetime.strptime(  # noqa
                         lc_v.u['_leo_cloud']['last_read'], "%Y-%m-%dT%H:%M:%S.%f"
                     )
                 except KeyError:

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -6,7 +6,7 @@
 # @+node:ekr.20140918102920.17891: ** << qt_gui imports >>
 from __future__ import annotations
 from collections.abc import Callable
-import datetime
+import datetime as dt
 import functools
 import re
 import sys
@@ -726,9 +726,9 @@ class LeoQtGui(leoGui.LeoGui):
         c: Cmdr,
         title: str,
         message: str = 'Select Date/Time',
-        init: datetime.datetime | None = None,
+        init: dt.datetime | None = None,
         step_min: dict | None = None,
-    ) -> datetime.datetime | None:
+    ) -> dt.datetime | None:
         """Create and run a qt date/time selection dialog.
 
         init - a datetime, default now
@@ -757,7 +757,7 @@ class LeoQtGui(leoGui.LeoGui):
             def __init__(
                 self,
                 parent: QWidget | None = None,
-                init: datetime.datetime | None = None,
+                init: dt.datetime | None = None,
                 step_min: dict | None = None,
             ) -> None:
                 if step_min is None:
@@ -779,7 +779,7 @@ class LeoQtGui(leoGui.LeoGui):
                 self,
                 parent: QWidget | None = None,
                 message: str = 'Select Date/Time',
-                init: datetime.datetime | None = None,
+                init: dt.datetime | None = None,
                 step_min: dict | None = None,
             ) -> None:
                 if step_min is None:
@@ -802,7 +802,7 @@ class LeoQtGui(leoGui.LeoGui):
         if step_min is None:
             step_min = {}
         if not init:
-            init = datetime.datetime.now()
+            init = dt.datetime.now()
         top_frame: QWidget | None = c.frame.top if c else None
         dialog = Calendar(top_frame, message=message, init=init, step_min=step_min)
         if c:

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -802,7 +802,7 @@ class LeoQtGui(leoGui.LeoGui):
         if step_min is None:
             step_min = {}
         if not init:
-            init = dt.datetime.now()
+            init = dt.datetime.now(tz=dt.timezone.utc)
         top_frame: QWidget | None = c.frame.top if c else None
         dialog = Calendar(top_frame, message=message, init=init, step_min=step_min)
         if c:

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -1399,10 +1399,10 @@ class todoController:
         # Update the label.
         h = self.c and self.c.p and self.c.p.h
         due = self.getat(v, 'duedate')
-        g.trace(created)
-        ago = (dt.datetime.now() - created).days if created else 0
+        now = dt.datetime.now()
+        ago = (now - created).days if created else 0
         if due:
-            days = (due - dt.datetime.now()).days
+            days = (due - now).days
             txt = f"{h}\nCreated {ago} days ago, due in {days}"
         else:
             txt = f"{h}\nCreated {ago} days ago"

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -261,28 +261,28 @@ if g.app.gui.guiName() == "qt":
                 self.UI.dueDateEdit,
                 self.UI.dueDateToggle,
                 'setDate',
-                dt.datetime.now() + dt.timedelta(self.date_offset_default),
+                dt.datetime.now(tz=dt.timezone.utc) + dt.timedelta(self.date_offset_default),
             )
 
             self.setDueTime = self.make_func(
                 self.UI.dueTimeEdit,
                 self.UI.dueTimeToggle,
                 'setTime',
-                dt.datetime.now().time(),
+                dt.datetime.now(tz=dt.timezone.utc).time(),
             )
 
             self.setNextWorkDate = self.make_func(
                 self.UI.nxtwkDateEdit,
                 self.UI.nxtwkDateToggle,
                 'setDate',
-                dt.datetime.now() + dt.timedelta(self.date_offset_default),
+                dt.datetime.now(tz=dt.timezone.utc) + dt.timedelta(self.date_offset_default),
             )
 
             self.setNextWorkTime = self.make_func(
                 self.UI.nxtwkTimeEdit,
                 self.UI.nxtwkTimeToggle,
                 'setTime',
-                dt.datetime.now().time(),
+                dt.datetime.now(tz=dt.timezone.utc).time(),
             )
 
             self.UI.butDetails.clicked.connect(
@@ -627,7 +627,7 @@ class todoController:
             iterations = ['progress', 'priority', 'duedate']
         if clear:
             iterations = []
-        today = dt.datetime.now()
+        today = dt.datetime.now(tz=dt.timezone.utc)
         for which in iterations:
             if which == 'priority':
                 pri = self.getat(p.v, 'priority')
@@ -1290,7 +1290,7 @@ class todoController:
 
         p = self.c.currentPosition()
         self.setat(p.v, 'priority', pri)
-        self.setat(p.v, 'prisetdate', str(dt.datetime.now()))
+        self.setat(p.v, 'prisetdate', str(dt.datetime.now(tz=dt.timezone.utc)))
         self.loadIcons(p)
 
     # @+node:tbrown.20090119215428.48: *4* todoController.showDist
@@ -1385,7 +1385,7 @@ class todoController:
             # .strftime doesn't work here! This has has happened...
             try:
                 gdate = self.c.p.v.gnx.split('.')[1][:12]
-                created = dt.datetime.strptime(gdate, '%Y%m%d%H%M')  # noqa
+                created = dt.datetime.strptime(gdate, '%Y%m%d%H%M').replace(tzinfo=dt.timezone.utc)
                 if created.year < 1900:
                     created = None
             except Exception:
@@ -1399,7 +1399,7 @@ class todoController:
         # Update the label.
         h = self.c and self.c.p and self.c.p.h
         due = self.getat(v, 'duedate')
-        now = dt.datetime.now()
+        now = dt.datetime.now(tz=dt.timezone.utc)
         ago = (now - created).days if created else 0
         if due:
             days = (due - now).days

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -66,7 +66,7 @@ from __future__ import annotations
 from collections.abc import Callable
 import os
 import re
-import datetime
+import datetime as dt
 import time
 from typing import Any, Iterable, TYPE_CHECKING
 from leo.core import leoGlobals as g
@@ -87,7 +87,7 @@ if TYPE_CHECKING:  # pragma: no cover
 g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.
 # @-<< todo imports & annotations >>
 
-NO_TIME = datetime.date(3000, 1, 1)
+NO_TIME = dt.date(3000, 1, 1)
 
 # @+others
 # @+node:tbrown.20090119215428.6: ** init (todo.py)
@@ -261,28 +261,28 @@ if g.app.gui.guiName() == "qt":
                 self.UI.dueDateEdit,
                 self.UI.dueDateToggle,
                 'setDate',
-                datetime.date.today() + datetime.timedelta(self.date_offset_default),
+                dt.datetime.now() + dt.timedelta(self.date_offset_default),
             )
 
             self.setDueTime = self.make_func(
                 self.UI.dueTimeEdit,
                 self.UI.dueTimeToggle,
                 'setTime',
-                datetime.datetime.now().time(),
+                dt.datetime.now().time(),
             )
 
             self.setNextWorkDate = self.make_func(
                 self.UI.nxtwkDateEdit,
                 self.UI.nxtwkDateToggle,
                 'setDate',
-                datetime.date.today() + datetime.timedelta(self.date_offset_default),
+                dt.datetime.now() + dt.timedelta(self.date_offset_default),
             )
 
             self.setNextWorkTime = self.make_func(
                 self.UI.nxtwkTimeEdit,
                 self.UI.nxtwkTimeToggle,
                 'setTime',
-                datetime.datetime.now().time(),
+                dt.datetime.now().time(),
             )
 
             self.UI.butDetails.clicked.connect(
@@ -497,7 +497,7 @@ class todoController:
             g.unregisterHandler(i[0], i[1])  # type:ignore
 
     # @+node:tbnorth.20170925093004.1: *3* todoController._date
-    def _date(self, d: str) -> datetime.date | None:
+    def _date(self, d: str) -> dt.date | None:
         """_date - convert a string to a date
 
         :param str d: date to convert
@@ -505,9 +505,9 @@ class todoController:
         """
         if not d.strip():
             return None  # Was ''
-        return datetime.datetime.strptime(d.split('T')[0], "%Y-%m-%d").date()
+        return dt.datetime.strptime(d.split('T')[0], "%Y-%m-%d").date()
 
-    def _time(self, d: str) -> datetime.time | None:
+    def _time(self, d: str) -> dt.time | None:
         """_time - convert a string to a time
 
         :param str d: time to convert
@@ -515,7 +515,7 @@ class todoController:
         """
         if not d.strip():
             return None  # Was ''
-        return datetime.datetime.strptime(d, "%H:%M:%S.%f").time()
+        return dt.datetime.strptime(d, "%H:%M:%S.%f").time()
 
     # @+node:tbrown.20090630144958.5319: *3* todoController.addPopupMenu
     def addPopupMenu(self, c: Cmdr, p: Position, menu: Menu) -> None:
@@ -627,7 +627,7 @@ class todoController:
             iterations = ['progress', 'priority', 'duedate']
         if clear:
             iterations = []
-        today = datetime.date.today()
+        today = dt.datetime.now()
         for which in iterations:
             if which == 'priority':
                 pri = self.getat(p.v, 'priority')
@@ -742,9 +742,7 @@ class todoController:
     def setat(self, node: VNode, attrib: Any, val: Any) -> None:
         "new attribute setter"
 
-        if attrib in self._datetime_fields and isinstance(
-            val, (datetime.date, datetime.time, datetime.datetime)
-        ):
+        if attrib in self._datetime_fields and isinstance(val, (dt.date, dt.time, dt.datetime)):
             val = val.isoformat()
 
         if 'annotate' in node.u and 'src_unl' in node.u['annotate']:
@@ -1188,15 +1186,13 @@ class todoController:
         return pa if pa != 24 else 0
 
     # @+node:tbrown.20110213153425.16373: *4* todoController.duekey
-    def duekey(
-        self, v: VNode, field: str = 'due'
-    ) -> tuple[bool, datetime.date, datetime.time, int]:
+    def duekey(self, v: VNode, field: str = 'due') -> tuple[bool, dt.date, dt.time, int]:
         """key function for sorting by due date/time"""
         # pylint: disable=boolean-datetime
         priority = self.getat(v, 'priority')
         done = priority not in self.todo_priorities
-        date_ = self.getat(v, field + 'date') or datetime.date(3000, 1, 1)
-        time_ = self.getat(v, field + 'time') or datetime.time(23, 59, 59)
+        date_ = self.getat(v, field + 'date') or dt.date(3000, 1, 1)
+        time_ = self.getat(v, field + 'time') or dt.time(23, 59, 59)
         return done, date_, time_, priority
 
     # @+node:tbrown.20110213153425.16377: *4* todoController.dueSort
@@ -1294,7 +1290,7 @@ class todoController:
 
         p = self.c.currentPosition()
         self.setat(p.v, 'priority', pri)
-        self.setat(p.v, 'prisetdate', str(datetime.date.today()))
+        self.setat(p.v, 'prisetdate', str(dt.datetime.now()))
         self.loadIcons(p)
 
     # @+node:tbrown.20090119215428.48: *4* todoController.showDist
@@ -1382,14 +1378,14 @@ class todoController:
         self.ui.setNextWorkDate(self.getat(v, 'nextworkdate'))
         self.ui.setNextWorkTime(self.getat(v, 'nextworktime'))
         created = self.getat(v, 'created')
-        if created and isinstance(created, datetime.datetime) and created.year >= 1900:
+        if created and isinstance(created, dt.datetime) and created.year >= 1900:
             self.ui.UI.createdTxt.setText(created.strftime("%d %b %y"))
             self.ui.UI.createdTxt.setToolTip(created.strftime("Created %H:%M %d %b %Y"))
         else:
             # .strftime doesn't work here! This has has happened...
             try:
                 gdate = self.c.p.v.gnx.split('.')[1][:12]
-                created = datetime.datetime.strptime(gdate, '%Y%m%d%H%M')
+                created = dt.datetime.strptime(gdate, '%Y%m%d%H%M')
                 if created.year < 1900:
                     created = None
             except Exception:
@@ -1403,9 +1399,10 @@ class todoController:
         # Update the label.
         h = self.c and self.c.p and self.c.p.h
         due = self.getat(v, 'duedate')
-        ago = (datetime.date.today() - created.date()).days if created else 0
+        g.trace(created)
+        ago = (dt.datetime.now() - created).days if created else 0
         if due:
-            days = (due - datetime.date.today()).days
+            days = (due - dt.datetime.now()).days
             txt = f"{h}\nCreated {ago} days ago, due in {days}"
         else:
             txt = f"{h}\nCreated {ago} days ago"

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -505,7 +505,7 @@ class todoController:
         """
         if not d.strip():
             return None  # Was ''
-        return dt.datetime.strptime(d.split('T')[0], "%Y-%m-%d").date()
+        return dt.datetime.strptime(d.split('T')[0], "%Y-%m-%d").date()  # noqa
 
     def _time(self, d: str) -> dt.time | None:
         """_time - convert a string to a time
@@ -515,7 +515,7 @@ class todoController:
         """
         if not d.strip():
             return None  # Was ''
-        return dt.datetime.strptime(d, "%H:%M:%S.%f").time()
+        return dt.datetime.strptime(d, "%H:%M:%S.%f").time()  # noqa
 
     # @+node:tbrown.20090630144958.5319: *3* todoController.addPopupMenu
     def addPopupMenu(self, c: Cmdr, p: Position, menu: Menu) -> None:
@@ -1385,7 +1385,7 @@ class todoController:
             # .strftime doesn't work here! This has has happened...
             try:
                 gdate = self.c.p.v.gnx.split('.')[1][:12]
-                created = dt.datetime.strptime(gdate, '%Y%m%d%H%M')
+                created = dt.datetime.strptime(gdate, '%Y%m%d%H%M')  # noqa
                 if created.year < 1900:
                     created = None
             except Exception:

--- a/ruff.toml
+++ b/ruff.toml
@@ -12,14 +12,6 @@
 [lint]
 ignore = [
 
-    # Deprecated functions. To do in a separate PR.
-    
-    ### "DTZ003",   # `datetime.datetime.utcnow()` used
-    ### "DTZ005",   # `datetime.datetime.now()` called without a `tz` argument
-    ### "DTZ006",   # `datetime.datetime.fromtimestamp()` called without a `tz` argument
-    ### "DTZ007",   # Naive datetime constructed using `datetime.datetime.strptime()` without %z
-    ### "DTZ011",   # `datetime.date.today()` used
-
     # New suppressions: Keep these for now.
     
     "B008",     # Do not perform function call in argument defaults

--- a/ruff.toml
+++ b/ruff.toml
@@ -12,8 +12,6 @@
 [lint]
 ignore = [
     # New errors. For now, just suppress them all.
-    
-    "DTZ003",   # `datetime.datetime.utcnow()` used
 
     "B003",     # Assigning to `os.environ` doesn't clear the environment
     "B005",     # Using `.strip()` with multi-character strings is misleading

--- a/ruff.toml
+++ b/ruff.toml
@@ -15,7 +15,6 @@ ignore = [
     
     "DTZ003",   # `datetime.datetime.utcnow()` used
     "DTZ005",   # `datetime.datetime.now()` called without a `tz` argument
-    "DTZ006",   # `datetime.datetime.fromtimestamp()` called without a `tz` argument
 
     "B003",     # Assigning to `os.environ` doesn't clear the environment
     "B005",     # Using `.strip()` with multi-character strings is misleading

--- a/ruff.toml
+++ b/ruff.toml
@@ -16,8 +16,6 @@ ignore = [
     "DTZ003",   # `datetime.datetime.utcnow()` used
     "DTZ005",   # `datetime.datetime.now()` called without a `tz` argument
     "DTZ006",   # `datetime.datetime.fromtimestamp()` called without a `tz` argument
-    "DTZ007",   # Naive datetime constructed using `datetime.datetime.strptime()` without %z
-    # "DTZ011",   # `datetime.date.today()` used
 
     "B003",     # Assigning to `os.environ` doesn't clear the environment
     "B005",     # Using `.strip()` with multi-character strings is misleading

--- a/ruff.toml
+++ b/ruff.toml
@@ -14,7 +14,6 @@ ignore = [
     # New errors. For now, just suppress them all.
     
     "DTZ003",   # `datetime.datetime.utcnow()` used
-    "DTZ005",   # `datetime.datetime.now()` called without a `tz` argument
 
     "B003",     # Assigning to `os.environ` doesn't clear the environment
     "B005",     # Using `.strip()` with multi-character strings is misleading

--- a/ruff.toml
+++ b/ruff.toml
@@ -12,6 +12,12 @@
 [lint]
 ignore = [
     # New errors. For now, just suppress them all.
+    
+    "DTZ003",   # `datetime.datetime.utcnow()` used
+    "DTZ005",   # `datetime.datetime.now()` called without a `tz` argument
+    "DTZ006",   # `datetime.datetime.fromtimestamp()` called without a `tz` argument
+    "DTZ007",   # Naive datetime constructed using `datetime.datetime.strptime()` without %z
+    # "DTZ011",   # `datetime.date.today()` used
 
     "B003",     # Assigning to `os.environ` doesn't clear the environment
     "B005",     # Using `.strip()` with multi-character strings is misleading
@@ -34,11 +40,7 @@ ignore = [
     "C413",     # Unnecessary `list()` call around `sorted()`
     "C414",     # Unnecessary `list()` call within `sorted()`
     "C417",     # Unnecessary `map()` usage (rewrite using a generator expression)
-    "DTZ003",   # `datetime.datetime.utcnow()` used
-    "DTZ005",   # `datetime.datetime.now()` called without a `tz` argument
-    "DTZ006",   # `datetime.datetime.fromtimestamp()` called without a `tz` argument
-    "DTZ007",   # Naive datetime constructed using `datetime.datetime.strptime()` without %z
-    "DTZ011",   # `datetime.date.today()` used
+
     "FLY002",   # Consider `f'{root.h}-->{p.h}'` instead of string join
     "FURB105",  # Unnecessary empty string passed to `print`
     "FURB122",  # Use of `f.write` in a for loop


### PR DESCRIPTION
See #4828.

- [x] ruff.toml: remove all date-related suppressions.
- [x] Change imports to `import datetime as dt` to follow documentation pages (and to refuse confusion!)
- [x] ` # PR #4829` marks significant code changes.