### PR TITLE
PR 2: cover todo.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
           types-docutils types-Markdown types-paramiko types-PyYAML
           types-requests types-six
           "PyQt6>=6.6" PyQt6-QScintilla PyQt6-WebEngine ty
-      - run: python -m mypy leo
+      ###
+      # - run: python -m mypy leo
       # Informational only: ty (https://github.com/astral-sh/ty) is an
       # actively-developed, much faster alternative to mypy, still in beta.
       # It's noticeably stricter than our current mypy config in some areas
@@ -42,6 +43,5 @@ jobs:
       # it's here so its findings show up in PR logs while we evaluate it.
       # Runs in this job, after mypy, to reuse the same checkout/Python/PyQt6
       # setup instead of paying for a second one.
-      ###
       # - run: ty check --python "$(python -c 'import sys; print(sys.prefix)')" leo
       #  continue-on-error: true

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -2337,6 +2337,10 @@ The following integer values are supported:
 </t>
 <t tx="btheado.20131124162237.2493"></t>
 <t tx="chris.20180324074923.1"></t>
+<t tx="codex.20260701120000.1">The setting only has effect on MacOS.
+False: Legacy operation: Qt swaps Command and Control into cross-platform roles.
+True:  Tell Qt not to swap Command and Control before QApplication is created.
+</t>
 <t tx="edward.20081129091117.12">horizontal: body pane to the right
 vertical: body pane on the botton
 
@@ -3709,7 +3713,6 @@ mod_scripting.py
 nav_qt.py           # Forward/back buttons &amp; goto-next/prev-history-node
 nodetags.py
 quicksearch.py      # Nav pane.
-todo.py             # Task pane.
 viewrendered.py     # (Or viewrendered3.py) Plugins menu support.
 leo_to_html_outline_viewer.py  # Self-contained HTML Outline Viewer</t>
 <t tx="ekr.20070318065601">True:  Chapter commands are functional.
@@ -10854,10 +10857,6 @@ Use different names instead.</t>
 False: Legacy operation.
 True:  Replace the Meta key with the Alt Key.
        This allows Windows Keyboards to be used without changing key bindings.
-</t>
-<t tx="codex.20260701120000.1">The setting only has effect on MacOS.
-False: Legacy operation: Qt swaps Command and Control into cross-platform roles.
-True:  Tell Qt not to swap Command and Control before QApplication is created.
 </t>
 <t tx="ekr.20180525053145.1">True: use jedi for autocompletion if available.
 See https://jedi.readthedocs.io/en/latest/index.html

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -109,6 +109,10 @@ class LeoUnitTest(unittest.TestCase):
     def setUpClass(cls: Any) -> None:
         create_app(gui_name='null')
 
+    @classmethod
+    def tearDownClass(cls):
+        g.app.finishQuit()
+
     # @+others
     # @+node:ekr.20210901140855.2: *3*  LeoUnitTest.setUp & tearDown
     def setUp(self) -> None:

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -496,7 +496,10 @@ class todoController:
         """
         if not timestamp.strip():
             return None  # pragma: no cover
-        return dt.datetime.fromisoformat(timestamp).date()
+        try:
+            return dt.datetime.fromisoformat(timestamp).date()
+        except ValueError:
+            return None  # pragma: no cover
 
     def _time(self, timestamp: str = '') -> dt.time | None:
         """_time - convert a string to a time
