### PR TITLE
Fix mypy arg-type error in EventWrapper.keyRelease

### DIFF
--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -574,7 +574,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
                 return self.oldEvent(event)
 
             # @+node:ekr.20131118172620.16895: *7* EventWrapper.keyRelease
-            def keyRelease(self, event: QEvent) -> bool:
+            def keyRelease(self, event: LeoKeyEvent) -> bool:
                 return self.oldEvent(event)
 
             # @+node:ekr.20131118172620.16893: *7* EventWrapper.wrapper


### PR DESCRIPTION
## Summary
- `EventWrapper.wrapper()` in `leo/plugins/qt_frame.py` is typed to accept a `LeoKeyEvent` and dispatches to `keyRelease()`, but `keyRelease()` was annotated to accept a `QEvent`, causing mypy's `arg-type` check to fail:
  ```
  leo/plugins/qt_frame.py:587: error: Argument 1 to "keyRelease" of "EventWrapper" has incompatible type "LeoKeyEvent"; expected "QEvent"  [arg-type]
  ```
- Aligned `keyRelease`'s annotation with the sibling method `keyPress`, which already uses `LeoKeyEvent`.

## Test plan
- [x] Verified with a local mypy run over the `leo` package that the `arg-type` error at `qt_frame.py:587` no longer appears.