### PR TITLE
CI: add unit test job running leo/unittests headlessly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,24 @@ jobs:
       - run: pip install ruff
       - run: ruff check leo
 
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    env:
+      # No display in CI; run Qt headless instead of pulling in xvfb.
+      QT_QPA_PLATFORM: offscreen
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: pip install asttokens Pygments "PyQt6>=6.6" PyQt6-QScintilla
+      - run: python run_travis_unit_tests.py
+
   mypy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends
           libegl1 libgl1 libxkbcommon0 libdbus-1-3 libfontconfig1
       - run: pip install asttokens Pygments "PyQt6>=6.6" PyQt6-QScintilla
-      - run: python run_travis_unit_tests.py
+      - run: python run_ci_unit_tests.py
 
   mypy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends
+          libegl1 libgl1 libxkbcommon0 libdbus-1-3 libfontconfig1
       - run: pip install asttokens Pygments "PyQt6>=6.6" PyQt6-QScintilla
       - run: python run_travis_unit_tests.py
 

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -14,6 +14,7 @@ To run externally, do `python -m leo.core.leoserver --password <password>`.
 # @+<< leoserver imports >>
 # @+node:felix.20210621233316.2: ** << leoserver imports >>
 # pylint: disable=raise-missing-from
+from __future__ import annotations
 import argparse
 import asyncio
 from collections.abc import Callable, Generator, Iterable, Iterator

--- a/run_ci_unit_tests.py
+++ b/run_ci_unit_tests.py
@@ -20,9 +20,8 @@ try:
         sys.stdout.flush()
         os._exit(1)
     print(f"{tag}: {n} unit tests passed.")
-    # os._exit, not sys.exit: skips Python/Qt interpreter finalization, which
-    # can segfault during Qt's atexit cleanup on some platforms after all
-    # tests have already passed, turning a green run into a false CI failure.
+    # os._exit, not sys.exit: avoids a Qt atexit segfault that could
+    # otherwise report this passing run as a CI failure.
     sys.stdout.flush()
     os._exit(0)
 except Exception:

--- a/run_ci_unit_tests.py
+++ b/run_ci_unit_tests.py
@@ -1,11 +1,11 @@
 # @+leo-ver=5-thin
-# @+node:ekr.20181009072707.1: * @file ../../run_travis_unit_tests.py
+# @+node:ekr.20181009072707.1: * @file ../../run_ci_unit_tests.py
 import os
 import sys
 import traceback
 import unittest
 
-tag = 'run_travis_unit_tests.py'
+tag = 'run_ci_unit_tests.py'
 try:
     base_dir = os.path.dirname(__file__)
     unittests_dir = os.path.abspath(os.path.join(base_dir, 'leo', 'unittests'))

--- a/run_travis_unit_tests.py
+++ b/run_travis_unit_tests.py
@@ -17,14 +17,20 @@ try:
     if result.errors or result.failures:
         errors, fails = len(result.errors), len(result.failures)
         print(f"{tag}: {errors} errors, {fails} failures")
-        sys.exit(1)
+        sys.stdout.flush()
+        os._exit(1)
     print(f"{tag}: {n} unit tests passed.")
-    sys.exit(0)
+    # os._exit, not sys.exit: skips Python/Qt interpreter finalization, which
+    # can segfault during Qt's atexit cleanup on some platforms after all
+    # tests have already passed, turning a green run into a false CI failure.
+    sys.stdout.flush()
+    os._exit(0)
 except Exception:
     typ, val, tb = sys.exc_info()
     lines = traceback.format_exception(typ, val, tb)
     print(f"{tag}: unexpected exception")
     for line in lines:
         print(line.rstrip())
-    sys.exit(1)
+    sys.stdout.flush()
+    os._exit(1)
 # @-leo


### PR DESCRIPTION
## Summary
- Add a `test` job to `.github/workflows/ci.yml` that runs `run_ci_unit_tests.py` (unittest discover over `leo/unittests`, 873 tests) across the same Python 3.10–3.13 matrix as `lint`, headless via `QT_QPA_PLATFORM=offscreen` (no display on GitHub Actions runners). Installs `libegl1 libgl1 libxkbcommon0 libdbus-1-3 libfontconfig1` via apt first — PyQt6 links against them at import time even under the offscreen platform, and the runner image doesn't ship them.
- Switch the runner script from `sys.exit()` to `os._exit()`: after all tests pass, letting the interpreter finalize normally can segfault during Qt's atexit cleanup on some platforms, which would otherwise show up as a false CI failure on an all-green run.
- Fix `leo/core/leoserver.py`: add the missing `from __future__ import annotations`. Every other `core/*.py` file with a `TYPE_CHECKING` block has this; without it, a `TYPE_CHECKING`-only alias (`Response`) used as a real annotation raises `NameError` at import time on Python <3.14 — a genuine latent bug the new test job caught immediately. (Python 3.14 made deferred annotation evaluation the default per PEP 649/749, which is why this went unnoticed locally.)
- Rename `run_travis_unit_tests.py` → `run_ci_unit_tests.py`. Travis CI was removed from this project years ago; the script now backs the GitHub Actions job, and the old name was misleading.

## Test plan
- [x] Locally verified all 873 tests pass (~8s) with a minimal dependency set (`asttokens`, `Pygments`, `PyQt6`, `PyQt6-QScintilla`) and `QT_QPA_PLATFORM=offscreen`
- [x] Reproduced the `leoserver.py` `NameError` locally on Python 3.12 and confirmed the fix resolves it
- [x] `lint`, `mypy`, and `test` (3.10–3.13) all green on GitHub Actions