### PR TITLE
Add non-blocking ty (astral-sh) check job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,20 @@ jobs:
           cache: pip
       - run: pip install ruff
       - run: ruff check leo
+
+  # Informational only: ty (https://github.com/astral-sh/ty) is an
+  # actively-developed, much faster alternative to mypy, still in beta.
+  # It's noticeably stricter than our current mypy config in some areas
+  # (see ty.toml), so this job is not allowed to fail the build -- it's
+  # here so its findings show up in PR logs while we evaluate it.
+  ty:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: pip install ty PyQt6 PyQt6-QScintilla
+      - run: ty check --python "$(python -c 'import sys; print(sys.prefix)')" leo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,22 +33,14 @@ jobs:
       - run: pip install "mypy<2" mypy-extensions typing_extensions
           types-docutils types-Markdown types-paramiko types-PyYAML
           types-requests types-six
-          "PyQt6>=6.6" PyQt6-QScintilla PyQt6-WebEngine
+          "PyQt6>=6.6" PyQt6-QScintilla PyQt6-WebEngine ty
       - run: python -m mypy leo
-
-  # Informational only: ty (https://github.com/astral-sh/ty) is an
-  # actively-developed, much faster alternative to mypy, still in beta.
-  # It's noticeably stricter than our current mypy config in some areas
-  # (see ty.toml), so this job is not allowed to fail the build -- it's
-  # here so its findings show up in PR logs while we evaluate it.
-  ty:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: pip
-      - run: pip install ty PyQt6 PyQt6-QScintilla
+      # Informational only: ty (https://github.com/astral-sh/ty) is an
+      # actively-developed, much faster alternative to mypy, still in beta.
+      # It's noticeably stricter than our current mypy config in some areas
+      # (see ty.toml), so this step is not allowed to fail the build --
+      # it's here so its findings show up in PR logs while we evaluate it.
+      # Runs in this job, after mypy, to reuse the same checkout/Python/PyQt6
+      # setup instead of paying for a second one.
       - run: ty check --python "$(python -c 'import sys; print(sys.prefix)')" leo
+        continue-on-error: true

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -34,7 +34,7 @@ except Exception:
 try:
     from pylint import lint
 except Exception:
-    lint = None
+    lint = None  # type:ignore
 
 # Leo imports.
 from leo.core import leoGlobals as g

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -23,18 +23,18 @@ except Exception:
 try:
     import flake8  # #2248: Import only flake8.
 except ImportError:
-    flake8 = None  # type:ignore
+    flake8 = None
 
 try:
     import pyflakes
     from pyflakes import api, reporter
 except Exception:
-    pyflakes = None  # type:ignore
+    pyflakes = None
 
 try:
     from pylint import lint
 except Exception:
-    lint = None  # type:ignore
+    lint = None
 
 # Leo imports.
 from leo.core import leoGlobals as g

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -2560,7 +2560,7 @@ class EditCommandsClass(BaseEditCommandsClass):
                     n = min(self.moveCol, max(0, len(line) - 1))
                 else:
                     n = min(self.moveCol, max(0, len(line)))  # A tricky boundary.
-                spot = g.convertRowColToPythonIndex(s, row, n)  # type:ignore
+                spot = g.convertRowColToPythonIndex(s, row, n)
             else:  # Plain move forward or back.
                 self.setMoveCol(w, spot)  # sets self.moveSpot.
         if extend:

--- a/leo/core/leoBeautify.py
+++ b/leo/core/leoBeautify.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 try:
     import black
 except Exception:
-    black = None  # type:ignore
+    black = None
 
 # Leo imports.
 from leo.core import leoGlobals as g

--- a/leo/core/leoBeautify.py
+++ b/leo/core/leoBeautify.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 try:
     import black
 except Exception:
-    black = None
+    black = None  # type:ignore
 
 # Leo imports.
 from leo.core import leoGlobals as g

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -3742,7 +3742,7 @@ class QScintillaColorizer(BaseColorizer):
         if aList:
             for z in [s.split(',') for s in aList]:  # #4753
                 if len(z) == 2:
-                    color, style = z  # type:ignore
+                    color, style = z
                     table.append((color.strip(), style.strip()))
                 else:
                     g.trace(f"entry: {z}")

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -555,7 +555,7 @@ class Commands:
         if not c.gui.isNullGui and not g.unitTesting:
             # #2485: register idle_focus_helper in the proper context.
             assert g.app.pluginsController
-            try:  # type:ignore
+            try:
                 g.app.pluginsController.loadingModuleNameStack.append('leo.core.leoCommands')
                 g.registerHandler('idle', c.idle_focus_helper)
             finally:
@@ -1264,7 +1264,7 @@ class Commands:
         except Exception:
             g.handleScriptException(c, p)
         finally:
