### PR TITLE
PR: Fix bugs in todo.py

### DIFF
--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -506,7 +506,6 @@ class todoController:
         """
         if not timestamp.strip():
             return None  # Was ''
-        # g.trace(f"{timestamp!r} => {dt.datetime.fromisoformat(timestamp).date()}")
         return dt.datetime.fromisoformat(timestamp).date()
 
     def _time(self, timestamp: str) -> dt.time | None:
@@ -517,7 +516,6 @@ class todoController:
         """
         if not timestamp.strip():
             return None  # Was ''
-        # g.trace(f"{timestamp!r} => {dt.datetime.fromisoformat(timestamp).time()}")
         return dt.datetime.fromisoformat(timestamp).time()
 
     # @+node:tbrown.20090630144958.5319: *3* todoController.addPopupMenu
@@ -624,8 +622,8 @@ class todoController:
     @redrawer
     def loadIcons(self, p: Position, clear: bool = False) -> None:
         c = self.c
-        com = c.editCommands
-        allIcons = com.getIconList(p.v)
+        editCommands = c.editCommands
+        allIcons = editCommands.getIconList(p.v)
         icons = [i for i in allIcons if 'cleoIcon' not in i]
         if self.icon_order == 'pri-first':
             iterations = ['priority', 'progress', 'duedate']
@@ -640,7 +638,7 @@ class todoController:
                 if pri:
                     pri = int(pri)
                 if pri in self.priorities:
-                    com.appendImageDictToList(
+                    editCommands.appendImageDictToList(
                         icons,
                         g.os_path_join('cleo', self.priorities[pri]['icon']),
                         2,
@@ -657,7 +655,7 @@ class todoController:
                     prog = int(prog or 0)
                     use = prog // 10 * 10
                     use = 'prg%03d.png' % use  # type:ignore
-                    com.appendImageDictToList(
+                    editCommands.appendImageDictToList(
                         icons,
                         g.os_path_join('cleo', use),
                         2,
@@ -677,7 +675,7 @@ class todoController:
                     else:
                         icon = "date_future.png"
                     # Append the icon to the icons list.
-                    com.appendImageDictToList(
+                    editCommands.appendImageDictToList(
                         icons,
                         g.os_path_join('cleo', icon),
                         2,
@@ -686,7 +684,7 @@ class todoController:
                         where=self.prog_location,
                     )
         # Set the p.v.u for the icons.
-        com.setIconList(p, icons)
+        editCommands.setIconList(p, icons)
         p.v.updateIcon()  # #2870.
 
     # @+node:tbrown.20090119215428.17: *3* todoController.close
@@ -709,7 +707,6 @@ class todoController:
     # @+node:tbrown.20090119215428.20: *4* todoController.delUD
     def delUD(self, node: VNode, udict: str = "annotate") -> None:
         """Remove our dict from the node"""
-        g.trace(f"{udict=} {node.h=} {g.callers(2)}")  ###
         if hasattr(node, "unknownAttributes") and udict in node.unknownAttributes:
             del node.unknownAttributes[udict]
 
@@ -799,9 +796,8 @@ class todoController:
             attrib not in node.unknownAttributes["annotate"]
             or node.unknownAttributes["annotate"][attrib] != val
         ):
-            g.trace(f"{attrib=} {val=}")  ###
+            # PR #4840: Don't dirty the node.
             self.c.setChanged()
-            node.setDirty()
 
         node.unknownAttributes["annotate"][attrib] = val
 
@@ -899,7 +895,9 @@ class todoController:
             p = self.c.currentPosition()
 
         for nd in p.self_and_subtree():
-            nd.h = re.sub(' <[^>]*>$', '', nd.headString())
+            new_h = re.sub(' <[^>]*>$', '', nd.headString())
+            if new_h != nd.h:  # PR #4840: Don't mark nodes dirty unless they change!
+                nd.h = new_h
             tr = self.getat(nd.v, 'time_req')
             pr = self.getat(nd.v, 'progress')
             try:
@@ -1298,7 +1296,6 @@ class todoController:
     # @+node:tbrown.20090119215428.47: *4* todoController.setPri
     @redrawer
     def setPri(self, priority: int) -> None:
-        ### g.trace(f"{priority=}: {self.recentIcons=}")
         if priority in self.recentIcons:
             self.recentIcons.remove(priority)
         self.recentIcons.insert(0, priority)
@@ -1367,11 +1364,8 @@ class todoController:
         if k and k['c'] != self.c:
             return  # wrong number
 
-        g.trace(self.c.p.h, g.callers(1))  ###
-
-        v = self.c.currentPosition().v
-
         # check work date < due date and do stylesheet re-evaluation stuff
+        v = self.c.currentPosition().v
         nwd = self.getat(v, 'nextworkdate')
         due = self.getat(v, 'duedate')
         if hasattr(self.ui.UI, "frmDates"):

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -83,8 +83,9 @@ if TYPE_CHECKING:  # pragma: no cover
     Menu = Any
     Priority = int | str
 
+###
 # Fail fast, right after all imports.
-g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.
+# g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.
 # @-<< todo imports & annotations >>
 
 NO_TIME = dt.date(3000, 1, 1)
@@ -130,244 +131,236 @@ def popup_entry(c: Cmdr, p: Position, menu: Menu) -> None:
 
 
 # @+node:tbrown.20090119215428.8: ** class todoQtUI(QWidget)
-if g.app.gui.guiName() == "qt":
+class todoQtUI(QtWidgets.QWidget):
+    # @+others
+    # @+node:ekr.20111118104929.10204: *3* ctor (todoQtUI(QWidget))
+    def __init__(self, owner: Any, logTab: bool = True) -> None:
+        self.owner = owner
+        super().__init__()
+        uiPath = g.os_path_join(g.app.leoDir, 'plugins', 'ToDo.ui')
 
-    class todoQtUI(QtWidgets.QWidget):
-        # @+others
-        # @+node:ekr.20111118104929.10204: *3* ctor (todoQtUI(QWidget))
-        def __init__(self, owner: Any, logTab: bool = True) -> None:
-            self.owner = owner
-            super().__init__()
-            uiPath = g.os_path_join(g.app.leoDir, 'plugins', 'ToDo.ui')
-
-            # change dir to get themed icons, needed for uic resources
-            # These are icons for todo UI, not the tree.
-            theme = g.app.config.getString('color-theme')
-            if theme:
-                testPath = g.os_path_join(g.app.homeLeoDir, 'themes', theme, 'Icons', 'cleo')
+        # change dir to get themed icons, needed for uic resources
+        # These are icons for todo UI, not the tree.
+        theme = g.app.config.getString('color-theme')
+        if theme:
+            testPath = g.os_path_join(g.app.homeLeoDir, 'themes', theme, 'Icons', 'cleo')
+            if g.os_path_exists(testPath):
+                iconPath = g.os_path_dirname(testPath)
+            else:
+                testPath = g.os_path_join(g.app.loadDir, '..', 'themes', theme, 'Icons', 'cleo')
                 if g.os_path_exists(testPath):
                     iconPath = g.os_path_dirname(testPath)
                 else:
-                    testPath = g.os_path_join(g.app.loadDir, '..', 'themes', theme, 'Icons', 'cleo')
-                    if g.os_path_exists(testPath):
-                        iconPath = g.os_path_dirname(testPath)
-                    else:
-                        iconPath = g.os_path_join(g.app.leoDir, 'Icons')
-            else:
-                iconPath = g.os_path_join(g.app.leoDir, 'Icons')
-            os.chdir(iconPath)
-            form_class, base_class = uic.loadUiType(uiPath)
-            if logTab:
-                self.owner.c.frame.log.createTab('Task', widget=self)
-            self.UI = form_class()
-            self.UI.setupUi(self)
-            u = self.UI
-            o = self.owner
-            self.menu = QtWidgets.QMenu()
-            self.populateMenu(self.menu, o)
-            u.butMenu.setMenu(self.menu)
+                    iconPath = g.os_path_join(g.app.leoDir, 'Icons')
+        else:
+            iconPath = g.os_path_join(g.app.leoDir, 'Icons')
+        os.chdir(iconPath)
+        form_class, base_class = uic.loadUiType(uiPath)
+        if logTab:
+            self.owner.c.frame.log.createTab('Task', widget=self)
+        self.UI = form_class()
+        self.UI.setupUi(self)
+        u = self.UI
+        o = self.owner
+        self.menu = QtWidgets.QMenu()
+        self.populateMenu(self.menu, o)
+        u.butMenu.setMenu(self.menu)
 
-            u.butHelp.clicked.connect(lambda checked: o.showHelp())
-            u.butClrProg.clicked.connect(lambda checked: o.progress_clear())
-            u.butClrTime.clicked.connect(lambda checked: o.clear_time_req())
-            u.butPriClr.clicked.connect(lambda checked: o.priority_clear())
-            # if live update is too slow change valueChanged(*) to editingFinished()
-            u.spinTime.valueChanged.connect(lambda v: o.set_time_req(val=u.spinTime.value()))
-            u.spinProg.valueChanged.connect(lambda v: o.set_progress(val=u.spinProg.value()))
+        u.butHelp.clicked.connect(lambda checked: o.showHelp())
+        u.butClrProg.clicked.connect(lambda checked: o.progress_clear())
+        u.butClrTime.clicked.connect(lambda checked: o.clear_time_req())
+        u.butPriClr.clicked.connect(lambda checked: o.priority_clear())
+        # if live update is too slow change valueChanged(*) to editingFinished()
+        u.spinTime.valueChanged.connect(lambda v: o.set_time_req(val=u.spinTime.value()))
+        u.spinProg.valueChanged.connect(lambda v: o.set_progress(val=u.spinProg.value()))
 
-            u.dueDateEdit.dateChanged.connect(lambda v: o.set_due_date(val=u.dueDateEdit.date()))
-            u.dueTimeEdit.timeChanged.connect(lambda v: o.set_due_time(val=u.dueTimeEdit.time()))
+        u.dueDateEdit.dateChanged.connect(lambda v: o.set_due_date(val=u.dueDateEdit.date()))
+        u.dueTimeEdit.timeChanged.connect(lambda v: o.set_due_time(val=u.dueTimeEdit.time()))
 
-            u.nxtwkDateEdit.dateChanged.connect(
-                lambda v: o.set_due_date(val=u.nxtwkDateEdit.date(), field='nextworkdate')
-            )
-            u.nxtwkTimeEdit.timeChanged.connect(
-                lambda v: o.set_due_time(val=u.nxtwkTimeEdit.time(), field='nextworktime')
-            )
+        u.nxtwkDateEdit.dateChanged.connect(
+            lambda v: o.set_due_date(val=u.nxtwkDateEdit.date(), field='nextworkdate')
+        )
+        u.nxtwkTimeEdit.timeChanged.connect(
+            lambda v: o.set_due_time(val=u.nxtwkTimeEdit.time(), field='nextworktime')
+        )
 
-            u.dueDateToggle.stateChanged.connect(
-                lambda v: o.set_due_date(val=u.dueDateEdit.date(), mode='check')
-            )
-            u.dueTimeToggle.stateChanged.connect(
-                lambda v: o.set_due_time(val=u.dueTimeEdit.time(), mode='check')
-            )
-            u.nxtwkDateToggle.stateChanged.connect(
-                lambda v: o.set_due_date(
-                    val=u.nxtwkDateEdit.date(), mode='check', field='nextworkdate'
-                )
-            )
-            u.nxtwkTimeToggle.stateChanged.connect(
-                lambda v: o.set_due_time(
-                    val=u.nxtwkTimeEdit.time(), mode='check', field='nextworktime'
-                )
-            )
+        u.dueDateToggle.stateChanged.connect(
+            lambda v: o.set_due_date(val=u.dueDateEdit.date(), mode='check')
+        )
+        u.dueTimeToggle.stateChanged.connect(
+            lambda v: o.set_due_time(val=u.dueTimeEdit.time(), mode='check')
+        )
+        u.nxtwkDateToggle.stateChanged.connect(
+            lambda v: o.set_due_date(val=u.nxtwkDateEdit.date(), mode='check', field='nextworkdate')
+        )
+        u.nxtwkTimeToggle.stateChanged.connect(
+            lambda v: o.set_due_time(val=u.nxtwkTimeEdit.time(), mode='check', field='nextworktime')
+        )
 
-            for but in [
-                "butPri1",
-                "butPri6",
-                "butPriChk",
-                "butPri2",
-                "butPri4",
-                "butPri5",
-                "butPri8",
-                "butPri9",
-                "butPri0",
-                "butPriToDo",
-                "butPriXgry",
-                "butPriBang",
-                "butPriX",
-                "butPriQuery",
-                "butPriBullet",
-                "butPri7",
-                "butPri3",
-            ]:
-                w = getattr(u, but)
-                # w.property() seems to give QVariant in python 2.x and int in 3.x!?
+        for but in [
+            "butPri1",
+            "butPri6",
+            "butPriChk",
+            "butPri2",
+            "butPri4",
+            "butPri5",
+            "butPri8",
+            "butPri9",
+            "butPri0",
+            "butPriToDo",
+            "butPriXgry",
+            "butPriBang",
+            "butPriX",
+            "butPriQuery",
+            "butPriBullet",
+            "butPri7",
+            "butPri3",
+        ]:
+            w = getattr(u, but)
+            # w.property() seems to give QVariant in python 2.x and int in 3.x!?
+            try:
+                pri = int(w.property('priority'))
+            except (TypeError, ValueError):
                 try:
-                    pri = int(w.property('priority'))
+                    pri, ok = w.property('priority').toInt()
                 except (TypeError, ValueError):
-                    try:
-                        pri, ok = w.property('priority').toInt()
-                    except (TypeError, ValueError):
-                        pri = -1
+                    pri = -1
 
-                def setter(pri: int = pri) -> None:
-                    o.setPri(pri)
+            def setter(pri: int = pri) -> None:
+                o.setPri(pri)
 
-                w.clicked.connect(lambda checked, setter=setter: setter())
+            w.clicked.connect(lambda checked, setter=setter: setter())
 
-            offsets = self.owner.c.config.getData('todo_due_date_offsets')
-            if not offsets:
-                offsets = (
-                    '+7 +0 +1 +2 +3 +4 +5 +6 +10 +14 +21 +28 +42 +60 +90 +120 +150 >7 <7 <14 >14 <28 >28'
-                ).split()
-            self.date_offset_default = int(offsets[0].strip('>').replace('<', '-'))
-            offsets = sorted(
-                set(offsets), key=lambda x: (x[0], int(x[1:].strip('>').replace('<', '-')))
-            )
-            u.dueDateOffset.addItems(offsets)
-            u.dueDateOffset.setCurrentIndex(self.date_offset_default)
+        offsets = self.owner.c.config.getData('todo_due_date_offsets')
+        if not offsets:
+            offsets = (
+                '+7 +0 +1 +2 +3 +4 +5 +6 +10 +14 +21 +28 +42 +60 +90 +120 +150 >7 <7 <14 >14 <28 >28'
+            ).split()
+        self.date_offset_default = int(offsets[0].strip('>').replace('<', '-'))
+        offsets = sorted(
+            set(offsets), key=lambda x: (x[0], int(x[1:].strip('>').replace('<', '-')))
+        )
+        u.dueDateOffset.addItems(offsets)
+        u.dueDateOffset.setCurrentIndex(self.date_offset_default)
 
-            self.UI.dueDateOffset.activated.connect(lambda v: o.set_date_offset(field='duedate'))
+        self.UI.dueDateOffset.activated.connect(lambda v: o.set_date_offset(field='duedate'))
 
-            u.nxtwkDateOffset.addItems(offsets)
-            u.nxtwkDateOffset.setCurrentIndex(self.date_offset_default)
+        u.nxtwkDateOffset.addItems(offsets)
+        u.nxtwkDateOffset.setCurrentIndex(self.date_offset_default)
 
-            self.UI.nxtwkDateOffset.activated.connect(
-                lambda v: o.set_date_offset(field='nextworkdate')
-            )
+        self.UI.nxtwkDateOffset.activated.connect(lambda v: o.set_date_offset(field='nextworkdate'))
 
-            self.setDueDate = self.make_func(
-                self.UI.dueDateEdit,
-                self.UI.dueDateToggle,
-                'setDate',
-                dt.datetime.now(tz=dt.timezone.utc) + dt.timedelta(self.date_offset_default),
-            )
+        self.setDueDate = self.make_func(
+            self.UI.dueDateEdit,
+            self.UI.dueDateToggle,
+            'setDate',
+            dt.datetime.now(tz=dt.timezone.utc) + dt.timedelta(self.date_offset_default),
+        )
 
-            self.setDueTime = self.make_func(
-                self.UI.dueTimeEdit,
-                self.UI.dueTimeToggle,
-                'setTime',
-                dt.datetime.now(tz=dt.timezone.utc).time(),
-            )
+        self.setDueTime = self.make_func(
+            self.UI.dueTimeEdit,
+            self.UI.dueTimeToggle,
+            'setTime',
+            dt.datetime.now(tz=dt.timezone.utc).time(),
+        )
 
-            self.setNextWorkDate = self.make_func(
-                self.UI.nxtwkDateEdit,
-                self.UI.nxtwkDateToggle,
-                'setDate',
-                dt.datetime.now(tz=dt.timezone.utc) + dt.timedelta(self.date_offset_default),
-            )
+        self.setNextWorkDate = self.make_func(
+            self.UI.nxtwkDateEdit,
+            self.UI.nxtwkDateToggle,
+            'setDate',
+            dt.datetime.now(tz=dt.timezone.utc) + dt.timedelta(self.date_offset_default),
+        )
 
-            self.setNextWorkTime = self.make_func(
-                self.UI.nxtwkTimeEdit,
-                self.UI.nxtwkTimeToggle,
-                'setTime',
-                dt.datetime.now(tz=dt.timezone.utc).time(),
-            )
+        self.setNextWorkTime = self.make_func(
+            self.UI.nxtwkTimeEdit,
+            self.UI.nxtwkTimeToggle,
+            'setTime',
+            dt.datetime.now(tz=dt.timezone.utc).time(),
+        )
 
-            self.UI.butDetails.clicked.connect(
-                lambda checked: self.UI.frmDetails.setVisible(not self.UI.frmDetails.isVisible())
-            )
+        self.UI.butDetails.clicked.connect(
+            lambda checked: self.UI.frmDetails.setVisible(not self.UI.frmDetails.isVisible())
+        )
 
-            if self.owner.c.config.getBool("todo-compact-interface"):
-                self.UI.frmDetails.setVisible(False)
+        if self.owner.c.config.getBool("todo-compact-interface"):
+            self.UI.frmDetails.setVisible(False)
 
-            self.UI.butNext.clicked.connect(lambda checked: self.owner.c.selectVisNext())
-            self.UI.butNextTodo.clicked.connect(lambda checked: self.owner.find_todo())
-            self.UI.butApplyDueOffset.clicked.connect(
-                lambda checked: o.set_date_offset(field='duedate')
-            )
-            self.UI.butApplyOffset.clicked.connect(
-                lambda checked: o.set_date_offset(field='nextworkdate')
-            )
+        self.UI.butNext.clicked.connect(lambda checked: self.owner.c.selectVisNext())
+        self.UI.butNextTodo.clicked.connect(lambda checked: self.owner.find_todo())
+        self.UI.butApplyDueOffset.clicked.connect(
+            lambda checked: o.set_date_offset(field='duedate')
+        )
+        self.UI.butApplyOffset.clicked.connect(
+            lambda checked: o.set_date_offset(field='nextworkdate')
+        )
 
-            n = g.app.config.getInt("todo-calendar-n")
-            cols = g.app.config.getInt("todo-calendar-cols")
-            if n or cols:
-                self.UI.dueDateEdit.calendarWidget().build(n or 3, cols or 3)
-                self.UI.nxtwkDateEdit.calendarWidget().build(n or 3, cols or 3)
+        n = g.app.config.getInt("todo-calendar-n")
+        cols = g.app.config.getInt("todo-calendar-cols")
+        if n or cols:
+            self.UI.dueDateEdit.calendarWidget().build(n or 3, cols or 3)
+            self.UI.nxtwkDateEdit.calendarWidget().build(n or 3, cols or 3)
 
-        # @+node:ekr.20111118104929.10203: *3* make_func
-        def make_func(self, edit: Any, toggle: Any, method: Any, default: Any) -> Callable:
-            def func(
-                value: Any,
-                edit: Any = edit,
-                toggle: Any = toggle,
-                method: Any = method,
-                default: Any = default,
-                self: Any = self,
-            ) -> None:
-                edit.blockSignals(True)
-                toggle.blockSignals(True)
-                if value:
-                    getattr(edit, method)(value)
-                    # edit.setEnabled(True)
-                    toggle.setChecked(True)
-                else:
-                    getattr(edit, method)(default)
-                    toggle.setChecked(False)
-                edit.blockSignals(False)
-                toggle.blockSignals(False)
+    # @+node:ekr.20111118104929.10203: *3* make_func
+    def make_func(self, edit: Any, toggle: Any, method: Any, default: Any) -> Callable:
+        def func(
+            value: Any,
+            edit: Any = edit,
+            toggle: Any = toggle,
+            method: Any = method,
+            default: Any = default,
+            self: Any = self,
+        ) -> None:
+            edit.blockSignals(True)
+            toggle.blockSignals(True)
+            if value:
+                getattr(edit, method)(value)
+                # edit.setEnabled(True)
+                toggle.setChecked(True)
+            else:
+                getattr(edit, method)(default)
+                toggle.setChecked(False)
+            edit.blockSignals(False)
+            toggle.blockSignals(False)
 
-            return func
+        return func
 
-        # @+node:ekr.20111118104929.10205: *3* populateMenu
-        @staticmethod
-        def populateMenu(menu: Menu, o: Any) -> None:
-            menu.addAction('Find next ToDo', o.find_todo)
-            m = menu.addMenu("Priority")
-            m.addAction('Priority Sort', o.priSort)
-            m.addAction('Due Date Sort', o.dueSort)
-            m.addAction('Next Work Date Sort', lambda: o.dueSort(field='nextwork'))
-            m.addAction('Clear Descendant Due Dates', o.dueClear)
-            m.addAction('Mark children todo', o.childrenTodo)
-            m.addAction('Show distribution', o.showDist)
-            m.addAction('Redistribute', o.reclassify)
-            m = menu.addMenu("Time")
-            m.addAction('Show times', lambda: o.show_times(show=True))
-            m.addAction('Hide times', lambda: o.show_times(show=False))
-            m.addAction('Re-calc. derived times', o.local_recalc)
-            m.addAction('Clear derived times', o.local_clear)
-            m = menu.addMenu("Misc.")
-            m.addAction('Hide all Todo icons', lambda: o.loadAllIcons(clear=True))
-            m.addAction('Show all Todo icons', o.loadAllIcons)
-            m.addAction('Delete Todo from node', o.clear_all)
-            m.addAction('Delete Todo from subtree', lambda: o.clear_all(recurse=True))
-            m.addAction('Delete Todo from all', lambda: o.clear_all(all=True))
+    # @+node:ekr.20111118104929.10205: *3* populateMenu
+    @staticmethod
+    def populateMenu(menu: Menu, o: Any) -> None:
+        menu.addAction('Find next ToDo', o.find_todo)
+        m = menu.addMenu("Priority")
+        m.addAction('Priority Sort', o.priSort)
+        m.addAction('Due Date Sort', o.dueSort)
+        m.addAction('Next Work Date Sort', lambda: o.dueSort(field='nextwork'))
+        m.addAction('Clear Descendant Due Dates', o.dueClear)
+        m.addAction('Mark children todo', o.childrenTodo)
+        m.addAction('Show distribution', o.showDist)
+        m.addAction('Redistribute', o.reclassify)
+        m = menu.addMenu("Time")
+        m.addAction('Show times', lambda: o.show_times(show=True))
+        m.addAction('Hide times', lambda: o.show_times(show=False))
+        m.addAction('Re-calc. derived times', o.local_recalc)
+        m.addAction('Clear derived times', o.local_clear)
+        m = menu.addMenu("Misc.")
+        m.addAction('Hide all Todo icons', lambda: o.loadAllIcons(clear=True))
+        m.addAction('Show all Todo icons', o.loadAllIcons)
+        m.addAction('Delete Todo from node', o.clear_all)
+        m.addAction('Delete Todo from subtree', lambda: o.clear_all(recurse=True))
+        m.addAction('Delete Todo from all', lambda: o.clear_all(all=True))
 
-        # @+node:ekr.20111118104929.10207: *3* setProgress
-        def setProgress(self, prgr: Any) -> None:
-            self.UI.spinProg.blockSignals(True)
-            self.UI.spinProg.setValue(prgr)
-            self.UI.spinProg.blockSignals(False)
+    # @+node:ekr.20111118104929.10207: *3* setProgress
+    def setProgress(self, prgr: Any) -> None:
+        self.UI.spinProg.blockSignals(True)
+        self.UI.spinProg.setValue(prgr)
+        self.UI.spinProg.blockSignals(False)
 
-        # @+node:ekr.20111118104929.10208: *3* setTime
-        def setTime(self, timeReq: Any) -> None:
-            self.UI.spinTime.blockSignals(True)
-            self.UI.spinTime.setValue(timeReq)
-            self.UI.spinTime.blockSignals(False)
+    # @+node:ekr.20111118104929.10208: *3* setTime
+    def setTime(self, timeReq: Any) -> None:
+        self.UI.spinTime.blockSignals(True)
+        self.UI.spinTime.setValue(timeReq)
+        self.UI.spinTime.blockSignals(False)
 
-        # @-others
+    # @-others
 
 
 # @+node:tbrown.20090119215428.9: ** class todoController

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -129,236 +129,244 @@ def popup_entry(c: Cmdr, p: Position, menu: QtWidgets.QMenu) -> None:
 
 
 # @+node:tbrown.20090119215428.8: ** class todoQtUI(QWidget)
-class todoQtUI(QtWidgets.QWidget):
-    # @+others
-    # @+node:ekr.20111118104929.10204: *3* ctor (todoQtUI(QWidget))
-    def __init__(self, owner: Any, logTab: bool = True) -> None:
-        self.owner = owner
-        super().__init__()
-        uiPath = g.os_path_join(g.app.leoDir, 'plugins', 'ToDo.ui')
+if 1:
 
-        # change dir to get themed icons, needed for uic resources
-        # These are icons for todo UI, not the tree.
-        theme = g.app.config.getString('color-theme')
-        if theme:
-            testPath = g.os_path_join(g.app.homeLeoDir, 'themes', theme, 'Icons', 'cleo')
-            if g.os_path_exists(testPath):
-                iconPath = g.os_path_dirname(testPath)
-            else:
-                testPath = g.os_path_join(g.app.loadDir, '..', 'themes', theme, 'Icons', 'cleo')
+    class todoQtUI(QtWidgets.QWidget):
+        # @+others
+        # @+node:ekr.20111118104929.10204: *3* ctor (todoQtUI(QWidget))
+        def __init__(self, owner: Any, logTab: bool = True) -> None:
+            self.owner = owner
+            super().__init__()
+            uiPath = g.os_path_join(g.app.leoDir, 'plugins', 'ToDo.ui')
+
+            # change dir to get themed icons, needed for uic resources
+            # These are icons for todo UI, not the tree.
+            theme = g.app.config.getString('color-theme')
+            if theme:
+                testPath = g.os_path_join(g.app.homeLeoDir, 'themes', theme, 'Icons', 'cleo')
                 if g.os_path_exists(testPath):
                     iconPath = g.os_path_dirname(testPath)
                 else:
-                    iconPath = g.os_path_join(g.app.leoDir, 'Icons')
-        else:
-            iconPath = g.os_path_join(g.app.leoDir, 'Icons')
-        os.chdir(iconPath)
-        form_class, base_class = uic.loadUiType(uiPath)
-        if logTab:
-            self.owner.c.frame.log.createTab('Task', widget=self)
-        self.UI = form_class()
-        self.UI.setupUi(self)
-        u = self.UI
-        o = self.owner
-        self.menu = QtWidgets.QMenu()
-        self.populateMenu(self.menu, o)
-        u.butMenu.setMenu(self.menu)
-
-        u.butHelp.clicked.connect(lambda checked: o.showHelp())
-        u.butClrProg.clicked.connect(lambda checked: o.progress_clear())
-        u.butClrTime.clicked.connect(lambda checked: o.clear_time_req())
-        u.butPriClr.clicked.connect(lambda checked: o.priority_clear())
-        # if live update is too slow change valueChanged(*) to editingFinished()
-        u.spinTime.valueChanged.connect(lambda v: o.set_time_req(val=u.spinTime.value()))
-        u.spinProg.valueChanged.connect(lambda v: o.set_progress(val=u.spinProg.value()))
-
-        u.dueDateEdit.dateChanged.connect(lambda v: o.set_due_date(val=u.dueDateEdit.date()))
-        u.dueTimeEdit.timeChanged.connect(lambda v: o.set_due_time(val=u.dueTimeEdit.time()))
-
-        u.nxtwkDateEdit.dateChanged.connect(
-            lambda v: o.set_due_date(val=u.nxtwkDateEdit.date(), field='nextworkdate')
-        )
-        u.nxtwkTimeEdit.timeChanged.connect(
-            lambda v: o.set_due_time(val=u.nxtwkTimeEdit.time(), field='nextworktime')
-        )
-
-        u.dueDateToggle.stateChanged.connect(
-            lambda v: o.set_due_date(val=u.dueDateEdit.date(), mode='check')
-        )
-        u.dueTimeToggle.stateChanged.connect(
-            lambda v: o.set_due_time(val=u.dueTimeEdit.time(), mode='check')
-        )
-        u.nxtwkDateToggle.stateChanged.connect(
-            lambda v: o.set_due_date(val=u.nxtwkDateEdit.date(), mode='check', field='nextworkdate')
-        )
-        u.nxtwkTimeToggle.stateChanged.connect(
-            lambda v: o.set_due_time(val=u.nxtwkTimeEdit.time(), mode='check', field='nextworktime')
-        )
-
-        for but in [
-            "butPri1",
-            "butPri6",
-            "butPriChk",
-            "butPri2",
-            "butPri4",
-            "butPri5",
-            "butPri8",
-            "butPri9",
-            "butPri0",
-            "butPriToDo",
-            "butPriXgry",
-            "butPriBang",
-            "butPriX",
-            "butPriQuery",
-            "butPriBullet",
-            "butPri7",
-            "butPri3",
-        ]:
-            w = getattr(u, but)
-            # w.property() seems to give QVariant in python 2.x and int in 3.x!?
-            try:
-                priority = int(w.property('priority'))
-            except (TypeError, ValueError):
-                try:
-                    priority, ok = w.property('priority').toInt()
-                except (TypeError, ValueError):
-                    priority = -1
-
-            def setter(priority: int = priority) -> None:
-                o.setPri(priority)
-
-            w.clicked.connect(lambda checked, setter=setter: setter())
-
-        offsets = self.owner.c.config.getData('todo_due_date_offsets')
-        if not offsets:
-            offsets = (
-                '+7 +0 +1 +2 +3 +4 +5 +6 +10 +14 +21 +28 +42 +60 +90 +120 +150 >7 <7 <14 >14 <28 >28'
-            ).split()
-        self.date_offset_default = int(offsets[0].strip('>').replace('<', '-'))
-        offsets = sorted(
-            set(offsets), key=lambda x: (x[0], int(x[1:].strip('>').replace('<', '-')))
-        )
-        u.dueDateOffset.addItems(offsets)
-        u.dueDateOffset.setCurrentIndex(self.date_offset_default)
-
-        self.UI.dueDateOffset.activated.connect(lambda v: o.set_date_offset(field='duedate'))
-
-        u.nxtwkDateOffset.addItems(offsets)
-        u.nxtwkDateOffset.setCurrentIndex(self.date_offset_default)
-
-        self.UI.nxtwkDateOffset.activated.connect(lambda v: o.set_date_offset(field='nextworkdate'))
-
-        self.setDueDate = self.make_func(
-            self.UI.dueDateEdit,
-            self.UI.dueDateToggle,
-            'setDate',
-            dt.datetime.now(tz=dt.timezone.utc) + dt.timedelta(self.date_offset_default),
-        )
-
-        self.setDueTime = self.make_func(
-            self.UI.dueTimeEdit,
-            self.UI.dueTimeToggle,
-            'setTime',
-            dt.datetime.now(tz=dt.timezone.utc).time(),
-        )
-
-        self.setNextWorkDate = self.make_func(
-            self.UI.nxtwkDateEdit,
-            self.UI.nxtwkDateToggle,
-            'setDate',
-            dt.datetime.now(tz=dt.timezone.utc) + dt.timedelta(self.date_offset_default),
-        )
-
-        self.setNextWorkTime = self.make_func(
-            self.UI.nxtwkTimeEdit,
-            self.UI.nxtwkTimeToggle,
-            'setTime',
-            dt.datetime.now(tz=dt.timezone.utc).time(),
-        )
-
-        self.UI.butDetails.clicked.connect(
-            lambda checked: self.UI.frmDetails.setVisible(not self.UI.frmDetails.isVisible())
-        )
-
-        if self.owner.c.config.getBool("todo-compact-interface"):
-            self.UI.frmDetails.setVisible(False)
-
-        self.UI.butNext.clicked.connect(lambda checked: self.owner.c.selectVisNext())
-        self.UI.butNextTodo.clicked.connect(lambda checked: self.owner.find_todo())
-        self.UI.butApplyDueOffset.clicked.connect(
-            lambda checked: o.set_date_offset(field='duedate')
-        )
-        self.UI.butApplyOffset.clicked.connect(
-            lambda checked: o.set_date_offset(field='nextworkdate')
-        )
-
-        n = g.app.config.getInt("todo-calendar-n")
-        cols = g.app.config.getInt("todo-calendar-cols")
-        if n or cols:
-            self.UI.dueDateEdit.calendarWidget().build(n or 3, cols or 3)
-            self.UI.nxtwkDateEdit.calendarWidget().build(n or 3, cols or 3)
-
-    # @+node:ekr.20111118104929.10203: *3* make_func
-    def make_func(self, edit: Any, toggle: Any, method: Any, default: Any) -> Callable:
-        def func(
-            value: Any,
-            edit: Any = edit,
-            toggle: Any = toggle,
-            method: Any = method,
-            default: Any = default,
-            self: Any = self,
-        ) -> None:
-            edit.blockSignals(True)
-            toggle.blockSignals(True)
-            if value:
-                getattr(edit, method)(value)
-                # edit.setEnabled(True)
-                toggle.setChecked(True)
+                    testPath = g.os_path_join(g.app.loadDir, '..', 'themes', theme, 'Icons', 'cleo')
+                    if g.os_path_exists(testPath):
+                        iconPath = g.os_path_dirname(testPath)
+                    else:
+                        iconPath = g.os_path_join(g.app.leoDir, 'Icons')
             else:
-                getattr(edit, method)(default)
-                toggle.setChecked(False)
-            edit.blockSignals(False)
-            toggle.blockSignals(False)
+                iconPath = g.os_path_join(g.app.leoDir, 'Icons')
+            os.chdir(iconPath)
+            form_class, base_class = uic.loadUiType(uiPath)
+            if logTab:
+                self.owner.c.frame.log.createTab('Task', widget=self)
+            self.UI = form_class()
+            self.UI.setupUi(self)
+            u = self.UI
+            o = self.owner
+            self.menu = QtWidgets.QMenu()
+            self.populateMenu(self.menu, o)
+            u.butMenu.setMenu(self.menu)
 
-        return func
+            u.butHelp.clicked.connect(lambda checked: o.showHelp())
+            u.butClrProg.clicked.connect(lambda checked: o.progress_clear())
+            u.butClrTime.clicked.connect(lambda checked: o.clear_time_req())
+            u.butPriClr.clicked.connect(lambda checked: o.priority_clear())
+            # if live update is too slow change valueChanged(*) to editingFinished()
+            u.spinTime.valueChanged.connect(lambda v: o.set_time_req(val=u.spinTime.value()))
+            u.spinProg.valueChanged.connect(lambda v: o.set_progress(val=u.spinProg.value()))
 
-    # @+node:ekr.20111118104929.10205: *3* populateMenu
-    @staticmethod
-    def populateMenu(menu: QtWidgets.QMenu, o: Any) -> None:
-        menu.addAction('Find next ToDo', o.find_todo)
-        m = menu.addMenu("Priority")
-        m.addAction('Priority Sort', o.priSort)
-        m.addAction('Due Date Sort', o.dueSort)
-        m.addAction('Next Work Date Sort', lambda: o.dueSort(field='nextwork'))
-        m.addAction('Clear Descendant Due Dates', o.dueClear)
-        m.addAction('Mark children todo', o.childrenTodo)
-        m.addAction('Show distribution', o.showDist)
-        m.addAction('Redistribute', o.reclassify)
-        m = menu.addMenu("Time")
-        m.addAction('Show times', lambda: o.show_times(show=True))
-        m.addAction('Hide times', lambda: o.show_times(show=False))
-        m.addAction('Re-calc. derived times', o.local_recalc)
-        m.addAction('Clear derived times', o.local_clear)
-        m = menu.addMenu("Misc.")
-        m.addAction('Hide all Todo icons', lambda: o.loadAllIcons(clear=True))
-        m.addAction('Show all Todo icons', o.loadAllIcons)
-        m.addAction('Delete Todo from node', o.clear_all)
-        m.addAction('Delete Todo from subtree', lambda: o.clear_all(recurse=True))
-        m.addAction('Delete Todo from all', lambda: o.clear_all(all=True))
+            u.dueDateEdit.dateChanged.connect(lambda v: o.set_due_date(val=u.dueDateEdit.date()))
+            u.dueTimeEdit.timeChanged.connect(lambda v: o.set_due_time(val=u.dueTimeEdit.time()))
 
-    # @+node:ekr.20111118104929.10207: *3* setProgress
-    def setProgress(self, prgr: Any) -> None:
-        self.UI.spinProg.blockSignals(True)
-        self.UI.spinProg.setValue(prgr)
-        self.UI.spinProg.blockSignals(False)
+            u.nxtwkDateEdit.dateChanged.connect(
+                lambda v: o.set_due_date(val=u.nxtwkDateEdit.date(), field='nextworkdate')
+            )
+            u.nxtwkTimeEdit.timeChanged.connect(
+                lambda v: o.set_due_time(val=u.nxtwkTimeEdit.time(), field='nextworktime')
+            )
 
-    # @+node:ekr.20111118104929.10208: *3* setTime
-    def setTime(self, timeReq: Any) -> None:
-        self.UI.spinTime.blockSignals(True)
-        self.UI.spinTime.setValue(timeReq)
-        self.UI.spinTime.blockSignals(False)
+            u.dueDateToggle.stateChanged.connect(
+                lambda v: o.set_due_date(val=u.dueDateEdit.date(), mode='check')
+            )
+            u.dueTimeToggle.stateChanged.connect(
+                lambda v: o.set_due_time(val=u.dueTimeEdit.time(), mode='check')
+            )
+            u.nxtwkDateToggle.stateChanged.connect(
+                lambda v: o.set_due_date(
+                    val=u.nxtwkDateEdit.date(), mode='check', field='nextworkdate'
+                )
+            )
+            u.nxtwkTimeToggle.stateChanged.connect(
+                lambda v: o.set_due_time(
+                    val=u.nxtwkTimeEdit.time(), mode='check', field='nextworktime'
+                )
+            )
 
-    # @-others
+            for but in [
+                "butPri1",
+                "butPri6",
+                "butPriChk",
+                "butPri2",
+                "butPri4",
+                "butPri5",
+                "butPri8",
+                "butPri9",
+                "butPri0",
+                "butPriToDo",
+                "butPriXgry",
+                "butPriBang",
+                "butPriX",
+                "butPriQuery",
+                "butPriBullet",
+                "butPri7",
+                "butPri3",
+            ]:
+                w = getattr(u, but)
+                # w.property() seems to give QVariant in python 2.x and int in 3.x!?
+                try:
+                    priority = int(w.property('priority'))
+                except (TypeError, ValueError):
+                    try:
+                        priority, ok = w.property('priority').toInt()
+                    except (TypeError, ValueError):
+                        priority = -1
+
+                def setter(priority: int = priority) -> None:
+                    o.setPri(priority)
+
+                w.clicked.connect(lambda checked, setter=setter: setter())
+
+            offsets = self.owner.c.config.getData('todo_due_date_offsets')
+            if not offsets:
+                offsets = (
+                    '+7 +0 +1 +2 +3 +4 +5 +6 +10 +14 +21 +28 +42 +60 +90 +120 +150 >7 <7 <14 >14 <28 >28'
+                ).split()
+            self.date_offset_default = int(offsets[0].strip('>').replace('<', '-'))
+            offsets = sorted(
+                set(offsets), key=lambda x: (x[0], int(x[1:].strip('>').replace('<', '-')))
+            )
+            u.dueDateOffset.addItems(offsets)
+            u.dueDateOffset.setCurrentIndex(self.date_offset_default)
+
+            self.UI.dueDateOffset.activated.connect(lambda v: o.set_date_offset(field='duedate'))
+
+            u.nxtwkDateOffset.addItems(offsets)
+            u.nxtwkDateOffset.setCurrentIndex(self.date_offset_default)
+
+            self.UI.nxtwkDateOffset.activated.connect(
+                lambda v: o.set_date_offset(field='nextworkdate')
+            )
+
+            self.setDueDate = self.make_func(
+                self.UI.dueDateEdit,
+                self.UI.dueDateToggle,
+                'setDate',
+                dt.datetime.now(tz=dt.timezone.utc) + dt.timedelta(self.date_offset_default),
+            )
+
+            self.setDueTime = self.make_func(
+                self.UI.dueTimeEdit,
+                self.UI.dueTimeToggle,
+                'setTime',
+                dt.datetime.now(tz=dt.timezone.utc).time(),
+            )
+
+            self.setNextWorkDate = self.make_func(
+                self.UI.nxtwkDateEdit,
+                self.UI.nxtwkDateToggle,
+                'setDate',
+                dt.datetime.now(tz=dt.timezone.utc) + dt.timedelta(self.date_offset_default),
+            )
+
+            self.setNextWorkTime = self.make_func(
+                self.UI.nxtwkTimeEdit,
+                self.UI.nxtwkTimeToggle,
+                'setTime',
+                dt.datetime.now(tz=dt.timezone.utc).time(),
+            )
+
+            self.UI.butDetails.clicked.connect(
+                lambda checked: self.UI.frmDetails.setVisible(not self.UI.frmDetails.isVisible())
+            )
+
+            if self.owner.c.config.getBool("todo-compact-interface"):
+                self.UI.frmDetails.setVisible(False)
+
+            self.UI.butNext.clicked.connect(lambda checked: self.owner.c.selectVisNext())
+            self.UI.butNextTodo.clicked.connect(lambda checked: self.owner.find_todo())
+            self.UI.butApplyDueOffset.clicked.connect(
+                lambda checked: o.set_date_offset(field='duedate')
+            )
+            self.UI.butApplyOffset.clicked.connect(
+                lambda checked: o.set_date_offset(field='nextworkdate')
+            )
+
+            n = g.app.config.getInt("todo-calendar-n")
+            cols = g.app.config.getInt("todo-calendar-cols")
+            if n or cols:
+                self.UI.dueDateEdit.calendarWidget().build(n or 3, cols or 3)
+                self.UI.nxtwkDateEdit.calendarWidget().build(n or 3, cols or 3)
+
+        # @+node:ekr.20111118104929.10203: *3* make_func
+        def make_func(self, edit: Any, toggle: Any, method: Any, default: Any) -> Callable:
+            def func(
+                value: Any,
+                edit: Any = edit,
+                toggle: Any = toggle,
+                method: Any = method,
+                default: Any = default,
+                self: Any = self,
+            ) -> None:
+                edit.blockSignals(True)
+                toggle.blockSignals(True)
+                if value:
+                    getattr(edit, method)(value)
+                    # edit.setEnabled(True)
+                    toggle.setChecked(True)
+                else:
+                    getattr(edit, method)(default)
+                    toggle.setChecked(False)
+                edit.blockSignals(False)
+                toggle.blockSignals(False)
+
+            return func
+
+        # @+node:ekr.20111118104929.10205: *3* populateMenu
+        @staticmethod
+        def populateMenu(menu: QtWidgets.QMenu, o: Any) -> None:
+            menu.addAction('Find next ToDo', o.find_todo)
+            m = menu.addMenu("Priority")
+            m.addAction('Priority Sort', o.priSort)
+            m.addAction('Due Date Sort', o.dueSort)
+            m.addAction('Next Work Date Sort', lambda: o.dueSort(field='nextwork'))
+            m.addAction('Clear Descendant Due Dates', o.dueClear)
+            m.addAction('Mark children todo', o.childrenTodo)
+            m.addAction('Show distribution', o.showDist)
+            m.addAction('Redistribute', o.reclassify)
+            m = menu.addMenu("Time")
+            m.addAction('Show times', lambda: o.show_times(show=True))
+            m.addAction('Hide times', lambda: o.show_times(show=False))
+            m.addAction('Re-calc. derived times', o.local_recalc)
+            m.addAction('Clear derived times', o.local_clear)
+            m = menu.addMenu("Misc.")
+            m.addAction('Hide all Todo icons', lambda: o.loadAllIcons(clear=True))
+            m.addAction('Show all Todo icons', o.loadAllIcons)
+            m.addAction('Delete Todo from node', o.clear_all)
+            m.addAction('Delete Todo from subtree', lambda: o.clear_all(recurse=True))
+            m.addAction('Delete Todo from all', lambda: o.clear_all(all=True))
+
+        # @+node:ekr.20111118104929.10207: *3* setProgress
+        def setProgress(self, prgr: Any) -> None:
+            self.UI.spinProg.blockSignals(True)
+            self.UI.spinProg.setValue(prgr)
+            self.UI.spinProg.blockSignals(False)
+
+        # @+node:ekr.20111118104929.10208: *3* setTime
+        def setTime(self, timeReq: Any) -> None:
+            self.UI.spinTime.blockSignals(True)
+            self.UI.spinTime.setValue(timeReq)
+            self.UI.spinTime.blockSignals(False)
+
+        # @-others
 
 
 # @+node:tbrown.20090119215428.9: ** class todoController

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -95,7 +95,7 @@ NO_TIME = dt.date(3000, 1, 1)
 warning_given = False
 
 
-def init() -> bool:
+def init() -> bool:  # pragma: no cover
     """Return True if the plugin has loaded successfully."""
     global warning_given
     if warning_given:

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -95,18 +95,18 @@ NO_TIME = dt.date(3000, 1, 1)
 warning_given = False
 
 
-def init() -> bool:  # pragma: no cover
+def init() -> bool:
     """Return True if the plugin has loaded successfully."""
     global warning_given
     if warning_given:
         return False
     name = g.app.gui.guiName()
-    if name != "qt":
+    if name != "qt":  # pragma: no cover
         warning_given = True
         if name not in ('browser', 'curses', 'nullGui'):
             print('todo.py plugin not loaded because gui is not Qt')
         return False
-    if not uic:
+    if not uic:  # pragma: no cover
         warning_given = True
         print('todo.py plugin not loaded because uic can not be imported')
         return False

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -77,6 +77,9 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position, VNode
+
+# May raise g.UiTypeException, caught by the plugins manager.
+g.assertUi('qt')
 # @-<< todo imports & annotations >>
 
 NO_TIME = dt.date(3000, 1, 1)

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -77,7 +77,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position, VNode
-    from leo.plugins.qt_frame import LeoQtMenu
 
     Icon = QtGui.QIcon
 
@@ -219,15 +218,15 @@ class todoQtUI(QtWidgets.QWidget):
             w = getattr(u, but)
             # w.property() seems to give QVariant in python 2.x and int in 3.x!?
             try:
-                pri = int(w.property('priority'))
+                priority = int(w.property('priority'))
             except (TypeError, ValueError):
                 try:
-                    pri, ok = w.property('priority').toInt()
+                    priority, ok = w.property('priority').toInt()
                 except (TypeError, ValueError):
-                    pri = -1
+                    priority = -1
 
-            def setter(pri: int = pri) -> None:
-                o.setPri(pri)
+            def setter(priority: int = priority) -> None:
+                o.setPri(priority)
 
             w.clicked.connect(lambda checked, setter=setter: setter())
 
@@ -404,7 +403,7 @@ class todoController:
         c.cleo = self
         self.donePriority = 100
         self.menuicons: dict[int | str, Icon] = {}
-        self.recentIcons: list[Icon] = []
+        self.recentIcons: list[int | str] = []  # PR #4840: was list[Icon] (!)
         self.redrawLevels = 0
         self._widget_to_style = None  # see updateStyle()
         self.reloadSettings()
@@ -529,8 +528,8 @@ class todoController:
             a = m.addAction(icon, self.priorities[i]["long"])
             a.setIconVisibleInMenu(True)
 
-            def icon_cb(checked: Any, pri: int = i) -> None:
-                self.setPri(pri)
+            def icon_cb(checked: Any, priority: int | str = i) -> None:
+                self.setPri(priority)
 
             a.triggered.connect(icon_cb)
         submenu = taskmenu.addMenu("Progress")
@@ -564,7 +563,7 @@ class todoController:
     # @+node:tbrown.20090630144958.5320: *3* todoController.menuicon
     def menuicon(self, pri: int | str, progress: bool = False) -> Icon:
         """return icon from cache, placing it there if needed"""
-        key: int | str = f"prog-{pri}" if progress else pri
+        key = f"prog-{pri}" if progress else pri
         # mypy doesn't know (and can't be told) that priorities[key]["icon"] is a string.
         fn: str = 'prg%03d.png' % pri if progress else self.priorities[key]["icon"]  # type:ignore
         if key not in self.menuicons:
@@ -1281,15 +1280,15 @@ class todoController:
 
     # @+node:tbrown.20090119215428.47: *4* todoController.setPri
     @redrawer
-    def setPri(self, pri: int) -> None:
-        ### g.trace(f"{pri=}: {self.recentIcons=}")
-        if pri in self.recentIcons:
-            self.recentIcons.remove(pri)
-        self.recentIcons.insert(0, pri)
+    def setPri(self, priority: int) -> None:
+        ### g.trace(f"{priority=}: {self.recentIcons=}")
+        if priority in self.recentIcons:
+            self.recentIcons.remove(priority)
+        self.recentIcons.insert(0, priority)
         self.recentIcons = self.recentIcons[:3]
 
         p = self.c.currentPosition()
-        self.setat(p.v, 'priority', pri)
+        self.setat(p.v, 'priority', priority)
         self.setat(p.v, 'prisetdate', str(dt.datetime.now(tz=dt.timezone.utc)))
         self.loadIcons(p)
 
@@ -1467,15 +1466,16 @@ def todo_dec_pri(event: Event, direction: int = 1) -> None:
     if not hasattr(c, 'cleo'):  # 2856.
         return
     p = c.p
-    pri = int(c.cleo.getat(p.v, 'priority'))
+    priority = int(c.cleo.getat(p.v, 'priority'))
 
-    if pri not in c.cleo.priorities:
-        pri = 1
+    if priority not in c.cleo.priorities:
+        priority = 1
     else:
-        ordered = sorted(c.cleo.priorities.keys())
-        pri = ordered[(ordered.index(pri) + direction) % len(ordered)]
+        keys = sorted(c.cleo.priorities.keys())
+        index = (keys.index(priority) + direction) % len(keys)
+        priority = keys[index]
 
-    pri = c.cleo.setPri(pri)
+    priority = c.cleo.setPri(priority)
     c.redraw()
     # c.doCommandByName("todo-inc-pri")
 

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -77,10 +77,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position, VNode
-
-    Icon = QtGui.QIcon
-
-
 # @-<< todo imports & annotations >>
 
 NO_TIME = dt.date(3000, 1, 1)
@@ -402,8 +398,8 @@ class todoController:
         self.c = c
         c.cleo = self
         self.donePriority = 100
-        self.menuicons: dict[int | str, Icon] = {}
-        self.recentIcons: list[int | str] = []  # PR #4840: was list[Icon] (!)
+        self.menuicons: dict[int | str, QtGui.QIcon] = {}
+        self.recentIcons: list[int | str] = []  # PR #4840: was list[QtGui.QIcon] (!)
         self.redrawLevels = 0
         self._widget_to_style = None  # see updateStyle()
         self.reloadSettings()
@@ -561,7 +557,7 @@ class todoController:
         todoQtUI.populateMenu(taskmenu, self)
 
     # @+node:tbrown.20090630144958.5320: *3* todoController.menuicon
-    def menuicon(self, pri: int | str, progress: bool = False) -> Icon:
+    def menuicon(self, pri: int | str, progress: bool = False) -> QtGui.QIcon:
         """return icon from cache, placing it there if needed"""
         key = f"prog-{pri}" if progress else pri
         # mypy doesn't know (and can't be told) that priorities[key]["icon"] is a string.

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -80,8 +80,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.plugins.qt_frame import LeoQtMenu
 
     Icon = QtGui.QIcon
-    Menu = QMenu
-    Priority = int | str
+
 
 # @-<< todo imports & annotations >>
 
@@ -115,14 +114,18 @@ def init() -> bool:
     return True
 
 
-# @+node:tbrown.20090119215428.7: ** onCreate
+# @+node:tbrown.20090119215428.7: ** onCreate (todo.py)
 def onCreate(tag: str, key: dict) -> None:
-    c = key.get('c')
-    todoController(c)
+    if c := key.get('c'):  # PR #4840
+        todoController(c)
 
 
 # @+node:tbrown.20090630144958.5318: ** popup_entry (todo.py)
-def popup_entry(c: Cmdr, p: Position, menu: LeoQtMenu) -> None:
+def popup_entry(c: Cmdr, p: Position, menu: QtWidgets.QMenu) -> None:
+    """Add the menus for the todo.py plugin.  Called from Qt."""
+
+    assert isinstance(menu, QtWidgets.QMenu)  # PR #4840
+
     if getattr(c, 'cleo', None):  # #2856.
         c.cleo.addPopupMenu(c, p, menu)
 
@@ -323,7 +326,7 @@ class todoQtUI(QtWidgets.QWidget):
 
     # @+node:ekr.20111118104929.10205: *3* populateMenu
     @staticmethod
-    def populateMenu(menu: Menu, o: Any) -> None:
+    def populateMenu(menu: QtWidgets.QMenu, o: Any) -> None:
         menu.addAction('Find next ToDo', o.find_todo)
         m = menu.addMenu("Priority")
         m.addAction('Priority Sort', o.priSort)
@@ -400,7 +403,7 @@ class todoController:
         self.c = c
         c.cleo = self
         self.donePriority = 100
-        self.menuicons: dict[Priority, Icon] = {}
+        self.menuicons: dict[int | str, Icon] = {}
         self.recentIcons: list[Icon] = []
         self.redrawLevels = 0
         self._widget_to_style = None  # see updateStyle()
@@ -510,7 +513,9 @@ class todoController:
         return dt.datetime.fromisoformat(timestamp).time()
 
     # @+node:tbrown.20090630144958.5319: *3* todoController.addPopupMenu
-    def addPopupMenu(self, c: Cmdr, p: Position, menu: LeoQtMenu) -> None:
+    def addPopupMenu(self, c: Cmdr, p: Position, menu: QtWidgets.QMenu) -> None:
+
+        assert isinstance(menu, QtWidgets.QMenu)
 
         def rnd(x: float) -> str:
             return re.sub('.0$', '', '%.1f' % x)
@@ -557,9 +562,9 @@ class todoController:
         todoQtUI.populateMenu(taskmenu, self)
 
     # @+node:tbrown.20090630144958.5320: *3* todoController.menuicon
-    def menuicon(self, pri: Priority, progress: bool = False) -> Icon:
+    def menuicon(self, pri: int | str, progress: bool = False) -> Icon:
         """return icon from cache, placing it there if needed"""
-        key: Priority = f"prog-{pri}" if progress else pri
+        key: int | str = f"prog-{pri}" if progress else pri
         # mypy doesn't know (and can't be told) that priorities[key]["icon"] is a string.
         fn: str = 'prg%03d.png' % pri if progress else self.priorities[key]["icon"]  # type:ignore
         if key not in self.menuicons:
@@ -1277,7 +1282,7 @@ class todoController:
     # @+node:tbrown.20090119215428.47: *4* todoController.setPri
     @redrawer
     def setPri(self, pri: int) -> None:
-        g.trace(f"{pri=}: {self.recentIcons=}")
+        ### g.trace(f"{pri=}: {self.recentIcons=}")
         if pri in self.recentIcons:
             self.recentIcons.remove(pri)
         self.recentIcons.insert(0, pri)

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -63,7 +63,7 @@ todo_calendar_cols
 # @+<< todo imports & annotations >>
 # @+node:tbrown.20090119215428.4: ** << todo imports & annotations >>
 from __future__ import annotations
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 import os
 import re
 import datetime as dt
@@ -350,15 +350,17 @@ if 1:
             m = menu.addMenu("Misc.")
             m.addAction('Hide all Todo icons', lambda: o.loadAllIcons(clear=True))
             m.addAction('Show all Todo icons', o.loadAllIcons)
-            m.addAction('Delete Todo from node', o.clear_all)
-            m.addAction('Delete Todo from subtree', lambda: o.clear_all(recurse=True))
-            m.addAction('Delete Todo from all', lambda: o.clear_all(all=True))
+            m.addAction('Delete Todo from node', o.clear_node)
+            m.addAction('Delete Todo from subtree', lambda: o.clear_subtree)
+            m.addAction('Delete Todo from all', lambda: o.clear_all)
 
         # @+node:ekr.20111118104929.10207: *3* setProgress
         def setProgress(self, prgr: Any) -> None:
-            self.UI.spinProg.blockSignals(True)
-            self.UI.spinProg.setValue(prgr)
-            self.UI.spinProg.blockSignals(False)
+            try:
+                self.UI.spinProg.blockSignals(True)
+                self.UI.spinProg.setValue(prgr)
+            finally:
+                self.UI.spinProg.blockSignals(False)
 
         # @+node:ekr.20111118104929.10208: *3* setTime
         def setTime(self, timeReq: Any) -> None:
@@ -707,6 +709,7 @@ class todoController:
     # @+node:tbrown.20090119215428.20: *4* todoController.delUD
     def delUD(self, node: VNode, udict: str = "annotate") -> None:
         """Remove our dict from the node"""
+        g.trace(f"{udict=} {node.h=} {g.callers(2)}")  ###
         if hasattr(node, "unknownAttributes") and udict in node.unknownAttributes:
             del node.unknownAttributes[udict]
 
@@ -796,6 +799,7 @@ class todoController:
             attrib not in node.unknownAttributes["annotate"]
             or node.unknownAttributes["annotate"][attrib] != val
         ):
+            g.trace(f"{attrib=} {val=}")  ###
             self.c.setChanged()
             node.setDirty()
 
@@ -830,18 +834,24 @@ class todoController:
             del d[k]
 
     # @+node:tbrown.20090119215428.27: *3* todoController:drawing...
-    # @+node:tbrown.20090119215428.29: *4* todoController.clear_all
+    # @+node:tbrown.20090119215428.29: *4* todoController.clear_*
     @redrawer
-    def clear_all(self, recurse: bool = False, all: bool = False) -> None:
-        what: Iterable
-        if all:
-            what = self.c.all_positions()
-        elif recurse:
-            what = self.c.currentPosition().self_and_subtree()
-        else:
-            what = iter([self.c.currentPosition()])
+    def clear_all(self) -> None:
+        for p in self.c.all_unique_positions():
+            self.delUD(p.v)
+            self.loadIcons(p)
+            self.show_times(p)
 
-        for p in what:
+    @redrawer
+    def clear_node(self) -> None:
+        p = self.c.p
+        self.delUD(p.v)
+        self.loadIcons(p)
+        self.show_times(p)
+
+    @redrawer
+    def clear_subtree(self) -> None:
+        for p in self.c.p.self_and_subtree():
             self.delUD(p.v)
             self.loadIcons(p)
             self.show_times(p)
@@ -1356,6 +1366,8 @@ class todoController:
     def updateUI(self, tag: str = '', k: dict | None = None) -> None:
         if k and k['c'] != self.c:
             return  # wrong number
+
+        g.trace(self.c.p.h, g.callers(1))  ###
 
         v = self.c.currentPosition().v
 

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -77,15 +77,12 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position, VNode
+    from leo.plugins.qt_frame import LeoQtMenu
 
-    Args = Any
-    Icon = Any  # QtGui.QIcon
-    Menu = Any
+    Icon = QtGui.QIcon
+    Menu = QMenu
     Priority = int | str
 
-###
-# Fail fast, right after all imports.
-# g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.
 # @-<< todo imports & annotations >>
 
 NO_TIME = dt.date(3000, 1, 1)
@@ -125,7 +122,7 @@ def onCreate(tag: str, key: dict) -> None:
 
 
 # @+node:tbrown.20090630144958.5318: ** popup_entry (todo.py)
-def popup_entry(c: Cmdr, p: Position, menu: Menu) -> None:
+def popup_entry(c: Cmdr, p: Position, menu: LeoQtMenu) -> None:
     if getattr(c, 'cleo', None):  # #2856.
         c.cleo.addPopupMenu(c, p, menu)
 
@@ -403,7 +400,7 @@ class todoController:
         self.c = c
         c.cleo = self
         self.donePriority = 100
-        self.menuicons: dict[Priority, Icon] = {}  # menu icon cache
+        self.menuicons: dict[Priority, Icon] = {}
         self.recentIcons: list[Icon] = []
         self.redrawLevels = 0
         self._widget_to_style = None  # see updateStyle()
@@ -489,29 +486,32 @@ class todoController:
         for i in self.handlers:
             g.unregisterHandler(i[0], i[1])  # type:ignore
 
-    # @+node:tbnorth.20170925093004.1: *3* todoController._date
-    def _date(self, d: str) -> dt.date | None:
+    # @+node:tbnorth.20170925093004.1: *3* todoController._date & _time
+    def _date(self, timestamp: str) -> dt.date | None:
         """_date - convert a string to a date
 
-        :param str d: date to convert
-        :return: datetime.date
+        :param timestamp: date to convert
+        :return: datetime.date or None.
         """
-        if not d.strip():
+        if not timestamp.strip():
             return None  # Was ''
-        return dt.datetime.strptime(d.split('T')[0], "%Y-%m-%d").date()  # noqa
+        # g.trace(f"{timestamp!r} => {dt.datetime.fromisoformat(timestamp).date()}")
+        return dt.datetime.fromisoformat(timestamp).date()
 
-    def _time(self, d: str) -> dt.time | None:
+    def _time(self, timestamp: str) -> dt.time | None:
         """_time - convert a string to a time
 
-        :param str d: time to convert
-        :return: datetime.time
+        :param timestamp: time to convert
+        :return: datetime.time or None.
         """
-        if not d.strip():
+        if not timestamp.strip():
             return None  # Was ''
-        return dt.datetime.strptime(d, "%H:%M:%S.%f").time()  # noqa
+        # g.trace(f"{timestamp!r} => {dt.datetime.fromisoformat(timestamp).time()}")
+        return dt.datetime.fromisoformat(timestamp).time()
 
     # @+node:tbrown.20090630144958.5319: *3* todoController.addPopupMenu
-    def addPopupMenu(self, c: Cmdr, p: Position, menu: Menu) -> None:
+    def addPopupMenu(self, c: Cmdr, p: Position, menu: LeoQtMenu) -> None:
+
         def rnd(x: float) -> str:
             return re.sub('.0$', '', '%.1f' % x)
 
@@ -557,7 +557,7 @@ class todoController:
         todoQtUI.populateMenu(taskmenu, self)
 
     # @+node:tbrown.20090630144958.5320: *3* todoController.menuicon
-    def menuicon(self, pri: int, progress: bool = False) -> Icon:
+    def menuicon(self, pri: Priority, progress: bool = False) -> Icon:
         """return icon from cache, placing it there if needed"""
         key: Priority = f"prog-{pri}" if progress else pri
         # mypy doesn't know (and can't be told) that priorities[key]["icon"] is a string.
@@ -574,7 +574,7 @@ class todoController:
     def redrawer(fn: Callable) -> Callable:  # type:ignore
         """decorator for methods which create the need for a redraw"""
 
-        def todo_redrawer_callback(self: Any, *args: Args, **kargs: Any) -> Any:
+        def todo_redrawer_callback(self: Any, *args: Any, **kargs: Any) -> Any:
             self.redrawLevels += 1
             try:
                 self.c.endEditing()  # #3932.
@@ -593,7 +593,7 @@ class todoController:
         """decorator for methods which change projects"""
 
         # pylint: disable=no-self-argument
-        def project_changer_callback(self, *args: Args, **kargs: Any) -> Any:
+        def project_changer_callback(self, *args: Any, **kargs: Any) -> Any:
             ans = fn(self, *args, **kargs)  # pylint: disable=not-callable
             self.update_project()
             return ans
@@ -718,6 +718,7 @@ class todoController:
             and attrib in node.unknownAttributes["annotate"]
         ):
             x: Any = node.unknownAttributes["annotate"][attrib]
+            ### g.trace(f"{x=}")
             if attrib in self._date_fields and isinstance(x, str):
                 x = self._date(x)
             if attrib in self._time_fields and isinstance(x, str):
@@ -1275,7 +1276,8 @@ class todoController:
 
     # @+node:tbrown.20090119215428.47: *4* todoController.setPri
     @redrawer
-    def setPri(self, pri: Any) -> None:
+    def setPri(self, pri: int) -> None:
+        g.trace(f"{pri=}: {self.recentIcons=}")
         if pri in self.recentIcons:
             self.recentIcons.remove(pri)
         self.recentIcons.insert(0, pri)

--- a/leo/scripts/fast_test_leo.py
+++ b/leo/scripts/fast_test_leo.py
@@ -19,7 +19,7 @@ EKR's ft.cmd runs all tests:
     cls
     cd {path-to-leo-editor}
     call python -m leo.scripts.fast_test_leo
-    echo fft.cmd: Done!
+    echo ft.cmd: Done!
 """
 
 import os

--- a/leo/scripts/fast_test_leo.py
+++ b/leo/scripts/fast_test_leo.py
@@ -1,0 +1,48 @@
+# @+leo-ver=5-thin
+# @+node:ekr.20260803073342.1: * @file ../scripts/fast_test_leo.py
+"""
+fast_test_leo.py: Run all these tests scripts in this order:
+
+- beautify_all_leo.py.
+- run_test_leo.py.
+- flake8_leo.py.
+- pyflakes_leo.py
+- mypy_leo.py.
+- ruff_leo.py.
+- check_leo.py.
+
+Info item #3867 describes all of Leo's test scripts:
+https://github.com/leo-editor/leo-editor/issues/2867
+
+EKR's ft.cmd runs all tests:
+    @echo off
+    cls
+    cd {path-to-leo-editor}
+    call python -m leo.scripts.fast_test_leo
+    echo fft.cmd: Done!
+"""
+
+import os
+import subprocess
+import sys
+
+print(os.path.basename(__file__))
+
+# cd to leo-editor
+leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
+os.chdir(leo_editor_dir)
+
+args = ' '.join(sys.argv[1:])
+python = sys.executable
+for command in [
+    rf'{python} -m leo.scripts.beautify_all_leo',
+    rf'{python} -m leo.scripts.flake8_leo',
+    rf'{python} -m leo.scripts.pyflakes_leo',
+    rf'{python} -m leo.scripts.run_test_leo',
+    rf'{python} -m leo.scripts.mypy_leo',
+    rf'{python} -m leo.scripts.ruff_leo',
+    rf'{python} -m leo.scripts.check_leo',
+    # rf'{python} -m leo.scripts.pylint_leo',
+]:
+    subprocess.Popen(command, shell=True).communicate()
+# @-leo

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -271,5 +271,17 @@ class TestIndentedLisp(LeoUnitTest):
     # @-others
 
 
+# @+node:ekr.20260802060059.1: ** class TestTodo(LeoUnitTest)
+class TestTodo(LeoUnitTest):
+    """Tests for todo.py plugin."""
+
+    # @+others
+    # @+node:ekr.20260802060227.1: *3* TestTodo.test_one
+    def test_one(self):
+        self.skipTest('Not Ready')
+
+    # @-others
+
+
 # @-others
 # @-leo

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -2,13 +2,59 @@
 # @+node:ekr.20210907081548.1: * @file ../unittests/plugins/test_plugins.py
 """General tests of plugins."""
 
+# @+<< test_plugins: imports >>
+# @+node:ekr.20260802082604.1: ** << test_plugins: imports >>
 import glob
 import os
 import re
 from leo.core import leoGlobals as g
-from leo.core.leoTest2 import LeoUnitTest
+from leo.core.leoTest2 import LeoUnitTest, create_app
 from leo.core.leoPlugins import LeoPluginsController
 from leo.plugins import indented_languages
+
+try:
+    from leo.core.leoQt import (
+        Qt,
+        QtCore,
+        QtGui,
+        QtWidgets,
+    )
+    from leo.core.leoAPI import StringTextWrapper
+    from leo.core.leoFrame import (
+        NullBody,
+        NullFrame,
+        NullIconBarClass,
+        NullLog,
+        NullStatusLineClass,
+        NullTree,
+    )
+    from leo.core.leoGui import LeoKeyEvent
+    from leo.plugins.qt_frame import (
+        DynamicWindow,
+        LeoQtBody,
+        LeoQtFrame,
+        LeoQtLog,
+        LeoQtMenu,
+        LeoQtTree,
+        LeoQTreeWidget,
+        QtIconBarClass,
+        QtStatusLineClass,
+    )
+    from leo.plugins.qt_text import (
+        LeoQTextBrowser,
+        QHeadlineWrapper,
+        QLineEditWrapper,
+        QMinibufferWrapper,
+        QScintillaWrapper,
+        QTextEditWrapper,
+        QTextMixin,
+    )
+
+    QTabWidget = QtWidgets.QTabWidget
+except Exception:
+    g.es_exception()
+    Qt = QtCore = QTabWidget = None
+# @-<< test_plugins: imports >>
 
 
 # @+others
@@ -275,12 +321,27 @@ class TestIndentedLisp(LeoUnitTest):
 class TestTodo(LeoUnitTest):
     """Tests for todo.py plugin."""
 
-    def setUp(self):
-        from leo.plugins import todo
+    @classmethod
+    def setUpClass(cls):
+        create_app(gui_name='qt')
 
-        self.todo = todo
+    def setUp(self):
+        super().setUp()
+        # Don't run *any* tests if Qt has not been installed.
+        if not Qt:
+            self.skipTest('import Qt failed')
 
     # @+others
+    # @+node:ekr.20260802060227.1: *3* TestTodo.test_init
+    def test_init(self):
+
+        from leo.plugins import todo
+
+        assert todo.init()
+
+        todo.warning_given = True
+        assert not todo.init()
+
     # @-others
 
 

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -138,8 +138,8 @@ class TestPlugins(LeoUnitTest):
         for filename in files:
             self.check_syntax(filename)
 
-    # @+node:ekr.20210907081455.3: *3* TestPlugins.xxx_test_all_qt_plugins_call_g_assertUi_qt_
-    def xxx_test_all_qt_plugins_call_g_assertUi_qt_(self):
+    # @+node:ekr.20210907081455.3: *3* TestPlugins.test_all_qt_plugins_call_g_assertUi_qt_
+    def test_all_qt_plugins_call_g_assertUi_qt_(self):
         files = self.get_plugins()
         excludes = (
             # Special cases, handling Qt imports in unusual ways.

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -16,39 +16,40 @@ try:
     from leo.core.leoQt import (
         Qt,
         QtCore,
-        QtGui,
+        # QtGui,
         QtWidgets,
     )
-    from leo.core.leoAPI import StringTextWrapper
-    from leo.core.leoFrame import (
-        NullBody,
-        NullFrame,
-        NullIconBarClass,
-        NullLog,
-        NullStatusLineClass,
-        NullTree,
-    )
-    from leo.core.leoGui import LeoKeyEvent
-    from leo.plugins.qt_frame import (
-        DynamicWindow,
-        LeoQtBody,
-        LeoQtFrame,
-        LeoQtLog,
-        LeoQtMenu,
-        LeoQtTree,
-        LeoQTreeWidget,
-        QtIconBarClass,
-        QtStatusLineClass,
-    )
-    from leo.plugins.qt_text import (
-        LeoQTextBrowser,
-        QHeadlineWrapper,
-        QLineEditWrapper,
-        QMinibufferWrapper,
-        QScintillaWrapper,
-        QTextEditWrapper,
-        QTextMixin,
-    )
+    # from leo.core.leoAPI import StringTextWrapper
+
+    # from leo.core.leoFrame import (
+    #     NullBody,
+    #     NullFrame,
+    #     NullIconBarClass,
+    #     NullLog,
+    #     NullStatusLineClass,
+    #     NullTree,
+    # )
+    # from leo.core.leoGui import LeoKeyEvent
+    # from leo.plugins.qt_frame import (
+    #     DynamicWindow,
+    #     LeoQtBody,
+    #     LeoQtFrame,
+    #     LeoQtLog,
+    #     LeoQtMenu,
+    #     LeoQtTree,
+    #     LeoQTreeWidget,
+    #     QtIconBarClass,
+    #     QtStatusLineClass,
+    # )
+    # from leo.plugins.qt_text import (
+    #     LeoQTextBrowser,
+    #     QHeadlineWrapper,
+    #     QLineEditWrapper,
+    #     QMinibufferWrapper,
+    #     QScintillaWrapper,
+    #     QTextEditWrapper,
+    #     QTextMixin,
+    # )
 
     QTabWidget = QtWidgets.QTabWidget
 except Exception:
@@ -116,6 +117,21 @@ class TestPlugins(LeoUnitTest):
         files = [g.os_path_abspath(z) for z in files]
         return sorted(files)
 
+    # @+node:ekr.20210909165720.1: *3* TestPlugins.slow_test_import_all_plugins
+    def slow_test_import_of_all_plugins(self):  # pragma: no cover
+        # This works, but is slow.
+        files = self.get_plugins()
+        for filename in files:
+            plugin_module = g.shortFileName(filename)[:-3]
+            try:
+                exec(f"import leo.plugins.{plugin_module}")
+            except g.UiTypeException:
+                pass
+            except AttributeError:
+                pass
+            except ImportError:
+                pass
+
     # @+node:ekr.20210907081455.2: *3* TestPlugins.test_all_plugins_have_top_level_init_method
     def test_all_plugins_have_top_level_init_method(self):
         # Ensure all plugins have top-level init method *without* importing them.
@@ -125,29 +141,6 @@ class TestPlugins(LeoUnitTest):
                 contents = f.read()
             s = g.toUnicode(contents)
             assert 'def init()' in s, repr(fn)
-
-    # @+node:ekr.20210907081455.3: *3* TestPlugins.test_all_qt_plugins_call_g_assertUi_qt_
-    def test_all_qt_plugins_call_g_assertUi_qt_(self):
-        files = self.get_plugins()
-        excludes = (
-            # Special cases, handling Qt imports in unusual ways.
-            'backlink.py',  # Qt code is optional, disabled with module-level guard.
-            'leoscreen.py',  # Qt imports are optional.
-            'mod_scripting.py',
-            'nodetags.py',  # #2031: Qt imports are optional.
-            'pyplot_backend.py',  # Not a real plugin.
-            'qt_layout.py',  # Not a real plugin.
-        )
-        pattern = re.compile(r'\b(QtCore|QtGui|QtWidgets)\b')  # Don't search for Qt.
-        for fn in files:
-            if g.shortFileName(fn) in excludes:
-                continue
-            with open(fn, 'rb') as f:
-                contents = f.read()
-            s = g.toUnicode(contents)
-            if not re.search(pattern, s):
-                continue
-            self.assertTrue(re.search(r"g\.assertUi\(['\"]qt['\"]\)", s), msg=fn)
 
     # @+node:ekr.20210909161328.2: *3* TestPlugins.test_c_vnode2position
     def test_c_vnode2position(self):
@@ -181,20 +174,28 @@ class TestPlugins(LeoUnitTest):
         for filename in files:
             self.check_syntax(filename)
 
-    # @+node:ekr.20210909165720.1: *3* TestPlugins.slow_test_import_all_plugins
-    def slow_test_import_of_all_plugins(self):  # pragma: no cover
-        # This works, but is slow.
+    # @+node:ekr.20210907081455.3: *3* TestPlugins.xxx_test_all_qt_plugins_call_g_assertUi_qt_
+    def xxx_test_all_qt_plugins_call_g_assertUi_qt_(self):
         files = self.get_plugins()
-        for filename in files:
-            plugin_module = g.shortFileName(filename)[:-3]
-            try:
-                exec(f"import leo.plugins.{plugin_module}")
-            except g.UiTypeException:
-                pass
-            except AttributeError:
-                pass
-            except ImportError:
-                pass
+        excludes = (
+            # Special cases, handling Qt imports in unusual ways.
+            'backlink.py',  # Qt code is optional, disabled with module-level guard.
+            'leoscreen.py',  # Qt imports are optional.
+            'mod_scripting.py',
+            'nodetags.py',  # #2031: Qt imports are optional.
+            'pyplot_backend.py',  # Not a real plugin.
+            'qt_layout.py',  # Not a real plugin.
+        )
+        pattern = re.compile(r'\b(QtCore|QtGui|QtWidgets)\b')  # Don't search for Qt.
+        for fn in files:
+            if g.shortFileName(fn) in excludes:
+                continue
+            with open(fn, 'rb') as f:
+                contents = f.read()
+            s = g.toUnicode(contents)
+            if not re.search(pattern, s):
+                continue
+            self.assertTrue(re.search(r"g\.assertUi\(['\"]qt['\"]\)", s), msg=fn)
 
     # @-others
 
@@ -332,8 +333,8 @@ class TestTodo(LeoUnitTest):
             self.skipTest('import Qt failed')
 
     # @+others
-    # @+node:ekr.20260802060227.1: *3* TestTodo.test_init
-    def test_init(self):
+    # @+node:ekr.20260802060227.1: *3* TestTodo.test_outer_functions
+    def test_outer_functions(self):
 
         from leo.plugins import todo
 
@@ -341,6 +342,12 @@ class TestTodo(LeoUnitTest):
 
         todo.warning_given = True
         assert not todo.init()
+
+        c = self.c
+
+        todo.onCreate(tag=g.my_name(), key={'c': c})
+
+        todo.popup_entry(c=c, p=c.p, menu=c.frame.menu)
 
     # @-others
 

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -275,11 +275,12 @@ class TestIndentedLisp(LeoUnitTest):
 class TestTodo(LeoUnitTest):
     """Tests for todo.py plugin."""
 
-    # @+others
-    # @+node:ekr.20260802060227.1: *3* TestTodo.test_one
-    def test_one(self):
-        self.skipTest('Not Ready')
+    def setUp(self):
+        from leo.plugins import todo
 
+        self.todo = todo
+
+    # @+others
     # @-others
 
 

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -13,43 +13,7 @@ from leo.core.leoPlugins import LeoPluginsController
 from leo.plugins import indented_languages
 
 try:
-    from leo.core.leoQt import (
-        Qt,
-        QtCore,
-        # QtGui,
-        QtWidgets,
-    )
-    # from leo.core.leoAPI import StringTextWrapper
-
-    # from leo.core.leoFrame import (
-    #     NullBody,
-    #     NullFrame,
-    #     NullIconBarClass,
-    #     NullLog,
-    #     NullStatusLineClass,
-    #     NullTree,
-    # )
-    # from leo.core.leoGui import LeoKeyEvent
-    # from leo.plugins.qt_frame import (
-    #     DynamicWindow,
-    #     LeoQtBody,
-    #     LeoQtFrame,
-    #     LeoQtLog,
-    #     LeoQtMenu,
-    #     LeoQtTree,
-    #     LeoQTreeWidget,
-    #     QtIconBarClass,
-    #     QtStatusLineClass,
-    # )
-    # from leo.plugins.qt_text import (
-    #     LeoQTextBrowser,
-    #     QHeadlineWrapper,
-    #     QLineEditWrapper,
-    #     QMinibufferWrapper,
-    #     QScintillaWrapper,
-    #     QTextEditWrapper,
-    #     QTextMixin,
-    # )
+    from leo.core.leoQt import Qt, QtWidgets
 
     QTabWidget = QtWidgets.QTabWidget
 except Exception:
@@ -344,10 +308,8 @@ class TestTodo(LeoUnitTest):
         assert not todo.init()
 
         c = self.c
-
         todo.onCreate(tag=g.my_name(), key={'c': c})
-
-        todo.popup_entry(c=c, p=c.p, menu=c.frame.menu)
+        todo.popup_entry(c=c, p=c.p, menu=QtWidgets.QMenu())
 
     # @-others
 


### PR DESCRIPTION
Part of #4822.

- [x] Fix crashers in _date and _time methods. These were introduced by a recent PR.
- [x] Add TestTodo test class.
- [x] Remove abbreviations for all annotations, especially Priority and Menu.
- [x] Fix annotations, especially the annotation for the misnamed recenticons ivar!
- [x] Add assertions for previously unclear annotations.
- [x] todoController.show_times: Don't mark nodes dirty unless they have actually changed.
- [x] Add leo/scripts/fast_test_leo.py. It runs without Qt info messages.
- ~~Full coverage for todo.py~~. Save for PR #4841.