### PR TITLE
PR: ruff doesn't understand c, g, p

### DIFF
--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -495,18 +495,15 @@ class RuffCommand:
             'check',
             '--isolated',  # Ignore all configuration files.
             '--config',
-            'lint.flake8-builtins.ignorelist = ["c", "g", "p"]',
+            'builtins=["c", "g", "p"]',
             '--output-format=concise',
-            '--verbose',
             fn,
         ]  # fmt: skip
-        g.trace(command)
         result = subprocess.run(command, capture_output=True, text=True)
         raw_s = (result.stdout + result.stderr).replace('All checks passed!', '').strip()
         # Strip out cruft.
         s = ''.join(z for z in g.splitLines(raw_s) if not z.startswith('Found')).strip()
         s = s.replace(fn, c.p.h)  # A hack.
-        g.printObj(s, tag=g.my_name())
         if s:
             c.frame.log.put_html_links(s)
         return result.returncode == 0

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -488,13 +488,25 @@ class RuffCommand:
         c = self.c
         if not ruff:
             return True
-        return True  ###
-        command = [sys.executable, '-m', 'ruff', 'check', '--output-format=concise', fn]
+        command = [
+            sys.executable,
+            '-m',
+            'ruff',
+            'check',
+            '--isolated',  # Ignore all configuration files.
+            '--config',
+            'lint.flake8-builtins.ignorelist = ["c", "g", "p"]',
+            '--output-format=concise',
+            '--verbose',
+            fn,
+        ]  # fmt: skip
+        g.trace(command)
         result = subprocess.run(command, capture_output=True, text=True)
         raw_s = (result.stdout + result.stderr).replace('All checks passed!', '').strip()
         # Strip out cruft.
         s = ''.join(z for z in g.splitLines(raw_s) if not z.startswith('Found')).strip()
         s = s.replace(fn, c.p.h)  # A hack.
+        g.printObj(s, tag=g.my_name())
         if s:
             c.frame.log.put_html_links(s)
         return result.returncode == 0

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -488,6 +488,7 @@ class RuffCommand:
         c = self.c
         if not ruff:
             return True
+        return True  ###
         command = [sys.executable, '-m', 'ruff', 'check', '--output-format=concise', fn]
         result = subprocess.run(command, capture_output=True, text=True)
         raw_s = (result.stdout + result.stderr).replace('All checks passed!', '').strip()

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1406,12 +1406,9 @@ class Commands:
             if c.write_script_file:
                 scriptFile = self.writeScriptFile(script)
                 if (
-                    False
-                    and scriptFile
-                    and language == 'python'
-                    and not g.unitTesting
+                    scriptFile and language == 'python' and not g.unitTesting
                     and c.config.getBool('run-ruff-on-write', default=False)
-                ):
+                ):  # fmt: skip
                     from leo.commands import checkerCommands
 
                     if checkerCommands.ruff:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1406,7 +1406,8 @@ class Commands:
             if c.write_script_file:
                 scriptFile = self.writeScriptFile(script)
                 if (
-                    scriptFile
+                    False
+                    and scriptFile
                     and language == 'python'
                     and not g.unitTesting
                     and c.config.getBool('run-ruff-on-write', default=False)


### PR DESCRIPTION
Oops! ruff will complain about any Leonine script containing c, g, or p.

- [x] check_script_file: fix the call to subprocess.run.
- [x] executeScriptHelper: reformat a test.