-            del sys.path[:2]  # type:ignore
+            del sys.path[:2]
 
     # @+node:ekr.20171123135625.4: *4* @cmd execute-script & public helpers
     @cmd('execute-script')
@@ -3181,7 +3181,7 @@ class Commands:
         aList = g.get_directives_dict_list(p)
         d: dict[str, Value] = {}
         for key, default, func in table:
-            val = func(aList)  # type:ignore
+            val = func(aList)
             d[key] = default if val is None else val
 
         # Post process: do *not* set commander ivars.

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1507,7 +1507,7 @@ class GlobalConfigManager:
         """Return the value of @float setting."""
         val = self.get(setting, "float")
         try:
-            return float(val)  # type:ignore
+            return float(val)
         except TypeError:
             return None
 
@@ -1547,7 +1547,7 @@ class GlobalConfigManager:
         """Return the value of @int setting."""
         val = self.get(setting, "int")
         try:
-            return int(val)  # type:ignore
+            return int(val)
         except TypeError:
             return None
 
@@ -1576,7 +1576,7 @@ class GlobalConfigManager:
         """
         val = self.get(setting, "ratio")
         try:
-            val_f = float(val)  # type:ignore
+            val_f = float(val)
             if 0.0 <= val_f <= 1.0:
                 return val_f
         except TypeError:
@@ -1886,7 +1886,7 @@ class LocalConfigManager:
         """Return the value of @float setting."""
         val = self.get(setting, "float")
         try:
-            return float(val)  # type:ignore
+            return float(val)
         except TypeError:
             return None
 
@@ -1926,7 +1926,7 @@ class LocalConfigManager:
         """Return the value of @int setting."""
         val = self.get(setting, "int")
         try:
-            return int(val)  # type:ignore
+            return int(val)
         except TypeError:
             return None
 

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -265,7 +265,7 @@ class LeoFrame:
         self.tree: LeoTree | NullTree | LeoQtTree
 
         # Add required inits.
-        self.menu = None  # type:ignore
+        self.menu = None
         self.miniBufferWidget = None  # type:ignore
         self.top = None  # type:ignore
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -626,7 +626,7 @@ def new_cmd_decorator(name: str, ivars: list[str]) -> Callable:
                 c = event.get('c')
             else:
                 c = event.c
-            self = g.ivars2instance(c, g, ivars)  # type:ignore
+            self = g.ivars2instance(c, g, ivars)
             try:
                 # Don't use a keyword for self.
                 # This allows the VimCommands class to use vc instead.

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -2457,7 +2457,7 @@ class ZimImportController:
             # mypy: error: "str" has no attribute "decode"; maybe "encode"?  [attr-defined]
             path = [
                 g.os_path_abspath(g.os_path_join(pathToZim, unquote(result[2]).decode('utf-8')))
-            ]  # type:ignore
+            ]
             results.append((level, name, path))
         return results
 

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -278,7 +278,7 @@ class Position:
         # PR #4767 correctly annotates self.v as VNode | None.
         # The "big little lie": p.v will *almost always* be a valid VNode.
 
-        self.v: VNode = v  # type:ignore # The big little lie.
+        self.v: VNode = v  # The big little lie.
 
         # Stack entries are tuples (v, childIndex).
         if stack:
@@ -2914,7 +2914,7 @@ class VNode:
             v._headString = s.replace('\n', '')
         else:  # pragma: no cover
             s = g.toUnicode(s, reportErrors=True)
-            v._headString = s.replace('\n', '')  # type:ignore
+            v._headString = s.replace('\n', '')
             self.contentModified()  # #1413.
         # #4394: Clear the the mod_time.
         if '_mod_time' in v.u:

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -418,8 +418,8 @@ class LeoPluginsController:
         for tag in self.handlers:
             bunches = self.handlers.get(tag, [])
             for bunch in bunches:
-                fn = bunch.fn  # type:ignore
-                name = bunch.moduleName  # type:ignore
+                fn = bunch.fn
+                name = bunch.moduleName
                 tags = modules_d.get(name, [])
                 tags.append(tag)
                 key = f"{name}.{fn.__name__}"

--- a/leo/plugins/attrib_edit.py
+++ b/leo/plugins/attrib_edit.py
@@ -448,7 +448,7 @@ AttributeGetter.register(AttributeGetterColon)
 
 
 # @+node:tbrown.20091028131637.1353: ** class ListDialog
-class ListDialog(QtWidgets.QDialog):  # type:ignore
+class ListDialog(QtWidgets.QDialog):
     # @+others
     # @+node:tbrown.20091028131637.1354: *3* __init__ (attrib_edit.py)
     def __init__(self, parent, title, text, entries):

--- a/leo/plugins/backlink.py
+++ b/leo/plugins/backlink.py
@@ -716,7 +716,7 @@ class backlinkController:
 # @+node:ekr.20090616105756.3939: ** class backlinkQtUI
 if QtWidgets:
 
-    class backlinkQtUI(QtWidgets.QWidget):  # type:ignore
+    class backlinkQtUI(QtWidgets.QWidget):
         # @+others
         # @+node:ekr.20140920145803.17987: *3* bc.__init__
         def __init__(self, owner):

--- a/leo/plugins/bigdash.py
+++ b/leo/plugins/bigdash.py
@@ -404,7 +404,7 @@ class GlobalSearch:
 
 
 # @+node:ekr.20140919160020.17920: ** class LeoConnector
-class LeoConnector(QtCore.QObject):  # type:ignore
+class LeoConnector(QtCore.QObject):
     pass
 
 

--- a/leo/plugins/bookmarks.py
+++ b/leo/plugins/bookmarks.py
@@ -502,7 +502,7 @@ def cmd_use_other_outline(event):
 
 
 # @+node:ekr.20140917180536.17896: ** class FlowLayout (QLayout)
-class FlowLayout(QtWidgets.QLayout):  # type:ignore
+class FlowLayout(QtWidgets.QLayout):
     """
     from http://ftp.ics.uci.edu/pub/centos0/ics-custom-build/BUILD/
     PyQt-x11-gpl-4.7.2/examples/layouts/flowlayout.py

