### PR TITLE
Add mypy check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,17 @@ jobs:
           cache: pip
       - run: pip install ruff
       - run: ruff check leo
+
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: pip install "mypy<2" mypy-extensions typing_extensions
+          types-docutils types-Markdown types-paramiko types-PyYAML
+          types-requests types-six
+          "PyQt6>=6.6" PyQt6-QScintilla PyQt6-WebEngine
+      - run: python -m mypy leo

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -574,7 +574,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
                 return self.oldEvent(event)
 
             # @+node:ekr.20131118172620.16895: *7* EventWrapper.keyRelease
-            def keyRelease(self, event: QEvent) -> bool:
+            def keyRelease(self, event: LeoKeyEvent) -> bool:
                 return self.oldEvent(event)
 
             # @+node:ekr.20131118172620.16893: *7* EventWrapper.wrapper


### PR DESCRIPTION
## Summary
- Adds a `mypy` job to `.github/workflows/ci.yml` that runs `python -m mypy leo` with the same dependencies `leo/scripts/mypy_leo.py` expects locally (PyQt6 + PyQt6-QScintilla + PyQt6-WebEngine, plus the `types-*` stub packages already listed in `requirements.txt`).
- Pins `mypy<2`: mypy 2.3.0 has a regression that reports spurious `arg-type` errors on plain `del some_list[i:]` slice deletions (hits `leo/core/leoColorizer.py` and `leo/commands/convertCommands.py`); 1.20.2 does not have this issue. Verified locally that without PyQt6 installed, mypy also produces a flood of unrelated `valid-type` noise (Qt classes resolve as untyped variables), so installing the real Qt bindings is necessary for a clean signal.
- Previously this repo's CI only ran `ruff check leo`; mypy was a manual/local-only step.
- Cherry-picked the one fix needed for a clean baseline: `EventWrapper.keyRelease`'s type annotation in `leo/plugins/qt_frame.py` was `QEvent` while the caller (`EventWrapper.wrapper`) and sibling method (`keyPress`) both use `LeoKeyEvent`, tripping mypy's `arg-type` check. Same fix as #4835 (opened separately, before this CI job existed); once one of the two merges, the other should rebase to avoid a duplicate diff.

## Test plan
- [x] Ran the equivalent command locally (`pip install "mypy<2" ... && python -m mypy leo`) and confirmed zero errors with the cherry-picked fix included.
- [x] Confirmed on CI: before the cherry-pick, the new `mypy` job failed with exactly the expected 1 pre-existing error and nothing else; `ruff` lint jobs (3.10-3.13) passed throughout.