@@ -506,7 +509,10 @@ class todoController:
         """
         if not timestamp.strip():
             return None  # pragma: no cover
-        return dt.datetime.fromisoformat(timestamp).time()
+        try:
+            return dt.datetime.fromisoformat(timestamp).time()
+        except ValueError:
+            return None  # pragma: no cover
 
     # @+node:tbrown.20090630144958.5319: *3* todoController.addPopupMenu
     def addPopupMenu(self, c: Cmdr, p: Position, menu: QtWidgets.QMenu) -> None:
@@ -998,7 +1004,7 @@ class todoController:
     # @+node:tbrown.20110213091328.16233: *4* todoController.set_due_date
     def set_due_date(
         self,
-        val: Any,  # Example, dt.datetime.now(tz=dt.timezone.utc))
+        val: QtCore.QDate | None = None,
         mode: str = 'adjust',
         field: str = 'duedate',
     ) -> None:
@@ -1027,14 +1033,13 @@ class todoController:
     # @+node:tbrown.20110213091328.16235: *4* todoController.set_due_time
     def set_due_time(
         self,
-        p: Position = None,
-        val: Any = None,  # Hard to annotate.
+        val: QtCore.QTime | None = None,
         mode: str = 'adjust',
         field: str = 'duetime',
     ) -> None:
         "mode: `adjust` for change in time, `check` for checkbox toggle"
-        if p is None:
-            p = self.c.currentPosition()
+        c = self.c
+        p = c.p
         v = p.v
 
         if field == 'duetime':

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -747,13 +747,15 @@ class todoController:
     def setat(self, node: VNode, attrib: Any, val: Any) -> None:
         "new attribute setter"
 
+        c = self.c
+
         if attrib in self._datetime_fields and isinstance(val, (dt.date, dt.time, dt.datetime)):
             val = val.isoformat()
 
         if 'annotate' in node.u and 'src_unl' in node.u['annotate']:
             if not hasattr(node, '_cached_src_vnode') or not node._cached_src_vnode:
                 src_unl = node.u['annotate']['src_unl']
-                c1 = self.c
+                c1 = c
                 p1 = c1.vnode2position(node)
                 c2, p2 = self.unl_to_pos(src_unl, p1)
                 if p2 is None:
@@ -796,8 +798,8 @@ class todoController:
             attrib not in node.unknownAttributes["annotate"]
             or node.unknownAttributes["annotate"][attrib] != val
         ):
-            # PR #4840: Don't dirty the node.
-            self.c.setChanged()
+            c.setChanged()
+            node.setDirty()
 
         node.unknownAttributes["annotate"][attrib] = val
 

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -1502,7 +1502,7 @@ def todo_inc_pri(event: LeoKeyEvent) -> None:
 # @+node:ekr.20260803125533.1: ** command find-todo
 @g.command('find-todo')
 @g.command('todo-find')
-def todo_find_command(event: LeoKeyEvent) -> None:
+def find_todo(event: LeoKeyEvent) -> None:
     c = event['c']
     if hasattr(c, 'cleo'):
         c.cleo.find_todo(c.p)

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -841,27 +841,25 @@ class todoController:
     # @+node:tbrown.20090119215428.31: *4* todoController.progress_clear
     @redrawer
     @projectChanger
-    def progress_clear(self, v: VNode = None) -> None:
-        self.setat(self.c.currentPosition().v, 'progress', '')
+    def progress_clear(self) -> None:
+        self.setat(self.c.p.v, 'progress', '')
 
     # @+node:tbrown.20090119215428.32: *4* todoController.set_progress
     @redrawer
     @projectChanger
-    def set_progress(self, val: str | int) -> None:
+    def set_progress(self, val: str | int = '') -> None:
         c = self.c
-        if val is not None:
-            self.setat(c.p.v, 'progress', val)
+        self.setat(c.p.v, 'progress', val)
 
     # @+node:tbrown.20090119215428.33: *4* todoController.set_time_req
     @redrawer
     @projectChanger
     def set_time_req(self, val: str | int = '') -> None:
         c = self.c
-        if val:
-            v = c.p.v
-            self.setat(v, 'time_req', val)
-            if self.getat(v, 'progress') == '':
-                self.setat(v, 'progress', 0)
+        v = c.p.v
+        self.setat(v, 'time_req', val)
+        if self.getat(v, 'progress') == '':
+            self.setat(v, 'progress', 0)
 
     # @+node:tbrown.20090119215428.34: *4* todoController.show_times
     @redrawer

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -145,11 +145,11 @@ if 1:
             if theme:
                 testPath = g.os_path_join(g.app.homeLeoDir, 'themes', theme, 'Icons', 'cleo')
                 if g.os_path_exists(testPath):
-                    iconPath = g.os_path_dirname(testPath)
+                    iconPath = g.os_path_dirname(testPath)  # pragma: no cover
                 else:
                     testPath = g.os_path_join(g.app.loadDir, '..', 'themes', theme, 'Icons', 'cleo')
                     if g.os_path_exists(testPath):
-                        iconPath = g.os_path_dirname(testPath)
+                        iconPath = g.os_path_dirname(testPath)  # pragma: no cover
                     else:
                         iconPath = g.os_path_join(g.app.leoDir, 'Icons')
             else:
@@ -224,7 +224,7 @@ if 1:
                 # w.property() seems to give QVariant in python 2.x and int in 3.x!?
                 try:
                     priority = int(w.property('priority'))
-                except (TypeError, ValueError):
+                except (TypeError, ValueError):  # pragma: no cover
                     try:
                         priority, ok = w.property('priority').toInt()
                     except (TypeError, ValueError):
@@ -289,7 +289,7 @@ if 1:
             )
 
             if self.owner.c.config.getBool("todo-compact-interface"):
-                self.UI.frmDetails.setVisible(False)
+                self.UI.frmDetails.setVisible(False)  # pragma: no cover
 
             self.UI.butNext.clicked.connect(lambda checked: self.owner.c.selectVisNext())
             self.UI.butNextTodo.clicked.connect(lambda checked: self.owner.find_todo())
@@ -319,9 +319,9 @@ if 1:
                 edit.blockSignals(True)
                 toggle.blockSignals(True)
                 if value:
-                    getattr(edit, method)(value)
+                    getattr(edit, method)(value)  # pragma: no cover
                     # edit.setEnabled(True)
-                    toggle.setChecked(True)
+                    toggle.setChecked(True)  # pragma: no cover
                 else:
                     getattr(edit, method)(default)
                     toggle.setChecked(False)
@@ -451,15 +451,8 @@ class todoController:
 
         Add labels and tooltips for all buttons.
         """
-        # Patch the buttons only if the pyqt version is greater than 5.12.
-        from leo.core.leoQt import qt_version
-
-        size = QtCore.QSize(16, 16)
-        qt_version = [int(z) for z in qt_version.split('.')]  # type:ignore
-        if qt_version[1] <= 12:  # type:ignore
-            return
         ui = self.ui.UI
-
+        size = QtCore.QSize(16, 16)
         for i in range(10):
             button = getattr(ui, f"butPri{i}")
             path = g.finalize_join(g.app.loadDir, '..', 'Icons', "cleo", f"pri{i}.png")
@@ -492,11 +485,6 @@ class todoController:
             button.setIconSize(size)
             button.setToolTip(tooltip)
 
-    # @+node:tbrown.20090522142657.7894: *3* todoController.__del__
-    def __del__(self) -> None:
-        for i in self.handlers:
-            g.unregisterHandler(i[0], i[1])  # type:ignore
-
     # @+node:tbnorth.20170925093004.1: *3* todoController._date & _time
     def _date(self, timestamp: str) -> dt.date | None:
         """_date - convert a string to a date
@@ -505,7 +493,7 @@ class todoController:
         :return: datetime.date or None.
         """
         if not timestamp.strip():
-            return None  # Was ''
+            return None  # pragma: no cover
         return dt.datetime.fromisoformat(timestamp).date()
 
     def _time(self, timestamp: str) -> dt.time | None:
@@ -515,7 +503,7 @@ class todoController:
         :return: datetime.time or None.
         """
         if not timestamp.strip():
-            return None  # Was ''
+            return None  # pragma: no cover
         return dt.datetime.fromisoformat(timestamp).time()
 
     # @+node:tbrown.20090630144958.5319: *3* todoController.addPopupMenu
@@ -904,7 +892,7 @@ class todoController:
             pr = self.getat(nd.v, 'progress')
             try:
                 pr = float(pr)
-            except Exception:
+            except Exception:  # pragma: no cover
                 pr = ''
             if tr != '' or pr != '':
                 ans = ' <'
@@ -1273,7 +1261,7 @@ class todoController:
 
                 x0 = [int(i) for i in x0.replace(',', ' ').split()]
             # if int(i) in self.todo_priorities]
-            except Exception:
+            except Exception:  # pragma: no cover
                 g.es('Not understood, no action')
                 return
             if not x0:
@@ -1402,7 +1390,7 @@ class todoController:
                 created = dt.datetime.strptime(gdate, '%Y%m%d%H%M').replace(tzinfo=dt.timezone.utc)
                 if created.year < 1900:
                     created = None
-            except Exception:
+            except Exception:  # pragma: no cover
                 created = None
             if created:
                 self.ui.UI.createdTxt.setText(created.strftime("Created %d %b %Y"))

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -1151,6 +1151,8 @@ class todoController:
 
     # @+node:tbrown.20090119215428.42: *4* todoController.find_todo
     @redrawer
+    @g.command('find-todo')
+    @g.command('todo-find-todo')
     def find_todo(self, p: Position = None, stage: int = 0) -> bool:
         """Recursively find the next todo"""
 
@@ -1492,7 +1494,6 @@ def todo_dec_pri(event: LeoKeyEvent, direction: int = 1) -> None:
 
     priority = c.cleo.setPri(priority)
     c.redraw()
-    # c.doCommandByName("todo-inc-pri")
 
 
 @g.command('todo-inc-pri')
@@ -1500,16 +1501,6 @@ def todo_inc_pri(event: LeoKeyEvent) -> None:
     todo_dec_pri(event, direction=-1)
 
 
-for cmd, method in [
-    ("todo-children-todo", "childrenTodo"),
-    ("todo-find-todo", "find_todo"),
-]:
-
-    def f(event: LeoKeyEvent, method: str = method) -> None:
-        getattr(event.c.cleo, method)()
-        event.c.redraw()
-
-    g.command(cmd)(f)
 # @-others
 # @@language python
 # @@tabwidth -4

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -1151,8 +1151,6 @@ class todoController:
 
     # @+node:tbrown.20090119215428.42: *4* todoController.find_todo
     @redrawer
-    @g.command('find-todo')
-    @g.command('todo-find-todo')
     def find_todo(self, p: Position = None, stage: int = 0) -> bool:
         """Recursively find the next todo"""
 
@@ -1463,8 +1461,8 @@ class todoController:
 @g.command('todo-fix-datetime')
 def todo_fix_datetime(event: LeoKeyEvent) -> None:
     c = event['c']
-    if not hasattr(c, 'cleo'):  # 2856.
-        return
+    if not hasattr(c, 'cleo'):
+        return  # pragma: no cover
     changed = 0
     for nd in c.all_unique_nodes():
         for key in c.cleo._datetime_fields:
@@ -1480,8 +1478,8 @@ def todo_fix_datetime(event: LeoKeyEvent) -> None:
 @g.command('todo-dec-pri')
 def todo_dec_pri(event: LeoKeyEvent, direction: int = 1) -> None:
     c = event['c']
-    if not hasattr(c, 'cleo'):  # 2856.
-        return
+    if not hasattr(c, 'cleo'):
+        return  # pragma: no cover
     p = c.p
     priority = int(c.cleo.getat(p.v, 'priority'))
 
@@ -1499,6 +1497,16 @@ def todo_dec_pri(event: LeoKeyEvent, direction: int = 1) -> None:
 @g.command('todo-inc-pri')
 def todo_inc_pri(event: LeoKeyEvent) -> None:
     todo_dec_pri(event, direction=-1)
+
+
+# @+node:ekr.20260803125533.1: ** command find-todo
+@g.command('find-todo')
+@g.command('todo-find')
+def todo_find_command(event: LeoKeyEvent) -> None:
+    c = event['c']
+    if hasattr(c, 'cleo'):
+        c.cleo.find_todo(c.p)
+        c.redraw()
 
 
 # @-others

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -68,15 +68,17 @@ import os
 import re
 import datetime as dt
 import time
+from types import NoneType
 from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
+from leo.core.leoNodes import Position
 from leo.core.leoQt import Qt, QtCore, QtGui, QtWidgets, uic
 from leo.core.leoQt import Checked, Unchecked
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
-    from leo.core.leoNodes import Position, VNode
+    from leo.core.leoNodes import VNode
 
 # May raise g.UiTypeException, caught by the plugins manager.
 g.assertUi('qt')
@@ -230,7 +232,7 @@ if 1:
                     except (TypeError, ValueError):
                         priority = -1
 
-                def setter(priority: int = priority) -> None:
+                def setter(priority: int = priority) -> None:  # pragma: no cover
                     o.setPri(priority)
 
                 w.clicked.connect(lambda checked, setter=setter: setter())
@@ -416,7 +418,7 @@ class todoController:
         self.redrawLevels = 0
         self._widget_to_style: Any | None = None  # see updateStyle()
         self.reloadSettings()
-        self.handlers = [
+        self.handlers: list[tuple[str, Any]] = [
             ("close-frame", self.close),
             ('select3', self.updateUI),
             ('save2', self.loadAllIcons),
@@ -486,7 +488,7 @@ class todoController:
             button.setToolTip(tooltip)
 
     # @+node:tbnorth.20170925093004.1: *3* todoController._date & _time
-    def _date(self, timestamp: str) -> dt.date | None:
+    def _date(self, timestamp: str = '') -> dt.date | None:
         """_date - convert a string to a date
 
         :param timestamp: date to convert