--- a/leo/plugins/contextmenu.py
+++ b/leo/plugins/contextmenu.py
@@ -392,7 +392,7 @@ def openatleo_rclick(c: Cmdr, p: Position, menu: LeoQtMenu) -> None:
     def openatleo_rclick_cb() -> None:
         path = c.fullPath(p)
         if g.os_path_exists(path):
-            g.openWithFileName(path, old_c=c)  # type:ignore
+            g.openWithFileName(path, old_c=c)
         else:
             g.red(f"file not found: {path}")
 

--- a/leo/plugins/demo.py
+++ b/leo/plugins/demo.py
@@ -842,7 +842,7 @@ class Callout(Label):
 
 
 # @+node:ekr.20170208065111.1: *3* class Image (QLabel)
-class Image(QtWidgets.QLabel):  # type:ignore
+class Image(QtWidgets.QLabel):
     def __init__(self, fn, pane=None, magnification=None, position=None, size=None):
         """Image.__init__."""
         demo, w = g.app.demo, self
@@ -891,7 +891,7 @@ class Image(QtWidgets.QLabel):  # type:ignore
 
 
 # @+node:ekr.20170208095240.1: *3* class Text (QPlainTextEdit)
-class Text(QtWidgets.QPlainTextEdit):  # type:ignore
+class Text(QtWidgets.QPlainTextEdit):
     def __init__(self, text, font=None, pane=None, position=None, size=None, stylesheet=None):
         """Pop up a QPlainTextEdit in the indicated pane."""
         demo, w = g.app.demo, self

--- a/leo/plugins/graphcanvas.py
+++ b/leo/plugins/graphcanvas.py
@@ -126,7 +126,7 @@ def toggle_autoload(event):
 
 
 # @+node:bob.20110119123023.7395: ** class graphcanvasUI
-class graphcanvasUI(QtWidgets.QWidget):  # type:ignore
+class graphcanvasUI(QtWidgets.QWidget):
     # @+others
     # @+node:bob.20110119123023.7396: *3* __init__
     def __init__(self, owner=None):
@@ -199,7 +199,7 @@ class graphcanvasUI(QtWidgets.QWidget):  # type:ignore
 
 
 # @+node:bob.20110119123023.7397: ** class GraphicsView
-class GraphicsView(QtWidgets.QGraphicsView):  # type:ignore
+class GraphicsView(QtWidgets.QGraphicsView):
     # @+others
     # @+node:bob.20110119123023.7398: *3* __init__
     def __init__(self, glue, *args, **kargs):
@@ -305,7 +305,7 @@ class GetImage:
 
 
 # @+node:tbrown.20110407091036.17531: ** class nodeBase
-class nodeBase(QtWidgets.QGraphicsItemGroup):  # type:ignore
+class nodeBase(QtWidgets.QGraphicsItemGroup):
     node_types: dict[str, Any] = {}
 
     @classmethod
@@ -618,7 +618,7 @@ nodeBase.node_types[nodeImage.__name__] = nodeImage
 
 
 # @+node:bob.20110121161547.3424: ** class linkItem
-class linkItem(QtWidgets.QGraphicsItemGroup):  # type:ignore
+class linkItem(QtWidgets.QGraphicsItemGroup):
     """Node on the canvas"""
 
     # @+others

