### PR TITLE
Fix stale filename in LeoPyRef.leo after run_travis_unit_tests.py rename

### DIFF
--- a/leo/core/LeoPyRef.leo
+++ b/leo/core/LeoPyRef.leo
@@ -186,7 +186,7 @@
 <v t="ekr.20240201175949.1"><vh>@file ../../requirements.txt</vh></v>
 <v t="axk.20260702120000.1"><vh>@file ../../make_macos_application.py</vh></v>
 <v t="ekr.20181014073705.1"><vh>@file ../../run_pytest_tests.py</vh></v>
-<v t="ekr.20181009072707.1"><vh>@file ../../run_travis_unit_tests.py</vh></v>
+<v t="ekr.20181009072707.1"><vh>@file ../../run_ci_unit_tests.py</vh></v>
 <v t="ekr.20150304130753.4"><vh>leo-viewer/leo_to_html.xsl</vh></v>
 </v>
 <v t="ekr.20180225010913.1"><vh>In leo/core</vh>


### PR DESCRIPTION
## Summary
- `937d7e568` renamed `run_travis_unit_tests.py` to `run_ci_unit_tests.py`, but `LeoPyRef.leo`'s `@file` node for it was never updated -- it still pointed at the old, now-deleted filename.
- This is why every `leoBridge`/GUI open of `LeoPyRef.leo` prints `can not open .../run_travis_unit_tests.py` noise, and the outline never picked up `run_ci_unit_tests.py`'s actual content.
- Fix is a one-line headline rename to the node's existing gnx (`ekr.20181009072707.1`) -- no structural change, no other node touched.

Found while auditing all 367 `@file`/`@clean` nodes in `LeoPyRef.leo` for drift against their mirrored files on disk (using `AtFileCommands.atFileToString` to compare the outline-derived content against the actual file, byte for byte). This was the only other genuine staleness found besides the `todo.py` stub fixed in #4858.

## Test plan
- [x] `python3 -c "import xml.etree.ElementTree as ET; ET.parse('leo/core/LeoPyRef.leo')"` -- XML still parses
- [x] Reopened via leoBridge: node resolves to `run_ci_unit_tests.py`, and `atFileToString(sentinels=True)` matches the on-disk file byte-for-byte
- [x] `QT_QPA_PLATFORM=offscreen python -m pytest leo/unittests` -- 864 passed, 1 pre-existing unrelated failure (`test_g_OptionsUtils`, a known pytest-argv-parsing artifact)