### PR TITLE
Work through ty's diagnostics: 733 -> 110, mypy clean throughout (v2, clean rebase)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,15 @@ jobs:
           types-docutils types-Markdown types-paramiko types-PyYAML
           types-requests types-six
           "PyQt6>=6.6" PyQt6-QScintilla PyQt6-WebEngine ty
-      ###
-      # - run: python -m mypy leo
+          black pylint Jinja2 flake8 pyflakes Pygments
+      # These 6 are optional runtime deps for individual plugins/commands
+      # (leoBeautify.py, checkerCommands.py, viewrendered.py, leoColorizer.py),
+      # each guarded by 'try: import X except: X = None'. Installing them
+      # here matches a typical dev environment (they're common enough to
+      # often be present) so mypy/ty check the same code path CI and
+      # contributors actually see, instead of only the ignore_missing_imports
+      # fallback.
+      - run: python -m mypy leo
       # Informational only: ty (https://github.com/astral-sh/ty) is an
       # actively-developed, much faster alternative to mypy, still in beta.
       # It's noticeably stricter than our current mypy config in some areas

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -23,13 +23,13 @@ except Exception:
 try:
     import flake8  # #2248: Import only flake8.
 except ImportError:
-    flake8 = None
+    flake8 = None  # type:ignore
 
 try:
     import pyflakes
     from pyflakes import api, reporter
 except Exception:
-    pyflakes = None
+    pyflakes = None  # type:ignore
 
 try:
     from pylint import lint
@@ -95,7 +95,7 @@ def check_nodes(event: LeoKeyEvent | None = None) -> None:
       Headlines that match these suppressions *exactly* are not considered dubious.
       Default: None.
     """
-    c = event and event.get('c')
+    c = event.c if event else None
     if not c:
         return
     CheckNodes(c).check(event)
@@ -108,7 +108,7 @@ def find_long_lines(event: LeoKeyEvent | None = None) -> None:
     Report long lines in c.p's tree.
     Generate clickable links in the log.
     """
-    c = event and event.get('c')
+    c = event.c if event else None
     if not c:
         return
 
@@ -168,7 +168,7 @@ def find_long_lines(event: LeoKeyEvent | None = None) -> None:
 @g.command('find-missing-docstrings')
 def find_missing_docstrings(event: LeoKeyEvent | None = None) -> None:
     """Report missing docstrings in the log, with clickable links."""
-    c = event and event.get('c')
+    c = event.c if event else None
     if not c:
         return
 
@@ -246,7 +246,7 @@ def flake8_command(event: LeoKeyEvent | None = None) -> None:
     if not flake8:
         g.es_print(f"{tag} can not import flake8")
         return
-    c = event and event.get('c')
+    c = event.c if event else None
     if not c or not c.p:
         return
     python = sys.executable
@@ -292,7 +292,7 @@ def mypy_command(event: LeoKeyEvent | None = None) -> None:
 
     See leoSettings.leo for details.
     """
-    c = event and event.get('c')
+    c = event.c if event else None
     if not c:
         return
     if c.isChanged():
@@ -310,7 +310,7 @@ def pyflakes_command(event: LeoKeyEvent | None = None) -> None:
     Run pyflakes on all nodes of the selected tree,
     or the first @<file> node in an ancestor.
     """
-    c = event and event.get('c')
+    c = event.c if event else None
     if not c:
         return
     if c.isChanged():
@@ -334,7 +334,7 @@ def pylint_command(event: LeoKeyEvent | None = None) -> None:
     or the last checked @<file> node.
     """
     global last_pylint_path
-    if c := event and event.get('c'):
+    if c := (event.c if event else None):
         if c.isChanged():
             c.save()
         if data := PylintCommand(c).run(c.p, last_path=last_pylint_path):

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -10,7 +10,7 @@ from collections.abc import Callable, Generator
 from xml.etree import ElementTree
 import json
 import time
-from typing import Any, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoNodes
 from leo.core import leoFileCommands
@@ -298,6 +298,9 @@ def pasteAsTemplate(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
 
         # create vnode
         v, _ = getv(gnx)
+        # h is never None here: this first row is always xv[0] itself (the
+        # root of the copied tree), which viter() never treats as "seen".
+        assert h is not None
         v.h = h
         v.b = b
 
@@ -312,6 +315,11 @@ def pasteAsTemplate(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
             # get or create a child `v`
             v, isNew = getv(gnx)
             if isNew:
+                # h is never None here: viter() only yields h=None for gnx
+                # values already in `seen` (nodes outside the copied tree),
+                # and those always resolve to an existing vnode, so isNew
+                # is False for them.
+                assert h is not None
                 v.h = h
                 v.b = b
                 if ua := uas.get(gnx):
@@ -347,7 +355,7 @@ def pasteAsTemplate(self: Cmdr, event: LeoKeyEvent | None = None) -> None:
 
     if not isJson:
         xroot = ElementTree.fromstring(s)
-        xvelements = xroot.find('vnodes')  # <v> elements.
+        xvelements = cast(Any, xroot.find('vnodes'))  # <v> elements.
         xtelements = xroot.find('tnodes')  # <t> elements.
         bodies, uas = x.scanTnodes(xtelements)
         root_gnx = xvelements[0].attrib.get('t')  # the gnx of copied node

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -475,7 +475,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def dumpCaches(self, event: LeoKeyEvent | None = None) -> None:  # pragma: no cover
         """Dump, all of Leo's file caches."""
         if hasattr(g.app.global_cacher, 'dump'):
-            g.app.global_cacher.dump()
+            cast(Any, g.app.global_cacher).dump()
         else:
             g.printObj(g.app.global_cacher)
 
@@ -2587,7 +2587,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         spots = ('end-line', 'finish-line', 'start-line')
         if hasattr(w, 'leoMoveCursorHelper') and spot not in spots:
             extend = extend or self.extendMode
-            w.leoMoveCursorHelper(kind=spot, extend=extend)
+            cast(Any, w).leoMoveCursorHelper(kind=spot, extend=extend)
         else:
             s = w.getAllText()
             ins = w.getInsertPoint()
@@ -2850,7 +2850,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         w.seeInsertPoint()
         if hasattr(w, 'leoMoveCursorHelper'):
             extend = extend or self.extendMode
-            w.leoMoveCursorHelper(kind=direction, extend=extend)
+            cast(Any, w).leoMoveCursorHelper(kind=direction, extend=extend)
         else:
             # Find the start of the next/prev line.
             row, col = g.convertPythonIndexToRowCol(s, ins)
@@ -2894,7 +2894,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             return  # pragma: no cover (defensive)
         if hasattr(w, 'leoMoveCursorHelper'):
             extend = extend or self.extendMode
-            w.leoMoveCursorHelper(kind=spot, extend=extend)
+            cast(Any, w).leoMoveCursorHelper(kind=spot, extend=extend)
         else:
             if spot == 'home':
                 self.moveToHelper(event, 0, extend=extend)
@@ -2933,7 +2933,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             return
         if hasattr(w, 'leoMoveCursorHelper'):
             extend = extend or self.extendMode
-            w.leoMoveCursorHelper(kind=spot, extend=extend)
+            cast(Any, w).leoMoveCursorHelper(kind=spot, extend=extend)
         else:
             i = w.getInsertPoint()
             if spot == 'left':
@@ -2993,7 +2993,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         if not g.isTextWrapper(w):
             return
         if hasattr(w, 'leoMoveCursorHelper'):
-            w.leoMoveCursorHelper(kind='exchange', extend=False)
+            cast(Any, w).leoMoveCursorHelper(kind='exchange', extend=False)
         else:
             c.widgetWantsFocusNow(w)
             i, j = w.getSelectionRange(sort=False)
@@ -3214,7 +3214,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         linesPerPage = 15  # To do.
         if hasattr(w, 'leoMoveCursorHelper'):
             extend = extend or self.extendMode