--- a/leo/plugins/history_tracer.py
+++ b/leo/plugins/history_tracer.py
@@ -69,7 +69,7 @@ def c12_hook(tag, keys):
 def init_idle_checker(tag, keys):
     global idle_checker
 
-    class IdleChecker(QtCore.QObject):  # type:ignore
+    class IdleChecker(QtCore.QObject):
         def __init__(self):
             QtCore.QObject.__init__(self)
             self._tid = self.startTimer(5000)

--- a/leo/plugins/import_cisco_config.py
+++ b/leo/plugins/import_cisco_config.py
@@ -81,7 +81,7 @@ def importCiscoConfig(c):
     c.redraw()
 
     try:
-        fh = open(name)  # type:ignore
+        fh = open(name)
         g.es("importing: %s" % name)
         linelist = fh.read().splitlines()
         fh.close()

--- a/leo/plugins/leo_babel/babel_lib.py
+++ b/leo/plugins/leo_babel/babel_lib.py
@@ -315,7 +315,7 @@ class MenuPopUp(QtWidgets.QMenu):
     # @+node:bob.20170726143458.13: *3* _info()
     def _info(self, what):
         QtWidgets.QMessageBox.information(self, 'Information Only', what)
-        self.exec_(QtWidgets.QApplication.desktop().screen().rect().center() - self.rect().center())  # type:ignore
+        self.exec_(QtWidgets.QApplication.desktop().screen().rect().center() - self.rect().center())
 
     # @-others
 

--- a/leo/plugins/leo_babel/tests/tests.py
+++ b/leo/plugins/leo_babel/tests/tests.py
@@ -97,7 +97,7 @@ def main():
     itPoll = leoG.IdleTime(
         (
             lambda itRunTests: lib_test.runTests(
-                itRunTests,  # type:ignore
+                itRunTests,
                 cmdrT,
                 fdR,
                 testCmdr,

--- a/leo/plugins/leoscreen.py
+++ b/leo/plugins/leoscreen.py
@@ -412,7 +412,7 @@ class leoscreen_Controller:
             [('CURRENT: ' if i == self.use_screen else '') + i, False, i]
             for i in out.split('\n')
             if i.startswith('\t')
-        ]  # type:ignore
+        ]
 
         ld = ListDialog(None, 'Pick screen', 'Pick screen', screens)
         ld.exec()

--- a/leo/plugins/nodetags.py
+++ b/leo/plugins/nodetags.py
@@ -281,7 +281,7 @@ class TagController:
 # @+node:peckj.20140804114520.15199: ** class LeoTagWidget
 if QtWidgets:
 
-    class LeoTagWidget(QtWidgets.QWidget):  # type:ignore
+    class LeoTagWidget(QtWidgets.QWidget):
         # @+others
         # @+node:peckj.20140804114520.15200: *3* tag_w.__init__
         def __init__(self, c: Cmdr, parent: QtWidgets.QWidget = None) -> None:

--- a/leo/plugins/nodewatch.py
+++ b/leo/plugins/nodewatch.py
@@ -153,7 +153,7 @@ class NodewatchController:
 
 
 # @+node:peckj.20131101132841.6451: ** class LeoNodewatchWidget
-class LeoNodewatchWidget(QtWidgets.QWidget):  # type:ignore
+class LeoNodewatchWidget(QtWidgets.QWidget):
     # @+others
     # @+node:peckj.20131101132841.6454: *3* __init__
     def __init__(self, c, parent=None):

--- a/leo/plugins/projectwizard.py
+++ b/leo/plugins/projectwizard.py
@@ -94,7 +94,7 @@ def project_wizard(event):
         ("Python files", "*.py"),
     ]
     fname = g.app.gui.runOpenFileDialog(c, title="Open", filetypes=filetypes)
-    pth = os.path.dirname(os.path.abspath(fname))  # type:ignore
+    pth = os.path.dirname(os.path.abspath(fname))
     g.es(pth)
     tgt = c.currentPosition().insertAsLastChild()
     c.selectPosition(tgt)

--- a/leo/plugins/python_terminal.py
+++ b/leo/plugins/python_terminal.py
@@ -73,7 +73,7 @@ g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.
 
 # @+others
 # @+node:peckj.20150428142729.3: ** class MyInterpreter
-class MyInterpreter(QtWidgets.QWidget):  # type:ignore
+class MyInterpreter(QtWidgets.QWidget):
     def __init__(self, parent, c):
         super().__init__(parent)
         hBox = QtWidgets.QHBoxLayout()
@@ -110,7 +110,7 @@ class InteractiveInterpreter(code.InteractiveInterpreter):
 # @+node:peckj.20150428142729.5: ** class PyInterp (QTextEdit)
 if QtWidgets:
 
