### PR TITLE
ruff.check_script_file: recognize c, g, p as script-injected builtins

### DIFF
--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -488,7 +488,21 @@ class RuffCommand:
         c = self.c
         if not ruff:
             return True
-        command = [sys.executable, '-m', 'ruff', 'check', '--output-format=concise', fn]
+        command = [
+            sys.executable,
+            '-m',
+            'ruff',
+            'check',
+            # Scripts get c, g and p injected into their namespace at exec time
+            # (see executeScriptHelper), so ruff can't see them as defined.
+            # --isolated skips any ancestor pyproject.toml/ruff.toml so this
+            # allowance can't leak into (or be overridden by) project-wide config.
+            '--isolated',
+            '--config',
+            'builtins=["c", "g", "p"]',
+            '--output-format=concise',
+            fn,
+        ]
         result = subprocess.run(command, capture_output=True, text=True)
         raw_s = (result.stdout + result.stderr).replace('All checks passed!', '').strip()
         # Strip out cruft.

--- a/leo/core/LeoPyRef.leo
+++ b/leo/core/LeoPyRef.leo
@@ -992,7 +992,7 @@ c.backup_helper(sub_dir='leoPy')
 <t tx="ekr.20150514035207.1"></t>
 <t tx="ekr.20160122104332.1">@language python
 </t>
-<t tx="ekr.20160123142722.1" _mod_time="4741da9d31854271d22e"># An example configuration file for make_stub_files.py.
+<t tx="ekr.20160123142722.1" _mod_time="4741da9d82292243352e"># An example configuration file for make_stub_files.py.
 # By default, this is ~/stubs/make_stub_files.cfg.
 # Can be changed using the --config=path command-line option.
 
@@ -1076,9 +1076,9 @@ print('done! wrote %s' % fn)
 <t tx="ekr.20180225010913.1"></t>
 <t tx="ekr.20180504191650.36"></t>
 <t tx="ekr.20180504191650.42"></t>
-<t tx="ekr.20180504191650.68" _mod_time="4741da9d31854421032e"></t>
+<t tx="ekr.20180504191650.68" _mod_time="4741da9d8229242b422e"></t>
 <t tx="ekr.20180504192522.1"></t>
-<t tx="ekr.20180708145905.1" _mod_time="4741da9d31854271d22e">@language rest
+<t tx="ekr.20180708145905.1" _mod_time="4741da9d82292243352e">@language rest
 @wrap
 
 This is the theory of operation document for py2cs.py. The most interesting aspect of this script is the TokenSync class. This class provides a reliable way of associating tokenizer tokens with ast nodes.
@@ -1880,7 +1880,7 @@ assert core_p and command_p and globals_p
     # 'toString', 'toUnicode', 'trace', 'translateString',
     # 'underline', 'undoHelper', 'unl', 'values', 'visit',
     # 'warn', 'warning', 'word',</t>
-<t tx="ekr.20220823195205.1" _mod_time="4741da9d318542633b2e">"""
+<t tx="ekr.20220823195205.1" _mod_time="4741da9d8229222f2a2e">"""
 Stand alone GUI free index builder for Leo's full text search system::
 
   python leoftsindex.py &lt;file1&gt; &lt;file2&gt; &lt;file3&gt;...
@@ -2043,7 +2043,7 @@ writers = 'leo.unittests.plugins.test_writers'
 # f"{plugins}.test_plugins",
 # f"{plugins}.test_writers",
 </t>
-<t tx="ekr.20230624114517.1" _mod_time="4741da9d318543cb102e"></t>
+<t tx="ekr.20230624114517.1" _mod_time="4741da9d822923cb5e2e"></t>
 <t tx="ekr.20230720115916.1">g.cls()
 import leo.commands.editFileCommands as efc
 
@@ -2128,7 +2128,7 @@ print('done')</t>
 <t tx="ekr.20240107154430.1"></t>
 <t tx="ekr.20240204082420.1"></t>
 <t tx="ekr.20240204082924.1"></t>
-<t tx="ekr.20240206161713.1" _mod_time="4741da9d914a2fa23d2e">@language ini
+<t tx="ekr.20240206161713.1" _mod_time="4741da9db9cc700b562e">@language ini
 
 [bdist_wheel]
 
@@ -2140,7 +2140,7 @@ universal=0
 # Becomes the home-page in `pip show leo`.
 url = https://leo-editor.github.io/leo-editor/
 </t>
-<t tx="ekr.20240317061516.1" _mod_time="4741da9d31853186802e">@language python
+<t tx="ekr.20240317061516.1" _mod_time="4741da9d82290f69ed2e">@language python
 
 # Order matters!
 


### PR DESCRIPTION
## Summary

#4869 added `run-ruff-on-write`/execute-script checking via `RuffCommand.check_script_file`, but ruff's F821 (undefined-name) flags `c`, `g`, `p` in virtually every script, since those are injected into the exec namespace by `executeScriptHelper` rather than imported. #4872 works around this by disabling the check entirely (`return True  ###` / `False and scriptFile`).

This PR fixes the actual cause instead: pass ruff an isolated, inline config that allowlists `c`, `g`, `p` as builtins for this one check, so real undefined-name errors in scripts are still caught.

```python
command = [
    sys.executable, '-m', 'ruff', 'check',
    '--isolated',
    '--config', 'builtins=["c", "g", "p"]',
    '--output-format=concise', fn,
]
```

`--isolated` means this allowlist can't leak into (or be shadowed by) the project's own `ruff.toml`/`pyproject.toml` — it only applies to this one-off script check.

This should supersede #4872's disable.

## Test plan
- [x] `ruff check leo/commands/checkerCommands.py` — passes
- [x] `ruff format --check leo/commands/checkerCommands.py` — passes
- [x] `python -m mypy leo/commands/checkerCommands.py` — clean (pre-existing unrelated `leoShadow.py` has-type errors aside)
- [x] `pytest leo/unittests -k checker` — passes
- [x] Manually verified via `leoBridge`: a script using `c`/`g`/`p` now passes `check_script_file`; a script with a genuinely undefined name still fails it