### PR TITLE
Remove stale todo.py stub from LeoPyRef.leo

### DIFF
--- a/leo/core/LeoPyRef.leo
+++ b/leo/core/LeoPyRef.leo
@@ -513,7 +513,6 @@
 <v t="tbrown.20130420091241.44181"><vh>@file ../plugins/screen_capture.py</vh></v>
 <v t="ville.20090815203828.5235"><vh>@file ../plugins/spydershell.py</vh></v>
 <v t="ekr.20100103093121.5329"><vh>@file ../plugins/stickynotes.py</vh></v>
-<v t="tbrown.20090119215428.2"><vh>@file ../plugins/todo.py</vh></v>
 <v t="tbrown.20100318101414.5990"><vh>@file ../plugins/viewrendered.py</vh></v>
 <v t="TomP.20191215195433.1"><vh>@file ../plugins/viewrendered3.py</vh></v>
 </v>


### PR DESCRIPTION
## Summary
- `leo/plugins/todo.py` was deleted in 3623947f2 ("Move todo.py to the attic"), but its outline placeholder (`<v t="tbrown.20090119215428.2"><vh>@file ../plugins/todo.py</vh></v>`) was left behind in `LeoPyRef.leo`.
- `leo/doc/leoAttic.txt`'s archived copy of the old source reuses that same gnx (`tbrown.20090119215428.2`) in its sentinel comments, since it's mirrored as `@file ../doc/leoAttic.txt` in the same outline.
- Because gnx identifies a single shared VNode within an outline, any `leoBridge`/GUI open-refresh-save cycle reads leoAttic.txt's sentinels and merges that archived content back into the stale stub's position — resurrecting the deleted plugin's whole node tree there and stripping the `@file ` prefix from its headline. Reproduces with zero explicit `refreshFromDisk` calls, purely from opening the file.
- Deleting the orphaned stub removes the gnx collision; the legitimate archived copy under "The attic" > "Temporary Attic" is untouched.

## Test plan
- [x] `python3 -c "import xml.etree.ElementTree as ET; ET.parse('leo/core/LeoPyRef.leo')"` — XML still parses
- [x] Reopened via leoBridge: only one occurrence of gnx `tbrown.20090119215428.2` remains, under `leoAttic.txt`'s attic section (no resurrection)
- [x] `QT_QPA_PLATFORM=offscreen python -m pytest leo/unittests` — 864 passed, 1 unrelated pre-existing failure (`test_g_OptionsUtils`, a known pytest-argv-parsing artifact unrelated to this change)