-            w.leoMoveCursorHelper(
+            cast(Any, w).leoMoveCursorHelper(
                 kind='page-down' if kind == 'forward' else 'page-up',
                 extend=extend,
                 linesPerPage=linesPerPage,
@@ -3912,7 +3912,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         w = event and event.w
         if w and hasattr(w, 'scrollDelegate'):
             kind = direction + '-' + distance
-            w.scrollDelegate(kind)
+            cast(Any, w).scrollDelegate(kind)
 
     # @+node:ekr.20150514063305.337: *4* ec.scrollOutlineUp/Down/Line/Page
     @cmd('scroll-outline-down-line')

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -232,7 +232,7 @@ class GoToCommands:
     # @+node:ekr.20150624085605.1: *3* goto.scan_nonsentinel_lines
     def scan_nonsentinel_lines(
         self, lines: list[str], n: int, root: Position
-    ) -> tuple[str, str, int]:
+    ) -> tuple[str | None, str | None, int]:
         """
         Scan a list of lines containing sentinels, looking for the node and
         offset within the node of the n'th (one-based) line.
@@ -290,7 +290,9 @@ class GoToCommands:
         return gnx, h, offset
 
     # @+node:ekr.20150623175314.1: *3* goto.scan_sentinel_lines
-    def scan_sentinel_lines(self, lines: list[str], n: int, root: Position) -> tuple[str, str, int]:
+    def scan_sentinel_lines(
+        self, lines: list[str], n: int, root: Position
+    ) -> tuple[str | None, str | None, int]:
         """
         Scan a list of lines containing sentinels, looking for the node and
         offset within the node of the n'th (one-based) line.

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 from collections.abc import Callable
 import re
-from typing import Any, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 
 # Third-party annotations
 try:
@@ -238,7 +238,7 @@ class DefaultWrapper(BaseSpellWrapper):
         self.c = c
         if not g.app.spellDict:
             g.app.spellDict = DefaultDict()  # 2024/05/15: bug fix.
-        self.d: dict = g.app.spellDict
+        self.d: dict = cast(dict, g.app.spellDict)
         self.user_fn = self.find_user_dict()
         if not g.os_path_exists(self.user_fn):
             self.create(self.user_fn)

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -255,7 +255,7 @@ class LeoApp:
         self.already_open_files: list[str] = []
         self.dragging = False  # True: dragging.
         self.inBridge = False  # True: running from leoBridge module.
-        self.inScript = False  # True: executing a script.
+        self.inScript: bool = False  # True: executing a script.
         self.initing = True  # True: we are initing the app.
         self.initComplete = False  # True: late bindings are not allowed.
         self.initStyleFlag = False  # True: setQtStyle called.
@@ -3041,15 +3041,15 @@ class LoadManager:
 
             def __init__(self, kind: str) -> None:
                 self.kind = kind
-                g.es_print = self.write
-                g.pr = self.write
+                g.es_print = cast(Any, self.write)
+                g.pr = cast(Any, self.write)
 
-            def flush(self, *args: list, **keys: dict) -> None:
+            def flush(self, *args: Any, **keys: Any) -> None:
                 pass
 
             # @+others
             # @+node:ekr.20160718102306.1: *7* LeoStdOut.write
-            def write(self, *args: list, **keys: dict) -> None:
+            def write(self, *args: Any, **keys: Any) -> None:
                 """Put all non-keyword args to the log pane, as in g.es."""
                 # Tracing will lead to unbounded recursion unless
                 # sys.stderr has been redirected on the command line.

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -386,7 +386,7 @@ if 1:  # pragma: no cover
             if isinstance(node, ast.Call):
                 node = node.func
             elif isinstance(node, ast.Tuple):
-                node = node.elts  # type:ignore
+                node = node.elts
             # Finally, try all other nodes.
             else:
                 # This will be used rarely.
@@ -893,7 +893,7 @@ class AstDumper:  # pragma: no cover
                 else:
                     assert isinstance(z, (ast.FormattedValue, ast.Constant))
                     if isinstance(z, ast.Constant):
-                        results.append(z.value)  # type:ignore
+                        results.append(z.value)
                         strings += 1
                     else:
                         results.append(z.__class__.__name__)

--- a/leo/core/leoBeautify.py
+++ b/leo/core/leoBeautify.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import sys
 import os
 import time
-from typing import TYPE_CHECKING
+from typing import overload, Literal, TYPE_CHECKING
 
 # Third-party tools.
 try:
@@ -268,6 +268,14 @@ class CPrettyPrinter:
         c.bodyWantsFocus()
 
     # @+node:ekr.20110917174948.6911: *3* cpp.indent & helpers
+    @overload
+    def indent(
+        self, p: Position, toList: Literal[True], giveWarnings: bool = True
+    ) -> list[str]: ...
+    @overload
+    def indent(
+        self, p: Position, toList: Literal[False] = False, giveWarnings: bool = True
+    ) -> str: ...
     def indent(
         self,
         p: Position,

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -12,7 +12,7 @@ from collections.abc import Callable, Generator, Sequence
 import re
 import string
 import time
-from typing import Any, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 from types import ModuleType
 import warnings
 
@@ -21,7 +21,7 @@ try:
     import pygments
     from pygments.lexer import DelegatingLexer, RegexLexer, _TokenType, Text, Error
 except ImportError:
-    pygments = None
+    pygments = None  # type:ignore
 
 # Leo imports...
 from leo.core import leoGlobals as g
@@ -471,7 +471,7 @@ class JEditColorizer(BaseColorizer):
         super().__init__(c)
         self.widget: QWidget = widget
         if widget:  # #503: widget may be None during unit tests.
-            widget.leo_colorizer = self
+            cast(Any, widget).leo_colorizer = self
 
         # Configuration dicts...
         self.configDict: dict[str, str] = {}  # Keys are tags, values are colors (names or values).
@@ -1972,7 +1972,7 @@ class JEditColorizer(BaseColorizer):
                 # Set the bindings to VNode callbacks.
                 tagName = "hyper" + str(self.hyperCount)
                 self.hyperCount += 1
-                ref.tagName = tagName
+                cast(Any, ref).tagName = tagName
                 # @-<< set the hyperlink >>
             else:
                 self.colorRangeWithTag(s, i + n1, k, 'link')
@@ -3375,7 +3375,7 @@ class PygmentsColorizer(JEditColorizer):
         self.getDefaultFormat: Callable
         self.old_v: VNode | None = None
         # Monkey-patch g.isValidLanguage.
-        g.isValidLanguage = self.pygments_isValidLanguage
+        g.isValidLanguage = cast(Any, self.pygments_isValidLanguage)
         # Init common data...
         self.reloadSettings()
 
@@ -3734,7 +3734,7 @@ class QScintillaColorizer(BaseColorizer):
         lexer.setFont(font)
         lexer.setEolFill(False, -1)
         if hasattr(lexer, 'setStringsOverNewlineAllowed'):
-            lexer.setStringsOverNewlineAllowed(False)
+            cast(Any, lexer).setStringsOverNewlineAllowed(False)
         table: list[tuple[str, str]] = []
         aList = c.config.getData('qt-scintilla-styles')
         color: str

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1421,7 +1421,7 @@ class Commands:
             g.inScript = g.app.inScript = True  # g.inScript is a synonym for g.app.inScript.
             if c.write_script_file:
                 scriptFile = self.writeScriptFile(script)
-                exec(compile(script, scriptFile, 'exec'), d)
+                exec(compile(script, scriptFile or '<string>', 'exec'), d)
             else:
                 exec(script, d)
             # Return the optional value of a 'result' global, if defined, to be returned.
@@ -3590,6 +3590,7 @@ class Commands:
 
         def minibufferCallback(event: LeoKeyEvent, function: Callable = function) -> None:
             # Avoid a pylint complaint.
+            keywords: dict[str, Any] | None
             if hasattr(self, 'theContextMenuController'):
                 cm = self.theContextMenuController
                 keywords = cm.mb_keywords
@@ -3609,8 +3610,8 @@ class Commands:
                     # Even if there is an error:
                     #   clear mb_keywords prior to next command and
                     #   ensure mb_retval from last command is wiped
-                    cm.mb_keywords = None
-                    cm.mb_retval = retval
+                    cast(Any, cm).mb_keywords = None
+                    cast(Any, cm).mb_retval = retval
 
         minibufferCallback.__doc__ = function.__doc__  # For g.getDocStringForFunction
         minibufferCallback.source_c = source_c  # For GetArgs.command_source
@@ -3620,7 +3621,7 @@ class Commands:
     universallCallback = universalCallback
 
     # @+node:ekr.20070115135502: *4* c.writeScriptFile
-    def writeScriptFile(self, script: str) -> str:
+    def writeScriptFile(self, script: str) -> str | None:
         # Get the path to the file.
         c = self
         if path := c.config.getString('script-file-path'):
@@ -4605,7 +4606,7 @@ class Commands:
         h = p.h.lower()
         if extend:
             prefix = c.navPrefix + ch
-            return h.startswith(prefix.lower()) and prefix
+            return prefix if h.startswith(prefix.lower()) else ''
         if h.startswith(ch):
             return ch
         # New feature: search for first non-blank character after @x for common x.
@@ -4864,7 +4865,7 @@ class Commands:
     # @+node:ekr.20031218072017.2958: *6* c.canContractParent
     def canContractParent(self) -> bool:
         c = self
-        return c.p.parent()
+        return bool(c.p.parent())
 
     # @+node:ekr.20031218072017.2959: *6* c.canContractSubheads
     def canContractSubheads(self) -> bool:
@@ -4973,7 +4974,7 @@ class Commands:
     # @+node:ekr.20031218072017.2970: *6* c.canMoveOutlineDown
     def canMoveOutlineDown(self) -> bool:
         c, p = self, self.p
-        return p and p.visNext(c)
+        return bool(p and p.visNext(c))
 
     # @+node:ekr.20031218072017.2971: *6* c.canMoveOutlineLeft
     def canMoveOutlineLeft(self) -> bool:
@@ -4984,15 +4985,15 @@ class Commands:
                 p.moveToParent()
                 return p != bunch.p and bunch.p.isAncestorOf(p)
             return False
-        return p and p.hasParent()
+        return bool(p and p.hasParent())
 
     # @+node:ekr.20031218072017.2972: *6* c.canMoveOutlineRight
     def canMoveOutlineRight(self) -> bool:
         c, p = self, self.p
         if c.hoistStack:
             bunch = c.hoistStack[-1]
-            return p and p.hasBack() and p != bunch.p
-        return p and p.hasBack()
+            return bool(p and p.hasBack() and p != bunch.p)
+        return bool(p and p.hasBack())
 
     # @+node:ekr.20031218072017.2973: *6* c.canMoveOutlineUp Bug!
     def canMoveOutlineUp(self) -> bool:
@@ -5032,7 +5033,7 @@ class Commands:
     # @+node:ekr.20031218072017.2975: *6* c.canPromote
     def canPromote(self) -> bool:
         p = self.p
-        return p and p.hasChildren()
+        return bool(p and p.hasChildren())
 
     # @+node:ekr.20031218072017.2977: *6* c.canSelect....
     def canSelectThreadBack(self) -> bool:
@@ -5045,11 +5046,11 @@ class Commands:
 
     def canSelectVisBack(self) -> bool:
         c, p = self, self.p
-        return p.visBack(c)
+        return bool(p.visBack(c))
 
     def canSelectVisNext(self) -> bool:
         c, p = self, self.p
-        return p.visNext(c)
+        return bool(p.visNext(c))
 
     # @+node:ekr.20031218072017.2978: *6* c.canShiftBodyLeft/Right
     def canShiftBodyLeft(self) -> bool:
@@ -5062,11 +5063,11 @@ class Commands:
     # @+node:ekr.20031218072017.2979: *6* c.canSortChildren, canSortSiblings
     def canSortChildren(self) -> bool:
         p = self.p
-        return p and p.hasChildren()
+        return bool(p and p.hasChildren())
 
     def canSortSiblings(self) -> bool:
         p = self.p
-        return p and (p.hasNext() or p.hasBack())
+        return bool(p and (p.hasNext() or p.hasBack()))
 
     # @+node:ekr.20031218072017.2980: *6* c.canUndo & canRedo
     def canUndo(self) -> bool:

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -12,7 +12,7 @@ import sys
 import re
 import textwrap
 import typing
-from typing import Any, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 from leo.plugins.mod_scripting import build_rclick_tree
 from leo.core import leoGlobals as g
 
@@ -1004,8 +1004,8 @@ class ActiveSettingsOutline:
         # Create the ordered list of commander tuples, including the local .leo file.
         self.create_commanders_list()
         # Jam the old settings into the new commander.
-        self.commander.config.settingsDict = settings_copy
-        self.commander.config.shortcutsDict = shortcuts_copy
+        cast(Any, self.commander.config).settingsDict = settings_copy
+        cast(Any, self.commander.config).shortcutsDict = shortcuts_copy
 
     # @+node:ekr.20190905091614.3: *4* aso.create_commanders_list
     def create_commanders_list(self) -> None:
@@ -1273,6 +1273,9 @@ class ActiveSettingsOutline:
 # @+node:ekr.20041119203941: ** class GlobalConfigManager
 class GlobalConfigManager:
     """A class to manage configuration settings."""
+
+    # context_menus is set lazily (see doPopup), not in __init__.
+    context_menus: dict
 
     # @+others
     # @+node:ekr.20041117062717.2: *3*  gcm.ctor

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1395,6 +1395,7 @@ class FileCommands:
             current = c.archivedPositionToPosition(str_pos)
         if not c.positionExists(current):  # #4789.
             current = c.rootPosition()
+        assert current is not None  # positionExists(None) is always False.
         c.p = current
 
     # @+node:ekr.20031218072017.3032: *3* fc: Writing
@@ -1738,7 +1739,7 @@ class FileCommands:
                         g.printObj(p.v.unknownAttributes)
 
             # result for specific starting p
-            result = {
+            result: dict[str, Value] = {
                 'leoHeader': {'fileFormat': 2},
                 'vnodes': [self.leojs_vnode(sp, gnxSet)],
                 'tnodes': {

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -14,7 +14,7 @@ from collections.abc import Callable
 import os
 import re
 import string
-from typing import Any, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 from leo.core import (
     leoColorizer,
     leoGlobals as g,
@@ -909,7 +909,7 @@ class LeoTree:
                 else:
                     c.outerUpdate()  # Bring the tree up to date.
                     if hasattr(self, 'setItemForCurrentPosition'):
-                        self.setItemForCurrentPosition()
+                        cast(Any, self).setItemForCurrentPosition()
             else:
                 c.requestLaterRedraw = True
 
@@ -963,7 +963,7 @@ class LeoTree:
             self.endEditLabel()
             # #1168: Ctrl-minus selects multiple nodes.
             if hasattr(self, 'unselectItem'):
-                self.unselectItem(old_p)
+                cast(Any, self).unselectItem(old_p)
         if call_event_handlers:
             g.doHook("unselect2", c=c, new_p=p, old_p=old_p, new_v=p, old_v=old_p)
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -38,7 +38,7 @@ import time
 import traceback
 import types
 from types import ModuleType
-from typing import cast, Any, IO, TYPE_CHECKING
+from typing import cast, Any, IO, NoReturn, TYPE_CHECKING
 import unittest
 import urllib
 import urllib.parse as urlparse
@@ -685,8 +685,8 @@ user_dict: dict[str, Value] = {}  # Non-persistent dictionary for scripts and pl
 app: LeoApp = None  # type:ignore # There seems to be no way to init g.app here.
 
 # Global status vars.
-inScript = False  # A synonym for app.inScript
-unitTesting = False  # A synonym for app.unitTesting.
+inScript: bool = False  # A synonym for app.inScript
+unitTesting: bool = False  # A synonym for app.unitTesting.
 
 
 # @+others
@@ -2338,7 +2338,10 @@ class NullObject:
     def __contains__(self, item: object) -> bool:
         return False
 
-    def __getitem__(self, key: str) -> None:
+    def __getitem__(self, key: str) -> NoReturn:
+        raise KeyError
+
+    def __delitem__(self, key: str) -> NoReturn:
         raise KeyError
 
     def __setitem__(self, key: str, val: Value) -> None:
@@ -2351,7 +2354,7 @@ class NullObject:
         return 0
 
     # Iteration methods:
-    def __next__(self) -> None:
+    def __next__(self) -> NoReturn:
         raise StopIteration
 
 
@@ -3413,7 +3416,7 @@ def isValidLanguage(language: str) -> bool:
 
 # @+node:ekr.20250403040834.1: *3* --- to be deprecated! Using directives list
 # @+node:ekr.20080827175609.52: *4* g.scanAtCommentAndLanguageDirectives (deprecated)
-def scanAtCommentAndAtLanguageDirectives(aList: list) -> dict[str, str] | None:
+def scanAtCommentAndAtLanguageDirectives(aList: list) -> dict[str, Any] | None:
     """
     Scan aList for @comment and @language directives.
 
@@ -3898,7 +3901,7 @@ def guessExternalEditor(c: Cmdr | None = None) -> str:
         and g.app.db.get("LEO_EDITOR")
     )
     if editor:
-        return editor
+        return str(editor)
     # fallbacks
     platform = sys.platform.lower()
     if platform.startswith('win'):
@@ -3914,7 +3917,7 @@ or do g.app.db['LEO_EDITOR'] = "gvim"''',
 
 
 # @+node:ekr.20160330204014.1: *3* g.init_dialog_folder
-def init_dialog_folder(c: Cmdr, p: Position, use_at_path: bool = True) -> str:
+def init_dialog_folder(c: Cmdr | None, p: Position | None, use_at_path: bool = True) -> str:
     """Return the most convenient folder to open or save a file."""
     if c and p and use_at_path:
         if path := c.fullPath(p):
@@ -7171,7 +7174,7 @@ def init_zodb(pathToZodbStorage: str, verbose: bool = True) -> Value:
     if init_zodb_failed.get(pathToZodbStorage):
         return None
     try:
-        import ZODB  # type:ignore
+        import ZODB
     except ImportError:
         if verbose:
             g.es('g.init_zodb: can not import ZODB')
@@ -7649,7 +7652,7 @@ def getDocStringForFunction(func: Callable) -> str:
     """Return the docstring for a function that creates a Leo command."""
 
     def name(func: Callable) -> str:
-        return func.__name__ if hasattr(func, '__name__') else '<no __name__>'
+        return str(func.__name__) if hasattr(func, '__name__') else '<no __name__>'
 
     def get_defaults(func: Callable, i: int) -> Value:
         defaults = inspect.getfullargspec(func)[3]
@@ -7849,7 +7852,7 @@ def findTopLevelNode(c: Cmdr, headline: str, exact: bool = True) -> Position | N
 # @+node:EKR.20040614071102.1: *3* g.getScript & helpers
 def getScript(
     c: Cmdr,
-    p: Position,
+    p: Position | None,
     useSelectedText: bool = True,
     forcePythonSentinels: bool = True,
     useSentinels: bool = True,

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -11,7 +11,7 @@ import re
 import textwrap
 import time
 from typing import Any, TYPE_CHECKING
-import urllib
+import urllib.parse
 
 #
 # Third-party imports.
@@ -1456,18 +1456,18 @@ class MindMapImporter:
             self.csv_string(row)
             if new_level > n:
                 p = p.insertAsLastChild().copy()
-                p.b = self.csv_string(row)
+                p.b = self.csv_string(row) or ''
                 n = n + 1
             elif new_level == n:
                 p = p.insertAfter().copy()
-                p.b = self.csv_string(row)
+                p.b = self.csv_string(row) or ''
             elif new_level < n:
                 for item in p.parents():
                     if item.level() == new_level - 1:
                         p = item.copy()
                         break
                 p = p.insertAsLastChild().copy()
-                p.b = self.csv_string(row)
+                p.b = self.csv_string(row) or ''
                 n = p.level()
         for p in target.unique_subtree():
             lines = p.b.splitlines()
@@ -1493,7 +1493,7 @@ class MindMapImporter:
     def csv_string(self, row: list[str]) -> str | None:
         """Return the string for the given csv row."""
         count = 0
-        while count <= len(row):
+        while count < len(row):
             if row[count]:
                 return row[count]
             count = count + 1

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -14,8 +14,7 @@ import string
 import sys
 import textwrap
 import time
-from typing import Any, TYPE_CHECKING
-from types import ModuleType
+from typing import Any, cast, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.external import codewise
 from leo.core.leoFrame import NullLog
@@ -806,7 +805,7 @@ class AutoCompleterClass:
         return aList
 
     # @+node:ekr.20110512090917.14466: *4* ac.get_leo_namespace
-    def get_leo_namespace(self, prefix: str) -> dict[str, ModuleType]:
+    def get_leo_namespace(self, prefix: str) -> dict[str, Any]:
         """
         Return an environment in which to evaluate prefix.
         Add some common standard library modules as needed.
@@ -1826,8 +1825,8 @@ class KeyHandlerClass:
         """Define internal ivars of the KeyHandlerClass class."""
         self.abbreviationsDict: dict = {}  # Abbreviations created by @alias nodes.
         # Previously defined bindings...
-        # Keys are Tk key names, values are lists of string or BindingInfo objects.
-        self.bindingsDict: dict[str, list] = {}
+        # Keys are KeyStroke objects, values are lists of BindingInfo objects.
+        self.bindingsDict: dict[Any, list] = {}
         # Previously defined binding tags.
         self.bindtagsDict: dict[str, bool] = {}  # Keys are strings (the tag), values are 'True'
         self.commandHistory: list[str] = []
@@ -2221,7 +2220,7 @@ class KeyHandlerClass:
         assert g.isStroke(stroke), stroke
         inv_d = lm.invert(c.config.shortcutsDict)
         inv_d[stroke] = []
-        c.config.shortcutsDict = lm.uninvert(inv_d)
+        cast(Any, c.config).shortcutsDict = lm.uninvert(inv_d)
 
     # @+node:ekr.20061031131434.92: *5* k.remove_conflicting_definitions
     def remove_conflicting_definitions(
@@ -2378,7 +2377,7 @@ class KeyHandlerClass:
         # strokes, so repeated startup-wide rebuilds must not reuse that
         # already-trimmed dict as input.
         raw_shortcuts = k.c.config.shortcutsDictRaw
-        k.c.config.shortcutsDict = raw_shortcuts.copy() if raw_shortcuts else None
+        cast(Any, k.c.config).shortcutsDict = raw_shortcuts.copy() if raw_shortcuts else None
         k.bindingsDict = {}
         k.addModeCommands()
         k.makeBindingsFromCommandsDict()

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -697,7 +697,7 @@ class LeoMenu:
     ) -> Any:
         pass
 
-    def new_menu(self, Any: Widget, tearoff: int = 0, label: str = '') -> Any:
+    def new_menu(self, parent: Widget, tearoff: int = 0, label: str = '') -> Any:
         pass
 
     # @+node:ekr.20031218072017.3810: *4* LeoMenu.9 Routines with new spellings

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2288,6 +2288,12 @@ class VNode:
         'tempAttributes',     # Injected by read code.
         'unknownAttributes',
     ]  # fmt: skip
+
+    # unknownAttributes is set lazily (see v.u property below), not in __init__.
+    unknownAttributes: dict
+    # tempAttributes is injected by read code (leoAtFile.py), not in __init__.
+    tempAttributes: dict
+
     # @+<< VNode constants >>
     # @+node:ekr.20031218072017.951: *3* << VNode constants >>
     # Define the meaning of status bits in new vnodes.

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 from collections.abc import Callable, Iterator, Sequence
 import sys
-from typing import Any, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 from types import ModuleType
 from leo.core import leoGlobals as g
 
@@ -307,7 +307,7 @@ class LeoPluginsController:
         self.signonModule: Any = None  # A hack for plugin_signon.
         # Settings.  Set these here in case finishCreate is never called.
         self.warn_on_failure = True
-        g.act_on_node = CommandChainDispatcher()
+        g.act_on_node = cast(Any, CommandChainDispatcher())
         g.visit_tree_item = CommandChainDispatcher()
         g.tree_popup_handlers = []
 
@@ -669,12 +669,11 @@ class LeoPluginsController:
     # @+node:ekr.20100908125007.6028: *4* plugins.registerExclusiveHandler
     def registerExclusiveHandler(self, tags: str | Sequence[str], fn: Callable) -> None:
         """Register one or more exclusive handlers"""
-        if isinstance(tags, (list, tuple)):
+        if isinstance(tags, str):
+            self.registerOneExclusiveHandler(tags, fn)
+        else:
             for tag in tags:
                 self.registerOneExclusiveHandler(tag, fn)
-        else:
-            # We have just tested the type.
-            self.registerOneExclusiveHandler(tags, fn)  # type:ignore[arg-type]
 
     def registerOneExclusiveHandler(self, tag: str, fn: Callable) -> None:
         """Register one exclusive handler"""
@@ -696,12 +695,11 @@ class LeoPluginsController:
     # @+node:ekr.20100908125007.6029: *4* plugins.registerHandler & registerOneHandler
     def registerHandler(self, tags: str | Sequence[str], fn: Callable) -> None:
         """Register one or more handlers"""
-        if isinstance(tags, (list, tuple)):
+        if isinstance(tags, str):
+            self.registerOneHandler(tags, fn)
+        else:
             for tag in tags:
                 self.registerOneHandler(tag, fn)
-        else:
-            # We have just tested the type.
-            self.registerOneHandler(tags, fn)  # type:ignore[arg-type]
 
     def registerOneHandler(self, tag: str, fn: Callable) -> None:
         """Register one handler"""
@@ -719,12 +717,11 @@ class LeoPluginsController:
 
     # @+node:ekr.20100908125007.6031: *4* plugins.unregisterHandler
     def unregisterHandler(self, tags: str | Sequence[str], fn: Callable) -> None:
-        if isinstance(tags, (list, tuple)):
+        if isinstance(tags, str):
+            self.unregisterOneHandler(tags, fn)
+        else:
             for tag in tags:
                 self.unregisterOneHandler(tag, fn)
-        else:
-            # We have just tested the type.
-            self.unregisterOneHandler(tags, fn)  # type:ignore[arg-type]
 
     def unregisterOneHandler(self, tag: str, fn: Callable) -> None:
         bunches = self.handlers.get(tag, [])

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -16,7 +16,7 @@ import textwrap
 import time
 import unittest
 import warnings
-from typing import Any, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoApp
 
@@ -80,7 +80,7 @@ def create_app(gui_name: str = 'null') -> Cmdr:
     settings_d, bindings_d = lm.createDefaultSettingsDicts()
     lm.globalSettingsDict = settings_d
     lm.globalBindingsDict = bindings_d
-    c.config.settingsDict = settings_d
+    cast(Any, c.config).settingsDict = settings_d
     assert g.unitTesting is True  # Defensive.
     t4 = time.process_time()
     if trace and t4 - t3 > 0.1:  # pragma: no cover

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -937,11 +937,11 @@ class Undoer:
     # @+node:ekr.20031218072017.3610: *4* u.canRedo & canUndo
     # Translation does not affect these routines.
 
-    def canRedo(self) -> None:
+    def canRedo(self) -> bool:
         u = self
         return u.redoMenuLabel != "Can't Redo"
 
-    def canUndo(self) -> None:
+    def canUndo(self) -> bool:
         u = self
         return u.undoMenuLabel != "Can't Undo"
 

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -31,7 +31,7 @@ import textwrap
 import time
 import hmac
 import ssl
-from typing import Any, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 import warnings
 
 # Third-party.
@@ -1025,7 +1025,7 @@ class LeoServer:
                 c.findCommands.ftm = StringFindTabManager(c)  # type: ignore
                 cc = QuickSearchController(c)
                 # Patch up quick-search controller to the commander
-                c.patched_quicksearch_controller = cc
+                cast(Any, c).patched_quicksearch_controller = cc
                 # Patch up for 'selection range' in headlines left by the search commands.
                 c.frame.tree.endEditLabel = self._endEditLabel
                 c.recreateGnxDict()  # refresh c.fileCommands.gnxDict used in ap_to_p
@@ -3191,7 +3191,7 @@ class LeoServer:
         p = self._get_p(param)
         oldPosition: Position | None = None if p == c.p else c.p
 
-        newHeadline = param.get('name')
+        newHeadline = param.get('name') or ''
         bunch = c.undoer.beforeInsertNode(p)
         newNode = p.insertAfter()
         # Set this node's new headline
@@ -3221,7 +3221,7 @@ class LeoServer:
         """
         c = self._check_c(param)
         p = self._get_p(param)
-        newHeadline = param.get('name')
+        newHeadline = param.get('name') or ''
         bunch = c.undoer.beforeInsertNode(p)
         if c.config.getBool('insert-new-nodes-at-end'):
             newNode = p.insertAsLastChild()

--- a/leo/core/signal_manager.py
+++ b/leo/core/signal_manager.py
@@ -17,7 +17,7 @@ Terry Brown, terrynbrown@gmail.com, Thu Mar 23 21:13:38 2017
 from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 
 # @-<< signal_manager imports >>
@@ -42,7 +42,7 @@ class MsgSignalHandled:
 # @+node:tbrown.20171028115601.5: ** _setup
 def _setup(obj: object) -> None:
     if not hasattr(obj, '_signal_data'):
-        obj._signal_data = SignalData()
+        cast(Any, obj)._signal_data = SignalData()
 
 
 # @+node:tbrown.20171028115601.6: ** emit

--- a/leo/plugins/QNCalendarWidget.py
+++ b/leo/plugins/QNCalendarWidget.py
@@ -25,7 +25,7 @@ def init():
     return True  # For unit tests.
 
 
-class QNCalendarWidget(QtWidgets.QCalendarWidget):  # type:ignore
+class QNCalendarWidget(QtWidgets.QCalendarWidget):
     def __init__(self, n=3, columns=3, year=None, month=None):
         """set up
 
@@ -117,7 +117,7 @@ class QNCalendarWidget(QtWidgets.QCalendarWidget):  # type:ignore
         self.activated.emit(date)
 
 
-class QNDateEdit(QtWidgets.QDateEdit):  # type:ignore
+class QNDateEdit(QtWidgets.QDateEdit):
     def __init__(self, parent=None, n=3, columns=3):
         """set up
 

--- a/leo/plugins/active_path.py
+++ b/leo/plugins/active_path.py
@@ -177,7 +177,7 @@ def popup_entry(c, p, menu):
     for key in d:
         if key.startswith('active-path'):
             a = pathmenu.addAction(key)
-            command = d.get(key)
+            command = d[key]
 
             def active_path_wrapper(aBool, command=command, c=c):
                 event = {'c': c}

--- a/leo/plugins/at_produce.py
+++ b/leo/plugins/at_produce.py
@@ -104,8 +104,9 @@ def run(c, all):
     def timer_callback(tag):
         timer_callback_helper(c, t, timer)
 
-    timer.handler = timer_callback
-    timer.start()
+    if timer:
+        timer.handler = timer_callback
+        timer.start()
 
 
 # @+node:ekr.20040915085351.2: *3* getList

--- a/leo/plugins/auto_colorize2_0.py
+++ b/leo/plugins/auto_colorize2_0.py
@@ -9,6 +9,7 @@ By Adrian Calvin.
 
 # @+<< imports auto_colorize2_0.py >>
 # @+node:ekr.20170619151859.3: ** << imports auto_colorize2_0.py >>
+from typing import Any, cast
 import yaml
 from leo.core import leoGlobals as g
 
@@ -99,7 +100,8 @@ def colorize(c, p, item):
             # color
             try:
                 if f['color']:
-                    item.setForeground(0, QBrush(QColor("#" + str(f['color']))))
+                    color = cast(Any, QColor)("#" + str(f['color']))
+                    item.setForeground(0, cast(Any, QBrush)(color))
             except Exception:
                 print(item)
             # weight

--- a/leo/plugins/backlink.py
+++ b/leo/plugins/backlink.py
@@ -84,7 +84,7 @@ from leo.core import leoGlobals as g
 try:  # #2343
     from leo.core.leoQt import QtGui, QtWidgets, uic
 except Exception:
-    QtGui = QtWidgets = None
+    QtGui = QtWidgets = None  # type:ignore
 # @+others
 # @+node:ekr.20140920145803.17995: ** top-level
 # @+node:ekr.20090616105756.3940: *3* init (backlink.py)

--- a/leo/plugins/contextmenu.py
+++ b/leo/plugins/contextmenu.py
@@ -75,6 +75,7 @@ def cm_external_editor(event: LeoKeyEvent | None = None) -> None:
 
     Set LEO_EDITOR/EDITOR environment variable to get the editor you want.
     """
+    assert event is not None
     c = event['c']
 
     editor, _ = getEditor(c)

--- a/leo/plugins/debugger_pudb.py
+++ b/leo/plugins/debugger_pudb.py
@@ -8,6 +8,8 @@ http://pypi.python.org/pypi/pudb
 """
 
 # By VMV.
+from typing import Any, cast
+
 try:
     import pudb
 except ImportError:
@@ -25,7 +27,7 @@ def init():
         def pudb_set_trace(*args):
             pudb.set_trace()
 
-        g.pdb = pudb_set_trace
+        g.pdb = cast(Any, pudb_set_trace)
         g.plugin_signon(__name__)
     return ok
 

--- a/leo/plugins/editpane/csvedit.py
+++ b/leo/plugins/editpane/csvedit.py
@@ -35,7 +35,7 @@ DELTA = {  # offsets for selection when moving row/column
 
 # list of separators to try, need a single chr separator that doesn't
 # occur in text
-SEPS = [
+_SEP_CODES = [
     32,
     33,
     34,
@@ -238,7 +238,7 @@ SEPS = [
     56,
     57,
 ]
-SEPS = [chr(i) for i in SEPS]
+SEPS = [chr(i) for i in _SEP_CODES]
 # @-<< data >>
 
 
@@ -324,7 +324,7 @@ class ListTable(QtCore.QAbstractTableModel):
 
     # @+node:ekr.20211210174103.8: *3* data
     # This function must exist, but it appears to hide the self._data array!
-    def data(self, index, role):
+    def data(self, index, role):  # ty: ignore[invalid-method-override]
         if role in (ItemDataRole.DisplayRole, ItemDataRole.EditRole):  # #2347
             return self._data[index.row()][index.column()]
         return None
@@ -357,7 +357,7 @@ class ListTable(QtCore.QAbstractTableModel):
         return text
 
     # @+node:ekr.20211210174103.10: *3* setData
-    def setData(self, index, value, role):
+    def setData(self, index, value, role):  # ty: ignore[invalid-method-override]
         self._data[index.row()][index.column()] = value
         self.dataChanged.emit(index, index)
         return True
@@ -467,12 +467,16 @@ class LEP_CSVEdit(QtWidgets.QWidget):
         ui.min_rows.setMinimum(1)
         ui.min_rows.setPrefix("tbl with ")
         ui.min_rows.setSuffix(" rows")
-        ui.min_rows.setValue(self.state['rows'])
+        rows = self.state['rows']
+        assert isinstance(rows, int)
+        ui.min_rows.setValue(rows)
         # separator text and line start / end text
         for attr in 'sep', 'start', 'end':
             buttons2.addWidget(QtWidgets.QLabel(attr.title() + ':'))
             w = QtWidgets.QLineEdit()
-            w.setText(self.state[attr])
+            val = self.state[attr]
+            assert isinstance(val, str)
+            w.setText(val)
             setattr(ui, attr + '_txt', w)
             # w.textEdited.connect(self.delim_changed)
             buttons2.addWidget(w)
@@ -565,7 +569,7 @@ class LEP_CSVEdit(QtWidgets.QWidget):
         self.ui.table.setFocus(Qt.OtherFocusReason)
 
     # @+node:ekr.20211210174103.19: *3* move
-    def move(self, name):
+    def move(self, name):  # ty: ignore[invalid-method-override]
         self.insert(name, move=True)
 
     # @+node:ekr.20211210174103.20: *3* prev_tbl
@@ -585,14 +589,14 @@ class LEP_CSVEdit(QtWidgets.QWidget):
         self.update_state()
 
     # @+node:ekr.20211210174103.21: *3* focusInEvent
-    def focusInEvent(self, event):
-        QtWidgets.QTextEdit.focusInEvent(self, event)
+    def focusInEvent(self, event: QtGui.QFocusEvent) -> None:  # ty: ignore[invalid-method-override]
+        QtWidgets.QWidget.focusInEvent(self, event)
         DBG("focusin()")
         self.lep.edit_widget_focus()
 
     # @+node:ekr.20211210174103.22: *3* focusOutEvent
-    def focusOutEvent(self, event):
-        QtWidgets.QTextEdit.focusOutEvent(self, event)
+    def focusOutEvent(self, event: QtGui.QFocusEvent) -> None:  # ty: ignore[invalid-method-override]
+        QtWidgets.QWidget.focusOutEvent(self, event)
         DBG("focusout()")
 
     # @+node:ekr.20211210174103.23: *3* new_data

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -40,7 +40,7 @@ try:  # #1973
     from leo.core.leoQt import MouseButton
     from leo.plugins.nested_splitter import NestedSplitter  # NestedSplitterChoice
 except Exception:
-    QtWidgets = None
+    QtWidgets = None  # type:ignore
     MouseButton = None  # type:ignore
     NestedSplitter = None  # type:ignore
 
@@ -184,7 +184,7 @@ class FreeLayoutController:
         layout = top_splitter.get_saveable_layout()
         nd = g.findNodeAnywhere(c, "@data free-layout-layout")
         if not nd:
-            settings: Position
+            settings: Position | None
             settings = g.findNodeAnywhere(c, "@settings")
             if not settings:
                 settings = c.rootPosition().insertAfter()

--- a/leo/plugins/indented_languages.py
+++ b/leo/plugins/indented_languages.py
@@ -93,9 +93,9 @@ def import_to_indented_typescript(event: Any) -> None:
 class Indented_Importer:
     """The base class for all indented importers."""
 
-    extensions: list[str] = None  # The file extension for the language.
-    language: str = None  # The name of the language.
-    importer_class: Callable = None  # The importer class
+    extensions: list[str] = None  # type:ignore # The file extension for the language.
+    language: str = None  # type:ignore # The name of the language.
+    importer_class: Callable = None  # type:ignore # The importer class
 
     def __init__(self, c):
         self.c = c
@@ -416,11 +416,11 @@ class Indented_Lisp(Indented_Importer):
     )
 
     # For error messages only. Set in indent_outline.
-    p: Position = None
+    p: Position = None  # type:ignore
 
     # @+others
     # @+node:ekr.20231024045727.1: *3* indented_lisp.find_matching_paren
-    def find_matching_paren(self, i: int, tokens: list[Token]) -> int:
+    def find_matching_paren(self, i: int, tokens: list[Token]) -> int | None:
         """Return the index of the matching closing parenthesis."""
         assert tokens[i].kind == '(', tokens[i]
         start_i = i

--- a/leo/plugins/leoOPML.py
+++ b/leo/plugins/leoOPML.py
@@ -74,6 +74,7 @@ If True, when expanding as above, skip blank dict entries.
 # @+<< imports >>
 # @+node:ekr.20060904103412.3: ** << imports >>
 import io
+from typing import Any, cast
 import xml.sax
 import xml.sax.saxutils
 from leo.core import leoGlobals as g
@@ -726,7 +727,7 @@ class SaxContentHandler(xml.sax.saxutils.XMLGenerator):
     def endBodyText(self):
         """End a <leo:body> element."""
         if self.content:
-            self.node.bodyString = ''.join(self.content)
+            cast(Any, self.node).bodyString = ''.join(self.content)
         self.content = []
 
     # @+node:ekr.20060917185948: *4* endOutline
@@ -782,7 +783,7 @@ class SaxContentHandler(xml.sax.saxutils.XMLGenerator):
 
     # @+node:ekr.20060904141220.34: *5* doOutlineAttributes
     def doOutlineAttributes(self, attrs):
-        node = self.node
+        node = cast(Any, self.node)
         for bunch in self.attrsToList(attrs):
             name, val = bunch.name, bunch.val
             if name == 'text':  # Text is the 'official' opml attribute for headlines.

--- a/leo/plugins/leo_babel/tests/lib_test.py
+++ b/leo/plugins/leo_babel/tests/lib_test.py
@@ -10,6 +10,7 @@
 # @+<< imports >>
 # @+node:bob.20180205135704.1: ** << imports >>
 import datetime as dt
+from typing import Any, cast
 
 from leo.core import leoGlobals as leoG
 
@@ -49,7 +50,7 @@ class EsCapture:
     # @+node:bob.20180116152036.1: *3* __init__()
     def __init__(self):
         self._es = leoG.es
-        leoG.es = self.esCapture
+        leoG.es = cast(Any, self.esCapture)
         self._colorDict = None
 
     # @+node:bob.20180116152548.1: *3* beginCollection()

--- a/leo/plugins/leofts.py
+++ b/leo/plugins/leofts.py
@@ -1,12 +1,13 @@
 # @+leo-ver=5-thin
 # @+node:ekr.20220823200700.1: * @file ../plugins/leofts.py
 import os
+from typing import Any
 from whoosh.index import create_in, open_dir
 from whoosh.fields import ID, TEXT, Schema
 from whoosh.qparser import MultifieldParser
 from whoosh.analysis import RegexTokenizer, LowercaseFilter, StopFilter
 
-g = None
+g: Any = None
 
 
 # @+others

--- a/leo/plugins/leoscreen.py
+++ b/leo/plugins/leoscreen.py
@@ -151,7 +151,7 @@ from leo.core import leoGlobals as g
 try:
     from leo.plugins import stickynotes
 except ImportError:
-    stickynotes = None
+    stickynotes = None  # type:ignore
 from leo.plugins.attrib_edit import ListDialog
 
 

--- a/leo/plugins/line_numbering.py
+++ b/leo/plugins/line_numbering.py
@@ -160,7 +160,7 @@ def universal_line_numbers(root, target_p, delim_st, delim_en):
     roots = c.user_dict.get('line_numbering_roots', set())
     roots.add(root.gnx)
     c.user_dict['line_numbering_roots'] = roots
-    flines_data = {}
+    flines_data: dict[tuple, tuple] = {}
     # @+others
     # @+node:vitalije.20170726110242.1: *3* write patterns
     section_pat = re.compile(r'^(\s*)(<{2}[^>]+>>)(.*)$')

--- a/leo/plugins/mod_http.py
+++ b/leo/plugins/mod_http.py
@@ -231,9 +231,10 @@ try:
     import asynchat
     import asyncore
 except Exception:
-    asynchat = asyncore = None
+    asynchat = asyncore = None  # type:ignore
 import http.server
 import json
+from typing import Any, cast
 import io
 import os
 import select
@@ -286,7 +287,7 @@ def init():
                 % (config.http_ip, config.http_port, e)
             )
             return False
-        asyncore.read = a_read
+        asyncore.read = cast(Any, a_read)
         g.registerHandler("idle", plugin_wrapper)
         g.es("http serving enabled at %s:%s" % (config.http_ip, config.http_port), color="purple")
     g.plugin_signon(__name__)
@@ -335,7 +336,7 @@ def onFileOpen(tag, keywords):
     getConfiguration(c)
     if config.http_active and not wasactive:  # Ok for unit testing:
         Server('', config.http_port, RequestHandler)
-        asyncore.read = a_read
+        asyncore.read = cast(Any, a_read)
         g.registerHandler("idle", plugin_wrapper)
         g.es("http serving enabled on port %s, " % (config.http_port), color="purple")
 
@@ -383,7 +384,7 @@ def getData(setting):
 class config:
     enabled = None  # True when security check re http-allow-remote-exec passes.
     http_active = False
-    http_timeout = 0
+    http_timeout: float = 0
     http_ip = '127.0.0.1'
     http_port = 8130
     rst2_http_attributename = 'rst_http_attribute'
@@ -765,7 +766,7 @@ class LeoActions:
         one_tab_links = []
         if 'www.one-tab.com' in url.lower():
             one_tab_links = query.get('ln', [''])[0]
-            one_tab_links = json.loads(one_tab_links)  # type:ignore
+            one_tab_links = json.loads(one_tab_links)
         c = None  # outline for bookmarks
         previous = None  # previous bookmark for adding selections
         parent = None  # parent node for new bookmarks
@@ -1061,7 +1062,7 @@ if asynchat:
             bytesToRead = int(self.headers.getheader('content-length'))
             # set terminator to length (will read bytesToRead bytes)
             self.set_terminator(bytesToRead)
-            self.buffer = StringIO()  # type:ignore
+            self.buffer = StringIO()
             # control will be passed to a new found_terminator
             self.found_terminator = self.handle_post_data  # type:ignore
 
@@ -1197,7 +1198,7 @@ if asyncore:
 
 # @+node:ekr.20140920145803.17997: ** functions
 # @+node:EKR.20040517080250.47: *3* a_read (asynchore override)
-def a_read(obj):
+def a_read(obj: Any) -> None:
     try:
         obj.handle_read_event()
     except asyncore.ExitNow:

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -170,7 +170,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # @+node:ekr.20180328085010.1: ** Top level (mod_scripting)
 # @+node:tbrown.20140819100840.37719: *3* mod_scripting.build_rclick_tree
 def build_rclick_tree(
-    command_p: Position, rclicks: RClicks = None, top_level: bool = False
+    command_p: Position, rclicks: RClicks | None = None, top_level: bool = False
 ) -> list:
     """
     Return a list of top level RClicks for the button at command_p, which can be
@@ -272,10 +272,10 @@ class AtButtonCallback:
         controller: ScriptingController,
         b: QtWidgets.QButton,
         c: Cmdr,
-        buttonText: str,
+        buttonText: str | None,
         docstring: str,
         gnx: str,
-        script: str,
+        script: str | None,
     ) -> None:
         """AtButtonCallback.__init__."""
         self.b = b  # A QButton.
@@ -288,7 +288,7 @@ class AtButtonCallback:
         self.__doc__ = docstring  # The docstring for this callback for g.getDocStringForFunction.
 
     # @+node:ekr.20141031053508.10: *3* __call__ (AtButtonCallback)
-    def __call__(self, event: Event = None) -> Value:
+    def __call__(self, event: Event | None = None) -> Value:
         """AtButtonCallbgack.__call__. The callback for @button nodes."""
         return self.execute_script()
 
@@ -320,7 +320,7 @@ class AtButtonCallback:
         return None
 
     # @+node:ekr.20180313171043.1: *4* AtButtonCallback.find_script
-    def find_script(self) -> str:
+    def find_script(self) -> str | None:
         gnx = self.gnx
         # First, search self.c for the gnx.
         for p in self.c.all_positions():
@@ -396,7 +396,7 @@ class ScriptingController:
 
     # @+node:ekr.20150401113822.1: *3* sc.Callbacks
     # @+node:ekr.20060328125248.23: *4* sc.addScriptButtonCommand
-    def addScriptButtonCommand(self, event: Event = None) -> None:
+    def addScriptButtonCommand(self, event: Event | None = None) -> None:
         """Called when the user presses the 'script-button' button or executes the script-button command."""
         c = self.c
         p = c.p
@@ -409,7 +409,7 @@ class ScriptingController:
         c.bodyWantsFocus()
 
     # @+node:ekr.20060522105937.1: *4* sc.runDebugScriptCommand
-    def runDebugScriptCommand(self, event: Event = None) -> None:
+    def runDebugScriptCommand(self, event: Event | None = None) -> None:
         """Called when user presses the 'debug-script' button or executes the debug-script command."""
         c = self.c
         p = c.p
@@ -471,7 +471,7 @@ class ScriptingController:
         c.bodyWantsFocus()
 
     # @+node:ekr.20060328125248.21: *4* sc.runScriptCommand
-    def runScriptCommand(self, event: Event = None) -> None:
+    def runScriptCommand(self, event: Event | None = None) -> None:
         """Called when user presses the 'run-script' button or executes the run-script command."""
         c, p = self.c, self.c.p
         args = self.getArgs(p)
@@ -527,7 +527,7 @@ class ScriptingController:
             else:
                 self.seen.add(gnx)
                 if m := pattern.match(p.h):
-                    func = d.get(m.group(1))
+                    func = d[m.group(1)]
                     func(p)
                 p.moveToThreadNext()
 
@@ -594,7 +594,7 @@ class ScriptingController:
         self,
         args: Args,
         text: str,
-        command: Callable,
+        command: Callable | None,
         statusLine: str,
         bg: str = '',
         kind: str = '',
@@ -631,7 +631,7 @@ class ScriptingController:
             )
 
         def deleteButtonCallback(
-            event: Event = None, self: Any = self, b: QtWidgets.QButton = b
+            event: Event | None = None, self: Any = self, b: QtWidgets.QButton = b
         ) -> None:
             self.deleteButton(b, event=event)
 
@@ -657,8 +657,8 @@ class ScriptingController:
     def executeScriptFromButton(
         self,
         b: QtWidgets.QButton,
-        buttonText: str,
-        p: Position,
+        buttonText: str | None,
+        p: Position | None,
         script: str,
         script_gnx: str = '',
     ) -> Value:
@@ -684,7 +684,7 @@ class ScriptingController:
         return result
 
     # @+node:ekr.20130912061655.11294: *3* sc.open_gnx
-    def open_gnx(self, c: Cmdr, gnx: str) -> tuple[Cmdr, Position]:
+    def open_gnx(self, c: Cmdr, gnx: str) -> tuple[Cmdr | None, Position | None]:
         """
         Find the node with the given gnx in c, myLeoSettings.leo and leoSettings.leo.
         If found, open the tab/outline and return c,p of the found node.
@@ -727,7 +727,7 @@ class ScriptingController:
                 self.createCommonButton(p, script, rclicks)
 
     # @+node:ekr.20070926084600: *4* sc.createCommonButton (common @button)
-    def createCommonButton(self, p: Position, script: str, rclicks: RClicks = None) -> None:
+    def createCommonButton(self, p: Position, script: str, rclicks: RClicks) -> None:
         """
         Create a button in the icon area for a common @button node in an
         @buttons node in an @setting tree. Binds button presses to a callback
@@ -866,7 +866,7 @@ class ScriptingController:
         args = self.getArgs(p)
 
         def atCommandCallback(
-            event: Event = None,
+            event: Event | None = None,
             args: Args = args,
             c: Cmdr = c,
             p: Position = p.copy(),
@@ -913,7 +913,7 @@ class ScriptingController:
         args = self.getArgs(p)
 
         def atCommandCallback(
-            event: Event = None,
+            event: Event | None = None,
             args: Args = args,
             c: Cmdr = c,
             p: Position = p.copy(),
@@ -1039,7 +1039,7 @@ class ScriptingController:
             self.c.bodyWantsFocus()
 
     # @+node:ekr.20080813064908.4: *4* sc.getArgs
-    def getArgs(self, p: Position) -> list[str]:
+    def getArgs(self, p: Position | None) -> list[str]:
         """Return the list of @args field of p.h."""
         args: list[str] = []
         if not p:
@@ -1089,7 +1089,7 @@ class ScriptingController:
     # @+node:peckj.20140103101946.10404: *4* sc.getColor
     def getColor(self, h: str) -> str:
         """Returns the background color from the given headline string"""
-        color = None
+        color = ''
         tag = '@color'
         i = h.find(tag)
         if i > -1:
@@ -1105,7 +1105,7 @@ class ScriptingController:
     # @+node:ekr.20060328125248.16: *4* sc.getShortcut
     def getShortcut(self, h: str) -> str:
         """Return the keyboard shortcut from the given headline string"""
-        shortcut = None
+        shortcut = ''
         i = h.find('@key')
         if i > -1:
             j = g.skip_ws(h, i + len('@key'))
@@ -1124,7 +1124,7 @@ class ScriptingController:
         return shortcut
 
     # @+node:ekr.20150402042350.1: *4* sc.getScript
-    def getScript(self, p: Position) -> str:
+    def getScript(self, p: Position | None) -> str:
         """Return the script composed from p and its descendants."""
         return g.getScript(
             self.c,
@@ -1141,7 +1141,7 @@ class ScriptingController:
         func: Callable,
         h: str,
         pane: str,
-        source_c: Cmdr = None,
+        source_c: Cmdr | None = None,
         tag: str = '',
     ) -> None:
         """Register @button <name> and @rclick <name> and <name>"""
@@ -1149,7 +1149,7 @@ class ScriptingController:
         trace = False and not g.unitTesting
         shortcut = self.getShortcut(h) or ''
         commandName = self.cleanButtonText(h)
-        fileName = source_c.fileName() if source_c else None
+        fileName = source_c.fileName() if source_c else ''
 
         if trace and not g.isascii(commandName):
             g.trace(commandName)
@@ -1172,7 +1172,7 @@ class ScriptingController:
                 # Create a *second* func, to avoid collision in c.commandsDict.
 
                 def registerAllCommandsCallback(
-                    event: Event = None, func: Callable = func
+                    event: Event | None = None, func: Callable = func
                 ) -> Callable:
                     return func()
 
@@ -1219,10 +1219,11 @@ class ScriptingController:
         if not bg.startswith('#'):
             bg0 = bg
             d = leoColor.leo_color_database
-            bg = d.get(bg.lower())
-            if not bg:
+            resolved_bg = d.get(bg.lower())
+            if not resolved_bg:
                 g.trace('bad color? %s' % bg0)
                 return
+            bg = resolved_bg
         try:
             b.button.setStyleSheet("QPushButton{background-color: %s}" % (bg))
         except Exception:

--- a/leo/plugins/multifile.py
+++ b/leo/plugins/multifile.py
@@ -60,7 +60,7 @@ multiprefix = '@multiprefix'
 multipath = '@multipath'
 haveseen: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 files: dict[str, Any] = {}  # Values are positions.
-original_precheck = None
+original_precheck: Any = None
 
 
 # @+others

--- a/leo/plugins/nav_qt.py
+++ b/leo/plugins/nav_qt.py
@@ -82,7 +82,7 @@ class NavController:
 
     # @+others
     # @+node:ville.20090518182905.5427: *3* NavController.makeButtons
-    def makeButtons(self) -> tuple[Action, Action]:
+    def makeButtons(self) -> tuple[Action, Action] | None:
         c = self.c
         w = c.frame.iconBar.w
         if not w:

--- a/leo/plugins/nested_splitter.py
+++ b/leo/plugins/nested_splitter.py
@@ -3,7 +3,7 @@
 """Nested splitter classes."""
 
 from __future__ import annotations
-from typing import Any
+from typing import Any, cast
 from leo.core import leoGlobals as g
 from leo.core.leoQt import QtCore, QtGui, QtWidgets
 from leo.core.leoQt import ContextMenuPolicy, Orientation, QAction
@@ -793,7 +793,7 @@ class NestedSplitter(QtWidgets.QSplitter):
         ns.setSizes([0, 1])  # but hide one initially
         self.root.windows.append(window)
         # copy the main main window's stylesheet to new window
-        w: QtCore.QObject = self.root  # A Qt Widget, class NestedSplitter
+        w: QtCore.QObject | None = self.root  # A Qt Widget, class NestedSplitter
         sheets = []
         while w:
             if s := w.styleSheet():
@@ -834,7 +834,7 @@ class NestedSplitter(QtWidgets.QSplitter):
         """
         # drop any providers with the same id
         if hasattr(provider, 'ns_provider_id'):
-            id_ = provider.ns_provider_id()
+            id_ = cast(Any, provider).ns_provider_id()
             cull = []
             for i in self.root.providers:
                 if hasattr(i, 'ns_provider_id') and i.ns_provider_id() == id_:

--- a/leo/plugins/nodetags.py
+++ b/leo/plugins/nodetags.py
@@ -108,7 +108,7 @@ try:
     from leo.core.leoQt import QtCore, QtWidgets
     from leo.core.leoQt import MouseButton
 except Exception:
-    QtCore = QtWidgets = None
+    QtCore = QtWidgets = None  # type:ignore
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
@@ -199,7 +199,7 @@ class TagController:
         # Print all tags.
         if d:
             for key in sorted(d):
-                aList = d.get(key)
+                aList = d[key]
                 for h in sorted(aList):
                     print(f"{key:>8} {h}")
         else:
@@ -284,7 +284,7 @@ if QtWidgets:
     class LeoTagWidget(QtWidgets.QWidget):
         # @+others
         # @+node:peckj.20140804114520.15200: *3* tag_w.__init__
-        def __init__(self, c: Cmdr, parent: QtWidgets.QWidget = None) -> None:
+        def __init__(self, c: Cmdr, parent: QtWidgets.QWidget | None = None) -> None:
             super().__init__(parent)
             self.c = c
             self.tc = self.c.theTagController
@@ -493,7 +493,7 @@ if QtWidgets:
             self.update_current_tags(self.c.p)
 
         # @+node:peckj.20140806145948.6579: *4* tag_w.add_tag
-        def add_tag(self, event: Event = None) -> None:
+        def add_tag(self, event: Event | None = None) -> None:
             p = self.c.p
             tag = str(self.comboBox.currentText()).strip()
             if not tag:

--- a/leo/plugins/pane_commands.py
+++ b/leo/plugins/pane_commands.py
@@ -33,7 +33,7 @@ def init() -> bool:
 @g.command('bottom-of-pane')
 def bottomOfPane(event: LeoKeyEvent | None = None) -> None:
     """move the text cursor to the last character visible in the body pane"""
-    c: Cmdr = event.c if event else None
+    c: Cmdr | None = event.c if event else None
     if not c:
         return
     w: QWidget = c.frame.body.widget
@@ -64,7 +64,7 @@ def bottomOfPane(event: LeoKeyEvent | None = None) -> None:
 @g.command('top-of-pane')
 def topOfPane(event: LeoKeyEvent | None = None) -> None:
     """move the text cursor to the first character visible in the body pane"""
-    c: Cmdr = event.c if event else None
+    c: Cmdr | None = event.c if event else None
     if not c:
         return
     w: QWidget = c.frame.body.widget

--- a/leo/plugins/plugins_menu.py
+++ b/leo/plugins/plugins_menu.py
@@ -58,7 +58,7 @@ __plugin_priority__
 # @+<< plugins_menu imports & annotations >>
 # @+node:ekr.20050101090207.10: ** << plugins_menu imports & annotations >>
 from __future__ import annotations
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 import configparser as ConfigParser
 import os
 from typing import Any, TYPE_CHECKING
@@ -113,11 +113,11 @@ def addPluginMenuItem(plugin: PlugIn, c: Cmdr) -> None:
             menu_location = "&Plugins"
         # @-<< Get menu location >>
         m = c.frame.menu.createNewMenu(plugin_name, menu_location)
-        table = [("About...", None, plugin.about)]
+        entries: list[tuple[str, None, Callable | None]] = [("About...", None, plugin.about)]
         if plugin.hasconfig:
-            table.append(("Properties...", None, plugin.properties))
+            entries.append(("Properties...", None, plugin.properties))
         if plugin.othercmds:
-            table.append(("-", None, None))
+            entries.append(("-", None, None))
             items = []
             d = plugin.othercmds
             for cmd in list(d.keys()):
@@ -125,8 +125,8 @@ def addPluginMenuItem(plugin: PlugIn, c: Cmdr) -> None:
                 items.append(
                     (cmd, None, fn),
                 )  # No need for a callback.
-            table.extend(sorted(items))
-        c.frame.menu.createMenuEntries(m, table)
+            entries.extend(sorted(items))
+        c.frame.menu.createMenuEntries(m, entries)
     else:
         table = [(plugin_name, None, plugin.about)]
         c.frame.menu.createMenuEntries(PluginDatabase.getMenu(plugin), table)
@@ -214,7 +214,7 @@ class _PluginDatabase:
         self.menus: dict[str, LeoMenu] = {}
 
     # @+node:pap.20050305152751.2: *3* addPlugin
-    def addPlugin(self, item: PlugIn, group: str) -> None:
+    def addPlugin(self, item: PlugIn, group: str | None) -> None:
         """Add a plugin"""
         if group:
             self.plugins_by_group.setdefault(group, []).append(item)
@@ -236,7 +236,7 @@ class _PluginDatabase:
     def getMenu(self, item: PlugIn) -> LeoMenu:
         """Get the menu for a particular item"""
         try:
-            return self.menus[item.group]
+            return self.menus[item.group] if item.group else self.menus["Default"]
         except KeyError:
             return self.menus["Default"]
 
@@ -250,9 +250,11 @@ PluginDatabase = _PluginDatabase()
 class PlugIn:
     """A class to hold information about one plugin"""
 
+    hastoplevel: Any
+
     # @+others
     # @+node:EKR.20040517080555.4: *3* PlugIn.__init__ & helper
-    def __init__(self, plgMod: ModuleType, c: Cmdr = None) -> None:
+    def __init__(self, plgMod: ModuleType, c: Cmdr | None = None) -> None:
         """
         @param plgMod: Module object for the plugin represented by this instance.
         @param c:  Leo-editor "commander" for the current .leo file
@@ -276,6 +278,7 @@ class PlugIn:
         self.version = self.mod.__dict__.get("__version__", "<unknown>")
         # g.pr(self.version,g.shortFileName(filename))
         # Configuration...
+        assert plgMod.__file__
         self.configfilename = "%s.ini" % os.path.splitext(plgMod.__file__)[0]
         # True if this can be configured.
         self.hasconfig = os.path.isfile(self.configfilename)
@@ -302,10 +305,11 @@ class PlugIn:
                 self.othercmds[func.command_name] = func
 
     # @+node:EKR.20040517080555.8: *3* PlugIn.about
-    def about(self, event: Event = None) -> None:
+    def about(self, event: Event | None = None) -> None:
         """Put information about this plugin in a scrolledMessage dialog."""
         c = self.c
         msg = self.doc.strip() + '\n' if self.doc else ''
+        assert self.name
         c.putHelpFor(msg, short_title=self.name)
 
     # @+node:pap.20050317183526: *3* PlugIn.getNiceName
@@ -326,7 +330,7 @@ class PlugIn:
         return name.capitalize()
 
     # @+node:EKR.20040517080555.9: *3* PlugIn.properties
-    def properties(self, event: Event = None) -> None:
+    def properties(self, event: Event | None = None) -> None:
         """Display a modal properties dialog for this plugin"""
         if self.hasapply:
 
@@ -353,6 +357,7 @@ class PlugIn:
         self.sourceConfig = data
         # Open a modal dialog and wait for it to return.
         # Provide the dialog with a callback for the 'Appply' function.
+        assert self.name
         title = "Properties of " + self.name
         result, data = g.app.gui.runPropertiesDialog(title, data, callback, buttons)
         if result != 'Cancel' and data:

--- a/leo/plugins/pygeotag/pygeotag.py
+++ b/leo/plugins/pygeotag/pygeotag.py
@@ -43,10 +43,10 @@ class PyGeoTag(object):
         self.synchronous = synchronous
 
         if callback is not None:
-            self.callback = callback  # type:ignore
+            self.callback = callback
 
         if synchronous:
-            self.callback = self._store  # type:ignore
+            self.callback = self._store
 
         self.server_thread: threading.Thread = None
         self.running = False

--- a/leo/plugins/python_terminal.py
+++ b/leo/plugins/python_terminal.py
@@ -51,7 +51,7 @@ with some modifications made for Leo embedding.
 import re
 import sys
 import code
-from typing import Any
+from typing import Any, cast
 from leo.core import leoGlobals as g
 from leo.core.leoQt import QtWidgets
 from leo.core.leoQt import Key
@@ -168,7 +168,7 @@ if QtWidgets:
                 # and reinsert the locals back into the interpreter dictionary
                 selfName = interpreterLocals['self'].__class__.__name__
                 interpreterLocalVars = interpreterLocals.pop('self')
-                self.interpreterLocals[selfName] = interpreterLocalVars
+                cast(Any, self.interpreterLocals)[selfName] = interpreterLocalVars
             else:
                 self.interpreterLocals = interpreterLocals
 
@@ -177,7 +177,7 @@ if QtWidgets:
         # @+node:peckj.20150428142729.14: *3* PyInterp.updateInterpreterLocals
         def updateInterpreterLocals(self, newLocals):
             className = newLocals.__class__.__name__
-            self.interpreterLocals[className] = newLocals
+            cast(Any, self.interpreterLocals)[className] = newLocals
 
         # @+node:peckj.20150428142729.15: *3* PyInterp.write
         def write(self, line):

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -12,7 +12,7 @@ import platform
 import string
 import sys
 import time
-import urllib
+import urllib.parse
 from typing import cast, Any, TYPE_CHECKING
 from leo.commands import gotoCommands
 from leo.core.leoAPI import StringTextWrapper
@@ -748,7 +748,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
             w.setLineWidth(lineWidth)
             self.setName(w, name)
         if not hasattr(w, 'leo_wrapper'):
-            w.leo_wrapper = QTextEditWrapper(widget=w, name=name, c=c)
+            cast(Any, w).leo_wrapper = QTextEditWrapper(widget=w, name=name, c=c)
         return w
 
     # @+node:ekr.20110605121601.18164: *4* dw.createTreeWidget
@@ -769,7 +769,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
 
     # @+node:ekr.20240730053128.1: *3* dw: events
     # @+node:ekr.20110605121601.18140: *4* dw.closeEvent
-    def closeEvent(self, event: QEvent) -> None:  # type:ignore[override]
+    def closeEvent(self, event: QEvent) -> None:  # type:ignore[override]  # ty: ignore[invalid-method-override]
         """Handle a close event in the Leo window."""
         c = self.leo_c
         if not c.exists:
@@ -975,12 +975,12 @@ class DynamicWindow(QtWidgets.QMainWindow):
         class VisLineEdit(QtWidgets.QLineEdit):
             """In case user has hidden minibuffer with gui-minibuffer-hide"""
 
-            def focusInEvent(self, event: QFocusEvent) -> None:  # type:ignore[override]
+            def focusInEvent(self, event: QFocusEvent) -> None:  # type:ignore[override]  # ty: ignore[invalid-method-override]  # pylint: disable=line-too-long
                 self.parent().show()
                 # Call the base class method.
                 super().focusInEvent(event)
 
-            def focusOutEvent(self, event: QFocusEvent) -> None:  # type:ignore[override]
+            def focusOutEvent(self, event: QFocusEvent) -> None:  # type:ignore[override]  # ty: ignore[invalid-method-override]  # pylint: disable=line-too-long
                 self.store_selection()
                 super().focusOutEvent(event)
 
@@ -1121,13 +1121,13 @@ class DynamicWindow(QtWidgets.QMainWindow):
     # @+node:ekr.20110605121601.18178: *4* dw.set_geometry
     # Mypy complaint because this overrides QMainWindow.setGeometry.
 
-    def setGeometry(self, rect: QRect) -> None:  # type:ignore[override,valid-type]
+    def setGeometry(self, rect: QRect) -> None:  # type:ignore[override,valid-type]  # ty: ignore[invalid-method-override]  # pylint: disable=line-too-long
         """Set the window geometry, but only once when using the qt gui."""
-        m = self.leo_master
         assert self.leo_master
+        m = self.leo_master
         # Only set the geometry once, even for new files.
         if not hasattr(m, 'leo_geom_inited'):
-            m.leo_geom_inited = True
+            cast(Any, m).leo_geom_inited = True
             self.leo_master.setGeometry(rect)
             super().setGeometry(rect)
 
@@ -1357,7 +1357,7 @@ class FindTabManager:
 
             def radio_button_callback(
                 n: int,
-                ivar: str = ivar,
+                ivar: str | None = ivar,
                 setting_name: str = setting_name,
                 w: QWidget = radio_button_w,
             ) -> None:
@@ -1567,7 +1567,7 @@ class LeoBaseTabWidget(QtWidgets.QTabWidget):
                 a.triggered.connect(lambda checked: self.reattach_all())
 
             global_point = self.mapToGlobal(point)
-            menu.exec(global_point)
+            menu.exec(global_point)  # ty: ignore[invalid-argument-type]
 
         self.setContextMenuPolicy(ContextMenuPolicy.CustomContextMenu)
         self.customContextMenuRequested.connect(tabContextMenu)
@@ -1650,7 +1650,7 @@ class LeoBaseTabWidget(QtWidgets.QTabWidget):
                 self.setTabToolTip(i, tooltip)  # #4558 also update tooltip if given.
 
     # @+node:ekr.20131115120119.17397: *3* qt_base_tab.closeEvent
-    def closeEvent(self, event: QEvent) -> None:  # type:ignore[override]
+    def closeEvent(self, event: QEvent) -> None:  # type:ignore[override]  # ty: ignore[invalid-method-override]
         """Handle a close event."""
         g.app.gui.close_event(event)
 
@@ -1768,7 +1768,7 @@ class LeoQtBody(leoFrame.LeoBody):
         if obj.objectName() == 'richTextEdit':
             self.onFocusColorHelper('focus-out', obj)
             if hasattr(obj, 'setReadOnly'):
-                obj.setReadOnly(True)
+                cast(Any, obj).setReadOnly(True)
 
     # @+node:ekr.20110605121601.18224: *4* LeoQtBody.qtBody.onFocusColorHelper (revised)
     def onFocusColorHelper(self, kind: str, obj: QObject) -> None:
@@ -2235,11 +2235,11 @@ class LeoQtFrame(leoFrame.LeoFrame):
         self.top.raise_()
 
     # @+node:ekr.20190611053431.8: *4* LeoQtFrame.setTitle
-    def setTitle(self, s: str) -> None:
+    def setTitle(self, title: str) -> None:
         assert self.top
         w = self.top.leo_master
         assert w
-        w.setWindowTitle(s)
+        w.setWindowTitle(title)
 
     # @+node:ekr.20190611053431.9: *4* LeoQtFrame.setTopGeometry
     def setTopGeometry(self, w: int, h: int, x: int, y: int) -> None:
@@ -2585,7 +2585,7 @@ class LeoQtLog(leoFrame.LeoLog):
         createText: bool = True,
         widget: QWidget | None = None,
         wrap: str = 'none',
-    ) -> QWidget:  # Widget or LeoQTextBrowser.
+    ) -> QWidget | qt_text.QTextEditWrapper:  # Widget or LeoQTextBrowser.
         """
         Create a new tab in tab widget
         if widget is None, Create a QTextBrowser,
@@ -2620,7 +2620,7 @@ class LeoQtLog(leoFrame.LeoLog):
             else:
                 widget.leo_log_wrapper = None  # Tell the truth.
             g.app.gui.setFilter(c, widget, contents, 'tabWidget')
-            self.contentsDict[tabName] = contents
+            self.contentsDict[tabName] = cast(Any, contents)
             self.tabWidget.addTab(contents, tabName)
         return contents
 
@@ -2660,19 +2660,19 @@ class LeoQtLog(leoFrame.LeoLog):
         return [w.tabText(i) for i in range(w.count())]
 
     # @+node:ekr.20221022062949.1: *4* LeoQtLog.renameTab
-    def renameTab(self, oldTabName: str, tabName: str) -> None:
+    def renameTab(self, oldName: str, newName: str) -> None:
         """Rename the text tab"""
         w = self.tabWidget
-        i = self.findTabIndex(oldTabName)
+        i = self.findTabIndex(oldName)
         if i is None:
-            self.createTab(tabName)
+            self.createTab(newName)
         else:
             # Update the dict.
-            self.logDict[tabName] = self.logDict[oldTabName]
-            del self.logDict[oldTabName]
+            self.logDict[newName] = self.logDict[oldName]
+            del self.logDict[oldName]
             # Update the tab's name.
-            w.setTabText(i, tabName)
-            self.tabName = tabName
+            w.setTabText(i, newName)
+            self.tabName = newName
 
     # @+node:ekr.20110605121601.18330: *4* LeoQtLog.numberOfVisibleTabs
     def numberOfVisibleTabs(self) -> int:
@@ -2720,7 +2720,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
         assert self.menuBar
         # Inject this dict into the commander.
         if not hasattr(c, 'menuAccels'):
-            c.menuAccels = {}  # PR #4827
+            cast(Any, c).menuAccels = {}  # PR #4827
         if 0:
             self.font = c.config.getFontFromParams(
                 'menu_text_font_family',
@@ -2782,7 +2782,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
         action = menu.addAction(label)
         assert action
         # Inject the command name into the action so that it can be enabled/disabled dynamically.
-        action.leo_command_name = commandName or ''
+        cast(Any, action).leo_command_name = commandName or ''
         if command:
 
             def qt_add_command_callback(
@@ -2799,7 +2799,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
             return
         action = menu.addSeparator()
         assert action
-        action.leo_menu_label = '*seperator*'
+        cast(Any, action).leo_menu_label = '*seperator*'
 
     # @+node:ekr.20110605121601.18347: *5* LeoQtMenu.delete
     def delete(self, menu: QtMenuWrapper, realItemName: str = '<no name>') -> None:
@@ -2868,7 +2868,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
         else:
             self.menuBar.addMenu(menu)
         if action := menu.menuAction():
-            action.leo_menu_label = label
+            cast(Any, action).leo_menu_label = label
         else:
             g.trace('no action for menu', label)
         return menu
@@ -3015,13 +3015,13 @@ class LeoQTreeWidget(QtWidgets.QTreeWidget):
 
     __str__ = __repr__
 
-    def dragMoveEvent(self, ev: QEvent) -> None:  # type:ignore[override]
+    def dragMoveEvent(self, ev: QEvent) -> None:  # type:ignore[override]  # ty: ignore[invalid-method-override]
         pass  # Called during drags.
 
     # @+others
     # @+node:ekr.20111022222228.16980: *3* LeoQTreeWidget: Event handlers
     # @+node:ekr.20110605121601.18364: *4* LeoQTreeWidget.dragEnterEvent & helper
-    def dragEnterEvent(self, ev: QEvent) -> None:  # type:ignore[override]
+    def dragEnterEvent(self, ev: QEvent) -> None:  # type:ignore[override]  # ty: ignore[invalid-method-override]
         """Export c.p's tree as a Leo mime-data."""
         c = self.c
         if not ev:
@@ -3052,7 +3052,7 @@ class LeoQTreeWidget(QtWidgets.QTreeWidget):
         md.setText(f"{fn},{s}")
 
     # @+node:ekr.20110605121601.18365: *4* LeoQTreeWidget.dropEvent & helpers
-    def dropEvent(self, ev: QEvent) -> None:  # type:ignore[override]
+    def dropEvent(self, ev: QEvent) -> None:  # type:ignore[override]  # ty: ignore[invalid-method-override]
         """Handle a drop event in the QTreeWidget."""
         if not ev:
             return
@@ -3675,7 +3675,7 @@ class LeoQtTreeTab:
                 # Fix #458: Chapters drop-down list is not automatically resized.
                 self.setSizeAdjustPolicy(SizeAdjustPolicy.AdjustToContents)
 
-            def focusInEvent(self, event: QFocusEvent) -> None:  # type:ignore[override]
+            def focusInEvent(self, event: QFocusEvent) -> None:  # type:ignore[override]  # ty: ignore[invalid-method-override]  # pylint: disable=line-too-long
                 self.leo_tt.setNames()
                 QtWidgets.QComboBox.focusInEvent(self, event)  # Call the base class
 
@@ -3833,7 +3833,7 @@ class QtIconBarClass:
                 self.text_val = text  # self.text is a method!
                 self.toolbar = toolbar
 
-            def createWidget(self, parent: QWidget) -> QtWidgets.QPushButton:  # type:ignore[override]
+            def createWidget(self, parent: QWidget) -> QtWidgets.QPushButton:  # type:ignore[override]  # ty: ignore[invalid-method-override]  # pylint: disable=line-too-long
                 self.button = QtWidgets.QPushButton(self.text_val, parent)
                 self.button.setProperty('button_kind', kind)  # for styling
                 return self.button
@@ -3855,7 +3855,7 @@ class QtIconBarClass:
         b.setObjectName(button_name)
         b.setContextMenuPolicy(ContextMenuPolicy.ActionsContextMenu)
 
-        def delete_callback(checked: str, action: str = action) -> None:
+        def delete_callback(checked: str, action: Any = action) -> None:
             self.w.removeAction(action)
 
         b.leo_removeAction = rb = QAction('Remove Button', b)
@@ -3921,6 +3921,7 @@ class QtIconBarClass:
         c = self.c
         c2, p = controller.open_gnx(c, gnx)
         if p:
+            assert c2 is not None
             assert c2.positionExists(p)
             if c == c2:
                 c2.selectPosition(p)
@@ -4032,7 +4033,7 @@ class QtIconBarClass:
 # mypy complains about the font ivar and incompatible destroy methods(!)
 
 
-class QtMenuWrapper(LeoQtMenu, QtWidgets.QMenu):  # type:ignore[misc,override]
+class QtMenuWrapper(LeoQtMenu, QtWidgets.QMenu):  # type:ignore[misc,override]  # ty: ignore[invalid-method-override]
     # @+others
     # @+node:ekr.20110605121601.18459: *3* QtMenuWrapper.__init__ and __repr__
     def __init__(
@@ -4055,7 +4056,7 @@ class QtMenuWrapper(LeoQtMenu, QtWidgets.QMenu):  # type:ignore[misc,override]
         label = label.replace('&', '').lower()
         self.leo_menu_label = label
         if action := self.menuAction():
-            action.leo_menu_label = label
+            cast(Any, action).leo_menu_label = label
         self.aboutToShow.connect(self.onAboutToShow)
 
     def __repr__(self) -> str:
@@ -4322,7 +4323,7 @@ class QtTabBarWrapper(QtWidgets.QTabBar):
         self.setMovable(True)
 
     # @+node:peckj.20140516114832.10109: *3* QtTabBarWrapper.mouseReleaseEvent
-    def mouseReleaseEvent(self, event: QMouseEvent) -> None:  # type:ignore[override]
+    def mouseReleaseEvent(self, event: QMouseEvent) -> None:  # type:ignore[override]  # ty: ignore[invalid-method-override]  # pylint: disable=line-too-long
         # middle click close on tabs -- JMP 20140505
         # closes Launchpad bug: https://bugs.launchpad.net/leo-editor/+bug/1183528
         if event.button() == MouseButton.MiddleButton:

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -13,7 +13,7 @@ import re
 import sys
 import textwrap
 from time import sleep
-from typing import Any, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 from leo.core import (
     leoColor,
     leoGlobals as g,
@@ -341,8 +341,8 @@ class LeoQtGui(leoGui.LeoGui):
             b: QPushButton = b,
             c: Cmdr = c,
             buttonText: str = buttonText,
-            p: Position = p and p.copy(),
-            script: str = script,
+            p: Position | None = p and p.copy(),
+            script: str | None = script,
         ) -> None:
             if c.disableCommandsMessage:
                 g.blue('', c.disableCommandsMessage)
@@ -621,7 +621,7 @@ class LeoQtGui(leoGui.LeoGui):
                 # dialog.setStyleSheet(c.active_stylesheet)
                 # Set the commander's FindTabManager.
                 assert g.app.globalFindTabManager
-                c.ftm = g.app.globalFindTabManager
+                cast(Any, c).ftm = g.app.globalFindTabManager
                 fn = c.shortFileName() or 'Untitled'
             else:
                 fn = 'Untitled'
@@ -681,7 +681,7 @@ class LeoQtGui(leoGui.LeoGui):
 
     def createSpellTab(
         self, c: Cmdr, spellHandler: Callable, tabName: str
-    ) -> qt_frame.LeoQtSpellTab:
+    ) -> qt_frame.LeoQtSpellTab | None:
         if g.unitTesting:
             return None
         return qt_frame.LeoQtSpellTab(c, spellHandler, tabName)
@@ -769,11 +769,11 @@ class LeoQtGui(leoGui.LeoGui):
                 else:
                     super().__init__(parent)
 
-            def stepBy(self, step: int) -> None:
+            def stepBy(self, steps: int) -> None:
                 cs = self.currentSection()
-                if cs in self.step_min and abs(step) < self.step_min[cs]:
-                    step = self.step_min[cs] if step > 0 else -self.step_min[cs]
-                QtWidgets.QDateTimeEdit.stepBy(self, step)
+                if cs in self.step_min and abs(steps) < self.step_min[cs]:
+                    steps = self.step_min[cs] if steps > 0 else -self.step_min[cs]
+                QtWidgets.QDateTimeEdit.stepBy(self, steps)
 
         class Calendar(QtWidgets.QDialog):
             def __init__(
@@ -889,11 +889,8 @@ class LeoQtGui(leoGui.LeoGui):
         dialog.setWindowTitle(title)
         dialog.setLabelText(message)
         dialog.setTextValue(default)
-        if wide:
-            # pylint: disable=unsubscriptable-object
-            dialog.resize(
-                int(g.windows()[0].get_window_info()[0] * 0.9), 100
-            )  # g.windows is a list.
+        if wide and (windows := g.windows()):
+            dialog.resize(int(windows[0].get_window_info()[0] * 0.9), 100)
         if cancelButtonText:
             dialog.setCancelButtonText(cancelButtonText)
         if okButtonText:
@@ -950,7 +947,7 @@ class LeoQtGui(leoGui.LeoGui):
 
         """
         if g.unitTesting:
-            return None
+            return 'cancel'
 
         # Create the dialog.
         top_frame: QWidget | None = c.frame.top if c else None
@@ -1013,7 +1010,7 @@ class LeoQtGui(leoGui.LeoGui):
         - `no_all`: bool - show NoToAll button
         """
         if g.unitTesting:
-            return None
+            return 'no'
 
         # Create the dialog.
         top_frame: QWidget | None = c.frame.top if c else None
@@ -1287,10 +1284,12 @@ class LeoQtGui(leoGui.LeoGui):
         dialog.setIcon(Icon.Information)
         dialog.addButton('Ok', ButtonRole.YesRole)
         try:
-            c.in_qt_dialog = True
+            if c:
+                c.in_qt_dialog = True
             dialog.exec()
         finally:
-            c.in_qt_dialog = False
+            if c:
+                c.in_qt_dialog = False
         # @-<< emergency fallback >>
 
     # @+node:ekr.20110607182447.16456: *3* LeoQtGui: Event handlers
@@ -1395,22 +1394,23 @@ class LeoQtGui(leoGui.LeoGui):
 
     # @+node:ekr.20110605121601.18508: *3* LeoQtGui: Focus
     # @+node:ekr.20190601055031.1: *4* LeoQtGui.ensure_commander_visible
-    def ensure_commander_visible(self, c1: Cmdr) -> None:
+    def ensure_commander_visible(self, c: Cmdr) -> None:
         """
         Check to see if c.frame is in a tabbed ui, and if so, make sure
         the tab is visible
         """
         if 'focus' in g.app.debug:
-            g.trace(c1)
+            g.trace(c)
         if hasattr(g.app.gui, 'frameFactory'):
             factory = g.app.gui.frameFactory
             if factory and hasattr(factory, 'setTabForCommander'):
-                c = c1
                 factory.setTabForCommander(c)
                 c.bodyWantsFocusNow()
 
     # @+node:ekr.20190601054958.1: *4* LeoQtGui.get_focus
-    def get_focus(self, c: Cmdr | None = None, raw: bool = False, at_idle: bool = False) -> QWidget:
+    def get_focus(
+        self, c: Cmdr | None = None, raw: bool = False, at_idle: bool = False
+    ) -> QWidget | None:
         """Returns the widget that has focus."""
         trace = 'focus' in g.app.debug and not at_idle
         w = QtWidgets.QApplication.focusWidget()
@@ -1535,7 +1535,7 @@ class LeoQtGui(leoGui.LeoGui):
 
     # @+node:ekr.20110605121601.18518: *4* LeoQtGui.getTreeImage
     @functools.lru_cache(maxsize=128)
-    def getTreeImage(self, c: Cmdr, path: str) -> tuple[QPixmap, int]:
+    def getTreeImage(self, c: Cmdr, path: str) -> tuple[QPixmap, int] | tuple[None, None]:
         image = QtGui.QPixmap(path)
         if image.height() > 0 and image.width() > 0:
             return image, image.height()
@@ -1543,7 +1543,7 @@ class LeoQtGui(leoGui.LeoGui):
 
     # @+node:ekr.20111215193352.10220: *3* LeoQtGui: Splash Screen
     # @+node:ekr.20110605121601.18479: *4* LeoQtGui.createSplashScreen
-    def createSplashScreen(self) -> QWidget:
+    def createSplashScreen(self) -> QWidget | None:
         """Put up a splash screen with Leo's logo."""
         try:
             QApplication = QtWidgets.QApplication
@@ -1571,7 +1571,9 @@ class LeoQtGui(leoGui.LeoGui):
                     svg_height, svg_width = size.height(), size.width()
 
                     # Scale to fraction of screen height
-                    geom = QScreen.availableGeometry(QApplication.primaryScreen())
+                    screen = QApplication.primaryScreen()
+                    assert screen is not None
+                    geom = QScreen.availableGeometry(screen)
                     screen_height = geom.height()
                     target_height_px = screen_height // 4
                     scaleby = target_height_px / svg_height
@@ -1645,7 +1647,7 @@ class LeoQtGui(leoGui.LeoGui):
         parent = widget.parent()
         while parent:
             if isinstance(parent, QtWidgets.QSplitter):
-                return parent, direct_child
+                return parent, cast(QWidget, direct_child)
             direct_child = parent
             parent = parent.parent()
         return None
@@ -1658,7 +1660,7 @@ class LeoQtGui(leoGui.LeoGui):
         return None
 
     # @+node:ekr.20240519115157.1: *4* LeoQtGui.get_top_splitter
-    def get_top_splitter(self, c: Cmdr) -> QWidget:
+    def get_top_splitter(self, c: Cmdr) -> QWidget | None:
         return self.find_widget_by_name(c, 'main_splitter')
 
     # @+node:ekr.20110605121601.18522: *4* LeoQtGui.isTextWidget/Wrapper
@@ -1679,7 +1681,7 @@ class LeoQtGui(leoGui.LeoGui):
     # @+node:ekr.20110605121601.18527: *4* LeoQtGui.widget_name
     def widget_name(self, w: QWidget) -> str:
         return (
-                 w.getName()    or '' if hasattr(w, 'getName')
+                 cast(Any, w).getName() or '' if hasattr(w, 'getName')
             else w.objectName() or '' if hasattr(w, 'objectName')
             else ''
         )  # fmt: skip
@@ -1816,7 +1818,7 @@ class StyleClassManager:
     def has_sclass(self, w: QTextMixin, prop: str) -> bool:
         """Check for style class or list of classes prop on QWidget w"""
         if not prop:
-            return None
+            return False
         props = self.sclasses(w)
         if isinstance(prop, str):
             ans = [prop in props]
@@ -2292,7 +2294,7 @@ class StyleSheetManager:
                 scaled = max(float(sz) * factor, 1)
             except Exception as e:
                 g.es('ssm.rescale_fonts:', e)
-                return None
+                return matchobj.group(0)
             return f'{prefix} {scaled:.1f}{units}'
 
         newsheet = re.sub(RE, scale, sheet)

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -627,7 +627,7 @@ class LayoutCacheWidget(QWidget):
         w: QWidget | None = None
         for kid in self.children():
             if kid.objectName() == name:
-                w = kid  # type: ignore [assignment]
+                w = kid  # type:ignore
         return w
 
     # @+node:ekr.20241027181931.1: *4* LCW.resize_pane
@@ -694,7 +694,7 @@ class LayoutCacheWidget(QWidget):
         # This is indicated by using the name VRX_PLACEHOLDER_NAME in the layout.
         # In building the SPLITTER dict we replace the placeholder
         # by VR3_OBJ_NAME if it exists, otherwise VR_OBJ_NAME.
-        SPLITTERS: dict[str, str] = dict()
+        SPLITTERS: dict[str, Any] = dict()
         for k, v in layout['SPLITTERS'].items():  # type:ignore
             if k == VRX_PLACEHOLDER_NAME:
                 k = VR3_OBJ_NAME if has_vr3 else VR_OBJ_NAME

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -6,7 +6,7 @@
 # @+node:ekr.20220416085845.1: ** << qt_text imports & annotations >>
 from __future__ import annotations
 from collections.abc import Callable
-from typing import Any, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core.leoQt import QtCore, QtGui, Qsci, QtWidgets
 from leo.core.leoQt import ContextMenuPolicy, Key, KeyboardModifier
@@ -528,7 +528,7 @@ class LeoLineTextWidget(QtWidgets.QFrame):
         e.viewport().installEventFilter(self)
 
     # @+node:ekr.20150403094706.10: *3* LeoLineTextWidget.eventFilter
-    def eventFilter(self, obj: QObject, event: QEvent) -> bool:
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:  # ty: ignore[invalid-method-override]
         """
         Update the line numbers for all events on the text edit and the viewport.
         This is easier than connecting all necessary signals.
@@ -607,7 +607,7 @@ if QtWidgets:
                 self.itemClicked.connect(self.select_callback)
 
             # @+node:ekr.20110605121601.18011: *5* LeoQListWidget.closeEvent
-            def closeEvent(self, event: QEvent) -> None:
+            def closeEvent(self, event: QEvent) -> None:  # ty: ignore[invalid-method-override]
                 """Kill completion and close the window."""
                 self.leo_c.k.autoCompleter.abort()
 
@@ -631,7 +631,7 @@ if QtWidgets:
                 return self.currentItem().text()
 
             # @+node:ekr.20110605121601.18013: *5* LeoQListWidget.keyPressEvent
-            def keyPressEvent(self, event: QKeyEvent) -> None:
+            def keyPressEvent(self, event: QKeyEvent) -> None:  # ty: ignore[invalid-method-override]
                 """Handle a key event from QListWidget."""
                 c = self.leo_c
                 w = c.frame.body.wrapper
@@ -719,6 +719,7 @@ if QtWidgets:
                 c = self.leo_c
                 w = c.frame.body.wrapper.widget
                 vp = self.viewport()
+                assert vp is not None
                 r = w.cursorRect()
                 geom = self.geometry()  # In viewport coordinates.
                 gr_topLeft = to_global(w, r.topLeft())
@@ -1018,7 +1019,7 @@ if QtWidgets:
 
         leo_vim_mode: bool | None = None
 
-        def paintEvent(self, event: QPaintEvent) -> None:
+        def paintEvent(self, event: QPaintEvent) -> None:  # ty: ignore[invalid-method-override]
             """
             LeoQTextBrowser.paintEvent.
 
@@ -1100,7 +1101,7 @@ if QtWidgets:
             qp.end()
 
         # @+node:tbrown.20130411145310.18855: *3* LeoQTextBrowser.wheelEvent
-        def wheelEvent(self, event: QWheelEvent) -> None:
+        def wheelEvent(self, event: QWheelEvent) -> None:  # ty: ignore[invalid-method-override]
             """Handle a wheel event."""
             if KeyboardModifier.ControlModifier & event.modifiers():
                 d = {'c': self.leo_c}
@@ -1154,7 +1155,7 @@ class NumberBar(QtWidgets.QFrame):
         self.y_adjust = c.config.getInt('gutter-y-adjust') or 10
 
     # @+node:ekr.20181005085507.1: *3* NumberBar.mousePressEvent
-    def mousePressEvent(self, event: QMouseEvent) -> None:
+    def mousePressEvent(self, event: QMouseEvent) -> None:  # ty: ignore[invalid-method-override]
         c = self.c
 
         def find_line(y: int) -> int:
@@ -1181,7 +1182,7 @@ class NumberBar(QtWidgets.QFrame):
             xdb.qc.put(f"b {path}:{n}")
 
     # @+node:ekr.20150403094706.5: *3* NumberBar.update
-    def update(self, *args: Any) -> None:
+    def update(self, *args: Any) -> None:  # ty: ignore[invalid-method-override]
         """
         Updates the number bar to display the current set of numbers.
         Also, adjusts the width of the number bar if necessary.
@@ -1194,7 +1195,7 @@ class NumberBar(QtWidgets.QFrame):
         QtWidgets.QWidget.update(self, *args)
 
     # @+node:ekr.20150403094706.6: *3* NumberBar.paintEvent
-    def paintEvent(self, event: QPaintEvent) -> None:
+    def paintEvent(self, event: QPaintEvent) -> None:  # ty: ignore[invalid-method-override]
         """
         Enhance QFrame.paintEvent.
         Paint all visible text blocks in the editor's document.
@@ -1691,7 +1692,7 @@ class QTextEditWrapper(QTextMixin):
                     c.k.keyboardQuit(setFocus=False)
 
             # @-others
-            self.widget.mouseReleaseEvent = mouseReleaseEvent
+            cast(Any, self.widget).mouseReleaseEvent = mouseReleaseEvent
 
     # @+node:ekr.20200312052821.1: *3* QTextEditWrapper.repr
     def __repr__(self) -> str:
@@ -1757,7 +1758,7 @@ class QTextEditWrapper(QTextMixin):
         def after(func: Callable) -> None:
             QtCore.QTimer.singleShot(delay, func)
 
-        def addFlashCallback(self: QTextEditWrapper = self, w: QWidget = w) -> None:
+        def addFlashCallback(self: QTextEditWrapper = self, w: Any = w) -> None:
             i = self.flashIndex
             cursor = w.textCursor()  # Must be the widget's cursor.
             cursor.setPosition(i)
@@ -1774,7 +1775,7 @@ class QTextEditWrapper(QTextMixin):
             self.flashCount -= 1
             after(removeFlashCallback)
 
-        def removeFlashCallback(self: QTextEditWrapper = self, w: QWidget = w) -> None:
+        def removeFlashCallback(self: QTextEditWrapper = self, w: Any = w) -> None:
             w.setExtraSelections(last_selections)
             if self.flashCount > 0:
                 after(addFlashCallback)
@@ -1831,7 +1832,7 @@ class QTextEditWrapper(QTextMixin):
         return self.widget.textCursor().hasSelection()
 
     # @+node:ekr.20110605121601.18089: *4* QTextEditWrapper.insert (avoid call to setAllText)
-    def insert(self, i: int, s: str) -> None:
+    def insert(self, i: int, s: str) -> None:  # ty: ignore[invalid-method-override]
         """QTextEditWrapper."""
         w = self.widget
         cursor = w.textCursor()

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from collections.abc import Callable
 import re
 import time
-from typing import Any, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 from leo.core.leoQt import QtCore, QtGui, QtWidgets
 from leo.core.leoQt import EndEditHint, Format, ItemFlag, KeyboardModifier
 from leo.core import leoGlobals as g
@@ -1054,7 +1054,7 @@ class LeoQtTree(leoFrame.LeoTree):
         if item:
             item.setText(0, s)
             if self.use_declutter:
-                item._real_text = s
+                cast(Any, item)._real_text = s
 
     # @+node:tbrown.20160406221505.1: *4* LeoQtTree.sizeTreeEditor
     @staticmethod

--- a/leo/plugins/quickMove.py
+++ b/leo/plugins/quickMove.py
@@ -343,8 +343,8 @@ class quickMove:
         # c.frame.menu.createNewMenu('Move', 'Outline')
 
         self.local_imps: list[tuple] = []  # make table for createMenuItemsFromTable()
-        for func, name, text in self.imps:
-            self.local_imps.append((text, None, func))
+        for fn, _name, text in self.imps:
+            self.local_imps.append((text, None, fn))
 
         self.local_imps.extend(self.table)
         c.frame.menu.createMenuItemsFromTable('Move', self.table)

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -117,7 +117,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
     QEvent: TypeAlias = QtCore.QEvent
     Match = re.Match
-    Match_Iter = Iterator[re.Match[str]]
+    Match_Iter = Iterator[re.Match[str]] | None
     Match_List = list[tuple[Position, Match_Iter]]
     QWidget = QtWidgets.QWidget
     QListWidget = QtWidgets.QListWidget
@@ -220,8 +220,10 @@ def install_qt_quicksearch_tab(c: Cmdr) -> None:
 
 
 # @+node:ekr.20111014074810.15659: *3* matchLines
-def matchlines(b: str, miter: Iterator[Match[str]]) -> list:
-    res = []
+def matchlines(b: str, miter: Iterator[Match[str]] | None) -> list:
+    res: list = []
+    if miter is None:
+        return res
     for m in miter:
         st, en = g.getLine(b, m.start())
         li = b[st:en].strip()
@@ -246,12 +248,15 @@ def show_unittest_failures(event: LeoKeyEvent) -> None:
     nav.scon.clear()
     if fails:
         for gnx, stack in fails:
-            pos: Position = None
+            pos: Position | None = None
             # sucks
             for p in c.all_positions():
                 if p.gnx == gnx:
                     pos = p.copy()
                     break
+            if pos is None:
+                # The position no longer exists (e.g. the node was deleted).
+                continue
 
             def mkcb(p: Position, stack: Any) -> Any:
                 def focus() -> None:
@@ -312,7 +317,7 @@ class LeoQuickSearchWidget(QtWidgets.QWidget):
 
     # @+others
     # @+node:ekr.20111015194452.15695: *3* quick_w.ctor
-    def __init__(self, c: Cmdr, mode: str = "nav", parent: QWidget = None) -> None:
+    def __init__(self, c: Cmdr, mode: str = "nav", parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.ui: Any = qt_quicksearch.Ui_LeoQuickSearchWidget()
         self.ui.setupUi(self)
@@ -405,7 +410,7 @@ class QuickSearchController:
 
         def searcher(inp: str) -> tuple[Match_List, Match_List]:
             if self.frozen:
-                return None
+                return [], []
             exp = inp.replace(" ", "*")
             res = self.bgSearch(exp)
             return res
@@ -660,7 +665,7 @@ class QuickSearchController:
     # @+node:ville.20121118193144.3620: *3* bgSearch
     def bgSearch(self, pat: str) -> tuple[Match_List, Match_List]:
         if self.frozen:
-            return None
+            return [], []
         if not pat.startswith('r:'):
             hpat = fnmatch.translate('*' + pat + '*').replace(r"\Z(?ms)", "")
             flags = re.IGNORECASE
@@ -741,7 +746,7 @@ class QuickSearchController:
 
         # tgt = self.its.get(it and id(it))
 
-        tgt: Callable = self.its.get(id(it))
+        tgt: Callable | None = self.its.get(id(it))
         if not tgt:
             return
         # if Ctrl key is down, delete item and

--- a/leo/plugins/richtext.py
+++ b/leo/plugins/richtext.py
@@ -64,6 +64,7 @@ To make a button to toggle the editor on and off, use::
 # @+<< imports >>
 # @+node:tbrown.20130813134319.14335: ** << imports >> (richtext.py)
 import time
+from typing import Any, cast
 from urllib.parse import unquote
 from leo.core import leoGlobals as g
 from leo.core.leoQt import QtCore, QtWidgets, QtWebKit, QtWebKitWidgets
@@ -137,7 +138,7 @@ class CKEEditor(QtWidgets.QWidget):
         # read autosave preference
         if not hasattr(self.c, '_ckeeditor_autosave'):
             auto = self.c.config.getBool("richtext-cke-autosave") or False
-            self.c._ckeeditor_autosave = auto
+            cast(Any, self.c)._ckeeditor_autosave = auto
             if auto:
                 g.es("NOTE: automatic saving of rich text edits")
         # load config

--- a/leo/plugins/rpcalc.py
+++ b/leo/plugins/rpcalc.py
@@ -232,7 +232,7 @@ def onCreate(tag: str, keys: Any) -> None:
 # @+node:tom.20230424130102.2: **  altbasedialog
 # @+others
 # @+node:tom.20230424130102.3: *3* class AltBaseDialog
-class AltBaseDialog(QWidget):  # type: ignore
+class AltBaseDialog(QWidget):
     """Displays edit boxes for other number bases."""
 
     baseCode = {'X': 16, 'O': 8, 'B': 2, 'D': 10}
@@ -367,7 +367,7 @@ class AltBaseDialog(QWidget):  # type: ignore
 
 
 # @+node:tom.20230424130102.13: *3* class AltBaseBox
-class AltBaseBox(QLabel):  # type: ignore
+class AltBaseBox(QLabel):
     """Displays an edit box at a particular base."""
 
     # @+others
@@ -403,7 +403,7 @@ class AltBaseBox(QLabel):  # type: ignore
 # @+node:tom.20230424130102.18: **  calcbutton
 # @+others
 # @+node:tom.20230424130102.19: *3* class CalcButton
-class CalcButton(QPushButton):  # type: ignore
+class CalcButton(QPushButton):
     """Calculator button class - size change & emits clicked text signal."""
 
     activated = pyqtSignal(str)
@@ -898,7 +898,7 @@ class CalcCore:
 # @@language python
 # @@tabwidth -4
 # @+node:tom.20230424130102.50: ** class CalcDlg
-class CalcDlg(QWidget):  # type: ignore
+class CalcDlg(QWidget):
     """Main dialog for calculator program."""
 
     # @+others
@@ -1443,7 +1443,7 @@ class CalcDlg(QWidget):  # type: ignore
 
 # @+others
 # @+node:tom.20230424130102.76: *3* class Lcd
-class Lcd(QLCDNumber):  # type: ignore
+class Lcd(QLCDNumber):
     """Main LCD Display."""
 
     # @+others
@@ -1475,7 +1475,7 @@ class Lcd(QLCDNumber):  # type: ignore
 
 
 # @+node:tom.20230424130102.80: *3* class LcdBox
-class LcdBox(QFrame):  # type: ignore
+class LcdBox(QFrame):
     """Frame for LCD display."""
 
     # @+others
@@ -1552,13 +1552,13 @@ class CalcStack(list):
 
 # @+others
 # @+node:tom.20230424130102.94: *3* class ExtraViewWidget(QTreeWidget)
-class ExtraViewWidget(QTreeWidget):  # type: ignore
+class ExtraViewWidget(QTreeWidget):
     """Base class of list views for ExtraDisplay."""
 
     # @+others
     # @+node:tom.20230424130102.95: *4* __init__
     def __init__(self, calcRef, parent=None):
-        QListView.__init__(self, parent)  # type:ignore  # pylint: disable=non-parent-init-called
+        QListView.__init__(self, parent)  # pylint: disable=non-parent-init-called
         self.calcRef = calcRef
         self.setRootIsDecorated(False)
 
@@ -1680,7 +1680,7 @@ class MemViewWidget(ExtraViewWidget):
 
 
 # @+node:tom.20230424130102.109: *3* class ExtraDisplay
-class ExtraDisplay(QWidget):  # type: ignore
+class ExtraDisplay(QWidget):
     """Displays registers, history or memory values, allows copies."""
 
     # @+others
@@ -1799,7 +1799,7 @@ class ExtraDisplay(QWidget):  # type: ignore
 # @+node:tom.20230424130102.121: **  helpview
 # @+others
 # @+node:tom.20230424130102.122: *3* class HelpView
-class HelpView(QMainWindow):  # type: ignore
+class HelpView(QMainWindow):
     """Main window for viewing an html help file."""
 
     # @+others
@@ -1897,7 +1897,7 @@ class HelpView(QMainWindow):  # type: ignore
 
 
 # @+node:tom.20230424130102.128: *3* class HelpViewer
-class HelpViewer(QTextBrowser):  # type: ignore
+class HelpViewer(QTextBrowser):
     """Shows an html help file."""
 
     # @+others
@@ -2024,8 +2024,8 @@ class Option:
                             print('Error - could not write to config dir')
                             self.path = ''
         self.keySpaces = keySpaces
-        self.dfltDict = {}  # type: ignore
-        self.userDict = {}  # type: ignore
+        self.dfltDict = {}
+        self.userDict = {}
         self.dictList = (self.userDict, self.dfltDict)
         self.chgList = []
 
@@ -2175,7 +2175,7 @@ class Option:
 # @+node:tom.20230424130102.156: **  optiondlg
 # @+others
 # @+node:tom.20230424130102.157: *3* class OptionDlg
-class OptionDlg(QDialog):  # type: ignore
+class OptionDlg(QDialog):
     """Works with Option class to provide a dialog for pref/options."""
 
     # @+others

--- a/leo/plugins/run_nodes.py
+++ b/leo/plugins/run_nodes.py
@@ -59,7 +59,7 @@ else:
 
 # misc global variables...
 RunNode = None
-RunList: list[Any] = None  # List of Positions.
+RunList: list[Any] | None = None  # List of Positions.
 WorkDir = None
 ExitCode = None
 

--- a/leo/plugins/screenshots.py
+++ b/leo/plugins/screenshots.py
@@ -312,6 +312,7 @@ the @slideshow tree whose sanitized name is
 # @+node:ekr.20100908110845.5604: ** << imports >>
 import copy
 import glob
+from typing import Any, cast
 import os
 import shutil
 import subprocess
@@ -624,6 +625,7 @@ class ScreenShotController:
     def build(self):
         """Do a complete sphinx build."""
         sc = self
+        assert sc.slideshow_path
         os.chdir(sc.slideshow_path)
         os.system('make clean')
         os.system('make html')
@@ -828,6 +830,7 @@ class ScreenShotController:
     def get_directive_fn(self):
         """Compute the path for use in an .. image:: directive."""
         sc = self
+        assert sc.output_fn
         return g.shortFileName(sc.output_fn)
 
     # @+node:ekr.20100911044508.5627: *5* get_output_fn
@@ -866,6 +869,7 @@ class ScreenShotController:
     # @+node:ekr.20101004082701.5738: *5* get_slide_base_name
     def get_slide_base_name(self):
         sc = self
+        assert sc.slideshow_path
         _, name = g.os_path_split(sc.slideshow_path)
         return name
 
@@ -1153,6 +1157,7 @@ class ScreenShotController:
             'Makefile',
             'make.bat',
         )
+        assert sc.slide_fn
         slide_path, _ = g.os_path_split(sc.slide_fn)
         for fn in table:
             path = g.finalize_join(slide_path, fn)
@@ -1226,6 +1231,7 @@ class ScreenShotController:
             ('_static       ', static_dir),
         )
         for tag, path in table:
+            assert path is not None
             if tag.strip().endswith('fn'):
                 path, _ = g.os_path_split(path)
             if not g.os_path_exists(path):
@@ -1241,6 +1247,7 @@ class ScreenShotController:
         h = '@url built slide'
         if not sc.find_node(p, h):
             c.selectPosition(p)
+            assert sc.slide_fn
             _, fn = g.os_path_split(sc.slide_fn)
             if fn.endswith('.txt'):
                 fn = fn[:-4]
@@ -1414,6 +1421,7 @@ class ScreenShotController:
         # "@url working file" inhibits making a new working file.
         if sc.find_node(sc.slide_node, '@url working file'):
             # Make a new output file *only* if the working file is newer.
+            assert sc.working_fn
             if (
                 g.os_path_exists(sc.working_fn)
                 and sc.output_fn
@@ -1439,6 +1447,7 @@ class ScreenShotController:
         g.red('Opening Inkscape...\n')
         sc.c.outerUpdate()
         sc.enable_filters(sc.working_fn, False)
+        assert sc.inkscape_bin and sc.working_fn
         cmd = [sc.inkscape_bin, "--with-gui", sc.working_fn]
         proc = subprocess.Popen(cmd, stderr=subprocess.PIPE)
         proc.communicate()  # Wait for Inkscape to terminate.
@@ -1484,10 +1493,12 @@ class ScreenShotController:
             if sc.verbose:
                 g.note('no output file')
             return
+        output_fn = sc.output_fn
+        assert sc.inkscape_bin and sc.working_fn
         cmd = (
             sc.inkscape_bin,
             "--without-gui",
-            "--export-png=" + sc.output_fn,
+            "--export-png=" + output_fn,
             "--export-area-drawing",
             "--export-area-snap",
             sc.working_fn,
@@ -1495,14 +1506,14 @@ class ScreenShotController:
         proc = subprocess.Popen(cmd, stderr=subprocess.PIPE)
         proc.communicate()  # Wait for Inkscape to terminate.
         if sc.verbose:
-            g.note('wrote:  %s' % g.shortFileName(sc.output_fn))
+            g.note('wrote:  %s' % g.shortFileName(output_fn))
         if Image:  # trim transparent border
             try:
-                img = Image.open(sc.output_fn)
+                img = Image.open(output_fn)
                 img = sc.trim(img, (255, 255, 255, 0))
-                img.save(sc.output_fn)
+                img.save(output_fn)
             except OSError:
-                g.trace('can not open %s' % sc.output_fn)
+                g.trace('can not open %s' % output_fn)
         sc.make_at_url_node_for_output_file()
 
     # @+node:ekr.20100908110845.5555: *5* trim
@@ -1524,6 +1535,7 @@ class ScreenShotController:
         """Write sc.slide_node.b to <sc.slide_fn>, a .html.txt file."""
         sc = self
         fn = sc.slide_fn
+        assert fn
         s = sc.make_slide_contents()
         try:
             f = open(fn, 'w')
@@ -1643,6 +1655,7 @@ class ScreenShotController:
     def get_template(self):
         """Load and check the template SVG and return DOM"""
         sc = self
+        assert sc.template_fn
         infile = open(sc.template_fn)
         template = etree.parse(infile)
         ids_d = sc.getIds(template.getroot())
@@ -1745,6 +1758,7 @@ class ScreenShotController:
         """Create the working file from the template."""
         sc = self
         fn = sc.working_fn
+        assert fn
         outfile = open(fn, 'w')
         template.write(outfile)
         if sc.verbose:
@@ -1763,6 +1777,7 @@ class ScreenShotController:
         ok = sc.setup_screen_shot(fn)
         if ok:
             if sc.verbose:
+                assert sc.screenshot_fn
                 g.note('wrote:  %s' % g.shortFileName(sc.screenshot_fn))
                 # g.note('slide node:  %s' % p.h)
             sc.add_image_directive()
@@ -1839,6 +1854,7 @@ class ScreenShotController:
         if sc.select_node:
             cmd.append('--select="%s"' % (sc.select_node))
         if sc.pause_flag:
+            assert sc.screenshot_fn
             g.red('Pausing:', g.shortFileName(sc.screenshot_fn))
             g.note('Please take the screenshot by hand')
             c.outerUpdate()
@@ -1950,7 +1966,7 @@ class ScreenShotController:
         else:
             s = '.. image:: %s' % sc.directive_fn.replace('\\', '/')
         if p.b.find(s) == -1:
-            p.b = p.b.rstrip() + '\n\n%s\n\n' % (s)
+            cast(Any, p).b = p.b.rstrip() + '\n\n%s\n\n' % (s)
 
     # @+node:ekr.20101113193341.5452: *6* delete_at_url_built_slide_node
     def delete_at_url_built_slide_node(self, p):
@@ -2057,6 +2073,7 @@ class ScreenShotController:
     def get_wink_screenshots(self):
         """Return the properly sorted list of wink screenshots."""
         sc = self
+        assert sc.wink_path
         aList = glob.glob(sc.wink_path + '/*.png')
 
         def key(s):

--- a/leo/plugins/sftp.py
+++ b/leo/plugins/sftp.py
@@ -102,7 +102,7 @@ from leo.core.leoQt import QtWidgets
 try:
     import paramiko
 except ImportError:
-    paramiko = None
+    paramiko = None  # type:ignore
     if not g.unitTesting:
         print('sftp.py: can not import paramiko')
 

--- a/leo/plugins/stickynotes.py
+++ b/leo/plugins/stickynotes.py
@@ -340,7 +340,7 @@ if encOK:
 
 
 # @+node:tbrown.20141214173054.3: ** class TextEditSearch
-class TextEditSearch(QtWidgets.QWidget):  # type:ignore
+class TextEditSearch(QtWidgets.QWidget):
     """A QTextEdit with a search box
 
     Used to make decoded encoded body text searchable, so when you've decoded
@@ -424,7 +424,7 @@ class FocusingPlaintextEdit(TextEditSearch):
 
 
 # @+node:ville.20091023181249.5264: ** class SimpleRichText
-class SimpleRichText(QtWidgets.QTextEdit):  # type:ignore
+class SimpleRichText(QtWidgets.QTextEdit):
     # pylint: disable=method-hidden
 
     def __init__(self, focusin, focusout):
@@ -657,7 +657,7 @@ def tabula_subtree_f(event):
 
 
 # @+node:ville.20100703194946.5584: *3* class Tabula(QMainWindow)
-class Tabula(QtWidgets.QMainWindow):  # type:ignore
+class Tabula(QtWidgets.QMainWindow):
     # @+others
     # @+node:ekr.20101114061906.5445: *4* __init__
     def __init__(self, c):

--- a/leo/plugins/threadutil.py
+++ b/leo/plugins/threadutil.py
@@ -234,7 +234,8 @@ class SysProcessRunner:
             err = str(p.readAllStandardError())
             cb = ent['cb'] or self.default_cb
             later(self.sched)
-            cb(out, err, status, ent)
+            if cb:
+                cb(out, err, status, ent)
 
         cmd = ent['arg'][0]
         args = ent['arg'][1:]

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -232,7 +232,7 @@ try:
     import docutils
     import docutils.core
 except ImportError:
-    docutils = None
+    docutils = None  # type:ignore
 if docutils:
     try:
         from docutils.core import publish_string
@@ -318,7 +318,7 @@ def init() -> bool:
 
 # @+node:ekr.20240727091022.1: *3* vr function: getVR
 def getVr(
-    *, c: Any = None, event: Any = None, parent: QtWidgets.QWidget = None
+    *, c: Any = None, event: Any = None, parent: QtWidgets.QWidget | None = None
 ) -> ViewRenderedController | None:
     """Return the ViewRenderedController instance or None."""
     if g.app.gui.guiName() != 'qt':
@@ -353,6 +353,8 @@ def onCreate(tag: str, keys: dict) -> None:
     if not c:
         return
     vr = getVr(c=c)
+    if not vr:
+        return
     g.registerHandler('select2', vr.update_vr)
     g.registerHandler('idle', vr.update_vr)
     vr.active = True
@@ -390,14 +392,14 @@ def show_scrolled_message(tag: str, kw: Any) -> None:
     if not vr:
         return
     # Make sure we will show the message.
-    vr.is_active = True
+    vr.active = True
     vr.is_visible = True
     vr.show()
     # A hack: suppress updates until the node changes.
     vr.gnx = p.v.gnx
     vr.length = len(p.v.b)
     # Render!
-    f = vr.dispatch_dict.get('rest')
+    f = vr.dispatch_dict['rest']
     f(s, kw)
     c.bodyWantsFocusNow()
 
@@ -646,7 +648,7 @@ class ViewRenderedController(QtWidgets.QWidget):
     # @-<< vr: default templates >>
     # @+others
     # @+node:ekr.20110317080650.14380: *3*  vr.ctor & helpers
-    def __init__(self, c: Cmdr, parent: QWidget = None) -> None:
+    def __init__(self, c: Cmdr, parent: QWidget | None = None) -> None:
         """Ctor for ViewRenderedController class."""
         self.c = c
         # Create the widget.
@@ -662,14 +664,14 @@ class ViewRenderedController(QtWidgets.QWidget):
         self.typst_template: str = ''
         self.pdf_zoom: int = 0
         # Widgets managed by destroy_widgets.
-        self.browser: QWidget = None
-        self.gs: QGraphicsScene = None
-        self.gv: QGraphicsView = None
+        self.browser: QWidget | None = None
+        self.gs: QGraphicsScene | None = None
+        self.gv: QGraphicsView | None = None
         self.vp: QMediaPlayer = None
-        self.w: QWidget = None  # The present widget in the rendering pane.
+        self.w: QWidget | None = None  # The present widget in the rendering pane.
         # Set the ivars.
         self.active = True
-        self.gnx: str = None
+        self.gnx: str | None = None
         self.keep_open = False  # True: keep the VR pane open even when showing text.
         self.is_visible = False
         self.length = 0  # The length of previous p.b.
@@ -744,7 +746,7 @@ class ViewRenderedController(QtWidgets.QWidget):
         self.typst_template = get_template('typst')
 
     # @+node:ekr.20190614065659.1: *4* vr.create_pane
-    def create_pane(self, parent: QWidget) -> None:
+    def create_pane(self, parent: QWidget | None) -> None:
         """Create the VR pane."""
         if g.unitTesting:
             return
@@ -860,7 +862,7 @@ class ViewRenderedController(QtWidgets.QWidget):
         if not self.must_update(keywords):
             return
         # Suppress updates until we change nodes.
-        f: Callable = None
+        f: Callable | None = None
         self.node_changed = self.gnx != p.v.gnx
         self.gnx = p.v.gnx
         self.length = len(p.b)  # not s
@@ -1494,19 +1496,21 @@ class ViewRenderedController(QtWidgets.QWidget):
         if not h.startswith('@jinja'):
             return
 
-        def find_root(p: Position) -> tuple[Position, Position] | None:
+        def find_root(p: Position) -> tuple[Position, Position] | tuple[None, None]:
             for newp in p.parents():
                 if newp.h.strip() == '@jinja':
                     oldp, p = p, newp
                     return oldp, p
             return None, None
 
-        def find_inputs(p: Position) -> tuple[Position, Position] | None:
+        def find_inputs(p: Position) -> tuple[Position, Position] | tuple[None, None]:
             for newp in p.parents():
                 if newp.h.strip() == '@jinja inputs':
                     oldp, p = p, newp
-                    _, p = find_root(p)
-                    return oldp, p
+                    _, root_p = find_root(p)
+                    if root_p is None:
+                        return None, None
+                    return oldp, root_p
             return None, None
 
         # if on jinja node's children, find the parent
@@ -1517,6 +1521,10 @@ class ViewRenderedController(QtWidgets.QWidget):
         elif h.startswith('@jinja variable'):
             # not at @jinja, first find @jinja inputs, then @jinja
             oldp, p = find_inputs(p)
+
+        if p is None:
+            g.es("Could not find enclosing @jinja node.")
+            return
 
         def untangle(c: Cmdr, p: Position) -> str:
             return g.getScript(c, p, useSelectedText=False, useSentinels=False)

--- a/leo/plugins/xdb_pane.py
+++ b/leo/plugins/xdb_pane.py
@@ -47,7 +47,7 @@ def onCreate(tag, key):
 # @+node:ekr.20181004143535.7: ** class XdbPane
 if g.app.gui.guiName() == "qt":
 
-    class XdbPane(QtWidgets.QWidget):  # type:ignore
+    class XdbPane(QtWidgets.QWidget):
         """Create the contents of the Debug pane."""
 
         def __init__(self, c):
@@ -93,7 +93,7 @@ if g.app.gui.guiName() == "qt":
                 for name, func in table:
                     w = QtWidgets.QPushButton()
                     w.setText(name)
-                    w.clicked.connect(func)  # type:ignore
+                    w.clicked.connect(func)
                     hlayout.addWidget(w)
                 vlayout.addLayout(hlayout)
             layout.addLayout(vlayout)

--- a/leo/plugins/xml_edit.py
+++ b/leo/plugins/xml_edit.py
@@ -118,7 +118,8 @@ filetypes = [
 ]
 
 # xml namespace mapping from prefix to full namespace
-NSMAP: dict[str, Any] = {}
+# (a None key holds the default namespace, per lxml's nsmap convention)
+NSMAP: dict[str | None, Any] = {}
 
 
 # @+node:tbrown.20110428102237.20325: ** append_element

--- a/leo/plugins/zenity_file_dialogs.py
+++ b/leo/plugins/zenity_file_dialogs.py
@@ -65,7 +65,7 @@ def callZenity(title: str, save: bool = False, test: bool = False) -> bytes | No
     if ret:
         return None
     # if multiple:
-    # return filename.split('|')  # type:ignore
+    # return filename.split('|')
     return filename
 
 
@@ -87,7 +87,7 @@ def runSaveFileDialog(
     *,
     filetypes: list[tuple[str, str]] | None = None,
     defaultextension='',  # Not used.
-) -> bytes:
+) -> bytes | None:
     """Call zenity's save file dialog."""
     # initialdir=g.app.globalOpenDir or g.os_path_abspath(os.getcwd())
     return callZenity(title, save=True)

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,12 +2,21 @@
 #@+node:ekr.20240406013108.1: * @file ../../ruff.toml
 #@@language toml
 
-# This file includes options only for the ruff linter.
-# pyproject.toml contains all `ruff format` options.
+# NOTE: when this file exists, ruff ignores pyproject.toml's [tool.ruff] and
+# [tool.ruff.format] tables entirely (no merging), so line-length and format
+# options must be repeated here to actually take effect.
 
 # To add suppressions
 # find: ^(\s+)(\w+) (.+?)$
 # repl: \1"\2", # \3
+
+line-length = 100
+
+[format]
+docstring-code-format = false
+indent-style = "space"
+line-ending = "native"
+quote-style = "preserve"
 
 [lint]
 ignore = [

--- a/ty.toml
+++ b/ty.toml
@@ -42,3 +42,18 @@ exclude = [
 # leo/core, leo/commands, leo/plugins, leo/modes, leo/external -- the
 # same reason .mypy.ini disables `attr-defined` for those packages.
 unresolved-attribute = "ignore"
+
+# Mirrors .mypy.ini's `ignore_missing_imports = True`. Covers both
+# genuinely optional third-party deps (flake8, matplotlib, enchant,
+# whoosh, ...) not installed in every environment, and Leo's
+# TYPE_CHECKING-only imports of names that are conditionally/
+# dynamically defined at runtime (leoQt.py, leoGui.py, leoApp.py).
+unresolved-import = "ignore"
+
+# mypy and ty enforce different (and sometimes incompatible) rules for
+# the same line -- e.g. ty's stricter Optional/override checks vs
+# mypy's. A `# type: ignore` that mypy's config requires is invisible
+# to ty when ty has nothing to report on that line, so ty calls it
+# "unused". Don't let that override mypy's needs: silence the warning
+# rather than deleting comments mypy still relies on.
+unused-type-ignore-comment = "ignore"


### PR DESCRIPTION
Fresh PR replacing #4837, rebased as a single clean commit on current `devel` per @edreamleo's request there ("Would it be possible to base a new PR on the present state of 'devel'?"). Same end-state diff, no fixup-commit history.

## Summary
- Work through `ty`'s diagnostics across `leo/core`, `leo/commands`, and `leo/plugins`: 733 -> 110, mypy clean throughout.
- Add `ty.toml` and a non-blocking `ty` CI job.
- Fix `ruff.toml`/`pyproject.toml` drift: `ruff format` was silently ignoring `pyproject.toml`'s `line-length = 100` / `quote-style = "preserve"` because `ruff.toml` exists standalone (no config merging), falling back to ruff's 88-char/double-quote defaults. Mirrored the settings into `ruff.toml`.

## Test plan
- [x] CI green (lint 3.10-3.13 + mypy) on the source branch before squashing
- [x] `ruff format --check leo/` clean under corrected settings
- [x] mypy clean