### PR TITLE
PR: improve ruff checks

### DIFF
--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -455,21 +455,6 @@ class RuffCommand:
         bpm = g.app.backgroundProcessManager
         bpm.start_process(c, command, fn=fn, kind='ruff')
 
-    # @+node:vv.20260807120000.5: *3* ruff.run (entry)
-    def run(self, p: Position) -> None:
-        """Run ruff on all Python @<file> nodes in c.p's tree."""
-        c = self.c
-        if not ruff:
-            print('install ruff with `pip install ruff`')
-            return
-        root = p.copy()
-        # Make sure the parent of the leo directory is on sys.path.
-        path = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
-        if path not in sys.path:
-            sys.path.insert(0, path)
-        roots = g.findRootsWithPredicate(c, root, predicate=None)
-        self.check_all(roots)
-
     # @+node:vv.20260807120000.6: *3* ruff.check_on_write (sync, for on-write checking)
     def check_on_write(self, root: Position) -> bool:
         """
@@ -486,11 +471,47 @@ class RuffCommand:
         fn = os.path.normpath(c.fullPath(root))
         command = [sys.executable, '-m', 'ruff', 'check', '--output-format=concise', fn]
         result = subprocess.run(command, capture_output=True, text=True)
-        s = (result.stdout + result.stderr).strip()
+        raw_s = (result.stdout + result.stderr).replace('All checks passed!', '').strip()
+        # Strip out cruft.
+        s = ''.join(z for z in g.splitLines(raw_s) if not z.startswith('Found')).strip()
         if s:
-            if not c.frame.log.put_html_links(s):
-                g.es(s)
+            c.frame.log.put_html_links(s)
         return result.returncode == 0
+
+    # @+node:ekr.20260808005852.1: *3* ruff.check_script_file
+    def check_script_file(self, fn: str) -> bool:
+        """
+        Run ruff synchronously the file. Return True if ruff reports no errors.
+
+        Used by execute-script.
+        """
+        c = self.c
+        if not ruff:
+            return True
+        command = [sys.executable, '-m', 'ruff', 'check', '--output-format=concise', fn]
+        result = subprocess.run(command, capture_output=True, text=True)
+        raw_s = (result.stdout + result.stderr).replace('All checks passed!', '').strip()
+        # Strip out cruft.
+        s = ''.join(z for z in g.splitLines(raw_s) if not z.startswith('Found')).strip()
+        s = s.replace(fn, c.p.h)  # A hack.
+        if s:
+            c.frame.log.put_html_links(s)
+        return result.returncode == 0
+
+    # @+node:vv.20260807120000.5: *3* ruff.run (entry)
+    def run(self, p: Position) -> None:
+        """Run ruff on all Python @<file> nodes in c.p's tree."""
+        c = self.c
+        if not ruff:
+            print('install ruff with `pip install ruff`')
+            return
+        root = p.copy()
+        # Make sure the parent of the leo directory is on sys.path.
+        path = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
+        if path not in sys.path:
+            sys.path.insert(0, path)
+        roots = g.findRootsWithPredicate(c, root, predicate=None)
+        self.check_all(roots)
 
     # @-others
 

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1405,17 +1405,17 @@ class Commands:
             g.inScript = g.app.inScript = True  # g.inScript is a synonym for g.app.inScript.
             if c.write_script_file:
                 scriptFile = self.writeScriptFile(script)
-                if scriptFile and language == 'python':
+                if (
+                    scriptFile
+                    and language == 'python'
+                    and not g.unitTesting
+                    and c.config.getBool('run-ruff-on-write', default=False)
+                ):
                     from leo.commands import checkerCommands
 
-                    if (
-                        checkerCommands.ruff
-                        and not g.unitTesting
-                        and c.config.getBool('run-ruff-on-write', default=False)
-                    ):
+                    if checkerCommands.ruff:
                         x = checkerCommands.RuffCommand(c)