-    class PyInterp(QtWidgets.QTextEdit):  # type:ignore
+    class PyInterp(QtWidgets.QTextEdit):
         # @+others
         # @+node:peckj.20150428142729.9: *3* PyInterp.__init__
         def __init__(self, parent, c):
@@ -257,7 +257,7 @@ if QtWidgets:
                 # #1212: Disable this by default.
                 if use_rlcompleter and event.key() == Key.Key_Tab:
                     line = str(self.document().lastBlock().text())[4:]
-                    completer = Completer(self.interpreter.locals)  # type:ignore
+                    completer = Completer(self.interpreter.locals)
                     suggestion = completer.complete(line, 0)
                     if suggestion is not None:
                         self.insertPlainText(suggestion[len(line) :])
@@ -421,8 +421,8 @@ if QtWidgets:
         def focusInEvent(self, event=None):
             # set stdout+stderr properly
             QtWidgets.QTextEdit.focusInEvent(self, event)
-            sys.stdout = self  # type:ignore
-            sys.stderr = self  # type:ignore
+            sys.stdout = self
+            sys.stderr = self
             self.ensureCursorVisible()
 
         # @+node:peckj.20150428142729.21: *3* PyInterp.focusOutEvent

--- a/leo/plugins/qt_commands.py
+++ b/leo/plugins/qt_commands.py
@@ -117,7 +117,7 @@ def showColorNames(event: LeoKeyEvent | None = None) -> None:
             sheet = template % (color, color)
             box.setStyleSheet(sheet)
             g.es("copied to clipboard:", color)
-            QtWidgets.QApplication.clipboard().setText(color)  # type:ignore
+            QtWidgets.QApplication.clipboard().setText(color)
 
         box.activated.connect(onActivated)
         color_db = leoColor.leo_color_database
@@ -147,7 +147,7 @@ def showColorWheel(self: Any, event: LeoKeyEvent | None = None) -> None:
     picker = QtWidgets.QColorDialog()
     in_color_setting = p.h.startswith('@color ')
     try:
-        text = QtWidgets.QApplication.clipboard().text()  # type:ignore
+        text = QtWidgets.QApplication.clipboard().text()
         if in_color_setting:
             text = p.h.split('=', 1)[1].strip()
         color = QtGui.QColor(text)
@@ -165,7 +165,7 @@ def showColorWheel(self: Any, event: LeoKeyEvent | None = None) -> None:
     else:
         text = picker.selectedColor().name()
         g.es("copied to clipboard:", text)
-        QtWidgets.QApplication.clipboard().setText(text)  # type:ignore
+        QtWidgets.QApplication.clipboard().setText(text)
 
 
 # @+node:ekr.20170324143944.3: ** qt: show-fonts

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -976,9 +976,9 @@ class DynamicWindow(QtWidgets.QMainWindow):
             """In case user has hidden minibuffer with gui-minibuffer-hide"""
 
             def focusInEvent(self, event: QFocusEvent) -> None:  # type:ignore[override]
-                self.parent().show()  # type:ignore
+                self.parent().show()
                 # Call the base class method.
-                super().focusInEvent(event)  # type:ignore
+                super().focusInEvent(event)
 
             def focusOutEvent(self, event: QFocusEvent) -> None:  # type:ignore[override]
                 self.store_selection()
@@ -1103,8 +1103,8 @@ class DynamicWindow(QtWidgets.QMainWindow):
             n = c.frame.body.numberOfEditors
         n = max(0, n - 1)
         # mypy error: grid is a QGridLayout, not a QLayout.
-        grid.addWidget(label, 0, n)  # type:ignore
-        grid.addWidget(w, 1, n)  # type:ignore
+        grid.addWidget(label, 0, n)
+        grid.addWidget(w, 1, n)
         grid.setRowStretch(0, 0)  # Don't grow the label vertically.
         grid.setRowStretch(1, 1)  # Give row 1 as much as vertical room as possible.
         # Inject the ivar.
@@ -1347,7 +1347,7 @@ class FindTabManager:
             ('suboutline_only', 'suboutline_only', self.radio_button_suboutline_only),
             ('file_only',       'file_only',       self.radio_button_file_only),
         )  # fmt: skip
-        for setting_name, ivar, radio_button_w in radio_buttons_table:  # type:ignore
+        for setting_name, ivar, radio_button_w in radio_buttons_table:
             val = c.config.getBool(setting_name, default=False)
             # The setting name is also the name of the LeoFind ivar.
             if ivar is not None:
@@ -4483,7 +4483,7 @@ class TabbedFrameFactory:
         del self.leoFrames[dw]
         if dw2 := tabw.currentWidget():
             g.app.selectLeoWindow(dw2.leo_c)
