### PR TITLE
Fix mypy arg-type error on QAction.triggered.connect in quickMove.py

### DIFF
--- a/leo/plugins/quickMove.py
+++ b/leo/plugins/quickMove.py
@@ -133,7 +133,7 @@ Tags
 
 # @+<< imports >>
 # @+node:tbrown.20070117104409.2: ** << imports >>
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from copy import deepcopy
 from typing import Any
 from leo.core import leoGlobals as g
@@ -418,12 +418,13 @@ class quickMove:
                 # def cb_clear(event=None, c=c, v=v):
                 #     c.quickMove.clearButton(v)
 
-                for cb, txt in [
+                cb_list: list[tuple[Callable, str]] = [
                     (cb_goto_target, 'Goto target'),
                     (cb_permanent, 'Make permanent'),
                     # (cb_clear, 'Clear permanent'),
                     (cb_set_parent, 'Set parent'),
-                ]:
+                ]
+                for cb, txt in cb_list:
                     but = b.button
                     rc = QAction(txt, but)
                     rc.triggered.connect(cb)


### PR DESCRIPTION
## Summary
- The per-button callback loop in `quickMove.py` (goto target / make permanent / set parent buttons) built a list of three structurally-similar-but-distinct callback functions inline, and mypy's join of their types didn't match `pyqtBoundSignal.connect()`'s expected `Callable[..., Any] | pyqtBoundSignal` signature, producing an `arg-type` error.
- Annotates the list explicitly as `list[tuple[Callable, str]]` (importing `Callable` from `collections.abc`) so mypy resolves it correctly.

## Test plan
- [x] `python -m mypy leo` — no issues found
- [x] `ruff check leo/plugins/quickMove.py` — no issues found