-                        ok = x.check_script_file(scriptFile)
-                        if not ok:
+                        if not x.check_script_file(scriptFile):
                             g.app.syntax_error_files.append(scriptFile)
                             c.syntaxErrorDialog()
                             return

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1355,7 +1355,7 @@ class Commands:
                         namespace.update(script_gnx=script_p.gnx)
                     # We *always* execute the script with p = c.p.
                     callResult = c.executeScriptHelper(
-                        args or [], define_g, define_name, namespace, script
+                        args or [], define_g, define_name, language, namespace, script
                     )
                 except KeyboardInterrupt:
                     g.es('interrupted')
@@ -1380,6 +1380,7 @@ class Commands:
         args: list,
         define_g: bool,
         define_name: str,
+        language: str,
         namespace: dict,
         script: str,
     ) -> Value:
@@ -1404,6 +1405,20 @@ class Commands:
             g.inScript = g.app.inScript = True  # g.inScript is a synonym for g.app.inScript.
             if c.write_script_file:
                 scriptFile = self.writeScriptFile(script)
+                if scriptFile and language == 'python':
+                    from leo.commands import checkerCommands
+
+                    if (
+                        checkerCommands.ruff
+                        and not g.unitTesting
+                        and c.config.getBool('run-ruff-on-write', default=False)
+                    ):
+                        x = checkerCommands.RuffCommand(c)
+                        ok = x.check_script_file(scriptFile)
+                        if not ok:
+                            g.app.syntax_error_files.append(scriptFile)
+                            c.syntaxErrorDialog()
+                            return
                 exec(compile(script, scriptFile or '<string>', 'exec'), d)
             else:
                 exec(script, d)

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -749,7 +749,6 @@ class LeoLog:
         Otherwise, return False.
         """
         c = self.c
-        trace = False and not g.unitTesting
         if not c:
             return False  # PR #4812
         assert c
@@ -811,19 +810,15 @@ class LeoLog:
             if m:
                 filename = m.group(filename_i)  # type:ignore
                 line_number = m.group(line_number_i)  # type:ignore
-                p = find_at_file_node(filename)
-                if p:
+                if p := find_at_file_node(filename):
                     unl = p.get_UNL()
                     found_matches += 1
-                    if trace:
-                        g.trace(f"{p.h} nodeLink: {unl}::-{line_number}")
+                    # g.trace(f"{p.h} nodeLink: {unl}::-{line_number}")
                     self.put(line, nodeLink=f"{unl}::-{line_number}")  # Use global line.
-                else:  # An unusual case.
-                    message = f"no p for {filename!r}"
-                    if g.unitTesting:
-                        raise ValueError(message)
-                        # g.trace(f"{i:2} p not found! {filename!r}")
-                    self.put(line)
+                else:
+                    unl = c.p.get_UNL()
+                    found_matches += 1
+                    self.put(line, nodeLink=f"{unl}::{line_number}")  # Use local line.
             else:  # None of the patterns match.
                 self.put(line)
         return bool(found_matches)


### PR DESCRIPTION
This PR:

- Allows optional checking of Leonine scripts with ruff check.
- Restores the checks (using ruff) that I used to have when using pyflakes and flake8.

### Tasks

- [x] Improve c.executeScriptHelper:
   - Optionally check scripts with ruff, per the recently added `@bool run-ruff-on-write` setting.
   - Optionally raise error dialogs on ruff errors, per existing `@bool syntax-error-popup` setting.
- [x] Add RuffCommand.check_script_file, similar to to RuffCommand.check_file.
- [x] Improve LeoLog.put_html_links: Create better links when the file isn't in the outline.
    For example, leo/test/scriptFile.py isn't usually in the outline!
- [x] Script cruft lines from the strings returned by ruff.
- [x] RuffCommand.check_file: fix a bug: avoid writing duplicate lines to the log.

## Discussion

I was anxious that recent PRs would prevent Leo from generating clickable error links for ruff errors.
I need not have worried.

I also worried that ruff errors would not generate syntax error popup dialogs.
For me, those dialogs are essential. Otherwise, it's too easy to overlook serious errors.
I'm not sure whether this worry was well founded. (How soon I forget). But now all is well.

Imo, this PR shows the dangers of relying too much on AI.
This PR was necessitated by previous PRs, but the AI was clueless.
In fairness, so was I, until I woke up in the middle of the night with worries!