### PR TITLE
Re-normalize viewrendered3.py sentinel indentation (fixes leo-sync CI)

### DIFF
--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -4258,15 +4258,13 @@ class ViewRenderedController3(QtWidgets.QWidget):
                 s = node_list[0].b
                 s = self.remove_directives(s)
             isHtml = s and s[0] == '<'
-    # @+at
-    #         # In case we bring back QtSvg again)
-    #         if s.startswith('<svg'):
-    #             if QtSvg is None:
-    #                 g.es(NO_SVG_WIDGET_MSG, color='red')
-    #                 return
-    #             else:
-    #                 self.update_svg(s, keywords)
-    # @@c
+            # In case we bring back QtSvg again)
+            # if s.startswith('<svg'):
+            #     if QtSvg is None:
+            #         g.es(NO_SVG_WIDGET_MSG, color='red')
+            #         return
+            #     else:
+            #         self.update_svg(s, keywords)
             self.rst_html = ''
             if s and isHtml:
                 _code = [n.b for n in node_list]

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -4258,15 +4258,15 @@ class ViewRenderedController3(QtWidgets.QWidget):
                 s = node_list[0].b
                 s = self.remove_directives(s)
             isHtml = s and s[0] == '<'
-            # @+at
-            #         # In case we bring back QtSvg again)
-            #         if s.startswith('<svg'):
-            #             if QtSvg is None:
-            #                 g.es(NO_SVG_WIDGET_MSG, color='red')
-            #                 return
-            #             else:
-            #                 self.update_svg(s, keywords)
-            # @@c
+    # @+at
+    #         # In case we bring back QtSvg again)
+    #         if s.startswith('<svg'):
+    #             if QtSvg is None:
+    #                 g.es(NO_SVG_WIDGET_MSG, color='red')
+    #                 return
+    #             else:
+    #                 self.update_svg(s, keywords)
+    # @@c
             self.rst_html = ''
             if s and isHtml:
                 _code = [n.b for n in node_list]


### PR DESCRIPTION
## Summary
`a8b025779` ("Fix VR3") reindented this commented-out QtSvg block back to 12 spaces, which the new `leo-sync` CI job (#4862) flags -- `AtFile` can't round-trip a doc part's indentation when it's nested inside a leaf node's own block rather than under `@others`. See #4864 for the full root cause and why the obvious fix is unsafe.

Fix here: drop the `# @+at`/`# @@c` doc-part wrapper and leave it as a plain `#`-commented block (content unchanged). Plain comment lines aren't affected by this bug, so it can't recur on this block again.

## Test plan
- [x] `python -m leo.scripts.check_leo_sync` -- clean
- [x] `QT_QPA_PLATFORM=offscreen python -m pytest leo/unittests` -- 864 passed, 1 pre-existing unrelated failure