-        tabw.tabBar().setVisible(self.alwaysShowTabs or tabw.count() > 1)  # type:ignore
+        tabw.tabBar().setVisible(self.alwaysShowTabs or tabw.count() > 1)
 
     # @+node:ekr.20110605121601.18471: *3* TabbedFrameFactory.focusCurrentBody
     def focusCurrentBody(self) -> None:
@@ -4784,7 +4784,7 @@ def toggleMinibuffer(event: LeoKeyEvent | None = None) -> None:
         dw = c.frame.top
         w = dw.leo_minibuffer_frame
         if w.isVisible():
-            w.hide()  # type:ignore
+            w.hide()
         else:
             w.show()
 

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -254,9 +254,9 @@ def swapLogPanel(event: LeoKeyEvent | None = None) -> None:
         return
     gui = g.app.gui
 
-    ms = gui.find_widget_by_name(c, 'main_splitter')  # type: ignore
-    ss = gui.find_widget_by_name(c, 'secondary_splitter')  # type: ignore
-    lf = gui.find_widget_by_name(c, 'logFrame')  # type: ignore
+    ms = gui.find_widget_by_name(c, 'main_splitter')
+    ss = gui.find_widget_by_name(c, 'secondary_splitter')
+    lf = gui.find_widget_by_name(c, 'logFrame')
 
     lf_parent = lf.parent()
     lf_parent_container = lf_parent.parent()
@@ -275,7 +275,7 @@ def swapLogPanel(event: LeoKeyEvent | None = None) -> None:
 
     if widget is not None:
         target.addWidget(widget)
-        gui.equalize_splitter(target)  # type: ignore
+        gui.equalize_splitter(target)
 
 
 # @+node:ekr.20241008175137.1: *3* command: 'layout-vertical-thirds'
@@ -705,7 +705,7 @@ class LayoutCacheWidget(QWidget):
         # and add it to self.created_splitter_dict.
         splitter: Any
         for _, name in SPLITTERS.items():
-            splitter = self.find_splitter_by_name(name)  # type:ignore
+            splitter = self.find_splitter_by_name(name)
             if splitter is None:
                 splitter = QSplitter(self)
                 splitter.setObjectName(name)
@@ -766,7 +766,7 @@ class LayoutCacheWidget(QWidget):
         # {'main_splitter':Orientation.Horizontal...}
 
         for splitter_name, splitter in SPLITTER_DICT.items():
-            orientation = ORIENTATIONS[splitter_name]  # type:ignore
+            orientation = ORIENTATIONS[splitter_name]
             splitter.setOrientation(orientation)
         # @-<< set default orientations >>
         # @+<< move widgets to targets >>

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -65,7 +65,7 @@ class LeoQtTree(leoFrame.LeoTree):
         self.reloadSettings()
         # Components...
         self.canvas = self  # Required! An official ivar used by Leo's core.
-        self.treeWidget: LeoQTreeWidget = frame.top.treeWidget  # type:ignore
+        self.treeWidget: LeoQTreeWidget = frame.top.treeWidget
         w = self.treeWidget
         # Declutter data...
         # list of pairs of patterns for decluttering

--- a/leo/plugins/quickMove.py
+++ b/leo/plugins/quickMove.py
@@ -426,7 +426,7 @@ class quickMove:
                 ]:
                     but = b.button
                     rc = QAction(txt, but)
-                    rc.triggered.connect(cb)  # type:ignore
+                    rc.triggered.connect(cb)
                     # insert rc before Remove Button
                     but.insertAction(but.actions()[-1], rc)
 

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -267,7 +267,7 @@ def show_unittest_failures(event: LeoKeyEvent) -> None:
 
 
 # @+node:ekr.20111015194452.15716: ** class QuickSearchEventFilter (QObject)
-class QuickSearchEventFilter(QtCore.QObject):  # type:ignore
+class QuickSearchEventFilter(QtCore.QObject):
     # @+others
     # @+node:ekr.20111015194452.15718: *3* quick_ev.ctor
     def __init__(self, c: Cmdr, w: QListWidget, lineedit: Any) -> None:
@@ -307,7 +307,7 @@ class QuickSearchEventFilter(QtCore.QObject):  # type:ignore
 
 
 # @+node:ville.20090314215508.2: ** class LeoQuickSearchWidget (QWidget)
-class LeoQuickSearchWidget(QtWidgets.QWidget):  # type:ignore
+class LeoQuickSearchWidget(QtWidgets.QWidget):
     """'Find in files'/grep style search widget"""
 
     # @+others

