### PR TITLE
Add CI check: LeoPyRef.leo must stay in sync with its mirrored files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,24 @@ jobs:
       - run: pip install asttokens Pygments "PyQt6>=6.6" PyQt6-QScintilla
       - run: python run_ci_unit_tests.py
 
+  leo-sync:
+    # Catches leo/core/LeoPyRef.leo drifting out of sync with the plain
+    # files it mirrors (stale/renamed filenames, un-refreshed content) --
+    # see leo/scripts/check_leo_sync.py.
+    runs-on: ubuntu-latest
+    env:
+      QT_QPA_PLATFORM: offscreen
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends
+          libegl1 libgl1 libxkbcommon0 libdbus-1-3 libfontconfig1
+      - run: pip install "PyQt6>=6.6" PyQt6-QScintilla
+      - run: python -m leo.scripts.check_leo_sync
+
   mypy:
     runs-on: ubuntu-latest
     steps:

--- a/leo/scripts/check_leo_sync.py
+++ b/leo/scripts/check_leo_sync.py
@@ -1,0 +1,102 @@
+"""
+check_leo_sync.py: Verify that LeoPyRef.leo is in sync with the plain
+files it mirrors.
+
+leo-editor's own source is tracked both as plain files (.py, .toml, .txt)
+and as @file/@clean nodes inside leo/core/LeoPyRef.leo. A plain-file edit
+that's never synced back into the outline (via refresh-from-disk) leaves
+LeoPyRef.leo stale -- invisible to anyone not using the Leo GUI, until
+someone next opens it there and gets a surprise (a resurrected stale node,
+a missing file, or a spurious reindent).
+
+This script opens LeoPyRef.leo headlessly and, for every @file/@clean node,
+compares what AtFile would derive from the outline against the actual
+mirrored file on disk, byte for byte. It exits nonzero (and lists every
+mismatch) if anything is out of sync, so drift gets caught in CI instead
+of by whoever next opens the outline in the GUI.
+
+Usage:
+    python -m leo.scripts.check_leo_sync
+"""
+
+import os
+import sys
+
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+# cd to leo-editor, matching this directory's other scripts (flake8_leo.py etc).
+leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
+os.chdir(leo_editor_dir)
+sys.path.insert(0, leo_editor_dir)
+
+from leo.core import leoBridge  # noqa: E402
+
+
+def main() -> int:
+    leo_path = os.path.join(leo_editor_dir, 'leo', 'core', 'LeoPyRef.leo')
+    bridge = leoBridge.controller(
+        gui='nullGui', loadPlugins=False, readSettings=False, silent=True, verbose=False,
+    )
+    c = bridge.openLeoFile(leo_path)
+    at = c.atFileCommands
+
+    missing: list[tuple[str, str]] = []
+    out_of_sync: list[tuple[str, str, str]] = []
+    checked = 0
+
+    for p in c.all_positions():
+        if not p.isAnyAtFileNode():
+            continue
+        h = p.h.strip()
+        # @auto/@edit don't have a stable derived-string round-trip to compare.
+        if h.startswith(('@auto', '@edit')):
+            continue
+        if not h.startswith(('@file', '@clean', '@thin', '@shadow', '@nosent')):
+            continue
+        full = c.fullPath(p)
+        if not os.path.exists(full):
+            missing.append((h, full))
+            continue
+        checked += 1
+        use_sentinels = not h.startswith('@clean')
+        try:
+            derived = at.atFileToString(p.copy(), sentinels=use_sentinels)
+        except Exception as e:  # pragma: no cover (defensive)
+            out_of_sync.append((h, full, f'error deriving content: {e}'))
+            continue
+        with open(full, 'r', encoding='utf-8', errors='replace') as f:
+            disk = f.read()
+        if derived != disk:
+            out_of_sync.append((h, full, 'content differs from what the outline would write'))
+
+    print(f"checked {checked} @file/@clean nodes in {leo_path}")
+
+    ok = True
+    if missing:
+        ok = False
+        print(f"\n{len(missing)} node(s) reference a file that no longer exists on disk:")
+        for h, full in missing:
+            print(f"  MISSING: {h} -> {full}")
+        print(
+            "  (the file was likely renamed or deleted without updating the "
+            "matching node's headline in LeoPyRef.leo)"
+        )
+
+    if out_of_sync:
+        ok = False
+        print(f"\n{len(out_of_sync)} node(s) are out of sync with their mirrored file:")
+        for h, full, reason in out_of_sync:
+            print(f"  DIFF: {h} -> {full} ({reason})")
+        print(
+            "  (re-sync via leoBridge: c.refreshFromDisk(p) for each node, "
+            "then c.fileCommands.save() -- see the leo-editor skill)"
+        )
+
+    if ok:
+        print("\nLeoPyRef.leo is in sync with all mirrored files.")
+        return 0
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- leo-editor's own source is tracked both as plain files and as `@file`/`@clean` nodes inside `leo/core/LeoPyRef.leo`. A plain-file edit that never gets synced back into the outline (via refresh-from-disk) leaves it stale -- invisible until someone next opens it in the Leo GUI.
- Adds `leo/scripts/check_leo_sync.py`, which opens `LeoPyRef.leo` headlessly and, for every `@file`/`@clean` node, compares what `AtFile` would derive from the outline against the actual file on disk, byte for byte. Exits nonzero and lists every mismatch (missing files and content drift) if anything is out of sync.
- Wired into `.github/workflows/ci.yml` as a new `leo-sync` job (single run, not matrixed -- the check is Python-version-independent).
- Not added as a mirrored `@file` node itself (`leo/scripts` is otherwise all mirrored) -- keeping it a plain standalone file avoided touching `LeoPyRef.leo`'s structure for a brand-new node, which felt like unnecessary risk for a CI-only utility script.

This script is literally the tool I used (as an ad hoc audit) to find the three issues fixed in #4858, #4859, and #4860 (a stale `todo.py` stub, a stale filename after `run_travis_unit_tests.py` was renamed, and an indentation round-trip drift in `viewrendered3.py`) -- turning it into a standing CI check means this class of drift gets caught automatically going forward instead of by whoever next opens the outline in the GUI.

**Note:** this PR's new `leo-sync` CI job will show red until #4858/#4859/#4860 merge, since it correctly detects those three still-open issues on `devel`. Verified locally that it goes green once their diffs are applied.

## Test plan
- [x] Ran `python -m leo.scripts.check_leo_sync` against current `devel` -- correctly reports the stale-rename and indentation-drift issues (exit 1)
- [x] Applied #4858/#4859/#4860's diffs locally and re-ran -- reports clean, exit 0
- [x] `ruff check leo/scripts/check_leo_sync.py` -- clean
- [x] Confirmed `leo/scripts` is excluded from the `mypy` CI job (`pyproject.toml`), matching the existing `check_leo.py`'s same pattern, so no mypy noise
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` -- valid YAML