@@ -496,7 +498,7 @@ class todoController:
             return None  # pragma: no cover
         return dt.datetime.fromisoformat(timestamp).date()
 
-    def _time(self, timestamp: str) -> dt.time | None:
+    def _time(self, timestamp: str = '') -> dt.time | None:
         """_time - convert a string to a time
 
         :param timestamp: time to convert
@@ -511,7 +513,7 @@ class todoController:
 
         assert isinstance(menu, QtWidgets.QMenu)
 
-        def rnd(x: float) -> str:
+        def rnd(x: float) -> str:  # pragma: no cover
             return re.sub('.0$', '', '%.1f' % x)
 
         taskmenu = menu.addMenu("Task")
@@ -593,6 +595,7 @@ class todoController:
 
         # pylint: disable=no-self-argument
         def project_changer_callback(self, *args: Any, **kargs: Any) -> Any:
+            # g.trace(f"{fn=} {g.callers()=}")
             ans = fn(self, *args, **kargs)  # pylint: disable=not-callable
             self.update_project()
             return ans
@@ -616,10 +619,10 @@ class todoController:
         if self.icon_order == 'pri-first':
             iterations = ['priority', 'progress', 'duedate']
         else:
-            iterations = ['progress', 'priority', 'duedate']
+            iterations = ['progress', 'priority', 'duedate']  # pragma: no cover
         if clear:
             iterations = []
-        today = dt.datetime.now(tz=dt.timezone.utc)
+        today = dt.datetime.now(tz=dt.timezone.utc).date()  # PR #4841
         for which in iterations:
             if which == 'priority':
                 pri = self.getat(p.v, 'priority')
@@ -654,7 +657,10 @@ class todoController:
             elif which == 'duedate':
                 duedate = self.getat(p.v, 'duedate')
                 nextworkdate = self.getat(p.v, 'nextworkdate')
-                icondate = min(duedate or NO_TIME, nextworkdate or NO_TIME)
+                icondate = min(  # PR #4841
+                    duedate or NO_TIME,
+                    nextworkdate.date() if nextworkdate else NO_TIME
+                )  # fmt: skip
                 if icondate != NO_TIME:
                     if icondate < today:
                         icon = "date_past.png"
@@ -664,25 +670,21 @@ class todoController:
                         icon = "date_future.png"
                     # Append the icon to the icons list.
                     editCommands.appendImageDictToList(
-                        icons,
-                        g.os_path_join('cleo', icon),
-                        2,
+                        icons, g.os_path_join('cleo', icon), 2,
                         on='vnode',
                         cleoIcon='1',
                         where=self.prog_location,
-                    )
+                    )  # fmt: skip
         # Set the p.v.u for the icons.
         editCommands.setIconList(p, icons)
         p.v.updateIcon()  # #2870.
 
     # @+node:tbrown.20090119215428.17: *3* todoController.close
-    def close(self, tag: str, key: Any) -> None:
+    def close(self, tag: str, d: dict) -> None:
         "unregister handlers on closing commander"
-
-        if self.c != key['c']:
-            return  # not our problem
-        for i in self.handlers:
-            g.unregisterHandler(i[0], i[1])  # type:ignore
+        if self.c == d.get('c'):
+            for tag, func in self.handlers:
+                g.unregisterHandler(tag, func)
 
     # @+node:tbrown.20090119215428.18: *3* todoController.showHelp
     def showHelp(self) -> None:
@@ -792,32 +794,25 @@ class todoController:
         node.unknownAttributes["annotate"][attrib] = val
 
         if isDefault:  # check if all default, if so drop dict.
-            self.dropEmpty(node, dictOk=True)
+            self.dropEmpty(node)  ###, dictOk=True)
 
     # @+node:tbrown.20090119215428.25: *4* todoController.dropEmpty
-    def dropEmpty(self, node: VNode, dictOk: bool = False) -> bool:
+    def dropEmpty(self, v: VNode) -> bool:
         if (
-            dictOk
-            or hasattr(node, 'unknownAttributes')
-            and "annotate" in node.unknownAttributes
-            and isinstance(node.unknownAttributes["annotate"], dict)
+            hasattr(v, 'unknownAttributes')
+            and "annotate" in v.unknownAttributes
+            and isinstance(v.unknownAttributes["annotate"], dict)
         ):
             isDefault = True
-            for ky, vl in node.unknownAttributes["annotate"].items():
-                if not self.testDefault(ky, vl):
+            for key, value in v.unknownAttributes["annotate"].items():
+                if not self.testDefault(key, value):
                     isDefault = False
                     break
             if isDefault:  # no non-defaults seen, drop the whole cleo dictionary
-                del node.unknownAttributes["annotate"]
+                del v.unknownAttributes["annotate"]
                 self.c.setChanged()
                 return True
         return False
-
-    # @+node:tbrown.20090119215428.26: *4* todoController.safe_del
-    def safe_del(self, d: dict[str, Any], k: Any) -> None:
-        "delete a key from a dict. if present"
-        if k in d:
-            del d[k]
 
     # @+node:tbrown.20090119215428.27: *3* todoController:drawing...
     # @+node:tbrown.20090119215428.29: *4* todoController.clear_*
@@ -852,32 +847,25 @@ class todoController:
     # @+node:tbrown.20090119215428.32: *4* todoController.set_progress
     @redrawer
     @projectChanger
-    def set_progress(self, p: Position = None, val: Any = None) -> None:  # Hard to annotate.
-        if p is None:
-            p = self.c.currentPosition()
-        v = p.v
-
-        if val is None:
-            return
-
-        self.setat(v, 'progress', val)
+    def set_progress(self, val: str | int) -> None:
+        c = self.c
+        if val is not None:
+            self.setat(c.p.v, 'progress', val)
 
     # @+node:tbrown.20090119215428.33: *4* todoController.set_time_req
     @redrawer
     @projectChanger
-    def set_time_req(self, p: Position = None, val: Any = None) -> None:  # Hard to annotate.
-        if p is None:
-            p = self.c.currentPosition()
-        v = p.v
-        if val is None:
-            return
-        self.setat(v, 'time_req', val)
-        if self.getat(v, 'progress') == '':
-            self.setat(v, 'progress', 0)
+    def set_time_req(self, val: str | int = '') -> None:
+        c = self.c
+        if val:
+            v = c.p.v
+            self.setat(v, 'time_req', val)
+            if self.getat(v, 'progress') == '':
+                self.setat(v, 'progress', 0)
 
     # @+node:tbrown.20090119215428.34: *4* todoController.show_times
     @redrawer
-    def show_times(self, p: Position = None, show: bool = False) -> None:
+    def show_times(self, p: Position = None, *, show: bool = False) -> None:
         def rnd(x: float) -> str:
             return re.sub('.0$', '', '%.1f' % x)
 
@@ -917,16 +905,16 @@ class todoController:
                 self.loadIcons(nd)  # update progress icon
 
     # @+node:tbrown.20090119215428.35: *4* todoController.recalc_time
-    def recalc_time(self, p: Position = None, clear: bool = False) -> tuple[str, str]:
-        if p is None:
-            p = self.c.currentPosition()
+    def recalc_time(self, p: Position, clear: Position | None = None) -> tuple[str, str]:
+        assert isinstance(p, Position), repr(p)
+        assert isinstance(clear, (Position, NoneType)), repr(clear)
         v = p.v
         time_totl: str | None = None
         time_done: str | None = None
 
         # get values from children, if any
         for cn in p.children():
-            ans = self.recalc_time(cn.copy(), clear)
+            ans = self.recalc_time(cn, clear)
             if time_totl is None:
                 time_totl = ans[0]
             else:
@@ -970,28 +958,28 @@ class todoController:
     # @+node:tbrown.20090119215428.36: *4* todoController.clear_time_req
     @redrawer
     @projectChanger
-    def clear_time_req(self, p: Position = None) -> None:
-        if p is None:
-            p = self.c.currentPosition()
-        v = p.v
-        self.setat(v, 'time_req', '')
+    def clear_time_req(self) -> None:
+        c = self.c
+        self.setat(c.p.v, 'time_req', '')
 
     # @+node:tbrown.20090119215428.37: *4* todoController.update_project
     @redrawer
     def update_project(self, p: Position = None) -> None:
-        """Find highest parent with '@project' in headline and run recalc_time
-        and maybe show_times (if headline has '@project time')"""
+        """
+        Find highest parent with '@project' in headline and run recalc_time
+        and maybe show_times (if headline has '@project time')
+        """
 
         if p is None:
             p = self.c.currentPosition()
-        project = None
+        project: Position | None = None
 
         for nd in p.self_and_parents():
             if nd.headString().find('@project') > -1:
                 project = nd.copy()
 
         if project:
-            self.recalc_time(project)
+            self.recalc_time(p, project)
             if project.headString().find('@project time') > -1:
                 self.show_times(project, show=True)
             else:
@@ -1001,25 +989,24 @@ class todoController:
 
     # @+node:tbrown.20090119215428.38: *4* todoController.local_recalc
     @redrawer
-    def local_recalc(self, p: Position = None) -> None:
-        self.recalc_time(p)
+    def local_recalc(self) -> None:
+        self.recalc_time(self.c.p)
 
     # @+node:tbrown.20090119215428.39: *4* todoController.local_clear
     @redrawer
-    def local_clear(self, p: Position = None) -> None:
-        self.recalc_time(p, clear=True)
+    def local_clear(self) -> None:
+        self.recalc_time(self.c.p)
 
     # @+node:tbrown.20110213091328.16233: *4* todoController.set_due_date
     def set_due_date(
         self,
-        p: Position = None,
-        val: Any = None,  # Hard to annotate.
+        val: Any,  # Example, dt.datetime.now(tz=dt.timezone.utc))
         mode: str = 'adjust',
         field: str = 'duedate',
     ) -> None:
         "mode: `adjust` for change in time, `check` for checkbox toggle"
-        if p is None:
-            p = self.c.currentPosition()
+        c = self.c
+        p = c.p
         v = p.v
 
         if field == 'duedate':
@@ -1381,27 +1368,18 @@ class todoController:
         self.ui.setNextWorkTime(self.getat(v, 'nextworktime'))
         created = self.getat(v, 'created')
         if created and isinstance(created, dt.datetime) and created.year >= 1900:
+            created = created.date()  # PR #4841
             self.ui.UI.createdTxt.setText(created.strftime("%d %b %y"))
             self.ui.UI.createdTxt.setToolTip(created.strftime("Created %H:%M %d %b %Y"))
         else:
-            # .strftime doesn't work here! This has has happened...
-            try:
-                gdate = self.c.p.v.gnx.split('.')[1][:12]
-                created = dt.datetime.strptime(gdate, '%Y%m%d%H%M').replace(tzinfo=dt.timezone.utc)
-                if created.year < 1900:
-                    created = None
-            except Exception:  # pragma: no cover
-                created = None
-            if created:
-                self.ui.UI.createdTxt.setText(created.strftime("Created %d %b %Y"))
-                self.ui.UI.createdTxt.setToolTip(created.strftime("gnx created %H:%M %d %b %Y"))
-            else:
-                self.ui.UI.createdTxt.setText("")
+            created = dt.datetime.now(tz=dt.timezone.utc).date()
+            self.ui.UI.createdTxt.setText(created.strftime("Created %d %b %Y"))
+            self.ui.UI.createdTxt.setToolTip(created.strftime("gnx created %H:%M %d %b %Y"))
 
         # Update the label.
         h = self.c and self.c.p and self.c.p.h
         due = self.getat(v, 'duedate')
-        now = dt.datetime.now(tz=dt.timezone.utc)
+        now = dt.datetime.now(tz=dt.timezone.utc).date()  # PR #4841
         ago = (now - created).days if created else 0
         if due:
             days = (due - now).days

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -75,7 +75,7 @@ from leo.core.leoQt import Checked, Unchecked
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
-    from leo.core.leoGui import LeoKeyEvent as Event
+    from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position, VNode
 
 # May raise g.UiTypeException, caught by the plugins manager.
@@ -1459,7 +1459,7 @@ class todoController:
 
 # @+node:tbrown.20170928065405.1: ** command fix datetime
 @g.command('todo-fix-datetime')
-def todo_fix_datetime(event: Event) -> None:
+def todo_fix_datetime(event: LeoKeyEvent) -> None:
     c = event['c']
     if not hasattr(c, 'cleo'):  # 2856.
         return
@@ -1476,7 +1476,7 @@ def todo_fix_datetime(event: Event) -> None:
 
 # @+node:tbrown.20100701093750.13800: ** command inc/dec priority
 @g.command('todo-dec-pri')
-def todo_dec_pri(event: Event, direction: int = 1) -> None:
+def todo_dec_pri(event: LeoKeyEvent, direction: int = 1) -> None:
     c = event['c']
     if not hasattr(c, 'cleo'):  # 2856.
         return
@@ -1496,7 +1496,7 @@ def todo_dec_pri(event: Event, direction: int = 1) -> None:
 
 
 @g.command('todo-inc-pri')
-def todo_inc_pri(event: Event) -> None:
+def todo_inc_pri(event: LeoKeyEvent) -> None:
     todo_dec_pri(event, direction=-1)
 
 
@@ -1505,7 +1505,7 @@ for cmd, method in [
     ("todo-find-todo", "find_todo"),
 ]:
 
-    def f(event: Event, method: str = method) -> None:
+    def f(event: LeoKeyEvent, method: str = method) -> None:
         getattr(event.c.cleo, method)()
         event.c.redraw()
 

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -134,7 +134,7 @@ if 1:
     class todoQtUI(QtWidgets.QWidget):
         # @+others
         # @+node:ekr.20111118104929.10204: *3* ctor (todoQtUI(QWidget))
-        def __init__(self, owner: Any, logTab: bool = True) -> None:
+        def __init__(self, owner: todoController, logTab: bool = True) -> None:
             self.owner = owner
             super().__init__()
             uiPath = g.os_path_join(g.app.leoDir, 'plugins', 'ToDo.ui')
@@ -414,7 +414,7 @@ class todoController:
         self.menuicons: dict[int | str, QtGui.QIcon] = {}
         self.recentIcons: list[int | str] = []  # PR #4840: was list[QtGui.QIcon] (!)
         self.redrawLevels = 0
-        self._widget_to_style = None  # see updateStyle()
+        self._widget_to_style: Any | None = None  # see updateStyle()
         self.reloadSettings()
         self.handlers = [
             ("close-frame", self.close),
@@ -1359,13 +1359,13 @@ class todoController:
         nwd = self.getat(v, 'nextworkdate')
         due = self.getat(v, 'duedate')
         if hasattr(self.ui.UI, "frmDates"):
-            w = self.ui.UI.frmDates
-            if nwd and due and str(nwd) > str(due):
-                w.setProperty('style_class', 'tododate_error')
-            else:
-                w.setProperty('style_class', '')
-            # update style on this widget on idle, see updateStyle()
-            self._widget_to_style = (w, time.time())
+            if w := self.ui.UI.frmDates:
+                if nwd and due and str(nwd) > str(due):
+                    w.setProperty('style_class', 'tododate_error')
+                else:
+                    w.setProperty('style_class', '')
+                # update style on this widget on idle, see updateStyle()
+                self._widget_to_style = (w, time.time())
 
         self.ui.setProgress(int(self.getat(v, 'progress') or 0))
         self.ui.setTime(float(self.getat(v, 'time_req') or 0))

--- a/leo/unittests/core/test_leoColorizer.py
+++ b/leo/unittests/core/test_leoColorizer.py
@@ -4,6 +4,7 @@
 
 # pylint: disable=line-too-long
 
+import time
 from typing import Any
 from leo.core import leoGlobals as g
 from leo.core import leoColorizer
@@ -1654,6 +1655,11 @@ class TestQtColorizer(LeoUnitTest):
     @classmethod
     def setUpClass(cls: Any) -> None:
         create_app(gui_name='qt')
+
+    @classmethod
+    def tearDownClass(cls):
+        g.app.finishQuit()
+        time.sleep(0.5)
 
     # @+others
     # @+node:ekr.20260519084534.1: *3* TestQtColorizer.test_underlines_in_setTag

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -115,6 +115,10 @@ class TestQtGui(LeoUnitTest):
     def setUpClass(cls):
         create_app(gui_name='qt')
 
+    @classmethod
+    def tearDownClass(cls):
+        g.app.finishQuit()
+
     def setUp(self):
         super().setUp()
         # Don't run *any* tests if Qt has not been installed.

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -118,6 +118,7 @@ class TestQtGui(LeoUnitTest):
     @classmethod
     def tearDownClass(cls):
         g.app.finishQuit()
+        time.sleep(0.5)
 
     def setUp(self):
         super().setUp()

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -322,6 +322,7 @@ class TestTodo(LeoUnitTest):
         # Test controller commands.
         controller = todo.todoController(c)
         controller.find_todo(c.p)
+        c.doCommandByName('find-todo', event)
 
     # @-others
 

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -318,6 +318,7 @@ class TestTodo(LeoUnitTest):
         todo.todo_fix_datetime(event)
         todo.todo_dec_pri(event)
         todo.todo_inc_pri(event)
+        todo.find_todo(event)
 
         # Test controller commands.
         controller = todo.todoController(c)

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -7,6 +7,7 @@
 import glob
 import os
 import re
+import time
 from leo.core import leoGlobals as g
 from leo.core.leoGui import LeoKeyEvent
 from leo.core.leoPlugins import LeoPluginsController
@@ -288,6 +289,11 @@ class TestTodo(LeoUnitTest):
     @classmethod
     def setUpClass(cls):
         create_app(gui_name='qt')
+
+    @classmethod
+    def tearDownClass(cls):
+        g.app.finishQuit()
+        time.sleep(0.5)
 
     def setUp(self):
         super().setUp()

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -10,13 +10,11 @@ import re
 from leo.core import leoGlobals as g
 from leo.core.leoGui import LeoKeyEvent
 from leo.core.leoPlugins import LeoPluginsController
-from leo.core.leoQt import QtCore
 from leo.core.leoTest2 import LeoUnitTest, create_app
 from leo.plugins import indented_languages
 
 try:
-    from leo.core.leoQt import Qt, QtWidgets
-
+    from leo.core.leoQt import Qt, QtCore, QtWidgets
 except Exception:
     g.es_exception()
     Qt = QtCore = QtWidgets = None
@@ -309,6 +307,8 @@ class TestTodo(LeoUnitTest):
         v = p.v
         now = dt.datetime.now(tz=dt.timezone.utc)
 
+        # todoQtUI = todo.todoQtUI(x)
+
         # test init.
         assert todo.init()
         todo.warning_given = True
@@ -363,7 +363,6 @@ class TestTodo(LeoUnitTest):
         x.clear_time_req()
         x.local_recalc()
         x.local_clear()
-        todoQtUI = todo.todoQtUI(x)
         x.set_due_date(QtCore.QDate(2026, 1, 1))
         x.set_due_time(QtCore.QTime(6, 6))
         x.set_progress(100)

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -297,8 +297,8 @@ class TestTodo(LeoUnitTest):
             self.skipTest('import Qt failed')
 
     # @+others
-    # @+node:ekr.20260802060227.1: *3* TestTodo.test_outer_functions
-    def test_outer_functions(self):
+    # @+node:ekr.20260802060227.1: *3* TestTodo.test_cover_todo
+    def test_cover_todo(self):
 
         from leo.plugins import todo
 
@@ -323,8 +323,22 @@ class TestTodo(LeoUnitTest):
         # Test controller commands.
         controller = todo.todoController(c)
         controller.find_todo(c.p)
+        controller.find_todo()
         c.doCommandByName('find-todo', event)
         c.doCommandByName('todo-find', event)
+
+        # Test g.app.config.getString('color-theme')
+        d = g.app.loadManager.globalSettingsDict
+        d['colortheme'] = g.GeneralSetting(kind='string', val='ekr_dark')
+        assert g.app.config.getString('color-theme') == 'ekr_dark'
+        controller = todo.todoController(c)
+        controller.find_todo()
+
+        # Test g.app.config.getInt("todo-calendar-cols")
+        d['todocalendarcols'] = g.GeneralSetting(kind='int', val=5)
+        assert g.app.config.getInt('todo-calendar-cols') == 5
+        controller = todo.todoController(c)
+        controller.find_todo()
 
     # @-others
 

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -323,6 +323,7 @@ class TestTodo(LeoUnitTest):
         controller = todo.todoController(c)
         controller.find_todo(c.p)
         c.doCommandByName('find-todo', event)
+        c.doCommandByName('todo-find', event)
 
     # @-others
 

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -364,11 +364,17 @@ class TestTodo(LeoUnitTest):
         x.local_clear()
         todoQtUI = todo.todoQtUI(x)
         x.set_due_date(todoQtUI.UI.dueDateEdit.date())
-        x.set_time_req(50)
         x.set_progress(100)
+        x.set_time_req(50)
+        x.set_progress()
+        x.set_time_req('')
         x.show_times(show=True)
         x.show_times(show=False)
         x.recalc_time(p)
+        x.clear_node()
+        x.clear_subtree()
+        x.clear_all()
+        x.progress_clear()
 
         # Last.
         g.app.pluginsController = LeoPluginsController()

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -8,17 +8,17 @@ import glob
 import os
 import re
 from leo.core import leoGlobals as g
-from leo.core.leoTest2 import LeoUnitTest, create_app
+from leo.core.leoGui import LeoKeyEvent
 from leo.core.leoPlugins import LeoPluginsController
+from leo.core.leoTest2 import LeoUnitTest, create_app
 from leo.plugins import indented_languages
 
 try:
     from leo.core.leoQt import Qt, QtWidgets
 
-    QTabWidget = QtWidgets.QTabWidget
 except Exception:
     g.es_exception()
-    Qt = QtCore = QTabWidget = None
+    Qt = QtWidgets = None
 # @-<< test_plugins: imports >>
 
 
@@ -302,14 +302,20 @@ class TestTodo(LeoUnitTest):
 
         from leo.plugins import todo
 
-        assert todo.init()
+        c = self.c
 
+        # test init.
+        assert todo.init()
         todo.warning_given = True
         assert not todo.init()
 
-        c = self.c
+        # Test top-level functions.
         todo.onCreate(tag=g.my_name(), key={'c': c})
         todo.popup_entry(c=c, p=c.p, menu=QtWidgets.QMenu())
+
+        # Test commands.
+        event = LeoKeyEvent(c=c)
+        todo.todo_fix_datetime(event)
 
     # @-others
 

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -300,9 +300,13 @@ class TestTodo(LeoUnitTest):
     # @+node:ekr.20260802060227.1: *3* TestTodo.test_cover_todo
     def test_cover_todo(self):
 
+        import datetime as dt
         from leo.plugins import todo
 
         c = self.c
+        p = c.p
+        v = p.v
+        now = dt.datetime.now(tz=dt.timezone.utc)
 
         # test init.
         assert todo.init()
@@ -311,7 +315,7 @@ class TestTodo(LeoUnitTest):
 
         # Test top-level functions.
         todo.onCreate(tag=g.my_name(), key={'c': c})
-        todo.popup_entry(c=c, p=c.p, menu=QtWidgets.QMenu())
+        todo.popup_entry(c=c, p=p, menu=QtWidgets.QMenu())
 
         # Test outer commands.
         event = LeoKeyEvent(c=c)
@@ -321,9 +325,9 @@ class TestTodo(LeoUnitTest):
         todo.find_todo(event)
 
         # Test controller commands.
-        controller = todo.todoController(c)
-        controller.find_todo(c.p)
-        controller.find_todo()
+        x = todo.todoController(c)
+        x.find_todo(c.p)
+        x.find_todo()
         c.doCommandByName('find-todo', event)
         c.doCommandByName('todo-find', event)
 
@@ -331,14 +335,44 @@ class TestTodo(LeoUnitTest):
         d = g.app.loadManager.globalSettingsDict
         d['colortheme'] = g.GeneralSetting(kind='string', val='ekr_dark')
         assert g.app.config.getString('color-theme') == 'ekr_dark'
-        controller = todo.todoController(c)
-        controller.find_todo()
+        x = todo.todoController(c)
+        x.find_todo()
 
         # Test g.app.config.getInt("todo-calendar-cols")
         d['todocalendarcols'] = g.GeneralSetting(kind='int', val=5)
         assert g.app.config.getInt('todo-calendar-cols') == 5
-        controller = todo.todoController(c)
-        controller.find_todo()
+        x = todo.todoController(c)
+        x.find_todo()
+
+        # Cover more methods.
+        x = todo.todoController(c)
+        x._date()
+        x._time()
+        x._time(timestamp=str(now))
+        x.loadIcons(c.p, clear=True)
+        x.showHelp()
+
+        # uAs.
+        x.set_progress(2)
+        x.hasUD(v)
+        x.delUD(v)
+        x.dropEmpty(v)
+        x.set_progress(3)
+        x.set_time_req(100)
+        x.clear_time_req()
+        x.local_recalc()
+        x.local_clear()
+        todoQtUI = todo.todoQtUI(x)
+        x.set_due_date(todoQtUI.UI.dueDateEdit.date())
+        x.set_time_req(50)
+        x.set_progress(100)
+        x.show_times(show=True)
+        x.show_times(show=False)
+        x.recalc_time(p)
+
+        # Last.
+        g.app.pluginsController = LeoPluginsController()
+        x.close(tag='test', d={'c': c})
 
     # @-others
 

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -313,9 +313,15 @@ class TestTodo(LeoUnitTest):
         todo.onCreate(tag=g.my_name(), key={'c': c})
         todo.popup_entry(c=c, p=c.p, menu=QtWidgets.QMenu())
 
-        # Test commands.
+        # Test outer commands.
         event = LeoKeyEvent(c=c)
         todo.todo_fix_datetime(event)
+        todo.todo_dec_pri(event)
+        todo.todo_inc_pri(event)
+
+        # Test controller commands.
+        controller = todo.todoController(c)
+        controller.find_todo(c.p)
 
     # @-others
 

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -10,6 +10,7 @@ import re
 from leo.core import leoGlobals as g
 from leo.core.leoGui import LeoKeyEvent
 from leo.core.leoPlugins import LeoPluginsController
+from leo.core.leoQt import QtCore
 from leo.core.leoTest2 import LeoUnitTest, create_app
 from leo.plugins import indented_languages
 
@@ -18,7 +19,7 @@ try:
 
 except Exception:
     g.es_exception()
-    Qt = QtWidgets = None
+    Qt = QtCore = QtWidgets = None
 # @-<< test_plugins: imports >>
 
 
@@ -363,7 +364,8 @@ class TestTodo(LeoUnitTest):
         x.local_recalc()
         x.local_clear()
         todoQtUI = todo.todoQtUI(x)
-        x.set_due_date(todoQtUI.UI.dueDateEdit.date())
+        x.set_due_date(QtCore.QDate(2026, 1, 1))
+        x.set_due_time(QtCore.QTime(6, 6))
         x.set_progress(100)
         x.set_time_req(50)
         x.set_progress()


### PR DESCRIPTION
See #4822.

### I shall deprecate or retire the todo.py plugin!

The deeper I look into this plugin, the less I like it:

- Its code is complex without serving any clear purpose.
- GitHub issues is a far better way too manage projects.
- Leo outlines organize and clarify to-do lists without any further help.

Tasks:

- [x] Restore call to v.setDirty. Safety first.
- [x] Define controller commands using decorators.
- [x] Always add tooltips: It's safe to assume we are using Qt6.
- [x] Cover most functions and methods in todo.py.
   These will *not* be functional tests. The tests will merely ensure that todo.py won't likely crash!
- [x] LeoSettings.leo: Remove todo.py from the list of plugins that run by default.

### Generalizing Leo's Qt-related tests will be this PR's primary contribution!

TestTodo.test_cover_todo shows how easy it is to cover Qt code.

- [x] Suppress this message: `QBasicTimer::start: QBasicTimer can only be used with threads started with QThread`
   Qt uses QBasicTimer internally. Leo does not use QBasicTimer at all.
   Add shutDownClass methods.