--- a/leo/plugins/read_only_nodes.py
+++ b/leo/plugins/read_only_nodes.py
@@ -158,7 +158,7 @@ class FTPurl:
         try:
             if self.mode == '':  # mode='': ASCII mode
                 slist: list = []
-                self.ftp.retrlines('RETR %s' % self.path, slist.append)  # type:ignore
+                self.ftp.retrlines('RETR %s' % self.path, slist.append)
                 s = '\n'.join(slist)
             else:  # mode='b': binary mode
                 file = StringIO()

--- a/leo/plugins/richtext.py
+++ b/leo/plugins/richtext.py
@@ -95,7 +95,7 @@ def init():
 
 
 # @+node:tbrown.20130813134319.5691: ** class CKEEditor
-class CKEEditor(QtWidgets.QWidget):  # type:ignore
+class CKEEditor(QtWidgets.QWidget):
     # @+others
     # @+node:tbrown.20130813134319.7225: *3* __init__ & reloadSettings (CKEEditor)
     def __init__(self, *args, **kwargs):

--- a/leo/plugins/threadutil.py
+++ b/leo/plugins/threadutil.py
@@ -146,7 +146,7 @@ class NowOrLater:
 
 
 # @+node:ekr.20121126095734.12427: ** class Repeater
-class Repeater(QtCore.QThread):  # type:ignore
+class Repeater(QtCore.QThread):
     """execute f forever, signal on every run"""
 
     fragment = QtCore.pyqtSignal(object)
@@ -180,7 +180,7 @@ class Repeater(QtCore.QThread):  # type:ignore
 
 
 # @+node:ekr.20121126095734.12424: ** class RRunner
-class RRunner(QtCore.QThread):  # type:ignore
+class RRunner(QtCore.QThread):
     # @+others
     # @+node:ekr.20121126095734.12425: *3* __init__
     def __init__(self, f, parent=None):
@@ -268,7 +268,7 @@ class ThreadQueue:
 
 
 # @+node:ekr.20121126095734.12436: ** class UnitWorker
-class UnitWorker(QtCore.QThread):  # type:ignore
+class UnitWorker(QtCore.QThread):
     """Work on one work item at a time, start new one when it's done"""
 
     resultReady = QtCore.pyqtSignal()

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -132,7 +132,7 @@ def popup_entry(c: Cmdr, p: Position, menu: Menu) -> None:
 # @+node:tbrown.20090119215428.8: ** class todoQtUI(QWidget)
 if g.app.gui.guiName() == "qt":
 
-    class todoQtUI(QtWidgets.QWidget):  # type:ignore
+    class todoQtUI(QtWidgets.QWidget):
         # @+others
         # @+node:ekr.20111118104929.10204: *3* ctor (todoQtUI(QWidget))
         def __init__(self, owner: Any, logTab: bool = True) -> None:
@@ -600,7 +600,7 @@ class todoController:
         """decorator for methods which change projects"""
 
         # pylint: disable=no-self-argument
-        def project_changer_callback(self, *args: Args, **kargs: Any) -> Any:  # type:ignore
+        def project_changer_callback(self, *args: Args, **kargs: Any) -> Any:
             ans = fn(self, *args, **kargs)  # pylint: disable=not-callable
             self.update_project()
             return ans

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -252,7 +252,7 @@ else:
 try:
     from jinja2 import Template
 except ImportError:
-    Template = None  # type:ignore
+    Template = None
 
 # Markdown.
 try:
@@ -260,7 +260,7 @@ try:
 
     got_markdown = True
 except ImportError:
-    got_markdown = False  # type:ignore
+    got_markdown = False
 
 # nbformat (@jupyter) support.
 try:

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -252,7 +252,7 @@ else:
 try:
     from jinja2 import Template
 except ImportError:
-    Template = None
+    Template = None  # type:ignore
 
 # Markdown.
 try:

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -25,7 +25,8 @@ os.chdir(leo_editor_dir)
 # @-<< mypy_leo.py: imports & startup >>
 
 python = sys.executable
-command = rf"{python} -m mypy leo"
+args = ''.join(sys.argv[1:])
+command = rf"{python} -m mypy {args} leo"
 subprocess.Popen(command, shell=True).communicate()
 
 # @@language python

