### PR TITLE
Fix ty errors for optional enchant/jedi/nbformat imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,14 +75,14 @@ jobs:
           types-docutils types-Markdown types-paramiko types-PyYAML
           types-requests types-six
           "PyQt6>=6.6" PyQt6-QScintilla PyQt6-WebEngine ty
-          black Jinja2 Pygments
-      # These 3 are optional runtime deps for individual plugins/commands
-      # (leoBeautify.py, viewrendered.py, leoColorizer.py),
-      # each guarded by 'try: import X except: X = None'. Installing them
-      # here matches a typical dev environment (they're common enough to
-      # often be present) so mypy/ty check the same code path CI and
-      # contributors actually see, instead of only the ignore_missing_imports
-      # fallback.
+          black Jinja2 Pygments docutils pyenchant jedi nbformat nbconvert
+      # These are optional runtime deps for individual plugins/commands
+      # (leoBeautify.py, viewrendered.py, leoColorizer.py, spellCommands.py,
+      # leoKeys.py), each guarded by 'try: import X except: X = None'.
+      # Installing them here matches a typical dev environment (they're
+      # common enough to often be present) so mypy/ty check the same code
+      # path CI and contributors actually see, instead of only the
+      # ignore_missing_imports fallback.
       - run: python -m mypy leo
       # ty (https://github.com/astral-sh/ty) is an actively-developed, much
       # faster alternative to mypy, still in beta. It's noticeably stricter

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -13,7 +13,7 @@ from typing import Any, cast, TYPE_CHECKING
 try:
     import enchant
 except Exception:  # May throw WinError(!)
-    enchant = None
+    enchant = None  # type:ignore
 from leo.commands.baseCommands import BaseEditCommandsClass
 from leo.core import leoGlobals as g
 
@@ -82,14 +82,14 @@ class BaseSpellWrapper:
     # @+node:ekr.20180207074613.1: *3* BaseSpellWrapper.default_dict
     def default_dict(self, language: str) -> SpellDict:
         try:
-            return enchant.Dict(language)
+            return enchant.Dict(language)  # type:ignore
         except Exception:
             return {}
 
     # @+node:ekr.20180207073536.1: *3* BaseSpellWrapper.create_dict_from_file
     def create_dict_from_file(self, fn: str, language: str) -> SpellDict:
         try:
-            return enchant.DictWithPWL(language, fn)
+            return enchant.DictWithPWL(language, fn)  # type:ignore
         except Exception:
             return {}
 
@@ -443,7 +443,7 @@ class EnchantWrapper(BaseSpellWrapper):
         if not d:
             g.es_print('Error opening dictionary')
             g.es_print('pip install pyenchant, NOT enchant')
-        return d
+        return d  # type:ignore
 
     # @-others
 

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -23,7 +23,7 @@ from leo.core.leoQt import QtWidgets
 try:
     import jedi
 except ImportError:
-    jedi = None
+    jedi = None  # type:ignore
 # @-<< leoKeys imports >>
 # @+<< leoKeys annotations >>
 # @+node:ekr.20220414165644.1: ** << leoKeys annotations >>
@@ -581,7 +581,7 @@ class AutoCompleterClass:
             try:
                 import jedi
             except ImportError:
-                jedi = None
+                jedi = None  # type:ignore
                 if not self.jedi_warning:
                     self.jedi_warning = True
                     g.es_print('can not import jedi')

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -268,7 +268,7 @@ try:
     import nbformat
     from nbconvert import HTMLExporter
 except ImportError:
-    nbformat = None
+    nbformat = None  # type:ignore
 
 try:
     import pyperclip


### PR DESCRIPTION
## Summary

Fixes #4868.

`ty` infers the declared type of a module from a successful `import x` inside
a `try` block, so the `x = None` fallback in the `except` branch reads as
`invalid-assignment`. `mypy` doesn't catch this today (no type stubs for
these optional deps, so it falls back to implicit `Any`), but `ty` infers
the real module type and flags the reassignment.

- `leo/commands/spellCommands.py`: `enchant = None` fallback, plus 3
  `invalid-return-type` errors where `enchant.Dict`/`DictWithPWL` objects
  are used duck-typed as `SpellDict` (`dict[str, list[str]]`) but aren't
  actual `dict` instances.
- `leo/core/leoKeys.py`: `jedi = None` fallback (module-level and the
  function-local re-import in `get_completions`).
- `leo/plugins/viewrendered.py`: `nbformat = None` fallback.

### Why CI didn't catch this

The `mypy` CI job already runs `ty check` unconditionally (it's not
optional/informational — a comment on that step says it's "clean against
this codebase, so it now blocks the build like mypy does"). But `ty` only
produces these specific errors when `enchant`/`jedi`/`nbformat` are actually
importable, since it needs the real module's type to compare `None`
against. The CI job's pip install line only had `black`/`Jinja2`/`Pygments`
as optional-dependency stand-ins (for `leoBeautify.py`/`leoColorizer.py`),
not these three — so `ty` in CI saw `enchant`/`jedi`/`nbformat` as
unresolved imports (`unresolved-import` is set to `"ignore"` in `ty.toml`),
which erases the "declared type is a module" fact that triggers the error.
The issue reporter hit this locally because their machine happens to have
these optional packages installed. This PR also adds them to the CI
install line (see below) so CI exercises the same path.

### Suppression approach

Suppressed with bare `# type:ignore` comments rather than
`# ty: ignore[<rule>]`. The latter is only valid — i.e. not itself flagged
as an "unused" suppression, which also fails the build — when the optional
package is actually installed at check time, so it would have reintroduced
the exact same "works on my machine, breaks in CI" gap. `viewrendered.py`
already used bare `# type:ignore` for the identical guard pattern
(`docutils`, `jinja2`), and `ty.toml` explicitly disables the
unused-comment check for that form (`unused-type-ignore-comment = "ignore"`),
so it's silent whether or not the optional package is present — verified
both ways locally.

Also added `pyenchant`/`jedi`/`nbformat`/`nbconvert`/`docutils` to the CI
`mypy` job's installs so `ty`/`mypy` exercise the same code path a typical
dev environment would, matching the existing `black`/`Jinja2`/`Pygments`
installs for `leoBeautify.py`/`leoColorizer.py`. This also means CI will
now actually catch a regression of this exact kind in the future.

## Test plan

- [x] `ty check leo` — clean both with and without
      `enchant`/`jedi`/`nbformat`/`nbconvert` installed (verified both ways
      locally, mirroring the gap that let this slip through)
- [x] `python -m mypy leo` — clean (pre-existing unrelated flaky
      `leoShadow.py` has-type errors only appear when checking that file in
      isolation; confirmed present on `devel` too, gone on a full-tree run)
- [x] `ruff check leo` / `ruff format --check leo` — clean
- [x] `python -m pytest leo/unittests` — 864 passed (1 pre-existing
      unrelated flake in `test_g_OptionsUtils`)
- [x] `python -m leo.scripts.check_leo_sync` — `LeoPyRef.leo` in sync
- [x] CI green on this PR: leo-sync, lint (3.10-3.13), mypy, test (3.10-3.13)