### PR TITLE
Normalize sentinel indentation in viewrendered3.py's commented QtSvg block

### DIFF
--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -4258,15 +4258,15 @@ class ViewRenderedController3(QtWidgets.QWidget):
                 s = node_list[0].b
                 s = self.remove_directives(s)
             isHtml = s and s[0] == '<'
-            # @+at
-            #         # In case we bring back QtSvg again)
-            #         if s.startswith('<svg'):
-            #             if QtSvg is None:
-            #                 g.es(NO_SVG_WIDGET_MSG, color='red')
-            #                 return
-            #             else:
-            #                 self.update_svg(s, keywords)
-            # @@c
+    # @+at
+    #         # In case we bring back QtSvg again)
+    #         if s.startswith('<svg'):
+    #             if QtSvg is None:
+    #                 g.es(NO_SVG_WIDGET_MSG, color='red')
+    #                 return
+    #             else:
+    #                 self.update_svg(s, keywords)
+    # @@c
             self.rst_html = ''
             if s and isHtml:
                 _code = [n.b for n in node_list]


### PR DESCRIPTION
## Summary
- Found while auditing all 367 `@file`/`@clean` nodes in `LeoPyRef.leo` against their mirrored files on disk (see #4858, #4859): `leo/plugins/viewrendered3.py` was the one file that wasn't self-consistent under a clean round-trip -- reopening it and re-deriving via `AtFileCommands.atFileToString` (no edits, no `refreshFromDisk`) produced different indentation than what's on disk for one small `# @+at ... # @@c` doc-part.
- Root cause: that doc-part (documenting old, disabled QtSvg-related code in `update_rst()`) is nested inside an `if got_docutils:` block *within* a single leaf node, not split out via `@others`/section references. Leo's `AtFile` writer only tracks indentation deltas at `@others`/section-reference boundaries (`at.indent`); it has no mechanism for a doc-part's *sentinel* lines (`# @+at`, `# @@c`) to inherit extra indentation from a block nested purely within a leaf node's own body. Doc *content* lines don't have this problem (their residual indentation rides along as literal stored text) -- only the two bare sentinel-marker lines were affected, landing at the `@others`-boundary indent (4) instead of the actual local block indent (12).
- This means every fresh `leoBridge`/GUI open+save of this file would silently reindent this one comment block, with zero content edits involved.
- This PR normalizes the block to the self-consistent (4-space-sentinel) form Leo's own writer produces, so the drift stops. It's a comment-only change (no executable code affected).

A real fix to `AtFile`'s doc-part indentation tracking (so sentinel lines *can* preserve block-local indentation) is a separate, riskier change to foundational write logic with no existing test coverage for this path -- tracked separately, not part of this PR.

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('leo/plugins/viewrendered3.py').read())"` -- still valid Python
- [x] Reopened via leoBridge and re-derived: full `LeoPyRef.leo` audit (367 nodes) now shows zero out-of-sync files
- [x] `QT_QPA_PLATFORM=offscreen python -m pytest leo/unittests` -- 864 passed, 1 pre-existing unrelated failure (`test_g_OptionsUtils`, a known pytest-argv-parsing artifact)