--- a/ty.toml
+++ b/ty.toml
@@ -1,0 +1,44 @@
+# Config for `ty` (https://github.com/astral-sh/ty), run as a second,
+# non-blocking type checker alongside mypy (see .mypy.ini).
+#
+# ty is still in beta, and is noticeably stricter than mypy's current
+# config in a few areas (Optional handling, PyQt override signatures).
+# This job is informational only -- see the "ty" job in
+# .github/workflows/ci.yml -- so this file intentionally does not try
+# to fully silence those findings, just the one pattern that's a
+# deliberate, accepted part of Leo's architecture.
+
+[src]
+include = ["leo"]
+exclude = [
+    # Mirrors the [mypy] exclude list in .mypy.ini.
+    "leo/doc",
+    "leo/dist",
+    "leo/editpane",
+    "leo/examples",
+    "leo/extensions",
+    "leo/external",
+    "leo/modes",
+    "leo/plugins/obsolete",
+    "leo/scripts",
+    "leo/themes",
+    "leo/unittests",
+    "leo/www",
+    "leo/plugins/freewin.py",
+    "leo/test/scriptFile.py",
+    "leo/plugins/beautify_node.py",
+    "leo/plugins/viewrendered3*",
+    "leo/plugins/leo_pdf*",
+    "leo/plugins/leo_to_rtf*",
+    "leo/plugins/mnplugins*",
+    "leo/plugins/mod_speedups*",
+    "leo/plugins/settings_finder*",
+    "leo/plugins/stickynotes_plus*",
+    "leo/plugins/qt_main*",
+]
+
+[rules]
+# Leo assigns attributes dynamically outside __init__ throughout
+# leo/core, leo/commands, leo/plugins, leo/modes, leo/external -- the
+# same reason .mypy.ini disables `attr-defined` for those packages.
+unresolved-attribute = "ignore"


### PR DESCRIPTION
## Summary

Stacked on #4830 (which restores `ci.yml`) — this PR's diff includes that one's
two commits until #4830 merges; the new commits here are "Add non-blocking ty
check job to CI", "Remove type:ignore comments confirmed dead by both mypy
and ty", and "Merge ty check into the mypy job as a second step".

Adds a second, **non-blocking** (`continue-on-error: true`) check that runs
[`ty`](https://github.com/astral-sh/ty), Astral's Rust type checker, alongside
the existing mypy setup — purely to make its findings visible in PR logs while
we evaluate it, without gating merges on it.

### Why evaluate `ty`
- ~10x faster than mypy in local testing on this repo (0.6-0.7s vs ~7-10s,
  warm cache, same file scope).
- With real deps installed (PyQt6), mypy is currently 0-error clean; `ty`
  still surfaces real findings mypy's config doesn't check for — mainly
  legacy implicit-`Optional` parameters (`.mypy.ini` sets
  `strict_optional = False` by default) and Qt method overrides with
  incompatible signatures (mypy skips override-compatibility checks for
  unannotated parameters; `ty` infers the expected type from the PyQt6 stub
  and checks anyway).
- Still beta (`Development Status :: 4 - Beta`, versioning weekly) and
  noticeably stricter than mypy's current config in places — not something to
  gate merges on yet, hence `continue-on-error`.

## Changes
- `.github/workflows/ci.yml`: `ty` runs as a second step in the `mypy` job
  (not a separate job) — both need essentially the same environment (Python
  3.12 + PyQt6), so this reuses the `mypy` job's checkout/setup/install
  instead of paying for a second one, which was the dominant cost of either
  job. The `ty` step has its own `continue-on-error: true`, which works the
  same at step level as at job level, so it still can't fail the build.
- `ty.toml`: mirrors `.mypy.ini`'s `exclude` list for the same file scope, and
  suppresses `unresolved-attribute` (ty's `attr-defined` equivalent) to match
  the existing suppression for Leo's dynamically-assigned attributes across
  `leo.core`/`leo.commands`/`leo.plugins`/`leo.modes`/`leo.external`. Nothing
  else is suppressed — since the job can't fail the build, there's no need to
  hide findings from it yet.

## Cleanup: dead `type:ignore` comments
Running `ty` surfaced 180 `unused-type-ignore-comment` findings. Most of those
are only "unused" from `ty`'s point of view — `python -m mypy
--warn-unused-ignores leo` (that flag is off in `.mypy.ini`) independently
flags just 96 of the same lines, and only 74 lines appear in *both* lists:
comments neither checker finds a reason for anymore. Those 74 are removed
here. The other ~106 `ty`-only findings are left alone, since mypy's stricter
inference in those spots still relies on them — deleting them would silently
un-suppress a real mypy error the next time mypy tightens up.

## Verification
- `ty check --python <venv-with-PyQt6> leo` runs successfully (exit 1, as
  expected — findings exist but the CI job won't fail on it).
- `ci.yml` and `ty.toml` both parse cleanly (YAML/TOML).
- After removing the 74 confirmed-dead comments: `python -m mypy leo` still
  reports "Success: no issues found", and `ty check leo`'s diagnostic count
  drops from 733 to 659.

## Test plan
- [ ] Confirm the `ty` step runs and reports (but doesn't block) in the `mypy`
      job on this PR
- [ ] Confirm the `lint` (ruff) job still passes

