### PR TITLE
Replace deprecated os.system/spawn*/popen calls with subprocess

### DIFF
--- a/leo/commands/commanderHelpCommands.py
+++ b/leo/commands/commanderHelpCommands.py
@@ -6,6 +6,7 @@
 # @+node:ekr.20220826122759.1: ** << commanderHelpCommands imports & annotations >>
 from __future__ import annotations
 import os
+import subprocess
 import sys
 import time
 from typing import TYPE_CHECKING
@@ -376,9 +377,9 @@ def openPythonWindow(self: Self, event: LeoKeyEvent | None = None) -> None:
     idle = g.os_path_join(idle_path, 'idle.py')
     args = [sys.executable, idle]
     if 1:  # Use present environment.
-        os.spawnv(os.P_NOWAIT, sys.executable, args)
+        subprocess.Popen(args)
     else:  # Use a pristine environment.
-        os.spawnve(os.P_NOWAIT, sys.executable, args, os.environ)
+        subprocess.Popen(args, env=os.environ)
 
 
 # @+node:ekr.20131213072223.19532: ** c_help.selectAtSettingsNode

--- a/leo/commands/debugCommands.py
+++ b/leo/commands/debugCommands.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 from collections.abc import Callable
 import os
+import subprocess
 import sys
 from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
@@ -59,8 +60,8 @@ class DebugCommandsClass(BaseEditCommandsClass):
             return
         # Invoke the debugger, retaining the present environment.
         os.chdir(g.app.loadDir)
-        args = [sys.executable, winpdb, '-t', filename]
-        os.spawnv(os.P_NOWAIT, python, args)
+        args = [python, winpdb, '-t', filename]
+        subprocess.Popen(args)
 
     # @+node:ekr.20150514063305.105: *3* debug.findDebugger
     def findDebugger(self) -> str | None:

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -472,7 +472,7 @@ class ExternalFilesController:
                 filename = g.os_path_basename(arg)
                 command = f"os.spawnl({arg},{filename},{fn})"
                 if not testing:
-                    os.spawnl(os.P_NOWAIT, arg, filename, fn)
+                    subprocess.Popen([filename, fn], executable=arg)
             elif kind == 'os.spawnv':
                 filename = os.path.basename(arg_tuple[0])
                 vtuple = arg_tuple[1:]
@@ -482,7 +482,7 @@ class ExternalFilesController:
                 vtuple.append(fn)
                 command = f"os.spawnv({vtuple})"
                 if not testing:
-                    os.spawnv(os.P_NOWAIT, arg[0], vtuple)
+                    subprocess.Popen(vtuple, executable=arg_tuple[0])
             elif kind == 'subprocess.Popen':
                 popen_arg: list | str = (
                     self.join(arg, fn) if os.name == 'nt' else

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7108,10 +7108,10 @@ def cls(
     """Clear the screen."""
     if g.isWindows:
         # Leo 6.7.5: Two calls seem to be required!
-        os.system('cls')
-        os.system('cls')
+        subprocess.run('cls', shell=True, check=False)
+        subprocess.run('cls', shell=True, check=False)
     else:
-        os.system('clear')
+        subprocess.run('clear', shell=True, check=False)
 
 
 # @+node:ekr.20131114124839.16665: *3* g.createScratchCommander

--- a/leo/plugins/FileActions.py
+++ b/leo/plugins/FileActions.py
@@ -45,6 +45,7 @@ actions, Leo does not do anything with or to such files.
 # @+node:ekr.20090317093747.1: ** << imports >>
 import fnmatch
 import os
+import subprocess
 import sys
 import tempfile
 from leo.core import leoGlobals as g
@@ -174,7 +175,7 @@ def shellScriptInWindow(c, script):
         os.close(handle)
         os.chmod(path, 0x700)
         # @-<< write script to temporary MacOS file >>
-        os.system("open -a /Applications/Utilities/Terminal.app " + path)
+        subprocess.run("open -a /Applications/Utilities/Terminal.app " + path, shell=True, check=False)
 
     elif sys.platform == 'win32':
         g.error("shellScriptInWindow not ready for Windows")
@@ -189,7 +190,7 @@ def shellScriptInWindow(c, script):
         os.close(handle)
         os.chmod(path, 0x700)
         # @-<< write script to temporary Unix file >>
-        os.system("xterm -e sh  " + path)
+        subprocess.run("xterm -e sh  " + path, shell=True, check=False)
 
 
 # @-others

--- a/leo/plugins/at_produce.py
+++ b/leo/plugins/at_produce.py
@@ -95,7 +95,7 @@ def run(c, all):
         runList(c, aList)
 
     t = threading.Thread(target=thread_target)
-    t.setDaemon(True)  # pylint: disable=deprecated-method
+    t.daemon = True
     t.start()
     timer = g.IdleTime(handler=None, delay=500, tag='at-produce')
     c._at_produce_max = 20

--- a/leo/plugins/gitarchive.py
+++ b/leo/plugins/gitarchive.py
@@ -5,6 +5,7 @@
 import hashlib
 import os
 import shutil
+import subprocess
 from leo.core import leoGlobals as g
 
 
@@ -42,7 +43,7 @@ def git_dump_f(event):
         g.es("Initializing git repo at " + flatroot)
         os.makedirs(flatroot)
         os.chdir(flatroot)
-        os.system('git init')
+        subprocess.run(['git', 'init'], check=False)
     assert os.path.isdir(flatroot)
     comment = g.app.gui.runAskOkCancelStringDialog(c, "Checkin comment", "Comment")
     if not comment:
@@ -61,8 +62,10 @@ def git_dump_f(event):
     with open(titlename, 'w', encoding='utf-8') as f:
         f.write(html)
     g.es("committing to " + flatroot)
-    os.system('git add *')
-    out = os.popen('git commit -m "%s"' % comment).read()
+    subprocess.run('git add *', shell=True, check=False)
+    out = subprocess.run(
+        ['git', 'commit', '-m', comment], capture_output=True, text=True, check=False
+    ).stdout
     g.es("committed")
     g.es(out)
     g.es('Outline in ' + os.path.abspath(titlename))
@@ -76,7 +79,7 @@ def git_log_f(event):
     # os.chdir ??
     inf = contfile(c, p)
     print("f", inf)
-    os.system("gitk %s" % inf)
+    subprocess.run(['gitk', inf], check=False)
 
 
 # @-others

--- a/leo/plugins/leo_babel/tests/tests.py
+++ b/leo/plugins/leo_babel/tests/tests.py
@@ -30,7 +30,6 @@ optional arguments:
 # @+<< imports >>
 # @+node:bob.20180125160501.1: ** << imports >>
 import argparse
-import codecs
 import os
 
 from leo.core import leoBridge
@@ -91,7 +90,7 @@ def main():
     cmdrT = bridge.openLeoFile(args.fpnTests)
     if os.path.exists(args.fpnResults):
         os.remove(args.fpnResults)
-    fdR = codecs.open(args.fpnResults, 'w', encoding='utf-8')
+    fdR = open(args.fpnResults, 'w', encoding='utf-8')
     testCmdr = lib_test.TestCmdr(cmdrT, fdR)
     genFindTests = lib_test.findTests(cmdrT)
     itPoll = leoG.IdleTime(

--- a/leo/plugins/open_shell.py
+++ b/leo/plugins/open_shell.py
@@ -23,6 +23,7 @@ Current limitations:
 
 # Written by Ed Taekema.  Modified by EKR
 import os
+import subprocess
 import sys
 from leo.core import leoGlobals as g
 
@@ -96,21 +97,21 @@ class pluginController:
 
         d = self._getCurrentNodePath()
         myCmd = 'cd ' + d
-        os.spawnl(os.P_NOWAIT, pathToCmd, '/k ', myCmd)
+        subprocess.Popen(['/k ', myCmd], executable=pathToCmd)
 
     # @+node:EKR.20040517080049.10: *3* launchExplorer
     def launchExplorer(self, event=None):
         # global pathToExplorer
 
         d = self._getCurrentNodePath()
-        os.spawnl(os.P_NOWAIT, pathToExplorer, ' ', d)
+        subprocess.Popen([' ', d], executable=pathToExplorer)
 
     # @+node:EKR.20040517080049.11: *3* launchxTerm
     def launchxTerm(self, event=None):
         d = self._getCurrentNodePath()
         curdir = os.getcwd()
         os.chdir(d)
-        os.spawnlp(os.P_NOWAIT, 'xterm', '-title Leo')
+        subprocess.Popen(['-title Leo'], executable='xterm')
         os.chdir(curdir)
 
     # @-others

--- a/leo/plugins/screenshots.py
+++ b/leo/plugins/screenshots.py
@@ -627,11 +627,8 @@ class ScreenShotController:
         sc = self
         assert sc.slideshow_path
         os.chdir(sc.slideshow_path)
-        os.system('make clean')
-        os.system('make html')
-        # cmd = ['make','html']
-        # proc = subprocess.Popen(cmd)
-        # proc.communicate() # Wait
+        subprocess.run(['make', 'clean'], check=False)
+        subprocess.run(['make', 'html'], check=False)
 
     # @+node:ekr.20100915074635.5651: *3* init
     def init(self, p):

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -201,6 +201,7 @@ from collections.abc import Callable
 import os
 from pathlib import Path
 import shutil
+import subprocess
 import sys
 import textwrap
 from typing import Any, TYPE_CHECKING
@@ -1477,8 +1478,10 @@ class ViewRenderedController(QtWidgets.QWidget):
         with open("temp.plantuml", "w") as f:
             f.write(s)
         pth_plantuml_jar = "~/.leo"
-        os.system(
-            "cat temp.plantuml | java -jar %s/plantuml.jar -pipe > %s" % (pth_plantuml_jar, path)
+        subprocess.run(
+            "cat temp.plantuml | java -jar %s/plantuml.jar -pipe > %s" % (pth_plantuml_jar, path),
+            shell=True,
+            check=False,
         )
         template = self.image_template % (path)
         template = textwrap.dedent(template).strip()

--- a/leo/plugins/vim.py
+++ b/leo/plugins/vim.py
@@ -218,8 +218,8 @@ class VimCommander:
         if path and self.should_open_old_file(path, root):
             cmd = self.vim_cmd + "--remote-send '<C-\\><C-N>:e " + path + "<CR>'"
             if self.trace:
-                g.trace('os.system(%s)' % cmd)
-            os.system(cmd)
+                g.trace('subprocess.run(%s)' % cmd)
+            subprocess.run(cmd, shell=True, check=False)
         else:
             # Open a new temp file.
             if path:
@@ -279,7 +279,7 @@ class VimCommander:
             if g.os_path_exists(path):
                 os.remove(path)
         cmd = self.vim_cmd + "--remote-send '<C-\\><C-N>:bd " + path + "<CR>'"
-        os.system(cmd)
+        subprocess.run(cmd, shell=True, check=False)
 
     # @+node:ekr.20150326181247.1: *4* vim.get_cursor_arg
     def get_cursor_arg(self):

--- a/leo/plugins/xemacs.py
+++ b/leo/plugins/xemacs.py
@@ -19,6 +19,7 @@ appear in Leo.
 # @+<< imports >>
 # @+node:ekr.20050218024153: ** << imports >> (xemacs.py)
 import os
+import subprocess
 import sys
 from typing import Any
 from leo.core import leoGlobals as g
@@ -92,7 +93,7 @@ def open_in_emacs_helper(c, p):
             # efc = g.app.externalFilesController
             # if efc: efc.forget_path(path)
             os.remove(path)
-            os.system(emacs_cmd)
+            subprocess.run(emacs_cmd, shell=True, check=False)
         v.OpenWithOldBody = v.b  # Remember the old contents
         # open the node in emacs (note the space after _emacs_cmd)
         # data = "os.spawnl", emacs_cmd, None
@@ -100,7 +101,7 @@ def open_in_emacs_helper(c, p):
         c.openWith(d=d)
     else:
         # Reopen the old temp file.
-        os.system(emacs_cmd)
+        subprocess.run(emacs_cmd, shell=True, check=False)
 
 
 # @+node:ekr.20120315101404.9747: ** g.command('emacs-open-node')


### PR DESCRIPTION
## Summary
- Fixes all 22 remaining `ty` diagnostics from #4851, which were all `deprecated`-category warnings (no type errors left).
- Replaces `os.system`, `os.spawnl`, `os.spawnv`, `os.spawnlp`, and `os.popen` with `subprocess.run`/`subprocess.Popen` across leo/commands, leo/core, and leo/plugins.
- Replaces `codecs.open` with builtin `open` (leo_babel/tests/tests.py).
- Replaces `Thread.setDaemon(True)` with the `.daemon = True` attribute (at_produce.py).
- Fixes a latent bug found while rewriting `leoExternalFiles.py`'s `os.spawnv` open-with handler: it passed `arg[0]` (the first *character* of a joined string) as the executable instead of `arg_tuple[0]` (the intended first list element).

This branch is based directly on `devel` rather than stacking on the still-open #4851, since none of the touched call sites overlap with that PR's changes.

## Test plan
- [x] `ty check` shows zero `deprecated` diagnostics for the touched files
- [x] `python3 -m py_compile` on all 13 changed files
- [x] `ruff check --select F401,F841` clean (no unused imports left behind)
- [ ] Manual smoke test of affected plugins (gitarchive, vim, xemacs, open_shell, screenshots) not performed — these are opt-in plugins requiring external tools (git, vim, xterm, gitk, sphinx) not exercised by CI