### PR TITLE
Add vv dark theme

### DIFF
--- a/leo/Icons/vv-dark/branch_closed.svg
+++ b/leo/Icons/vv-dark/branch_closed.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <path d="M10 8l4 4-4 4" fill="none" stroke="#89929d" stroke-width="1.5"
+        stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/leo/Icons/vv-dark/branch_open.svg
+++ b/leo/Icons/vv-dark/branch_open.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <path d="M8 10l4 4 4-4" fill="none" stroke="#89929d" stroke-width="1.5"
+        stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/leo/Icons/vv-dark/nav_back.svg
+++ b/leo/Icons/vv-dark/nav_back.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <path d="M14 7l-5 5 5 5" fill="none" stroke="#89929d" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/leo/Icons/vv-dark/nav_forward.svg
+++ b/leo/Icons/vv-dark/nav_forward.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <path d="M10 7l5 5-5 5" fill="none" stroke="#89929d" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/leo/themes/vv-dark.leo
+++ b/leo/themes/vv-dark.leo
@@ -1,0 +1,2730 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Created by Leo: https://leo-editor.github.io/leo-editor/leo_toc.html -->
+<leo_file xmlns:leo="https://leo-editor.github.io/leo-editor/namespaces/leo-python-editor/1.1" >
+<leo_header file_format="2"/>
+<globals/>
+<preferences/>
+<find_panel_settings/>
+<vnodes>
+<v t="ville.20260807001457.1"><vh>Read me</vh></v>
+<v t="ville.20260807001457.2"><vh>Tests</vh>
+<v t="ville.20260807001457.3"><vh>Syntax coloring template</vh>
+<v t="ville.20260807001457.4"><vh>&lt;&lt; defined section &gt;&gt;</vh></v>
+</v>
+<v t="ville.20260807001457.5"><vh>Test g.es(color=*)</vh></v>
+<v t="ville.20260807001457.6"><vh>g.error/note/warning test</vh></v>
+</v>
+<v t="ville.20260807001457.7"><vh>Notes</vh></v>
+<v t="ville.20260807001457.8" descendentVnodeUnknownAttributes="7d7100285803000000302e3171017d7102580b0000005f5f626f6f6b6d61726b7371037d7104580700000069735f6475706571054930300a73735803000000302e3271067d7107580b0000005f5f626f6f6b6d61726b7371087d7109580700000069735f64757065710a4930300a73735803000000302e33710b7d710c580b0000005f5f626f6f6b6d61726b73710d7d710e580700000069735f64757065710f4930300a7373752e"><vh>@settings</vh>
+<v t="ville.20260807001457.9"><vh>Appearance (miscellaneous)</vh>
+<v t="ville.20260807001457.10"><vh>@string color_theme = transparent/boxes/solarized-monochromatic/base0</vh></v>
+<v t="ville.20260807001457.11"><vh>@string tree-image-closed = vv-dark/branch_closed.svg</vh></v>
+<v t="ville.20260807001457.12"><vh>@string tree-image-open = vv-dark/branch_open.svg</vh></v>
+</v>
+<v t="ville.20260807001457.13" descendentVnodeUnknownAttributes="7d710058010000003071017d7102580b0000005f5f626f6f6b6d61726b7371037d7104580700000069735f6475706571054930300a7373732e"><vh>Colors</vh>
+<v t="ville.20260807001457.14"><vh>vv-dark color definitions</vh>
+<v t="ville.20260807001457.15"><vh>@color dark-base0 = #d8dee9</vh></v>
+<v t="ville.20260807001457.16"><vh>@color dark-base1 = #89929d</vh></v>
+<v t="ville.20260807001457.17"><vh>@color dark-base2 = #f2f5f8</vh></v>
+<v t="ville.20260807001457.18"><vh>@color dark-base3 = #20262c</vh></v>
+<v t="ville.20260807001457.19"><vh>@color dark-base4 = #303840</vh></v>
+<v t="ville.20260807001457.20"><vh>@color dark-base5 = #171c21</vh></v>
+<v t="ville.20260807001457.21"><vh>@color dark-base6 = #6ea8fe</vh></v>
+<v t="ville.20260807001457.22"><vh>@color dark-base7 = #293744</vh></v>
+<v t="ville.20260807001457.23"><vh>@color dark-base8 = #f47067</vh></v>
+</v>
+<v t="ville.20260807001457.24"><vh>Colors: Logical colors</vh>
+<v t="ville.20260807001457.25"><vh>@color log_black_color = @text-foreground</vh></v>
+<v t="ville.20260807001457.26"><vh>@color log_blue_color = @solarized-blue</vh></v>
+<v t="ville.20260807001457.27"><vh>@color log_cyan_color = @solarized-cyan</vh></v>
+<v t="ville.20260807001457.28"><vh>@color log_error_color = @solarized-red</vh></v>
+<v t="ville.20260807001457.29"><vh>@color log_green_color = @solarized-green</vh></v>
+<v t="ville.20260807001457.30"><vh>@color log_info_color = @solarized-blue</vh></v>
+<v t="ville.20260807001457.31"><vh>@color log_magenta_color = @solarized-magenta</vh></v>
+<v t="ville.20260807001457.32"><vh>@color log_note_color = @solarized-blue</vh></v>
+<v t="ville.20260807001457.33"><vh>@color log_orange_color = @solarized-orange</vh></v>
+<v t="ville.20260807001457.34"><vh>@color log_red_color = @solarized-red</vh></v>
+<v t="ville.20260807001457.35"><vh>@color log_violet_color = @solarized-violet</vh></v>
+<v t="ville.20260807001457.36"><vh>@color log_warning_color_= @solarized-red</vh></v>
+<v t="ville.20260807001457.37"><vh>@color log_white_color = @solarized-white</vh></v>
+<v t="ville.20260807001457.38"><vh>@color log_yellow_color = @solarized-yellow</vh></v>
+</v>
+<v t="ville.20260807001457.39"><vh>Colors: Syntax coloring</vh>
+<v t="ville.20260807001457.40"><vh>Colors: defaults</vh>
+<v t="ville.20260807001457.41"><vh>@color blank_color = grey</vh></v>
+<v t="ville.20260807001457.42"><vh>@color tab_color = red</vh></v>
+<v t="ville.20260807001457.43"><vh>@color label_color = red</vh></v>
+<v t="ville.20260807001457.44"><vh>@color keyword1_color = #c792ea</vh></v>
+<v t="ville.20260807001457.45"><vh>@color keyword2_color = #82aaff</vh></v>
+<v t="ville.20260807001457.46"><vh>@color keyword3_color = #f78c6c</vh></v>
+<v t="ville.20260807001457.47"><vh>@color keyword4_color = #ffc777</vh></v>
+<v t="ville.20260807001457.48"><vh>@color literal1_color = #c3e88d</vh></v>
+<v t="ville.20260807001457.49"><vh>@color literal2_color = #f78c6c</vh></v>
+<v t="ville.20260807001457.50"><vh>@color literal3_color = #89ddff</vh></v>
+<v t="ville.20260807001457.51"><vh>@color literal4_color = #ffcb6b</vh></v>
+<v t="ville.20260807001457.52"><vh>@color markup_color = #d8dee9</vh></v>
+<v t="ville.20260807001457.53"><vh>@color comment1_color = #74808b</vh></v>
+<v t="ville.20260807001457.54"><vh>@color comment2_color = #89929d</vh></v>
+<v t="ville.20260807001457.55"><vh>@color comment3_color = #a0a9b4</vh></v>
+<v t="ville.20260807001457.56"><vh>@color comment4_color = #b3bbc5</vh></v>
+</v>
+<v t="ville.20260807001457.57"><vh>Colors: Leo constructs</vh>
+<v t="ville.20260807001457.58"><vh>@color section_name_brackets_color = #82aaff</vh></v>
+<v t="ville.20260807001457.59"><vh>@color null_color = #d8dee9</vh></v>
+<v t="ville.20260807001457.60"><vh>@color operator_color = #89ddff</vh></v>
+<v t="ville.20260807001457.61"><vh>@color doc_part_color = #f47067</vh></v>
+<v t="ville.20260807001457.62"><vh>@color leo_keyword_color = #ffcb6b</vh></v>
+<v t="ville.20260807001457.63"><vh>@color section_name_color = #82aaff</vh></v>
+<v t="ville.20260807001457.64"><vh>@color show_invisibles_space_color = #E5E5E5</vh></v>
+<v t="ville.20260807001457.65"><vh>@color show_invisibles_tab_color = #CCCCCC</vh></v>
+<v t="ville.20260807001457.66"><vh>@color undefined_section_name_color = red</vh></v>
+<v t="ville.20260807001457.67"><vh>@color url_color = #f21eec</vh></v>
+</v>
+</v>
+<v t="ville.20260807001457.68"><vh>Colors: Text</vh>
+<v t="ville.20260807001457.69"><vh>@color log_text_background_color = @dark-base3</vh></v>
+<v t="ville.20260807001457.70"><vh>@color log_text_foreground_color = @dark-base0</vh></v>
+<v t="ville.20260807001457.71"><vh>@color text-background = @dark-base4</vh></v>
+<v t="ville.20260807001457.72"><vh>@color text-background-bright = @dark-base4</vh></v>
+<v t="ville.20260807001457.73"><vh>@color text-foreground = @dark-base0</vh></v>
+<v t="ville.20260807001457.74"><vh>@color text-foreground-bright = @dark-base2</vh></v>
+<v t="ville.20260807001457.75"><vh>@color status-bg = @dark-base3</vh></v>
+<v t="ville.20260807001457.76"><vh>@color status-fg = @dark-base0</vh></v>
+</v>
+<v t="ville.20260807001457.77"><vh>Colors: Widgets</vh>
+<v t="ville.20260807001457.78"><vh>@color button-hover-fg = @dark-base7</vh></v>
+</v>
+</v>
+<v t="ville.20260807001457.79" descendentVnodeUnknownAttributes="7d710058010000003071017d7102580b0000005f5f626f6f6b6d61726b7371037d7104580700000069735f6475706571054930300a7373732e"><vh>Fonts &amp; text sizes</vh>
+<v t="ville.20260807001457.80"><vh>@string font-family = Segoe UI, Inter, sans-serif</vh></v>
+<v t="ville.20260807001457.81"><vh>@string font-family-body = Cascadia Mono, Consolas, monospace</vh></v>
+<v t="ville.20260807001457.82"><vh>@string font-family-log = Cascadia Mono, Consolas, monospace</vh></v>
+<v t="ville.20260807001457.83"><vh>@string font-family-tree = @font-family</vh></v>
+<v t="ville.20260807001457.84"><vh>@string font-size-body = 11pt</vh></v>
+<v t="ville.20260807001457.85"><vh>@string font-size-log = 10pt</vh></v>
+<v t="ville.20260807001457.86"><vh>@string font-size-tree = 10pt</vh></v>
+<v t="ville.20260807001457.87"><vh>@string font-size-menubar = 10pt</vh></v>
+<v t="ville.20260807001457.88"><vh>@string font-size-menu = 10pt</vh></v>
+<v t="ville.20260807001457.89"><vh>@string font-size-tabs = 10pt</vh></v>
+</v>
+<v t="ville.20260807001457.90" descendentVnodeUnknownAttributes="7d710058010000003071017d7102580b0000005f5f626f6f6b6d61726b7371037d7104580700000069735f6475706571054930300a7373732e"><vh>Plugins settings</vh>
+<v t="ville.20260807001457.91"><vh>@bool color_theme_is_dark = True</vh></v>
+<v t="ville.20260807001457.92"><vh>bookmarks</vh>
+<v t="ville.20260807001457.93"><vh>@color bookmarks_current_color = @solarized-orange</vh></v>
+<v t="ville.20260807001457.94"><vh>bookmarks base</vh>
+<v t="ville.20260807001457.95"><vh>@color bookmarks_base_color = @text-foreground</vh></v>
+<v t="ville.20260807001457.96"><vh>@string bookmarks_base_border = none</vh></v>
+<v t="ville.20260807001457.97"><vh>@string bookmarks_base_decoration = underline</vh></v>
+<v t="ville.20260807001457.98"><vh>@string bookmarks_base_family = none</vh></v>
+<v t="ville.20260807001457.99"><vh>@string bookmarks_base_margin = 0</vh></v>
+<v t="ville.20260807001457.100"><vh>@string bookmarks_base_padding = 1</vh></v>
+<v t="ville.20260807001457.101"><vh>@string bookmarks_base_size = @bookmarks_font_size</vh></v>
+<v t="ville.20260807001457.102"><vh>@string bookmarks_base_style = normal</vh></v>
+<v t="ville.20260807001457.103"><vh>@string bookmarks_base_weight = regular</vh></v>
+</v>
+<v t="ville.20260807001457.104"><vh>bookmarks children</vh>
+<v t="ville.20260807001457.105"><vh>@color bookmarks_children_color = @text-foreground</vh></v>
+<v t="ville.20260807001457.106"><vh>@string bookmarks_children_decoration = underline</vh></v>
+<v t="ville.20260807001457.107"><vh>@string bookmarks_children_family = none</vh></v>
+<v t="ville.20260807001457.108"><vh>@string bookmarks_children_size = ignore</vh></v>
+<v t="ville.20260807001457.109"><vh>@string bookmarks_children_style = ignore</vh></v>
+<v t="ville.20260807001457.110"><vh>@string bookmarks_children_weight = ignore</vh></v>
+</v>
+<v t="ville.20260807001457.111"><vh>bookmarks current</vh>
+<v t="ville.20260807001457.112"><vh>@color bookmarks_current_color = blue</vh></v>
+<v t="ville.20260807001457.113"><vh>@string bookmarks_current_decoration = ignore</vh></v>
+<v t="ville.20260807001457.114"><vh>@string bookmarks_current_size = ignore</vh></v>
+<v t="ville.20260807001457.115"><vh>@string bookmarks_current_style = ignore</vh></v>
+<v t="ville.20260807001457.116"><vh>@string bookmarks_current_weight = bold</vh></v>
+</v>
+<v t="ville.20260807001457.117"><vh>bookmarks expanded</vh>
+<v t="ville.20260807001457.118"><vh>@color bookmarks_expanded_color = @text-foreground</vh></v>
+<v t="ville.20260807001457.119"><vh>@string bookmarks_expanded_decoration = underline</vh></v>
+<v t="ville.20260807001457.120"><vh>@string bookmarks_expanded_size = ignore</vh></v>
+<v t="ville.20260807001457.121"><vh>@string bookmarks_expanded_style = ignore</vh></v>
+<v t="ville.20260807001457.122"><vh>@string bookmarks_expanded_weight = bold</vh></v>
+<v t="ville.20260807001457.123"><vh>@string bookmarks_font_size = 11pt</vh></v>
+</v>
+</v>
+</v>
+<v t="ville.20260807001457.124"><vh>Stylesheet</vh>
+<v t="ville.20260807001457.125"><vh>@data qt-gui-plugin-style-sheet</vh>
+<v t="ville.20260807001457.126"><vh>General Widgets</vh></v>
+<v t="ville.20260807001457.127"><vh>Body &amp; other text</vh></v>
+<v t="ville.20260807001457.128"><vh>Minibuffer &amp; label</vh></v>
+<v t="ville.20260807001457.129"><vh>Borders</vh></v>
+<v t="ville.20260807001457.130"><vh>Buttons</vh></v>
+<v t="ville.20260807001457.131"><vh>Checkboxes</vh></v>
+<v t="ville.20260807001457.132"><vh>Dock</vh></v>
+<v t="ville.20260807001457.133"><vh>Log, Find, Spell, Tag</vh></v>
+<v t="ville.20260807001457.134"><vh>Menus</vh></v>
+<v t="ville.20260807001457.135"><vh>Plugins</vh></v>
+<v t="ville.20260807001457.136"><vh>Radio Buttons</vh></v>
+<v t="ville.20260807001457.137"><vh>Scroll bars</vh></v>
+<v t="ville.20260807001457.138"><vh>Splitters</vh></v>
+<v t="ville.20260807001457.139"><vh>Tab bar</vh></v>
+<v t="ville.20260807001457.140"><vh>Tree</vh></v>
+<v t="ville.20260807001457.141"><vh>Status area</vh></v>
+</v>
+</v>
+</v>
+<v t="ville.20260807001457.79" descendentVnodeUnknownAttributes="7d710058010000003071017d7102580b0000005f5f626f6f6b6d61726b7371037d7104580700000069735f6475706571054930300a7373732e"></v>
+</vnodes>
+<tnodes>
+<t tx="ville.20260807001457.8">@language rest
+@wrap
+
+Notes:
+
+1. This file should *not* contain @string theme-name.
+2. This file should contain *only* appearance-related settings.</t>
+<t tx="ville.20260807001457.20"></t>
+<t tx="ville.20260807001457.112"></t>
+<t tx="ville.20260807001457.113">none or underline</t>
+<t tx="ville.20260807001457.114"></t>
+<t tx="ville.20260807001457.115"></t>
+<t tx="ville.20260807001457.116">bold or regular</t>
+<t tx="ville.20260807001457.117"></t>
+<t tx="ville.20260807001457.118"></t>
+<t tx="ville.20260807001457.119">none or underline</t>
+<t tx="ville.20260807001457.120"></t>
+<t tx="ville.20260807001457.121"></t>
+<t tx="ville.20260807001457.21"></t>
+<t tx="ville.20260807001457.122">bold or regular</t>
+<t tx="ville.20260807001457.123"></t>
+<t tx="ville.20260807001457.11">Must be relative to either the users home directory or leo/Icons directory.
+
+</t>
+<t tx="ville.20260807001457.12"></t>
+<t tx="ville.20260807001457.9"></t>
+<t tx="ville.20260807001457.91">Set to true for dark themes, so bookmarks.py can generate
+random background colors which are appropriate etc.</t>
+<t tx="ville.20260807001457.10">Name of the theme,
+used to find icon files</t>
+<t tx="ville.20260807001457.125">/*
+
+  BreezeDarkTheme.leo: @data qt-gui-plugin-style-sheet
+  at-tabwidth -2 causes a crash in parse-template!
+
+@language css
+*/</t>
+<t tx="ville.20260807001457.126">QDockWidget {
+ border: none;
+}
+QSpinBox {
+  border: none;
+  padding: 3px;
+  margin-right: 5px;
+}
+QLabel {
+  color: @dark-base0;
+}
+QLineEdit {
+  border: none;
+  padding: 3px;
+}
+
+QWidget {
+  /* Not for text widgets */
+  background:  @dark-base3;
+  color: @dark-base0;
+  border-color: @dark-base4;
+  font-family: @font-family-tree;
+  font-size: 10pt;
+}
+
+</t>
+<t tx="ville.20260807001457.22"></t>
+<t tx="ville.20260807001457.127">/* The body pane */
+QTextEdit#richTextEdit {
+  background-color: @dark-base5;
+  color: @dark-base0;
+  font-family: @font-family-body;
+  font-size: @font-size-body;
+  font-weight: normal; /* normal,bold,100,..,900 */
+  font-style: normal; /* normal,italic,oblique */
+  padding-left: 3px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+  padding-right: 3px;
+  height: 200%;
+}</t>
+<t tx="ville.20260807001457.129">/* active pane highlighting */
+QTextEdit#log-widget, LeoQTreeWidget#treeWidget, QTextEdit#richTextEdit {
+  border-style: solid;
+  border-width: 1px;
+}
+QTextEdit#log-widget {
+  border-color: @text-background;
+}
+LeoQTreeWidget#treeWidget {
+  border-color: @dark-base4;
+}
+QTextEdit#richTextEdit {
+  border-color: @text-background;
+}
+
+QTextEdit:focus#log-widget,LeoQTreeWidget:focus#treeWidget, QTextEdit:focus#richTextEdit {
+  border-color: @dark-base6;
+}
+
+QLineEdit#lineEdit:focus {
+    border: 1px solid @dark-base6;
+    background-color: @dark-base5;
+}</t>
+<t tx="ville.20260807001457.130">QPushButton
+{
+    color: @dark-base0;
+    background-color: @dark-base3;
+    border-width: 1px;
+    border-color: @dark-base4;
+    border-style: solid;
+    padding: 4px 8px;
+    border-radius: 4px;
+    outline: none;
+}
+
+/*
+QPushButton:disabled
+{
+    background-color: @dark-base3;
+    border-width: 0.1ex;
+    border-color: @dark-base4;
+    border-style: solid;
+    padding-top: 0.5ex;
+    padding-bottom: 0.5ex;
+    padding-left: 1ex;
+    padding-right: 1ex;
+    border-radius: 0.2ex;
+    color: @dark-base4;
+}
+*/
+
+QPushButton:hover
+{
+    background-color: @dark-base7;
+}
+
+QPushButton:focus
+{
+    color: white;
+}
+
+QPushButton:pressed
+{
+    background-color: @dark-base3;
+    padding-top: -1.5ex;
+    padding-bottom: -1.7ex;
+}
+
+QToolBar
+{
+    background-color: @dark-base3;
+    color: @dark-base0;
+}
+
+QToolButton#prev-button,
+QToolButton#next-button
+
+{
+    color: @dark-base0;
+    background-color: @dark-base3;
+    border: 1px solid @dark-base4;
+    border-radius: 4px;
+    margin: 0 1px;
+    padding: 0;
+    min-height: 26px;
+    max-height: 26px;
+}
+
+QToolButton#prev-button[popupMode="1"],
+QToolButton#next-button[popupMode="1"]
+{
+    padding-right: 2px;
+}
+
+QToolButton#prev-button
+{
+    qproperty-icon: url(vv-dark/nav_back.svg);
+    qproperty-iconSize: 20px 20px;
+}
+
+QToolButton#next-button
+{
+    qproperty-icon: url(vv-dark/nav_forward.svg);
+    qproperty-iconSize: 20px 20px;
+}
+
+QToolButton#prev-button::menu-button,
+QToolButton#next-button::menu-button
+{
+    width: 5px;
+    border: none;
+    border-left: 1px solid #252d34;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+}
+
+QToolButton#prev-button::menu-arrow,
+QToolButton#next-button::menu-arrow,
+QToolButton#prev-button::menu-indicator,
+QToolButton#next-button::menu-indicator
+{
+    image: none;
+    border-image: none;
+    width: 0;
+    height: 0;
+}
+</t>
+<t tx="ville.20260807001457.133">QTextEdit#log-widget {
+  background-color: @dark-base3;
+  color: @dark-base0;
+  /* selection-color: white; */
+  /* selection-background-color: blue; */
+  font-family: @font-family-log;
+  font-size: @font-size-log;
+  font-weight: normal; /* normal,bold,100,..,900 */
+  font-style: normal; /* normal, italic,oblique */
+}
+
+
+QLineEdit#findPattern {
+  background-color: @dark-base5;
+}
+
+QLineEdit#findChange {
+  background-color: @dark-base5;
+}
+
+QListWidget#nodetags-listWidget {
+  background-color: @dark-base5;
+}
+
+QWidget#qt_scrollarea_viewport {
+  background-color: @dark-base5;
+}
+</t>
+<t tx="ville.20260807001457.134">QMenuBar
+{
+    background-color: @dark-base3;
+    color: @dark-base0;
+    font-size: @font-size-menubar;
+}
+
+QMenuBar::item
+{
+    background: transparent;
+}
+
+QMenuBar::item:selected
+{
+    background: @dark-base7;
+    border: 0.1ex solid @dark-base4;
+}
+
+QMenuBar::item:pressed
+{
+    border: 0.1ex solid @dark-base4;
+    background-color: @dark-base6;
+    color: @dark-base0;
+    margin-bottom: -0.1ex;
+    padding-bottom: 0.1ex;
+}
+
+QMenu
+{
+    border: 2px solid @dark-base4;
+    color: @dark-base0;
+    margin: 0.2ex;
+    font-size: @font-size-menu;
+}
+
+QMenu::icon
+{
+    margin: 0.5ex;
+}
+
+QMenu::item
+{
+    padding: 0.5ex 3ex 0.5ex 3ex;
+    margin-left: 0.5ex;
+    border: 0.1ex solid transparent; /* reserve space for selection border */
+}
+
+QMenu::item:selected
+{
+    background: @dark-base7;
+    color: @dark-base0;
+}
+
+QMenu::separator
+{
+    height: 2px;
+    background: @dark-base4;
+    margin-left: 1ex;
+    margin-right: 0.5ex;
+}</t>
+<t tx="ville.20260807001457.128">/* The mini-buffer */
+QLabel#minibufferLabel {
+  color: @dark-base6;
+}
+/* The minibuffer */
+QLineEdit#lineEdit {
+    background-color: @dark-base3;
+    padding: 0.5ex;
+    border: 3px solid @dark-base4;
+    border-radius: 0.2ex;
+    color: @dark-base0;
+}
+
+</t>
+<t tx="ville.20260807001457.135">/* bookmarks plugin styling */
+
+#show_bookmarks QPushButton {
+  margin: 0; padding: 1; border: none;
+  font-size: @bookmarks_base_size;
+  color: @bookmarks_base_color;
+  font-weight: @bookmarks_base_weight;
+  text-decoration: @bookmarks_base_decoration;
+}
+#show_bookmarks QPushButton[style_class='bookmark_children'] {
+  font-size: @bookmarks_children_size;
+  color: @bookmarks_children_color;
+  font-weight: @bookmarks_children_weight;
+  text-decoration: @bookmarks_children_decoration;
+}
+#show_bookmarks QPushButton[style_class='bookmark_expanded'] {
+  font-size: @bookmarks_expanded_size;
+  color: @bookmarks_expanded_color;
+  font-weight: @bookmarks_expanded_weight;
+  text-decoration: @bookmarks_expanded_decoration;
+}
+#show_bookmarks QPushButton[style_class='bookmark_current'] {
+  font-size: @bookmarks_current_size;
+  color: @bookmarks_current_color;
+  font-weight: @bookmarks_current_weight;
+  text-decoration: @bookmarks_current_decoration;
+}
+</t>
+<t tx="ville.20260807001457.137">QAbstractScrollArea
+{
+    border-radius: 0.2ex;
+    border: 0.1ex solid @dark-base4;
+    background-color: transparent;
+}
+
+QScrollBar:horizontal
+{
+    height: 1.5ex;
+    margin: 0.3ex 1.5ex 0.3ex 1.5ex;
+    border: 0.1ex transparent @dark-base3;
+    border-radius: 0.4ex;
+    background-color: @dark-base3;
+}
+
+QScrollBar:horizontal:hover
+{
+    height: 1.5ex;
+    margin: 0.3ex 1.5ex 0.3ex 1.5ex;
+    border: 0.1ex transparent @dark-base4;
+    border-radius: 0.4ex;
+    background-color: @dark-base4;
+}
+
+QScrollBar::handle:horizontal
+{
+    background-color: @dark-base1;
+    min-width: 0.5ex;
+    border-radius: 0.4ex;
+}
+
+QScrollBar::handle:horizontal:hover
+{
+    background-color: @dark-base6;
+    min-width: 0.5ex;
+    border-radius: 0.4ex;
+}
+
+QScrollBar::add-line:horizontal
+{
+    margin: 0px 0.3ex 0px 0.3ex;
+    border-image: url(dark/right_arrow_disabled.svg);
+    width: 1ex;
+    height: 1ex;
+    subcontrol-position: right;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::sub-line:horizontal
+{
+    margin: 0ex 0.3ex 0ex 0.3ex;
+    border-image: url(dark/left_arrow_disabled.svg);
+    width: 1ex;
+    height: 1ex;
+    subcontrol-position: left;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::add-line:horizontal:hover,
+QScrollBar::add-line:horizontal:on
+{
+    border-image: url(dark/right_arrow.svg);
+    width: 1ex;
+    height: 1ex;
+    subcontrol-position: right;
+    subcontrol-origin: margin;
+}
+
+
+QScrollBar::sub-line:horizontal:hover,
+QScrollBar::sub-line:horizontal:on
+{
+    border-image: url(dark/left_arrow.svg);
+    width: 1ex;
+    height: 1ex;
+    subcontrol-position: left;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::up-arrow:horizontal,
+QScrollBar::down-arrow:horizontal
+{
+    background: none;
+}
+
+
+QScrollBar::add-page:horizontal,
+QScrollBar::sub-page:horizontal
+{
+    background: none;
+}
+QScrollBar:vertical
+{
+    width: 1.5ex;
+    margin: 1.5ex 0.3ex 1.5ex 0.3ex;
+    border: 0.1ex transparent @dark-base3;
+    border-radius: 0.4ex;
+    background-color: @dark-base3;
+}
+
+QScrollBar:vertical:hover
+{
+    width: 1.5ex;
+    margin: 1.5ex 0.3ex 1.5ex 0.3ex;
+    border: 0.1ex transparent @dark-base4;
+    border-radius: 0.4ex;
+    background-color: @dark-base4;
+}
+
+QScrollBar::handle:vertical
+{
+    background-color: @dark-base1;
+    min-height: 0.5ex;
+    border-radius: 0.4ex;
+}
+
+QScrollBar::handle:vertical:hover
+{
+    background-color: @dark-base6;
+    min-height: 0.5ex;
+    border-radius: 0.4ex;
+}
+
+QScrollBar::sub-line:vertical
+{
+    margin: 0.3ex 0ex 0.3ex 0ex;
+    border-image: url(dark/up_arrow_disabled.svg);
+    height: 1ex;
+    width: 1ex;
+    subcontrol-position: top;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::add-line:vertical
+{
+    margin: 0.3ex 0ex 0.3ex 0ex;
+    border-image: url(dark/down_arrow_disabled.svg);
+    height: 1ex;
+    width: 1ex;
+    subcontrol-position: bottom;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::sub-line:vertical:hover,
+QScrollBar::sub-line:vertical:on
+{
+
+    border-image: url(dark/up_arrow.svg);
+    height: 1ex;
+    width: 1ex;
+    subcontrol-position: top;
+    subcontrol-origin: margin;
+}
+
+
+QScrollBar::add-line:vertical:hover,
+QScrollBar::add-line:vertical:on
+{
+    border-image: url(dark/down_arrow.svg);
+    height: 1ex;
+    width: 1ex;
+    subcontrol-position: bottom;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical
+{
+    background: none;
+}
+
+
+QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical
+{
+    background: none;
+}</t>
+<t tx="ville.20260807001457.138">QSplitter::handle
+{
+    border: 0.2ex dashed @dark-base4;
+}
+
+QSplitter::handle:hover
+{
+    background-color: @dark-base1;
+    border: 0.2ex solid @dark-base4;
+}
+
+QSplitter::handle:horizontal
+{
+    width: 0.2ex;
+}
+
+QSplitter::handle:vertical
+{
+    height: 0.2ex;
+}
+</t>
+<t tx="ville.20260807001457.139">QTabBar
+{
+    left: 0;
+    font-size: @font-size-tabs;
+}
+
+QTabBar::tab {
+    background: @dark-base3;
+    color: @dark-base1;
+    border: none;
+    border-bottom: 2px solid transparent;
+    min-width: 9ex;
+    padding: 7px 10px;
+}
+
+QTabBar::tab:hover {
+    background: @dark-base7;
+    color: @dark-base2;
+}
+
+QTabBar::tab:selected {
+    background-color: @dark-base4;
+    color: @dark-base2;
+    border-bottom-color: @dark-base6;
+}
+
+QTabBar::tab:!selected {
+    margin-top: 0;
+}</t>
+<t tx="ville.20260807001457.23"></t>
+<t tx="ville.20260807001457.140">
+LeoQTreeWidget#treeWidget 
+{
+  color: @dark-base0;
+  background-color: @dark-base3;
+  border: 1px solid @dark-base4;
+  font-family: @font-family-tree;
+  font-size: @font-size-tree;
+  font-weight: normal;
+  font-style: normal;
+}
+
+QTreeView {
+  color: @dark-base0;
+  background: @dark-base5;
+}
+
+QTreeView::branch:has-children:!has-siblings:closed,
+QTreeView::branch:closed:has-children:has-siblings
+{
+    image: @tree-image-closed;
+}
+
+QTreeView::branch:open:has-children:!has-siblings,
+QTreeView::branch:open:has-children:has-siblings
+{
+    image: @tree-image-open;
+}
+
+QTreeView::item:hover {
+  background-color: @dark-base7;
+  color: @dark-base0;
+}
+
+QTreeView::item:selected {
+  background-color: #31536f;
+  color: @dark-base0;
+}
+
+QTreeView::item:selected:!active {
+  background-color: @dark-base4;
+  color: @dark-base0;
+}
+
+QTreeView QLineEdit {
+  color: @dark-base0;
+  background: @dark-base5;
+  selection-color: @dark-base5; 
+  selection-background-color: @dark-base1;
+  font-family: @font-family-tree;
+  font-size: @font-size-tree;
+  font-weight: normal;
+  font-style: normal;
+}</t>
+<t tx="ville.20260807001457.141">QLineEdit#status1 {
+  background: @dark-base3;
+  border-color: @dark-base4;
+  border-width: 1px;
+  border-style: solid;
+}
+
+QLineEdit#status2 {
+  background: @dark-base3;
+  border-color: @dark-base4;
+  border-width: 1px;
+  border-style: solid;
+}
+
+/*
+QLineEdit#status1[style_class ~= 'info'],
+QLineEdit#status2[style_class ~= 'info'] {
+    background: @dark-base3;
+    color:      @dark-base0;
+}
+
+QLineEdit#status1[style_class ~= 'fail'],
+QLineEdit#status2[style_class ~= 'fail'] {
+    background: @dark-base8;
+    color:      @dark-base0;
+}
+*/</t>
+<t tx="ville.20260807001457.24"></t>
+<t tx="ville.20260807001457.25">Use a light color, not black!
+@solarized-white</t>
+<t tx="ville.20260807001457.26"></t>
+<t tx="ville.20260807001457.27"></t>
+<t tx="ville.20260807001457.28"></t>
+<t tx="ville.20260807001457.29"></t>
+<t tx="ville.20260807001457.30"></t>
+<t tx="ville.20260807001457.31"></t>
+<t tx="ville.20260807001457.32"></t>
+<t tx="ville.20260807001457.33"></t>
+<t tx="ville.20260807001457.34"></t>
+<t tx="ville.20260807001457.35"></t>
+<t tx="ville.20260807001457.36"></t>
+<t tx="ville.20260807001457.37"># Not an official solarized color: same as solorarized-base3</t>
+<t tx="ville.20260807001457.38"></t>
+<t tx="ville.20260807001457.7">Inspiration and code borrowed shamelessly. Modifications were required. :-)
+
+Chris George
+
+/*
+ *  BreezeDark stylesheet.
+ *
+ *  :author: Colin Duquesnoy
+ *  :editor: Alex Huszagh
+ *  :license: MIT, see LICENSE.md
+ *
+ *  This is originally a fork of QDarkStyleSheet, and is based on Breeze/
+ *  BreezeDark color scheme, but is in no way affiliated with KDE.
+ *
+ * ---------------------------------------------------------------------
+ *  The MIT License (MIT)
+ *
+ * Copyright (c) &lt;2013-2014&gt; &lt;Colin Duquesnoy&gt;
+ * Copyright (c) &lt;2015-2016&gt; &lt;Alex Huszagh&gt;
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * ---------------------------------------------------------------------
+ */
+
+QToolTip
+{
+    border: 0.1ex solid #eff0f1;
+    background-color: @dark-base3;
+    alternate-background-color: #3b4045;
+    color: #eff0f1;
+    padding: 0.5ex;
+    opacity: 200;
+}
+
+QWidget
+{
+    color: #eff0f1;
+    background-color: @dark-base3;
+    selection-background-color:#3daee9;
+    selection-color: #eff0f1;
+    background-clip: border;
+    border-image: none;
+    border: 0px transparent black;
+    outline: 0;
+}
+
+QWidget:item:hover
+{
+    background-color: #3daee9;
+    color: #eff0f1;
+}
+
+QWidget:item:selected
+{
+    background-color: #3daee9;
+}
+
+
+QCheckBox
+{
+    spacing: 0.5ex;
+    outline: none;
+    color: #eff0f1;
+    margin-bottom: 0.2ex;
+    opacity: 200;
+}
+
+QCheckBox:disabled
+{
+    color: #76797c;
+}
+
+QGroupBox::indicator
+{
+    margin-left: 0.2ex;
+}
+
+QCheckBox::indicator:unchecked,
+QCheckBox::indicator:unchecked:focus
+{
+    border-image: url(:/dark/checkbox_unchecked_disabled.svg);
+}
+
+QCheckBox::indicator:unchecked:hover,
+QCheckBox::indicator:unchecked:pressed,
+QGroupBox::indicator:unchecked:hover,
+QGroupBox::indicator:unchecked:focus,
+QGroupBox::indicator:unchecked:pressed
+{
+    border: none;
+    border-image: url(:/dark/checkbox_unchecked.svg);
+}
+
+QCheckBox::indicator:checked
+{
+    border-image: url(:/dark/checkbox_checked.svg);
+}
+
+QCheckBox::indicator:checked:hover,
+QCheckBox::indicator:checked:focus,
+QCheckBox::indicator:checked:pressed,
+QGroupBox::indicator:checked:hover,
+QGroupBox::indicator:checked:focus,
+QGroupBox::indicator:checked:pressed
+{
+    border: none;
+    border-image: url(:/dark/checkbox_checked.svg);
+}
+
+QCheckBox::indicator:indeterminate
+{
+    border-image: url(:/dark/checkbox_indeterminate.svg);
+}
+
+QCheckBox::indicator:indeterminate:focus,
+QCheckBox::indicator:indeterminate:hover,
+QCheckBox::indicator:indeterminate:pressed
+{
+    border-image: url(:/dark/checkbox_indeterminate.svg);
+}
+
+QCheckBox::indicator:indeterminate:disabled
+{
+    border-image: url(:/dark/checkbox_indeterminate_disabled.svg);
+}
+
+QCheckBox::indicator:checked:disabled,
+QGroupBox::indicator:checked:disabled
+{
+    border-image: url(:/dark/checkbox_checked_disabled.svg);
+}
+
+QCheckBox::indicator:unchecked:disabled,
+QGroupBox::indicator:unchecked:disabled
+{
+    border-image: url(:/dark/checkbox_unchecked_disabled.svg);
+}
+
+QRadioButton
+{
+    spacing: 0.5ex;
+    outline: none;
+    color: #eff0f1;
+    margin-bottom: 0.2ex;
+}
+
+QRadioButton:disabled
+{
+    color: #76797c;
+}
+
+QRadioButton::indicator:unchecked,
+QRadioButton::indicator:unchecked:focus
+{
+    border-image: url(:/dark/radio_unchecked_disabled.svg);
+}
+
+
+QRadioButton::indicator:unchecked:hover,
+QRadioButton::indicator:unchecked:pressed
+{
+    border: none;
+    outline: none;
+    border-image: url(:/dark/radio_unchecked.svg);
+}
+
+
+QRadioButton::indicator:checked
+{
+    border: none;
+    outline: none;
+    border-image: url(:/dark/radio_checked.svg);
+}
+
+QRadioButton::indicator:checked:hover,
+QRadioButton::indicator:checked:focus,
+QRadioButton::indicator:checked:pressed
+{
+    border: none;
+    outline: none;
+    border-image: url(:/dark/radio_checked.svg);
+}
+
+QRadioButton::indicator:checked:disabled
+{
+    outline: none;
+    border-image: url(:/dark/radio_checked_disabled.svg);
+}
+
+QRadioButton::indicator:unchecked:disabled
+{
+    border-image: url(:/dark/radio_unchecked_disabled.svg);
+}
+
+QMenuBar
+{
+    background-color: @dark-base3;
+    color: #eff0f1;
+}
+
+QMenuBar::item
+{
+    background: transparent;
+}
+
+QMenuBar::item:selected
+{
+    background: transparent;
+    border: 0.1ex solid #76797c;
+}
+
+QMenuBar::item:pressed
+{
+    border: 0.1ex solid #76797c;
+    background-color: #3daee9;
+    color: #eff0f1;
+    margin-bottom: -0.1ex;
+    padding-bottom: 0.1ex;
+}
+
+QMenu
+{
+    border: 0.1ex solid #76797c;
+    color: #eff0f1;
+    margin: 0.2ex;
+}
+
+QMenu::icon
+{
+    margin: 0.5ex;
+}
+
+QMenu::item
+{
+    padding: 0.5ex 3ex 0.5ex 3ex;
+    margin-left: 0.5ex;
+    border: 0.1ex solid transparent; /* reserve space for selection border */
+}
+
+QMenu::item:selected
+{
+    color: #eff0f1;
+}
+
+QMenu::separator
+{
+    height: 0.2ex;
+    background: lightblue;
+    margin-left: 1ex;
+    margin-right: 0.5ex;
+}
+
+/* non-exclusive indicator = check box style indicator
+   (see QActionGroup::setExclusive) */
+QMenu::indicator:non-exclusive:unchecked
+{
+    border-image: url(:/dark/checkbox_unchecked_disabled.svg);
+}
+
+QMenu::indicator:non-exclusive:unchecked:selected
+{
+    border-image: url(:/dark/checkbox_unchecked_disabled.svg);
+}
+
+QMenu::indicator:non-exclusive:checked
+{
+    border-image: url(:/dark/checkbox_checked.svg);
+}
+
+QMenu::indicator:non-exclusive:checked:selected
+{
+    border-image: url(:/dark/checkbox_checked.svg);
+}
+
+/* exclusive indicator = radio button style indicator (see QActionGroup::setExclusive) */
+QMenu::indicator:exclusive:unchecked
+{
+    border-image: url(:/dark/radio_unchecked_disabled.svg);
+}
+
+QMenu::indicator:exclusive:unchecked:selected
+{
+    border-image: url(:/dark/radio_unchecked_disabled.svg);
+}
+
+QMenu::indicator:exclusive:checked
+{
+    border-image: url(:/dark/radio_checked.svg);
+}
+
+QMenu::indicator:exclusive:checked:selected
+{
+    border-image: url(:/dark/radio_checked.svg);
+}
+
+QMenu::right-arrow
+{
+    margin: 0.5ex;
+    border-image: url(:/light/right_arrow.svg);
+    width: 0.6ex;
+    height: 0.9ex;
+}
+
+
+QWidget:disabled
+{
+    color: #454545;
+    background-color: @dark-base3;
+}
+
+QAbstractItemView
+{
+    alternate-background-color: @dark-base3;
+    color: #eff0f1;
+    border: 0.1ex solid 3A3939;
+    border-radius: 0.2ex;
+}
+
+QWidget:focus,
+QMenuBar:focus
+{
+    border: 0.1ex solid #3daee9;
+}
+
+QTabWidget:focus,
+QCheckBox:focus,
+QRadioButton:focus,
+QSlider:focus
+{
+    border: none;
+}
+
+QLineEdit
+{
+    background-color: #232629;
+    padding: 0.5ex;
+    border-style: solid;
+    border: 0.1ex solid #76797c;
+    border-radius: 0.2ex;
+    color: #eff0f1;
+}
+
+QGroupBox
+{
+    border: 0.1ex solid #76797c;
+    border-radius: 0.2ex;
+    padding-top: 1ex;
+    margin-top: 1ex;
+}
+
+QGroupBox::title
+{
+    subcontrol-origin: margin;
+    subcontrol-position: top center;
+    padding-left: 0.1ex;
+    padding-right: 0.1ex;
+    margin-top: -0.7ex;
+}
+
+QAbstractScrollArea
+{
+    border-radius: 0.2ex;
+    border: 0.1ex solid #76797c;
+    background-color: transparent;
+}
+
+QScrollBar:horizontal
+{
+    height: 1.5ex;
+    margin: 0.3ex 1.5ex 0.3ex 1.5ex;
+    border: 0.1ex transparent #2A2929;
+    border-radius: 0.4ex;
+    background-color: #2A2929;
+}
+
+QScrollBar::handle:horizontal
+{
+    background-color: #3daee9;
+    min-width: 0.5ex;
+    border-radius: 0.4ex;
+}
+
+QScrollBar::add-line:horizontal
+{
+    margin: 0px 0.3ex 0px 0.3ex;
+    border-image: url(:/dark/right_arrow_disabled.svg);
+    width: 1ex;
+    height: 1ex;
+    subcontrol-position: right;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::sub-line:horizontal
+{
+    margin: 0ex 0.3ex 0ex 0.3ex;
+    border-image: url(:/dark/left_arrow_disabled.svg);
+    width: 1ex;
+    height: 1ex;
+    subcontrol-position: left;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::add-line:horizontal:hover,
+QScrollBar::add-line:horizontal:on
+{
+    border-image: url(:/dark/right_arrow.svg);
+    width: 1ex;
+    height: 1ex;
+    subcontrol-position: right;
+    subcontrol-origin: margin;
+}
+
+
+QScrollBar::sub-line:horizontal:hover,
+QScrollBar::sub-line:horizontal:on
+{
+    border-image: url(:/dark/left_arrow.svg);
+    width: 1ex;
+    height: 1ex;
+    subcontrol-position: left;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::up-arrow:horizontal,
+QScrollBar::down-arrow:horizontal
+{
+    background: none;
+}
+
+
+QScrollBar::add-page:horizontal,
+QScrollBar::sub-page:horizontal
+{
+    background: none;
+}
+
+QScrollBar:vertical
+{
+    background-color: #2A2929;
+    width: 1.5ex;
+    margin: 1.5ex 0.3ex 1.5ex 0.3ex;
+    border: 0.1ex transparent #2A2929;
+    border-radius: 0.4ex;
+}
+
+QScrollBar::handle:vertical
+{
+    background-color: #3daee9;
+    min-height: 0.5ex;
+    border-radius: 0.4ex;
+}
+
+QScrollBar::sub-line:vertical
+{
+    margin: 0.3ex 0ex 0.3ex 0ex;
+    border-image: url(:/dark/up_arrow_disabled.svg);
+    height: 1ex;
+    width: 1ex;
+    subcontrol-position: top;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::add-line:vertical
+{
+    margin: 0.3ex 0ex 0.3ex 0ex;
+    border-image: url(:/dark/down_arrow_disabled.svg);
+    height: 1ex;
+    width: 1ex;
+    subcontrol-position: bottom;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::sub-line:vertical:hover,
+QScrollBar::sub-line:vertical:on
+{
+
+    border-image: url(:/dark/up_arrow.svg);
+    height: 1ex;
+    width: 1ex;
+    subcontrol-position: top;
+    subcontrol-origin: margin;
+}
+
+
+QScrollBar::add-line:vertical:hover,
+QScrollBar::add-line:vertical:on
+{
+    border-image: url(:/dark/down_arrow.svg);
+    height: 1ex;
+    width: 1ex;
+    subcontrol-position: bottom;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical
+{
+    background: none;
+}
+
+
+QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical
+{
+    background: none;
+}
+
+QTextEdit
+{
+    background-color: #232629;
+    color: #eff0f1;
+    border: 0.1ex solid #76797c;
+}
+
+QPlainTextEdit
+{
+    background-color: #232629;;
+    color: #eff0f1;
+    border-radius: 0.2ex;
+    border: 0.1ex solid #76797c;
+}
+
+QHeaderView::section
+{
+    background-color: #76797c;
+    color: #eff0f1;
+    padding: 0.5ex;
+    border: 0.1ex solid #76797c;
+}
+
+QSizeGrip
+{
+    border-image: url(:/dark/sizegrip.svg);
+    width: 1.2ex;
+    height: 1.2ex;
+}
+
+QMainWindow::separator
+{
+    background-color: @dark-base3;
+    color: white;
+    padding-left: 0.4ex;
+    spacing: 0.2ex;
+    border: 0.1ex dashed #76797c;
+}
+
+QMainWindow::separator:hover
+{
+
+    background-color: #787876;
+    color: white;
+    padding-left: 0.4ex;
+    border: 0.1ex solid #76797c;
+    spacing: 0.2ex;
+}
+
+QMenu::separator
+{
+    height: 0.1ex;
+    background-color: #76797c;
+    color: white;
+    padding-left: 0.4ex;
+    margin-left: 1ex;
+    margin-right: 0.5ex;
+}
+
+QFrame[frameShape="2"],  /* QFrame::Panel == 0x0003 */
+QFrame[frameShape="3"],  /* QFrame::WinPanel == 0x0003 */
+QFrame[frameShape="4"],  /* QFrame::HLine == 0x0004 */
+QFrame[frameShape="5"],  /* QFrame::VLine == 0x0005 */
+QFrame[frameShape="6"]  /* QFrame::StyledPanel == 0x0006 */
+{
+    border-width: 0.1ex;
+    padding: 0.1ex;
+    border-style: solid;
+    border-color: @dark-base3;
+    background-color: #76797c;
+    border-radius: 0.5ex;
+}
+
+QStackedWidget
+{
+    border: 0.1ex transparent black;
+}
+
+QToolBar
+{
+    border: 0.1ex transparent #393838;
+    background: 0.1ex solid @dark-base3;
+    font-weight: bold;
+}
+
+QToolBar::handle:horizontal
+{
+    border-image: url(:/dark/hmovetoolbar.svg);
+    width = 1.6ex;
+    height = 6.4ex;
+}
+
+QToolBar::handle:vertical
+{
+    border-image: url(:/dark/vmovetoolbar.svg);
+    width = 5.4ex;
+    height = 1ex;
+}
+
+QToolBar::separator:horizontal
+{
+    border-image: url(:/dark/hsepartoolbar.svg);
+    width = 0.7ex;
+    height = 6.3ex;
+}
+
+QToolBar::separator:vertical
+{
+    border-image: url(:/dark/vsepartoolbars.svg);
+    width = 6.3ex;
+    height = 0.7ex;
+}
+
+QPushButton
+{
+    color: #eff0f1;
+    background-color: qlineargradient(x1: 0.5, y1: 0.5 x2: 0.5, y2: 1, stop: 0 #3b4045, stop: 0.5 @dark-base3);
+    border-width: 0.1ex;
+    border-color: #76797c;
+    border-style: solid;
+    padding: 0.5ex;
+    border-radius: 0.2ex;
+    outline: none;
+}
+
+QPushButton:disabled
+{
+    background-color: @dark-base3;
+    border-width: 0.1ex;
+    border-color: #454545;
+    border-style: solid;
+    padding-top: 0.5ex;
+    padding-bottom: 0.5ex;
+    padding-left: 1ex;
+    padding-right: 1ex;
+    border-radius: 0.2ex;
+    color: #454545;
+}
+
+QPushButton:focus
+{
+    color: white;
+}
+
+QPushButton:pressed
+{
+    background-color: @dark-base3;
+    padding-top: -1.5ex;
+    padding-bottom: -1.7ex;
+}
+
+QComboBox
+{
+    selection-background-color: #3daee9;
+    border-style: solid;
+    border: 0.1ex solid #76797c;
+    border-radius: 0.2ex;
+    padding: 0.5ex;
+    min-width: 7.5ex;
+}
+
+QPushButton:checked
+{
+    background-color: #76797c;
+    border-color: #6A6969;
+}
+
+QPushButton:hover
+{
+    background-color: qlineargradient(x1: 0.5, y1: 0.5 x2: 0.5, y2: 1, stop: 0 #454a4f, stop: 0.5 #3b4045);
+    border: 0.1ex solid #3daee9;
+    color: #eff0f1;
+}
+
+QPushButton:checked:hover
+{
+    background-color: qlineargradient(x1: 0.5, y1: 0.5 x2: 0.5, y2: 1, stop: 0 #808386, stop: 0.5 #76797c);
+    border: 0.1ex solid #3daee9;
+    color: #eff0f1;
+}
+
+QComboBox:hover,
+QAbstractSpinBox:hover,
+QLineEdit:hover,
+QTextEdit:hover,
+QPlainTextEdit:hover,
+QAbstractView:hover,
+QTreeView:hover
+{
+    border: 0.1ex solid #3daee9;
+    color: #eff0f1;
+}
+
+QComboBox:hover:pressed,
+QPushButton:hover:pressed,
+QAbstractSpinBox:hover:pressed,
+QLineEdit:hover:pressed,
+QTextEdit:hover:pressed,
+QPlainTextEdit:hover:pressed,
+QAbstractView:hover:pressed,
+QTreeView:hover:pressed
+{
+    background-color: @dark-base3;
+}
+
+QComboBox:on
+{
+    padding-top: 0.3ex;
+    padding-left: 0.4ex;
+    selection-background-color: #4a4a4a;
+}
+
+QComboBox QAbstractItemView
+{
+    background-color: #232629;
+    border-radius: 0.2ex;
+    border: 0.1ex solid #76797c;
+    selection-background-color: #3daee9;
+}
+
+QComboBox::drop-down
+{
+    subcontrol-origin: padding;
+    subcontrol-position: top right;
+    width: 1.5ex;
+
+    border-left-width: 0ex;
+    border-left-color: darkgray;
+    border-left-style: solid;
+    border-top-right-radius: 0.3ex;
+    border-bottom-right-radius: 0.3ex;
+}
+
+QComboBox::down-arrow
+{
+    border-image: url(:/dark/down_arrow_disabled.svg);
+    width: 0.9ex;
+    height: 0.6ex;
+}
+
+QComboBox::down-arrow:on,
+QComboBox::down-arrow:hover,
+QComboBox::down-arrow:focus
+{
+    border-image: url(:/dark/down_arrow.svg);
+    width: 0.9ex;
+    height: 0.6ex;
+}
+
+QAbstractSpinBox
+{
+    padding: 0.5ex;
+    border: 0.1ex solid #76797c;
+    background-color: #232629;
+    color: #eff0f1;
+    border-radius: 0.2ex;
+    min-width: 7.5ex;
+}
+
+QAbstractSpinBox:up-button
+{
+    background-color: transparent;
+    subcontrol-origin: border;
+    subcontrol-position: center right;
+}
+
+QAbstractSpinBox:down-button
+{
+    background-color: transparent;
+    subcontrol-origin: border;
+    subcontrol-position: center left;
+}
+
+QAbstractSpinBox::up-arrow,
+QAbstractSpinBox::up-arrow:disabled,
+QAbstractSpinBox::up-arrow:off
+{
+    border-image: url(:/dark/up_arrow_disabled.svg);
+    width: 0.9ex;
+    height: 0.6ex;
+}
+
+QAbstractSpinBox::up-arrow:hover
+{
+    border-image: url(:/dark/up_arrow.svg);
+    width: 0.9ex;
+    height: 0.6ex;
+}
+
+QAbstractSpinBox::down-arrow,
+QAbstractSpinBox::down-arrow:disabled,
+QAbstractSpinBox::down-arrow:off
+{
+    border-image: url(:/dark/down_arrow_disabled.svg);
+    width: 0.9ex;
+    height: 0.6ex;
+}
+
+QAbstractSpinBox::down-arrow:hover
+{
+    border-image: url(:/dark/down_arrow.svg);
+    width: 0.9ex;
+    height: 0.6ex;
+}
+
+QLabel
+{
+    border: 0ex solid black;
+}
+
+/* BORDERS */
+QTabWidget::pane
+{
+    padding: 0.5ex;
+    margin: 0.1ex;
+}
+
+QTabWidget::pane:top
+{
+    border: 0.1ex solid #76797c;
+    top: -0.1ex;
+}
+
+QTabWidget::pane:bottom
+{
+    border: 0.1ex solid #76797c;
+    bottom: -0.1ex;
+}
+
+QTabWidget::pane:left
+{
+    border: 0.1ex solid #76797c;
+    right: -0.1ex;
+}
+
+QTabWidget::pane:right
+{
+    border: 0.1ex solid #76797c;
+    left: -0.1ex;
+}
+
+
+QTabBar
+{
+    qproperty-drawBase: 0;
+    left: 0.5ex; /* move to the right by 0.5ex */
+    border-radius: 0.3ex;
+}
+
+QTabBar:focus
+{
+    border: 0ex transparent black;
+}
+
+QTabBar::close-button
+{
+    border-image: url(:/dark/close.svg);
+    background: transparent;
+}
+
+QTabBar::close-button:hover
+{
+    border-image: url(:/dark/close-hover.svg);
+    width: 1.2ex;
+    height: 1.2ex;
+    background: transparent;
+}
+
+QTabBar::close-button:pressed
+{
+    border-image: url(:/dark/close-pressed.svg);
+    width: 1.2ex;
+    height: 1.2ex;
+    background: transparent;
+}
+
+/* TOP TABS */
+QTabBar::tab:top
+{
+    color: #eff0f1;
+    border: 0.1ex transparent black;
+    border-left: 0.1ex solid #76797c;
+    border-top: 0.1ex solid #76797c;
+    background-color: @dark-base3;
+    padding: 0.5ex;
+    min-width: 50px;
+    border-top-left-radius: 0.2ex;
+    border-top-right-radius: 0.2ex;
+}
+
+QTabBar::tab:top:last,
+QTabBar::tab:top:only-one
+{
+    color: #eff0f1;
+    border: 0.1ex transparent black;
+    border-left: 0.1ex solid #76797c;
+    border-right: 0.1ex solid #76797c;
+    border-top: 0.1ex solid #76797c;
+    background-color: @dark-base3;
+    padding: 0.5ex;
+    min-width: 50px;
+    border-top-left-radius: 0.2ex;
+    border-top-right-radius: 0.2ex;
+}
+
+QTabBar::tab:top:!selected
+{
+    color: #eff0f1;
+    background-color: #54575B;
+    border: 0.1ex transparent black;
+    border-left: 0.1ex solid #76797c;
+    border-top-left-radius: 0.2ex;
+    border-top-right-radius: 0.2ex;
+}
+
+QTabBar::tab:top:first:!selected
+{
+    color: #eff0f1;
+    background-color: #54575B;
+    border: 0.1ex transparent black;
+    border-top-left-radius: 0.2ex;
+    border-top-right-radius: 0.2ex;
+}
+
+QTabBar::tab:top:!selected:hover
+{
+    background-color: rgba(61, 173, 232, 0.2);
+    border: 0.1ex rgba(61, 173, 232, 0.2);
+    border-left: 0.1ex solid #76797c;
+}
+
+QTabBar::tab:top:!selected:first:hover
+{
+    background-color: rgba(61, 173, 232, 0.2);
+    border: 0.1ex rgba(61, 173, 232, 0.2);
+}
+
+/* BOTTOM TABS */
+
+QTabBar::tab:bottom
+{
+    color: #eff0f1;
+    border: 0.1ex transparent black;
+    border-left: 0.1ex solid #76797c;
+    border-bottom: 0.1ex solid #76797c;
+    background-color: @dark-base3;
+    padding: 0.5ex;
+    border-bottom-left-radius: 0.2ex;
+    border-bottom-right-radius: 0.2ex;
+    min-width: 50px;
+}
+
+QTabBar::tab:bottom:last,
+QTabBar::tab:bottom:only-one
+{
+    color: #eff0f1;
+    border: 0.1ex transparent black;
+    border-left: 0.1ex solid #76797c;
+    border-right: 0.1ex solid #76797c;
+    border-bottom: 0.1ex solid #76797c;
+    background-color: @dark-base3;
+    padding: 0.5ex;
+    border-bottom-left-radius: 0.2ex;
+    border-bottom-right-radius: 0.2ex;
+    min-width: 50px;
+}
+
+QTabBar::tab:bottom:!selected
+{
+    color: #eff0f1;
+    background-color: #54575B;
+    border: 0.1ex transparent black;
+    border-left: 0.1ex solid #76797c;
+    border-bottom-left-radius: 0.2ex;
+    border-bottom-right-radius: 0.2ex;
+}
+
+QTabBar::tab:bottom:first:!selected
+{
+    color: #eff0f1;
+    background-color: #54575B;
+    border: 0.1ex transparent black;
+    border-top-left-radius: 0.2ex;
+    border-top-right-radius: 0.2ex;
+}
+
+QTabBar::tab:bottom:!selected:hover
+{
+    background-color: rgba(61, 173, 232, 0.2);
+    border: 0.1ex rgba(61, 173, 232, 0.2);
+    border-left: 0.1ex solid #76797c;
+}
+
+QTabBar::tab:bottom:!selected:first:hover
+{
+    background-color: rgba(61, 173, 232, 0.2);
+    border: 0.1ex rgba(61, 173, 232, 0.2);
+}
+
+/* LEFT TABS */
+QTabBar::tab:left
+{
+    color: #eff0f1;
+    border: 0.1ex transparent black;
+    border-top: 0.1ex solid #76797c;
+    border-right: 0.1ex solid #76797c;
+    background-color: @dark-base3;
+    padding: 0.5ex;
+    border-top-right-radius: 0.2ex;
+    border-bottom-right-radius: 0.2ex;
+    min-height: 50px;
+}
+
+QTabBar::tab:left:last,
+QTabBar::tab:left:only-one
+{
+    color: #eff0f1;
+    border: 0.1ex transparent black;
+    border-top: 0.1ex solid #76797c;
+    border-bottom: 0.1ex solid #76797c;
+    border-right: 0.1ex solid #76797c;
+    background-color: @dark-base3;
+    padding: 0.5ex;
+    border-top-right-radius: 0.2ex;
+    border-bottom-right-radius: 0.2ex;
+    min-height: 50px;
+}
+
+QTabBar::tab:left:!selected
+{
+    color: #eff0f1;
+    background-color: #54575B;
+    border: 0.1ex transparent black;
+    border-top: 0.1ex solid #76797c;
+    border-top-right-radius: 0.2ex;
+    border-bottom-right-radius: 0.2ex;
+}
+
+QTabBar::tab:left:!selected:hover
+{
+    background-color: rgba(61, 173, 232, 0.2);
+    border: 0.1ex rgba(61, 173, 232, 0.2);
+    border-top: 0.1ex solid #76797c;
+}
+
+QTabBar::tab:left:!selected:first:hover
+{
+    background-color: rgba(61, 173, 232, 0.2);
+    border: 0.1ex rgba(61, 173, 232, 0.2);
+}
+
+/* RIGHT TABS */
+QTabBar::tab:right
+{
+    color: #eff0f1;
+    border: 0.1ex transparent black;
+    border-top: 0.1ex solid #76797c;
+    border-left: 0.1ex solid #76797c;
+    background-color: @dark-base3;
+    padding: 0.5ex;
+    border-top-left-radius: 0.2ex;
+    border-bottom-left-radius: 0.2ex;
+    min-height: 50px;
+}
+
+QTabBar::tab:right:last,
+QTabBar::tab:right:only-one
+{
+    color: #eff0f1;
+    border: 0.1ex transparent black;
+    border-top: 0.1ex solid #76797c;
+    border-bottom: 0.1ex solid #76797c;
+    border-left: 0.1ex solid #76797c;
+    background-color: @dark-base3;
+    padding: 0.5ex;
+    border-top-left-radius: 0.2ex;
+    border-bottom-left-radius: 0.2ex;
+    min-height: 50px;
+}
+
+QTabBar::tab:right:!selected
+{
+    color: #eff0f1;
+    background-color: #54575B;
+    border: 0.1ex transparent black;
+    border-top: 0.1ex solid #76797c;
+    border-top-left-radius: 0.2ex;
+    border-bottom-left-radius: 0.2ex;
+}
+
+QTabBar::tab:right:!selected:hover
+{
+    background-color: rgba(61, 173, 232, 0.2);
+    border: 0.1ex rgba(61, 173, 232, 0.2);
+    border-top: 0.1ex solid #76797c;
+}
+
+QTabBar::tab:right:!selected:first:hover
+{
+    background-color: rgba(61, 173, 232, 0.2);
+    border: 0.1ex rgba(61, 173, 232, 0.2);
+}
+
+QTabBar QToolButton::right-arrow:enabled
+{
+    border-image: url(:/dark/right_arrow.svg);
+}
+
+QTabBar QToolButton::left-arrow:enabled
+{
+    border-image: url(:/dark/left_arrow.svg);
+}
+
+QTabBar QToolButton::right-arrow:disabled
+{
+    border-image: url(:/dark/right_arrow_disabled.svg);
+}
+
+QTabBar QToolButton::left-arrow:disabled
+{
+    border-image: url(:/dark/left_arrow_disabled.svg);
+}
+
+QDockWidget
+{
+    background: @dark-base3;
+    border: 0.1ex solid #403F3F;
+    titlebar-close-icon: url(:/dark/transparent.svg);
+    titlebar-normal-icon: url(:/dark/transparent.svg);
+}
+
+QDockWidget::close-button,
+QDockWidget::float-button
+{
+    border: 0.1ex solid transparent;
+    border-radius: 0.2ex;
+    background: transparent;
+}
+
+QDockWidget::float-button
+{
+    border-image: url(:/dark/undock.svg);
+}
+
+QDockWidget::float-button:hover
+{
+    border-image: url(:/dark/undock-hover.svg) ;
+}
+
+QDockWidget::close-button
+{
+    border-image: url(:/dark/close.svg) ;
+}
+
+QDockWidget::close-button:hover
+{
+    border-image: url(:/dark/close-hover.svg) ;
+}
+
+QDockWidget::close-button:pressed
+{
+    border-image: url(:/dark/close-pressed.svg) ;
+}
+
+QTreeView,
+QListView
+{
+    border: 0.1ex solid #76797c;
+    background-color: #232629;
+}
+
+QTreeView::branch:has-siblings:!adjoins-item
+{
+    border-image: url(:/dark/stylesheet-vline.svg) 0;
+}
+
+QTreeView::branch:has-siblings:adjoins-item
+{
+    border-image: url(:/dark/stylesheet-branch-more.svg) 0;
+}
+
+QTreeView::branch:!has-children:!has-siblings:adjoins-item
+{
+    border-image: url(:/dark/stylesheet-branch-end.svg) 0;
+}
+
+QTreeView::branch:has-children:!has-siblings:closed,
+QTreeView::branch:closed:has-children:has-siblings
+{
+    border-image: url(:/dark/branch-closed.svg);
+}
+
+QTreeView::branch:open:has-children:!has-siblings,
+QTreeView::branch:open:has-children:has-siblings
+{
+    border-image: url(:/dark/branch-open.svg);
+}
+
+QTableView::item,
+QListView::item,
+QTreeView::item
+{
+    padding: 0.3ex;
+}
+
+QTableView::item:!selected:hover,
+QListView::item:!selected:hover,
+QTreeView::item:!selected:hover
+{
+    background-color: @dark-base7;
+    outline: 0;
+    color: #eff0f1;
+    padding: 0.3ex;
+}
+
+QSlider::groove:horizontal
+{
+    border: 0.1ex solid @dark-base3;
+    height: 0.4ex;
+    background: #565a5e;
+    margin: 0ex;
+    border-radius: 0.2ex;
+}
+
+QSlider::handle:horizontal
+{
+    background: #232629;
+    border: 0.1ex solid #626568;
+    width: 1.6ex;
+    height: 1.6ex;
+    margin: -0.8ex 0;
+    border-radius: 0.9ex;
+}
+
+QSlider::groove:vertical
+{
+    border: 0.1ex solid @dark-base3;
+    width: 0.4ex;
+    background: #565a5e;
+    margin: 0ex;
+    border-radius: 0.3ex;
+}
+
+QSlider::handle:vertical
+{
+    background: #232629;
+    border: 0.1ex solid #626568;
+    width: 1.6ex;
+    height: 1.6ex;
+    margin: 0 -0.8ex;
+    border-radius: 0.9ex;
+}
+
+QSlider::handle:horizontal:hover,
+QSlider::handle:horizontal:focus,
+QSlider::handle:vertical:hover,
+QSlider::handle:vertical:focus
+{
+    border: 0.1ex solid #3daee9;
+}
+
+QSlider::sub-page:horizontal,
+QSlider::add-page:vertical
+{
+    background: #3daee9;
+    border-radius: 0.3ex;
+}
+
+QSlider::add-page:horizontal,
+QSlider::sub-page:vertical
+{
+    background: #626568;
+    border-radius: 0.3ex;
+}
+
+QToolButton
+{
+    background-color: transparent;
+    border: 0.1ex solid #76797c;
+    border-radius: 0.2ex;
+    margin: 0.3ex;
+    padding: 0.5ex;
+}
+
+QToolButton[popupMode="1"]  /* only for MenuButtonPopup */
+{
+    padding-right: 2ex; /* make way for the popup button */
+}
+
+QToolButton[popupMode="2"]  /* only for InstantPopup */
+{
+    padding-right: 1ex; /* make way for the popup button */
+}
+
+QToolButton::menu-indicator
+{
+    border-image: none;
+    image: url(:/dark/down_arrow.svg);
+    top: -0.7ex;
+    left: -0.2ex;
+}
+
+QToolButton::menu-arrow
+{
+    border-image: none;
+    image: url(:/dark/down_arrow.svg);
+}
+
+QToolButton:hover,
+QToolButton::menu-button:hover
+{
+    background-color: transparent;
+    border: 0.1ex solid #3daee9;
+}
+
+QToolButton:checked,
+QToolButton:pressed,
+QToolButton::menu-button:pressed
+{
+    background-color: #3daee9;
+    border: 0.1ex solid #3daee9;
+    padding: 0.5ex;
+}
+
+QToolButton::menu-button
+{
+    border: 0.1ex solid #76797c;
+    border-top-right-radius: 6px;
+    border-bottom-right-radius: 6px;
+    /* 1ex width + 0.4ex for border + no text = 2ex allocated above */
+    width: 1ex;
+    padding: 0.5ex;
+    outline: none;
+}
+
+QToolButton::menu-arrow:open
+{
+    border: 0.1ex solid #76797c;
+}
+
+QPushButton::menu-indicator
+{
+    subcontrol-origin: padding;
+    subcontrol-position: bottom right;
+    left: 0.8ex;
+}
+
+QTableView
+{
+    border: 0.1ex solid #76797c;
+    gridline-color: @dark-base3;
+    background-color: #232629;
+}
+
+
+QTableView,
+QHeaderView
+{
+    border-radius: 0px;
+}
+
+QTableView::item:pressed,
+QListView::item:pressed,
+QTreeView::item:pressed
+{
+    background: #31536f;
+    color: #eff0f1;
+}
+
+QTableView::item:selected:active,
+QTreeView::item:selected:active,
+QListView::item:selected:active
+{
+    background: #31536f;
+    color: #eff0f1;
+}
+
+QListView::item:selected:hover,
+QTreeView::item:selected:hover
+{
+    background-color: #3b5f7b;
+    color: #eff0f1;
+}
+
+QHeaderView
+{
+    background-color: @dark-base3;
+    border: 0.1ex transparent;
+    border-radius: 0px;
+    margin: 0px;
+    padding: 0px;
+
+}
+
+QHeaderView::section
+{
+    background-color: @dark-base3;
+    color: #eff0f1;
+    padding: 0.5ex;
+    border: 0.1ex solid #76797c;
+    border-radius: 0px;
+    text-align: center;
+}
+
+QHeaderView::section::vertical::first,
+QHeaderView::section::vertical::only-one
+{
+    border-top: 0.1ex solid #76797c;
+}
+
+QHeaderView::section::vertical
+{
+    border-top: transparent;
+}
+
+QHeaderView::section::horizontal::first,
+QHeaderView::section::horizontal::only-one
+{
+    border-left: 0.1ex solid #76797c;
+}
+
+QHeaderView::section::horizontal
+{
+    border-left: transparent;
+}
+
+
+QHeaderView::section:checked
+{
+    color: white;
+    background-color: #334e5e;
+}
+
+ /* style the sort indicator */
+QHeaderView::down-arrow
+{
+    image: url(:/dark/down_arrow.svg);
+}
+
+QHeaderView::up-arrow
+{
+    image: url(:/dark/up_arrow.svg);
+}
+
+QTableCornerButton::section
+{
+    background-color: @dark-base3;
+    border: 0.1ex transparent #76797c;
+    border-radius: 0px;
+}
+
+QToolBox
+{
+    padding: 0.5ex;
+    border: 0.1ex transparent black;
+}
+
+QToolBox:selected
+{
+    background-color: @dark-base3;
+    border-color: #3daee9;
+}
+
+QToolBox:hover
+{
+    border-color: #3daee9;
+}
+
+QStatusBar::item
+{
+    border: 0px transparent dark;
+}
+
+QFrame[height="3"],
+QFrame[width="3"]
+{
+    background-color: #76797c;
+}
+
+QSplitter::handle
+{
+    border: 0.1ex dashed #76797c;
+}
+
+QSplitter::handle:hover
+{
+    background-color: #787876;
+    border: 0.1ex solid #76797c;
+}
+
+QSplitter::handle:horizontal
+{
+    width: 0.1ex;
+}
+
+QSplitter::handle:vertical
+{
+    height: 0.1ex;
+}
+
+QProgressBar:horizontal
+{
+    background-color: #626568;
+    border: 0.1ex solid @dark-base3;
+    border-radius: 0.3ex;
+    height: 0.5ex;
+    text-align: right;
+    margin-top: 0.5ex;
+    margin-bottom: 0.5ex;
+    margin-right: 5ex;
+    padding: 0px;
+}
+
+QProgressBar::chunk:horizontal
+{
+    background-color: #3daee9;
+    border: 0.1ex transparent;
+    border-radius: 0.3ex;
+}
+
+QSpinBox,
+QDoubleSpinBox
+{
+    padding-right: 1.5ex;
+}
+
+QSpinBox::up-button,
+QDoubleSpinBox::up-button
+{
+    subcontrol-origin: content;
+    subcontrol-position: right top;
+
+    width: 1.6ex;
+    border-width: 0.1ex;
+}
+
+QSpinBox::up-arrow,
+QDoubleSpinBox::up-arrow
+{
+    border-image: url(:/dark/up_arrow.svg);
+    width: 0.9ex;
+    height: 0.6ex;
+}
+
+QSpinBox::up-arrow:hover,
+QSpinBox::up-arrow:pressed,
+QDoubleSpinBox::up-arrow:hover,
+QDoubleSpinBox::up-arrow:pressed
+{
+    border-image: url(:/dark/up_arrow-hover.svg);
+    width: 0.9ex;
+    height: 0.6ex;
+}
+
+QSpinBox::up-arrow:disabled,
+QSpinBox::up-arrow:off,
+QDoubleSpinBox::up-arrow:disabled,
+QDoubleSpinBox::up-arrow:off
+{
+   border-image: url(:/dark/up_arrow_disabled.svg);
+}
+
+QSpinBox::down-button,
+QDoubleSpinBox::down-button
+{
+    subcontrol-origin: content;
+    subcontrol-position: right bottom;
+
+    width: 1.6ex;
+    border-width: 0.1ex;
+}
+
+QSpinBox::down-arrow,
+QDoubleSpinBox::down-arrow
+{
+    border-image: url(:/dark/down_arrow.svg);
+    width: 0.9ex;
+    height: 0.6ex;
+}
+
+QSpinBox::down-arrow:hover,
+QSpinBox::down-arrow:pressed,
+QDoubleSpinBox::down-arrow:hover,
+QDoubleSpinBox::down-arrow:pressed
+{
+    border-image: url(:/dark/down_arrow-hover.svg);
+    width: 0.9ex;
+    height: 0.6ex;
+}
+
+QSpinBox::down-arrow:disabled,
+QSpinBox::down-arrow:off,
+QDoubleSpinBox::down-arrow:disabled,
+QDoubleSpinBox::down-arrow:off
+{
+   border-image: url(:/dark/down_arrow_disabled.svg);
+}</t>
+<t tx="ville.20260807001457.39">These settings must exist because they are *not* used in the css.</t>
+<t tx="ville.20260807001457.40">Maroon #9b0000
+Brown #a26b22
+Olive #808100
+Teal #008080
+Navy #000082
+Black #000000
+Red #ff0000
+Orange #ff9a00
+Yellow #ffec00
+Lime #beff00
+Green #00c200
+Cyan #65ffff
+Blue #3875db
+Purple #8700a1
+Magenta #f21eec
+Grey #b7b7b7
+Pink #ffc9de
+Coral #ffd9ae
+Beige #f7f6cd
+Mint #a5ffc1
+Lavender #e4bcff
+White #ffffff</t>
+<t tx="ville.20260807001457.41"></t>
+<t tx="ville.20260807001457.42"></t>
+<t tx="ville.20260807001457.43"></t>
+<t tx="ville.20260807001457.44">was blue
+
+Solarized blue      #268bd2</t>
+<t tx="ville.20260807001457.45">was blue
+
+Solarized blue      #268bd2</t>
+<t tx="ville.20260807001457.46">was blue
+
+Solarized blue      #268bd2</t>
+<t tx="ville.20260807001457.47">was blue
+
+Solarized blue      #268bd2</t>
+<t tx="ville.20260807001457.48">was #00aa00 (Idle comment green)
+
+Solarize green      #859900
+Solarized cyan      #2aa198
+Solarized violet    #6c71c4
+Solarized orange    #cb4b16</t>
+<t tx="ville.20260807001457.14"></t>
+<t tx="ville.20260807001457.49"></t>
+<t tx="ville.20260807001457.50"></t>
+<t tx="ville.20260807001457.51"></t>
+<t tx="ville.20260807001457.52">was black
+was #2aa198</t>
+<t tx="ville.20260807001457.53">was firebrick3
+
+Solarized colors:
+
+magenta   #d33682
+
+
+</t>
+<t tx="ville.20260807001457.54"></t>
+<t tx="ville.20260807001457.55"></t>
+<t tx="ville.20260807001457.56"></t>
+<t tx="ville.20260807001457.57"></t>
+<t tx="ville.20260807001457.58"># New: solarized-blue
+</t>
+<t tx="ville.20260807001457.15"></t>
+<t tx="ville.20260807001457.59"></t>
+<t tx="ville.20260807001457.60"></t>
+<t tx="ville.20260807001457.61">The color of text in doc parts.
+
+firebrick3
+</t>
+<t tx="ville.20260807001457.62">The color of Leo keywords such as @ignore, @color, etc.
+
+#00aa00
+</t>
+<t tx="ville.20260807001457.63">The color of name in &lt; &lt; name &gt; &gt; when name is defined.
+
+red
+
+</t>
+<t tx="ville.20260807001457.64">The background color that represents spaces when Show Invisibles mode is in effect.
+
+gray80: #CCCCCC
+gray90: #E5E5E5
+</t>
+<t tx="ville.20260807001457.65">The foreground color that represents tabs when Show Invisibles mode is in effect.
+
+gray80: #CCCCCC
+gray90: #E5E5E5
+</t>
+<t tx="ville.20260807001457.66">The color of name in &lt;&lt; name &gt;&gt; when name is undefined.
+</t>
+<t tx="ville.20260807001457.67">purple
+</t>
+<t tx="ville.20260807001457.68">Text to test with.</t>
+<t tx="ville.20260807001457.16"></t>
+<t tx="ville.20260807001457.69">Background color of log text.</t>
+<t tx="ville.20260807001457.70">Foreground color of log text.
+
+</t>
+<t tx="ville.20260807001457.71"></t>
+<t tx="ville.20260807001457.72"></t>
+<t tx="ville.20260807001457.73"></t>
+<t tx="ville.20260807001457.74"></t>
+<t tx="ville.20260807001457.77">Most widgets are colored in their css nodes.
+
+Only colors appearing in several places are given here.</t>
+<t tx="ville.20260807001457.78"></t>
+<t tx="ville.20260807001457.79" __bookmarks="7d7100580700000069735f6475706571014930300a732e">Most users will want to change these settings first.
+
+The stylesheet uses these settings.</t>
+<t tx="ville.20260807001457.80"></t>
+<t tx="ville.20260807001457.17"></t>
+<t tx="ville.20260807001457.81"></t>
+<t tx="ville.20260807001457.82"></t>
+<t tx="ville.20260807001457.83"></t>
+<t tx="ville.20260807001457.84"></t>
+<t tx="ville.20260807001457.85"></t>
+<t tx="ville.20260807001457.86"></t>
+<t tx="ville.20260807001457.90" __bookmarks="7d7100580700000069735f6475706571014930300a732e"></t>
+<t tx="ville.20260807001457.18"></t>
+<t tx="ville.20260807001457.92"></t>
+<t tx="ville.20260807001457.93"></t>
+<t tx="ville.20260807001457.94"></t>
+<t tx="ville.20260807001457.95"></t>
+<t tx="ville.20260807001457.96"></t>
+<t tx="ville.20260807001457.97">none or underline</t>
+<t tx="ville.20260807001457.98"></t>
+<t tx="ville.20260807001457.99"></t>
+<t tx="ville.20260807001457.100"></t>
+<t tx="ville.20260807001457.101"></t>
+<t tx="ville.20260807001457.19"></t>
+<t tx="ville.20260807001457.102">Valid values are: normal,italic,oblique</t>
+<t tx="ville.20260807001457.103">Huh?
+valid values are: normal,bold,100,..,900
+</t>
+<t tx="ville.20260807001457.104"></t>
+<t tx="ville.20260807001457.105"></t>
+<t tx="ville.20260807001457.106">none or underline</t>
+<t tx="ville.20260807001457.107"></t>
+<t tx="ville.20260807001457.108"></t>
+<t tx="ville.20260807001457.109"></t>
+<t tx="ville.20260807001457.110">bold or regular</t>
+<t tx="ville.20260807001457.111"></t>
+<t tx="ville.20260807001457.2"></t>
+<t tx="ville.20260807001457.3">@ A doc part.  *All* languages colorize doc parts as follows:
+
+1. The '@' sign itself is colored with @color leokeyword constant.
+
+2. The rest of the doc parts depends on the @bool color-doc-parts-as-rest setting:
+   True:  Colorize the doc part as **markdown**.
+   False: Colorize the doc part using @color docpart.
+   
+Leo colorizes constructs with two kinds of color constants.
+- **Default colors** defined in the node "Colors: defaults".
+  These constants correspond to jEdit names used in leo/modes/*.py.
+  See the "Colors: defaults" node for more details.
+- **Leo-specific colors**, defined in the node "Colors: Leo constructs".
+  
+Most languages use only a subset of these color names.
+Here are all the colors used to color python:
+@c # @color leo_keyword_color
+
+# Comments: @color comment1
+
+def spam():
+    
+    # Reserved words...
+    pass     # Python keywords: @color keyword1
+    abs(1)   # Standard functions: @color keyword2.
+    __file__ # double underscore names: @color keyword3
+    try:
+        frobnicate()
+            # Function calls are not specially colored.
+            # The default is the text foreground color in the body pane.
+    except IOError: # Exception names: @color keyword3
+        pass
+    a = 2    # Operators (the = sign): @color operator_color
+    
+    # Strings...
+    a = 'Regular string' # @color literal1
+    '''Triple single-quoted docstring''' # @color literal2
+    """Triple double-quoted docstring""" # @color literal2
+    
+# All languages use the following names...
+    
+# Urls: http://leoeditor.com/  @color url_color
+&lt;&lt; undefined section &gt;&gt;      # @color undefined_section_name_color
+&lt;&lt; defined section &gt;&gt;
+    # The brackets:            @color section_name_brackets_color
+    # The section name itself: @color section_name_color
+    
+@language python # @color leo_keyword_color
+</t>
+<t tx="ville.20260807001457.4"></t>
+<t tx="ville.20260807001457.5">@language python
+
+table = (
+    # g.actualColor calls 
+    'error', 'info', 'warning',
+    'black', 'white',
+    'xxx',
+    'firebrick', 'grey', 'pink', 'purple', # Tk colors.
+    # Solarized colors...
+    'blue', 'cyan', 'green','magenta', 'orange', 'red',
+    'violet', 'yellow',
+)
+for s in table:
+    g.es(s, color=s)
+</t>
+<t tx="ville.20260807001457.6"># g.cls()
+g.error('error')
+g.note('note')
+g.warning('warning')
+g.blue('blue')
+g.red('red')
+g.es_print('test')
+g.es_print('black',color='black')</t>
+<t tx="ville.20260807001457.87"></t>
+<t tx="ville.20260807001457.88"></t>
+<t tx="ville.20260807001457.89"></t>
+<t tx="ville.20260807001457.13" __bookmarks="7d7100580700000069735f6475706571014930300a732e"></t>
+<t tx="ville.20260807001457.75"></t>
+<t tx="ville.20260807001457.76"></t>
+<t tx="ville.20260807001457.1">A dark theme based loosely on Breeze Dark for KDE Plasma and the Breeze Dark stylesheet by Colin Duquesnoy. Some modifications were required. :-)
+
+</t>
+<t tx="ville.20260807001457.132">QMainWindow::separator {
+    /* The separator between QDockWidget's. */
+    background: @dark-base01;
+    width: 4px; height: 4px;
+    border: 2px solid black;
+}
+QDockWidget::title {
+    color: @dark-base0;
+    background: @dark-base3;
+    border: 1px solid @dark-base2;
+}
+QDockWidget::close-button, QDockWidget::float-button {
+    background: @solarized-base2;
+}
+QLineEdit#editorLabel {
+    border: 1px solid @dark-base2;
+}
+</t>
+<t tx="ville.20260807001457.124"></t>
+<t tx="ville.20260807001457.136">QRadioButton::indicator {
+    width: 14px;
+    height: 14px;
+    border-radius: 7px;
+    background-color: @text-background;
+    border: 1px solid @text_foreground;
+}
+
+QRadioButton::indicator:checked {
+    background-color: @text_foreground;
+    image: none;
+}
+
+QRadioButton::indicator:unchecked {
+    background-color: @text-background;
+}</t>
+<t tx="ville.20260807001457.131">QCheckBox::indicator {
+    width: 14px;
+    height: 14px;
+    background-color: @text-background;
+    border: 1px solid @text_foreground;
+}
+
+QCheckBox::indicator:checked {
+    background-color: @text_foreground;
+    image: none;
+}
+
+QCheckBox::indicator:unchecked {
+    background-color: @text-background;
+}</t>
+</tnodes>
+</leo_file>


### PR DESCRIPTION
## Summary

- add a modern dark theme with a restrained, Windows-friendly palette
- add theme-local tree and navigation chevrons
- use muted node-state icons and consistent tree interaction colors
- align and simplify the toolbar navigation controls

## Screenshot

<img width="682" height="663" alt="image" src="https://github.com/user-attachments/assets/8bd62523-8d6b-4e07-8260-f4ba4e9bf682" />


## Validation

- theme and SVG XML parse successfully
- git diff --check
- python -m pytest leo/unittests/misc_tests/test_syntax.py -q

## Usage

Add this setting to `myLeoSettings.leo`:

```text
@string theme-name = vv-dark.leo
```

Restart Leo to apply the theme.
