### PR TITLE
PR: test mypy developmental snapshot

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -14,9 +14,6 @@ ignore_missing_imports = True
 show_error_codes = True
 strict_optional = False
 
-# 2026/07/27: These appear to be serious mypy bugs.
-disable_error_code=index,arg-type
-
 # For v0.931, per https://github.com/python/mypy/issues/11936
 
 exclude =

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -16,7 +16,7 @@ strict_optional = False
 
 # Suppress a serious mypy bug until mypy releases an official fix.
 # Fixed in mypy 2.4.0+dev.869d6ef8b9e70ebb2f2c7a18d2ad2f70f2d49d06 (compiled: yes)
-disable_error_code=index
+# disable_error_code=index
 
 # For v0.931, per https://github.com/python/mypy/issues/11936
 

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -46,6 +46,7 @@ from leo.core.leoQt import Key, KeyboardModifier, Type
 if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
+    from QtCore import QKeyEvent
 
 
 # @+others
@@ -416,7 +417,7 @@ class LeoQtEventFilter(QtCore.QObject):
 
     # @+node:ekr.20140907103315.18767: *3* LeoQtEventFilter: Tracing
     # @+node:ekr.20190922075339.1: *4* LeoQtEventFilter.traceKeys
-    def traceKeys(self, obj: Any, event: LeoKeyEvent) -> None:
+    def traceKeys(self, obj: Any, event: QKeyEvent) -> None:
         if g.unitTesting:
             return
         e = QtCore.QEvent

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -2,8 +2,22 @@
 # @+node:ekr.20140907103315.18766: * @file ../plugins/qt_events.py
 """Leo's Qt event handling code."""
 
+# @+<< qt_events.py: imports & annotations >>
+# @+node:ekr.20260731163956.1: ** << qt_events.py: imports & annotations >>
 from __future__ import annotations
 
+import sys
+from typing import Any, TYPE_CHECKING
+from leo.core import leoGlobals as g
+from leo.core import leoGui
+from leo.core.leoQt import QtCore, QtGui, QtWidgets
+from leo.core.leoQt import Key, KeyboardModifier, Type
+
+if TYPE_CHECKING:
+    from leo.core.leoCommands import Commands as Cmdr
+    from leo.core.leoGui import LeoKeyEvent
+    from QtCore import QKeyEvent
+# @-<< qt_events.py: imports & annotations >>
 # @+<< about internal bindings >>
 # @+node:ekr.20110605121601.18538: ** << about internal bindings >>
 # @@language rest
@@ -36,17 +50,6 @@ from __future__ import annotations
 # with Tk's key-event specifiers). It is also, I think, the least confusing set of
 # rules.
 # @-<< about internal bindings >>
-import sys
-from typing import Any, TYPE_CHECKING
-from leo.core import leoGlobals as g
-from leo.core import leoGui
-from leo.core.leoQt import QtCore, QtGui, QtWidgets
-from leo.core.leoQt import Key, KeyboardModifier, Type
-
-if TYPE_CHECKING:
-    from leo.core.leoCommands import Commands as Cmdr
-    from leo.core.leoGui import LeoKeyEvent
-    from QtCore import QKeyEvent
 
 
 # @+others

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -427,7 +427,7 @@ class LeoQtEventFilter(QtCore.QObject):
             e.Type.Shortcut: 'shortcut',  # 117
             e.Type.ShortcutOverride: 'shortcut-override',  # 51
         }
-        if kind := key_events.get(event.type()):  # type:ignore
+        if kind := key_events.get(event.type()):
             mods = ','.join(self.qtMods(event))
             g.trace(f"{kind:>20}: {mods:>7} {event.text()!r}")
 


### PR DESCRIPTION
This PR confirms that mypy issue [#21777](https://github.com/python/mypy/issues/21777) works as expected.

- [x] Install mypy 2.4.0+dev.869d6ef8b9e70ebb2f2c7a18d2ad2f70f2d49d06 (compiled: yes) from the corresponding wheel file.
- [x] .mypy.toml: Remove emergency suppression.
- [x] Fix the in qt_text.py as reported by the daily snapshot.
    This fix no longer appears in the diff. It is now part of "devel"

## This PR is moot

Leo no longer uses mypy.