### PR TITLE
ci.yml: enable ty check and ruff format --check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,9 @@ jobs:
           cache: pip
       - run: pip install ruff
       - run: ruff check leo
-      # Enable once leo/modes is reformatted to lf (issue #4847):
-      # - run: ruff format --check leo
+      # Requires #4857 (normalizes leo/modes to lf) to be merged first;
+      # see issue #4847.
+      - run: ruff format --check leo
 
   test:
     runs-on: ubuntu-latest
@@ -83,12 +84,10 @@ jobs:
       # contributors actually see, instead of only the ignore_missing_imports
       # fallback.
       - run: python -m mypy leo
-      # Informational only: ty (https://github.com/astral-sh/ty) is an
-      # actively-developed, much faster alternative to mypy, still in beta.
-      # It's noticeably stricter than our current mypy config in some areas
-      # (see ty.toml), so this step is not allowed to fail the build --
-      # it's here so its findings show up in PR logs while we evaluate it.
+      # ty (https://github.com/astral-sh/ty) is an actively-developed, much
+      # faster alternative to mypy, still in beta. It's noticeably stricter
+      # than our current mypy config in some areas (see ty.toml). It's clean
+      # against this codebase, so it now blocks the build like mypy does.
       # Runs in this job, after mypy, to reuse the same checkout/Python/PyQt6
       # setup instead of paying for a second one.
-      # - run: ty check --python "$(python -c 'import sys; print(sys.prefix)')" leo
-      #  continue-on-error: true
+      - run: ty check --python "$(python -c 'import sys; print(sys.prefix)')" leo


### PR DESCRIPTION
## Summary
- `ty check` (https://github.com/astral-sh/ty) passes cleanly (0 diagnostics) against `leo` today with PyQt6 installed. It was previously commented out entirely rather than left as the non-blocking `continue-on-error` job it was designed as. Since it's clean, make it blocking like `mypy` instead — no reason to let it silently regress.
- `ruff format --check leo` is re-enabled in the `lint` job (was commented out per #4847, blocked on mixed line endings). **This will fail on `devel` as-is** because 122 files under `leo/modes/` still carry CRLF bytes. #4857 fixes exactly this (normalizes line endings to lf) — I verified locally against that branch that `ruff format --check leo` then passes cleanly (557/557 files).

@edreamleo — #4857 is approved and mergeable; it needs to land before this PR's `ruff format --check` step will go green on `devel`. Flagging so it doesn't get lost.

## Test plan
- [x] `ty check --python "$(python -c 'import sys; print(sys.prefix)')" leo` passes locally
- [x] `ruff format --check leo` verified to pass against #4857's branch in a scratch worktree
- [ ] CI on this PR will show `ruff format --check` red until #4857 merges into `devel`