### PR TITLE
Spike: LSP-backed completions + live diagnostics via ty server (#4871)

### DIFF
--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -446,7 +446,9 @@ class AutoCompleterClass:
         elif ch == 'Escape':
             self.exit()
         elif ch in ('\t', 'Tab'):
-            self.compute_completion_list()
+            common_prefix, prefix, tabList = self.compute_completion_list()
+            if self.use_lsp and tabList and len(common_prefix) > len(prefix):
+                self.insert_string(common_prefix[len(prefix) :])
         elif ch in ('\b', 'BackSpace'):
             self.do_backspace()
         elif ch == '.':
@@ -1173,7 +1175,9 @@ class AutoCompleterClass:
             # @verbatim
             # @bool auto_tab_complete is deprecated.
             # Auto-completion makes no sense if it is False.
-            elif self.auto_tab and len(common_prefix) > len(prefix):
+            # LSP completion is filter-only while typing. Tab explicitly
+            # accepts the common prefix in auto_completer_state_handler.
+            elif self.auto_tab and not self.use_lsp and len(common_prefix) > len(prefix):
                 extend = common_prefix[len(prefix) :]
                 ins = w.getInsertPoint()
                 if trace:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -19,7 +19,8 @@ from leo.core import leoGlobals as g
 from leo.external import codewise
 from leo.external import leo_lsp_client
 from leo.core.leoFrame import NullLog
-from leo.core.leoQt import QtWidgets
+from leo.core.leoQt import QtGui, QtWidgets
+from leo.core.leoQt import MoveMode, UnderlineStyle
 
 try:
     import jedi
@@ -864,7 +865,7 @@ class AutoCompleterClass:
         truncated_lines[target_line_no] = truncated_lines[target_line_no][:column] + '\n'
         truncated_source = ''.join(truncated_lines)
 
-        abs_path = os.path.abspath(fileName)
+        abs_path = g.fullPath(c, root)
         try:
             client = leo_lsp_client.get_client(self.lsp_command.split(), os.path.dirname(abs_path))
         except Exception:
@@ -875,7 +876,107 @@ class AutoCompleterClass:
         names = sorted(
             {it.get('label', '') for it in items if it.get('label', '').startswith(typed)}
         )
+        # The server's last-known document is now the *truncated* copy, which
+        # would make diagnostics lie about the missing tail of this line
+        # (e.g. flag an unmatched paren that only exists because we cut the
+        # line short). Push the real source back so the next
+        # publishDiagnostics notification -- which show_lsp_diagnostics reads,
+        # possibly one keystroke later since it's async -- reflects the truth.
+        client.sync_document(uri, source)
+        self.show_lsp_diagnostics()
         return [self.add_prefix(prefix, z) for z in names]
+
+    # @+node:spike4871.20260808130000.1: *5* ac.get_lsp_diagnostics_for_node
+    def get_lsp_diagnostics_for_node(self) -> list[tuple[int, int, int, int, str]]:
+        """
+        Spike for #4871: return (start_row, start_col, end_row, end_col,
+        message) tuples, in NODE-LOCAL coordinates, for whatever diagnostics
+        the LSP client currently has cached for c.p's @file root.
+
+        Doesn't talk to the server -- reads whatever the last
+        publishDiagnostics notification put in LspClient.diagnostics, so
+        it's only as fresh as the last sync_document call (see
+        get_lsp_completions).
+        """
+        c = self.c
+        p = c.p
+        body_s = p.b
+        goto = c.gotoCommands
+        root, fileName = goto.find_root(p)
+        if not root or not fileName:
+            return []
+        source = goto.get_external_file_with_sentinels(root=root)
+        n0 = goto.find_node_start(p=p, s=source)
+        if n0 is None:
+            return []
+        lines = g.splitLines(body_s)
+        source_lines = g.splitLines(source)
+        n1 = n0 + len(lines)
+
+        # Every line of a node is written with the same constant indent
+        # offset relative to p.b -- that's how Leo derives external files,
+        # via @others expansion -- so one delta (from the node's first
+        # non-blank line) applies to every diagnostic in the node.
+        delta = 0
+        for local_line, global_line in zip(lines, source_lines[n0:n1]):
+            if local_line.strip():
+                delta = (len(global_line) - len(global_line.lstrip())) - (
+                    len(local_line) - len(local_line.lstrip())
+                )
+                break
+
+        abs_path = g.fullPath(c, root)
+        uri = 'file://' + abs_path
+        try:
+            client = leo_lsp_client.get_client(self.lsp_command.split(), os.path.dirname(abs_path))
+        except Exception:
+            return []
+        results = []
+        for d in client.diagnostics.get(uri, []):
+            rng = d.get('range', {})
+            start, end = rng.get('start', {}), rng.get('end', {})
+            srow, erow = start.get('line', -1), end.get('line', -1)
+            if not (n0 <= srow < n1 and n0 <= erow < n1):
+                continue  # Diagnostic belongs to another node in this file.
+            results.append(
+                (
+                    srow - n0,
+                    max(0, start.get('character', 0) - delta),
+                    erow - n0,
+                    max(0, end.get('character', 0) - delta),
+                    d.get('message', ''),
+                )
+            )
+        return results
+
+    # @+node:spike4871.20260808130000.2: *5* ac.show_lsp_diagnostics
+    def show_lsp_diagnostics(self) -> None:
+        """
+        Spike for #4871: render get_lsp_diagnostics_for_node's results as
+        wavy red underlines in the body pane -- the "live squigglies" half
+        of the issue. Qt only; a harmless no-op under other guis.
+        """
+        c = self.c
+        widget = c.frame.body.wrapper.widget
+        if not isinstance(widget, QtWidgets.QTextEdit):
+            return
+        doc = widget.document()
+        selections = []
+        for srow, scol, erow, ecol, message in self.get_lsp_diagnostics_for_node():
+            start_block = doc.findBlockByNumber(srow)
+            end_block = doc.findBlockByNumber(erow)
+            if not start_block.isValid() or not end_block.isValid():
+                continue
+            cursor = QtGui.QTextCursor(start_block)
+            cursor.setPosition(start_block.position() + scol)
+            cursor.setPosition(end_block.position() + ecol, MoveMode.KeepAnchor)
+            selection = widget.ExtraSelection()
+            selection.cursor = cursor
+            selection.format.setUnderlineStyle(UnderlineStyle.WaveUnderline)
+            selection.format.setUnderlineColor(QtGui.QColor('red'))
+            selection.format.setToolTip(message)
+            selections.append(selection)
+        widget.setExtraSelections(selections)
 
     # @+node:ekr.20110509064011.14557: *5* ac.get_leo_completions
     def get_leo_completions(self, prefix: str) -> list[str]:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -17,6 +17,7 @@ import time
 from typing import Any, cast, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.external import codewise
+from leo.external import leo_lsp_client
 from leo.core.leoFrame import NullLog
 from leo.core.leoQt import QtWidgets
 
@@ -207,6 +208,9 @@ class AutoCompleterClass:
         self.auto_tab = c.config.getBool('auto-tab-complete', True)
         self.forbid_invalid = c.config.getBool('forbid-invalid-completions', False)
         self.use_jedi = c.config.getBool('use-jedi', False)
+        # Spike for #4871: LSP-backed completions. See ac.get_lsp_completions.
+        self.use_lsp = c.config.getBool('use-lsp', False)
+        self.lsp_command = c.config.getString('lsp-command') or 'ty server'
         # True: show results in autocompleter tab.
         # False: show results in a QCompleter widget.
         self.use_qcompleter = c.config.getBool('use-qcompleter', False)
@@ -575,8 +579,12 @@ class AutoCompleterClass:
     jedi_warning = False
 
     def get_completions(self, prefix: str) -> list[str]:
-        """Return jedi or codewise completions."""
+        """Return lsp, jedi, or codewise completions."""
         d = self.completionsDict
+        if self.use_lsp:
+            aList = self.get_lsp_completions(prefix) or self.get_leo_completions(prefix)
+            d[prefix] = aList
+            return aList
         if self.use_jedi:
             try:
                 import jedi
@@ -794,6 +802,76 @@ class AutoCompleterClass:
             aList = prefix.split('.')
             prefix = '.'.join(aList[:-1]) + '.'
         return s if s.startswith(prefix) else prefix + s
+
+    # @+node:spike4871.20260808120000.1: *5* ac.get_lsp_completions (spike, #4871)
+    def get_lsp_completions(self, prefix: str) -> list[str]:
+        """
+        Spike for #4871: return completions from an LSP server (default:
+        `ty server`) instead of jedi.
+
+        Reuses get_jedi_completions' source-reconstruction and
+        position-mapping: turning a node-local row/col into a file-global
+        row/col is the same problem no matter which backend answers the
+        completion request.
+
+        Only handles @file-backed nodes: an LSP server wants a real
+        `file://` URI, per the design sketched in #4871 (no virtual-document
+        scheme). Falls back to get_leo_completions otherwise.
+        """
+        c = self.c
+        w = c.frame.body.wrapper
+        i = w.getInsertPoint()
+        p = c.p
+        body_s = p.b
+
+        goto = c.gotoCommands
+        root, fileName = goto.find_root(p)
+        if not root or not fileName:
+            return []
+        source = goto.get_external_file_with_sentinels(root=root)
+        n0 = goto.find_node_start(p=p, s=source) or 0
+
+        lines = g.splitLines(body_s)
+        row, column = g.convertPythonIndexToRowCol(body_s, i)
+        if row >= len(lines):
+            return []
+        line = lines[row]
+
+        source_lines = g.splitLines(source)
+        for lsp_line, g_line in enumerate(source_lines[n0:]):
+            if line.lstrip() == g_line.lstrip():
+                indent1 = len(line) - len(line.lstrip())
+                indent2 = len(g_line) - len(g_line.lstrip())
+                if indent2 >= indent1:
+                    column += abs(indent2 - indent1)
+                    break
+        else:
+            return []
+
+        # ty only returns completions when there's no text after the cursor
+        # on the same physical line (confirmed by spiking: a dangling "self."
+        # at true end-of-line returns members; the identical dot mid-line,
+        # with real code continuing after the cursor, returns nothing, even
+        # one character further in). That's fine for the common
+        # type-then-complete flow (cursor sits at the true end of the typed
+        # text), but it's a real maturity gap next to jedi, which handles
+        # mid-line completion without trouble -- worth keeping in mind
+        # against the pyright fallback #4871 already flags.
+        dot = prefix.rfind('.')
+        typed = prefix[dot + 1 :] if dot != -1 else prefix
+
+        abs_path = os.path.abspath(fileName)
+        try:
+            client = leo_lsp_client.get_client(self.lsp_command.split(), os.path.dirname(abs_path))
+        except Exception:
+            return []
+        uri = 'file://' + abs_path
+        client.sync_document(uri, source)
+        items = client.completions(uri, line=n0 + lsp_line, character=column)
+        names = sorted(
+            {it.get('label', '') for it in items if it.get('label', '').startswith(typed)}
+        )
+        return [self.add_prefix(prefix, z) for z in names]
 
     # @+node:ekr.20110509064011.14557: *5* ac.get_leo_completions
     def get_leo_completions(self, prefix: str) -> list[str]:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -19,7 +19,7 @@ from leo.core import leoGlobals as g
 from leo.external import codewise
 from leo.external import leo_lsp_client
 from leo.core.leoFrame import NullLog
-from leo.core.leoQt import QtGui, QtWidgets
+from leo.core.leoQt import QtCore, QtGui, QtWidgets
 from leo.core.leoQt import MoveMode, UnderlineStyle
 
 try:
@@ -202,6 +202,7 @@ class AutoCompleterClass:
         # Codewise pre-computes...
         self.codewiseSelfList: list[str] = []  # The (global) completions for "self."
         self.completionsDict: dict[str, list[str]] = {}  # keys: prefixes. values: completion lists.
+        self.lsp_change_serial = 0
         self.reloadSettings()
 
     def reloadSettings(self) -> None:
@@ -868,9 +869,10 @@ class AutoCompleterClass:
         abs_path = g.fullPath(c, root)
         try:
             client = leo_lsp_client.get_client(self.lsp_command.split(), os.path.dirname(abs_path))
-        except Exception:
+        except Exception as exception:
+            g.es_print(f"LSP: could not start server: {exception!r}")
             return []
-        uri = 'file://' + abs_path
+        uri = leo_lsp_client.path_to_uri(abs_path)
         client.sync_document(uri, truncated_source)
         items = client.completions(uri, line=target_line_no, character=column)
         names = sorted(
@@ -885,6 +887,82 @@ class AutoCompleterClass:
         client.sync_document(uri, source)
         self.show_lsp_diagnostics()
         return [self.add_prefix(prefix, z) for z in names]
+
+    # @+node:spike4871.20260808130000.3: *5* ac.schedule_lsp_diagnostics & helpers
+    def schedule_lsp_diagnostics(self) -> None:
+        """Debounce an LSP document sync after a body-pane edit."""
+        if not self.use_lsp or not self.c.exists:
+            return
+        self.lsp_change_serial += 1
+        serial = self.lsp_change_serial
+        QtCore.QTimer.singleShot(300, lambda: self.sync_lsp_diagnostics(serial))
+
+    def sync_lsp_diagnostics(self, serial: int) -> None:
+        """Sync the current @file document and schedule asynchronous rendering."""
+        if serial != self.lsp_change_serial or not self.c.exists:
+            return
+        c, p = self.c, self.c.p
+        goto = c.gotoCommands
+        root, fileName = goto.find_root(p)
+        if not root or not fileName:
+            return
+        source = goto.get_external_file_with_sentinels(root=root)
+        abs_path = g.fullPath(c, root)
+        uri = leo_lsp_client.path_to_uri(abs_path)
+        try:
+            client = leo_lsp_client.get_client(self.lsp_command.split(), os.path.dirname(abs_path))
+            client.sync_document(uri, source)
+        except Exception as exception:
+            g.es_print(f"LSP: diagnostic sync failed: {exception!r}")
+            return
+        # publishDiagnostics is asynchronous. Repaint quickly when possible,
+        # then again after slower initial workspace indexing.
+        for delay in (100, 500, 1500):
+            QtCore.QTimer.singleShot(
+                delay, lambda serial=serial: self.render_lsp_diagnostics(serial)
+            )
+
+    def render_lsp_diagnostics(self, serial: int) -> None:
+        """Render diagnostics unless a newer body edit superseded this sync."""
+        if serial == self.lsp_change_serial and self.c.exists:
+            self.show_lsp_diagnostics()
+
+    def get_lsp_hover(self, body_position: int) -> str:
+        """Return LSP hover text for a body-pane character position."""
+        if not self.use_lsp:
+            return ''
+        c, p = self.c, self.c.p
+        body_s = p.b
+        row, column = g.convertPythonIndexToRowCol(body_s, body_position)
+        lines = g.splitLines(body_s)
+        if row >= len(lines):
+            return ''
+        goto = c.gotoCommands
+        root, fileName = goto.find_root(p)
+        if not root or not fileName:
+            return ''
+        source = goto.get_external_file_with_sentinels(root=root)
+        n0 = goto.find_node_start(p=p, s=source)
+        if n0 is None:
+            return ''
+        source_lines = g.splitLines(source)
+        target_row = n0 + row
+        if target_row >= len(source_lines):
+            return ''
+        local_line = lines[row]
+        global_line = source_lines[target_row]
+        column += max(
+            0,
+            (len(global_line) - len(global_line.lstrip()))
+            - (len(local_line) - len(local_line.lstrip())),
+        )
+        abs_path = g.fullPath(c, root)
+        uri = leo_lsp_client.path_to_uri(abs_path)
+        try:
+            client = leo_lsp_client.get_client(self.lsp_command.split(), os.path.dirname(abs_path))
+            return client.hover(uri, target_row, column)
+        except Exception:
+            return ''
 
     # @+node:spike4871.20260808130000.1: *5* ac.get_lsp_diagnostics_for_node
     def get_lsp_diagnostics_for_node(self) -> list[tuple[int, int, int, int, str]]:
@@ -926,10 +1004,11 @@ class AutoCompleterClass:
                 break
 
         abs_path = g.fullPath(c, root)
-        uri = 'file://' + abs_path
+        uri = leo_lsp_client.path_to_uri(abs_path)
         try:
             client = leo_lsp_client.get_client(self.lsp_command.split(), os.path.dirname(abs_path))
-        except Exception:
+        except Exception as exception:
+            g.es_print(f"LSP: could not read diagnostics: {exception!r}")
             return []
         results = []
         for d in client.diagnostics.get(uri, []):
@@ -962,7 +1041,8 @@ class AutoCompleterClass:
             return
         doc = widget.document()
         selections = []
-        for srow, scol, erow, ecol, message in self.get_lsp_diagnostics_for_node():
+        diagnostics = self.get_lsp_diagnostics_for_node()
+        for srow, scol, erow, ecol, message in diagnostics:
             start_block = doc.findBlockByNumber(srow)
             end_block = doc.findBlockByNumber(erow)
             if not start_block.isValid() or not end_block.isValid():
@@ -976,7 +1056,11 @@ class AutoCompleterClass:
             selection.format.setUnderlineColor(QtGui.QColor('red'))
             selection.format.setToolTip(message)
             selections.append(selection)
-        widget.setExtraSelections(selections)
+        widget.leo_lsp_selections = selections
+        if hasattr(widget, 'highlightCurrentLine'):
+            widget.highlightCurrentLine()
+        else:
+            widget.setExtraSelections(selections)
 
     # @+node:ekr.20110509064011.14557: *5* ac.get_leo_completions
     def get_leo_completions(self, prefix: str) -> list[str]:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -852,13 +852,17 @@ class AutoCompleterClass:
         # on the same physical line (confirmed by spiking: a dangling "self."
         # at true end-of-line returns members; the identical dot mid-line,
         # with real code continuing after the cursor, returns nothing, even
-        # one character further in). That's fine for the common
-        # type-then-complete flow (cursor sits at the true end of the typed
-        # text), but it's a real maturity gap next to jedi, which handles
-        # mid-line completion without trouble -- worth keeping in mind
-        # against the pyright fallback #4871 already flags.
+        # one character further in). Work around it with a "phantom EOL":
+        # send the server a copy of the source with just the cursor's line
+        # truncated at the cursor, so it always sees end-of-line there. The
+        # untruncated `source` is still what get_jedi_completions/future
+        # diagnostics work with -- this copy exists only for this request.
         dot = prefix.rfind('.')
         typed = prefix[dot + 1 :] if dot != -1 else prefix
+        target_line_no = n0 + lsp_line
+        truncated_lines = list(source_lines)
+        truncated_lines[target_line_no] = truncated_lines[target_line_no][:column] + '\n'
+        truncated_source = ''.join(truncated_lines)
 
         abs_path = os.path.abspath(fileName)
         try:
@@ -866,8 +870,8 @@ class AutoCompleterClass:
         except Exception:
             return []
         uri = 'file://' + abs_path
-        client.sync_document(uri, source)
-        items = client.completions(uri, line=n0 + lsp_line, character=column)
+        client.sync_document(uri, truncated_source)
+        items = client.completions(uri, line=target_line_no, character=column)
         names = sorted(
             {it.get('label', '') for it in items if it.get('label', '').startswith(typed)}
         )

--- a/leo/external/leo_lsp_client.py
+++ b/leo/external/leo_lsp_client.py
@@ -49,7 +49,13 @@ import os
 import subprocess
 import threading
 import time
+from pathlib import Path
 from typing import Any
+
+
+def path_to_uri(path: str) -> str:
+    """Return a standards-compliant absolute file URI on every platform."""
+    return Path(path).resolve().as_uri()
 
 
 class LspClient:
@@ -82,10 +88,11 @@ class LspClient:
             'initialize',
             {
                 'processId': os.getpid(),
-                'rootUri': 'file://' + self.root_path,
+                'rootUri': path_to_uri(self.root_path),
                 'capabilities': {
                     'textDocument': {
                         'completion': {'completionItem': {'snippetSupport': False}},
+                        'hover': {'contentFormat': ['plaintext', 'markdown']},
                         'publishDiagnostics': {},
                     },
                 },
@@ -193,6 +200,40 @@ class LspClient:
             return []
         items = result.get('items', []) if isinstance(result, dict) else result
         return items or []
+
+    def hover(self, uri: str, line: int, character: int, timeout: float = 2.0) -> str:
+        """Return plain hover text at the given 0-based position."""
+        try:
+            response = self.request(
+                'textDocument/hover',
+                {
+                    'textDocument': {'uri': uri},
+                    'position': {'line': line, 'character': character},
+                },
+                timeout=timeout,
+            )
+        except TimeoutError:
+            return ''
+        result = response.get('result')
+        if not isinstance(result, dict):
+            return ''
+        contents = result.get('contents', '')
+        if isinstance(contents, str):
+            text = contents
+        elif isinstance(contents, dict):
+            text = contents.get('value', '')
+        elif isinstance(contents, list):
+            parts = [z.get('value', '') if isinstance(z, dict) else str(z) for z in contents]
+            text = '\n\n'.join(z for z in parts if z)
+        else:
+            return ''
+        # LSP markdown commonly wraps type signatures in a fenced code block.
+        lines = text.splitlines()
+        if lines and lines[0].startswith('```'):
+            lines = lines[1:]
+        if lines and lines[-1] == '```':
+            lines = lines[:-1]
+        return '\n'.join(lines).strip()
 
     def shutdown(self) -> None:
         if not self._started or self.proc is None:

--- a/leo/external/leo_lsp_client.py
+++ b/leo/external/leo_lsp_client.py
@@ -33,12 +33,14 @@ Python language server, `pip install ty`):
   end-of-line returns members; the identical position with real code
   continuing after the cursor on the same line (e.g. mid-edit of an
   existing statement) returns nothing, even one character further in.
-  It *does* do server-side prefix filtering once positioned correctly
-  (`self.f` at end-of-line returns only names starting with `f`), so
-  no client-side re-implementation of that part was needed. This is a
-  real maturity gap next to jedi, which completes mid-line without
-  trouble -- see `AutoCompleterClass.get_lsp_completions` in
-  leoKeys.py, and the pyright-as-fallback note already in #4871.
+  Worked around with a "phantom EOL": `get_lsp_completions` sends a copy
+  of the source with just the cursor's line truncated at the cursor, so
+  the server always sees end-of-line there (confirmed this restores
+  mid-line completions). The untruncated source is unaffected -- the
+  truncated copy exists only for that one completion request.
+  `ty` *does* do server-side prefix filtering once positioned correctly
+  (`self.f` at end-of-line returns only names starting with `f`), so no
+  client-side re-implementation of that part was needed.
 """
 
 from __future__ import annotations

--- a/leo/external/leo_lsp_client.py
+++ b/leo/external/leo_lsp_client.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python
+"""
+Spike / proof-of-concept LSP client for issue #4871.
+
+https://github.com/leo-editor/leo-editor/issues/4871
+
+Goal of the spike: prove that a *generic* LSP client (any conforming
+server, not a jedi-shaped API) can drive Leo's body-pane completions,
+reusing the existing jedi position-mapping logic in
+leoKeys.py::AutoCompleterClass.get_jedi_completions.
+
+This is deliberately minimal and NOT production code:
+
+- Synchronous request/response (blocks the caller while waiting for
+  the server). The real implementation described in #4871 would need
+  an async round trip with a callback, since cold-start indexing can
+  be slow.
+- No process crash/restart handling.
+- No per-@language server selection (`@data language-servers`):
+  the caller passes the server command explicitly.
+- Diagnostics are collected but nothing in Leo consumes them yet;
+  they're exposed on LspClient.diagnostics for a future body-pane
+  squiggly-underline feature to read.
+
+Protocol notes discovered while spiking against `ty server` (Astral's
+Python language server, `pip install ty`):
+
+- Completion requests need an *absolute* `file://` URI. A relative
+  path is treated as an opaque URI and diagnostics/completions for it
+  silently fail.
+- `ty` only returns completions -- member or otherwise -- when there is
+  no text after the cursor on that physical line. `self.` at true
+  end-of-line returns members; the identical position with real code
+  continuing after the cursor on the same line (e.g. mid-edit of an
+  existing statement) returns nothing, even one character further in.
+  It *does* do server-side prefix filtering once positioned correctly
+  (`self.f` at end-of-line returns only names starting with `f`), so
+  no client-side re-implementation of that part was needed. This is a
+  real maturity gap next to jedi, which completes mid-line without
+  trouble -- see `AutoCompleterClass.get_lsp_completions` in
+  leoKeys.py, and the pyright-as-fallback note already in #4871.
+"""
+
+from __future__ import annotations
+import json
+import os
+import subprocess
+import threading
+import time
+from typing import Any
+
+
+class LspClient:
+    """A blocking client for one LSP server subprocess."""
+
+    def __init__(self, command: list[str], root_path: str) -> None:
+        self.command = command
+        self.root_path = root_path
+        self.proc: subprocess.Popen | None = None
+        self.diagnostics: dict[str, list[dict]] = {}  # uri -> latest diagnostics.
+        self._id = 0
+        self._lock = threading.Lock()
+        self._pending: dict[int, dict] = {}
+        self._doc_versions: dict[str, int] = {}
+        self._started = False
+
+    def start(self, timeout: float = 10.0) -> None:
+        """Spawn the server and perform the initialize/initialized handshake."""
+        if self._started:
+            return
+        self._started = True
+        self.proc = subprocess.Popen(
+            self.command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        threading.Thread(target=self._read_loop, daemon=True).start()
+        self.request(
+            'initialize',
+            {
+                'processId': os.getpid(),
+                'rootUri': 'file://' + self.root_path,
+                'capabilities': {
+                    'textDocument': {
+                        'completion': {'completionItem': {'snippetSupport': False}},
+                        'publishDiagnostics': {},
+                    },
+                },
+            },
+            timeout=timeout,
+        )
+        self.notify('initialized', {})
+
+    def _read_loop(self) -> None:
+        """Runs in a daemon thread: demux responses (by id) from notifications."""
+        stdout = self.proc.stdout
+        buf = b''
+        while True:
+            chunk = stdout.read(1)
+            if not chunk:
+                break
+            buf += chunk
+            if not buf.endswith(b'\r\n\r\n'):
+                continue
+            length = 0
+            for header in buf.decode('ascii', errors='replace').split('\r\n'):
+                if header.lower().startswith('content-length'):
+                    length = int(header.split(':', 1)[1].strip())
+            buf = b''
+            body = stdout.read(length)
+            try:
+                msg = json.loads(body)
+            except ValueError:
+                continue
+            if 'id' in msg and ('result' in msg or 'error' in msg):
+                with self._lock:
+                    self._pending[msg['id']] = msg
+            elif msg.get('method') == 'textDocument/publishDiagnostics':
+                params = msg.get('params', {})
+                self.diagnostics[params.get('uri', '')] = params.get('diagnostics', [])
+
+    def _send(self, payload: dict) -> None:
+        data = json.dumps(payload).encode('utf-8')
+        header = f"Content-Length: {len(data)}\r\n\r\n".encode('ascii')
+        self.proc.stdin.write(header + data)
+        self.proc.stdin.flush()
+
+    def request(self, method: str, params: Any, timeout: float = 10.0) -> dict:
+        """Send a request and block until the matching response arrives."""
+        with self._lock:
+            self._id += 1
+            msg_id = self._id
+        self._send({'jsonrpc': '2.0', 'id': msg_id, 'method': method, 'params': params})
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            with self._lock:
+                if msg_id in self._pending:
+                    return self._pending.pop(msg_id)
+            time.sleep(0.01)
+        raise TimeoutError(f"leo_lsp_client: no response to {method!r}")
+
+    def notify(self, method: str, params: Any) -> None:
+        self._send({'jsonrpc': '2.0', 'method': method, 'params': params})
+
+    def sync_document(self, uri: str, text: str, language_id: str = 'python') -> None:
+        """didOpen the first time a uri is seen, full-text didChange after."""
+        version = self._doc_versions.get(uri)
+        if version is None:
+            self._doc_versions[uri] = 1
+            self.notify(
+                'textDocument/didOpen',
+                {
+                    'textDocument': {
+                        'uri': uri,
+                        'languageId': language_id,
+                        'version': 1,
+                        'text': text,
+                    },
+                },
+            )
+        else:
+            version += 1
+            self._doc_versions[uri] = version
+            self.notify(
+                'textDocument/didChange',
+                {
+                    'textDocument': {'uri': uri, 'version': version},
+                    'contentChanges': [{'text': text}],
+                },
+            )
+
+    def completions(self, uri: str, line: int, character: int, timeout: float = 5.0) -> list[dict]:
+        """Return raw LSP CompletionItem dicts at the given 0-based position."""
+        try:
+            response = self.request(
+                'textDocument/completion',
+                {
+                    'textDocument': {'uri': uri},
+                    'position': {'line': line, 'character': character},
+                    'context': {'triggerKind': 1},
+                },
+                timeout=timeout,
+            )
+        except TimeoutError:
+            return []
+        if 'error' in response:
+            return []
+        result = response.get('result')
+        if result is None:
+            return []
+        items = result.get('items', []) if isinstance(result, dict) else result
+        return items or []
+
+    def shutdown(self) -> None:
+        if not self._started or self.proc is None:
+            return
+        try:
+            self.request('shutdown', None, timeout=2)
+            self.notify('exit', None)
+        except Exception:
+            pass
+        try:
+            self.proc.terminate()
+        except Exception:
+            pass
+
+
+# One client per (command, root_path), kept alive for the process lifetime.
+# Matches the "spawn once per session" note in #4871; there's no eviction,
+# which is fine for a spike but would need addressing for real use
+# (closing Leo should shut these down; a long session with many
+# different @file roots would otherwise accumulate server processes).
+_clients: dict[str, LspClient] = {}
+
+
+def get_client(command: list[str], root_path: str) -> LspClient:
+    """Return the (lazily started) LspClient for this server command + root."""
+    key = f"{' '.join(command)}::{root_path}"
+    client = _clients.get(key)
+    if client is None:
+        client = LspClient(command, root_path)
+        client.start()
+        _clients[key] = client
+    return client

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -158,6 +158,7 @@ class QTextMixin:
         """Ctor for QTextMixin class"""
         self.c = c
         self.changingText = False  # A lockout for onTextChanged.
+
         self.enabled = True
         self.tags: dict[str, str] = {}
         self.permanent = True  # False if selecting the minibuffer will make the widget go away.
@@ -192,6 +193,7 @@ class QTextMixin:
         # because it generates no events in the body pane.
         if not name.startswith('body'):
             return
+        c.k.autoCompleter.schedule_lsp_diagnostics()
         if hasattr(c.frame, 'statusLine'):
             c.frame.statusLine.update()
 
@@ -231,6 +233,7 @@ class QTextMixin:
             newInsert=newInsert,
             newSel=newSel,
         )
+        c.k.autoCompleter.schedule_lsp_diagnostics()
 
     # @+node:ekr.20140901122110.18734: *3* QTextMixin.Generic high-level interface
     # These call only wrapper methods.
@@ -565,6 +568,7 @@ if QtWidgets:
             # Connect event handlers...
             self.cursorPositionChanged.connect(self.highlightCurrentLine)
             self.textChanged.connect(self.highlightCurrentLine)
+            self.viewport().installEventFilter(self)
             self.setContextMenuPolicy(ContextMenuPolicy.CustomContextMenu)
             self.customContextMenuRequested.connect(self.onContextMenu)
             # This event handler is the easy way to keep track of the vertical scroll position.
@@ -585,6 +589,27 @@ if QtWidgets:
                 'last_bg': '',
                 'last_hl_color': hl_color,
             }
+
+        # @+node:spike4871.20260808150000.1: *3* LeoQTextBrowser.eventFilter
+        def eventFilter(self, obj: QObject, event: QEvent) -> bool:
+            """Show an LSP diagnostic while hovering its squiggly range."""
+            if obj is self.viewport() and event.type() == QtCore.QEvent.Type.ToolTip:
+                position = self.cursorForPosition(event.pos()).position()
+                for selection in getattr(self, 'leo_lsp_selections', []):
+                    cursor = selection.cursor
+                    if cursor.selectionStart() <= position < cursor.selectionEnd():
+                        message = selection.format.toolTip()
+                        if message:
+                            QtWidgets.QToolTip.showText(event.globalPos(), message, self)
+                            return True
+                message = self.leo_c.k.autoCompleter.get_lsp_hover(position)
+                if message:
+                    QtWidgets.QToolTip.showText(event.globalPos(), message, self)
+                    return True
+                QtWidgets.QToolTip.hideText()
+                event.ignore()
+                return True
+            return super().eventFilter(obj, event)
 
         # @+node:ekr.20110605121601.18007: *3* LeoQTextBrowser. __repr__ & __str__
         def __repr__(self) -> str:
@@ -877,7 +902,7 @@ if QtWidgets:
                 return
 
             if not c.config.getBool('highlight-body-line', True):
-                editor.setExtraSelections([])
+                editor.setExtraSelections(getattr(editor, 'leo_lsp_selections', []))
                 return
 
             curs = editor.textCursor()
@@ -939,7 +964,8 @@ if QtWidgets:
             selection.cursor = curs
             selection.cursor.clearSelection()
 
-            editor.setExtraSelections([selection])
+            lsp_selections = getattr(editor, 'leo_lsp_selections', [])
+            editor.setExtraSelections([selection, *lsp_selections])
             # @-<< Apply Highlight >>
 
         # @+node:ekr.20141103061944.31: *3* LeoQTextBrowser.get/setXScrollPosition

--- a/leo/unittests/core/test_leo_lsp_client.py
+++ b/leo/unittests/core/test_leo_lsp_client.py
@@ -1,0 +1,13 @@
+"""Tests for leo.external.leo_lsp_client."""
+
+from pathlib import Path
+
+from leo.external import leo_lsp_client
+
+
+def test_path_to_uri_uses_canonical_file_uri() -> None:
+    path = Path.cwd() / 'leo' / 'core' / 'leoKeys.py'
+    uri = leo_lsp_client.path_to_uri(str(path))
+
+    assert uri == path.resolve().as_uri()
+    assert '\\' not in uri


### PR DESCRIPTION
> **This PR stays as the simple, synchronous spike for anyone who wants to try it.** Follow-on productization work (non-blocking client, typed `lsprotocol` messages, crash recovery, two real protocol bugs found+fixed against a live server) continues in #4877, based on top of this branch.

## How to try it

1. Check out this PR and install the Python LSP server: `python -m pip install ty`.
2. Add these settings to `myLeoSettings.leo`:

   ```text
   @bool use-lsp = True
   @bool enable-autocompleter-initially = True
   ```

3. Restart Leo and open a Python node backed by an `@file` tree. Diagnostics currently require a real external-file path.
4. Edit or move the body cursor to trigger a debounced LSP sync. Type errors should appear as red squiggles; hover a squiggle for its diagnostic, or hover a symbol for its inferred type/documentation.
5. For completion, type a dot and continue typing to filter candidates. LSP completion does not insert text eagerly; press Tab to explicitly extend/accept the common completion.

## Summary

Proof-of-concept for #4871: a generic LSP client driving both body-pane completions and live diagnostics, using `ty server` as the first backend. **Not production-ready** — see caveats below. Opened as a draft so the approach can be kicked around before any of this is polished.

- `leo/external/leo_lsp_client.py` — minimal synchronous JSON-RPC/LSP client (spawn, initialize, didOpen/didChange, `textDocument/completion`, diagnostics collection). No new dependency; hand-rolled framing.
- `leoKeys.py::AutoCompleterClass.get_lsp_completions` — gated by `@bool use-lsp` (default `False`, zero behavior change when unset). Reuses `get_jedi_completions`' existing source-reconstruction / row-col mapping rather than duplicating it.
- `leoKeys.py::AutoCompleterClass.get_lsp_diagnostics_for_node` / `show_lsp_diagnostics` — the "live squigglies" half of the issue: maps the server's `publishDiagnostics` notifications back to node-local coordinates and renders them as wavy red underlines via `QTextEdit.setExtraSelections` (the same idiom `qt_text.py` already uses for current-line highlighting).

## Findings worth flagging on the issue

- `ty`'s completion endpoint only returns results when there's no text after the cursor on the physical line — a dangling trailing dot at true end-of-line completes fine, but the identical position with real code continuing on the same line (the common case when editing, not just appending) returns nothing. Worked around with a "phantom EOL" trick: send the server a copy of the source with just the cursor's line truncated at the cursor, request completion there, then immediately re-sync the real untruncated source so diagnostics don't end up reflecting the truncated line. This is a real maturity gap next to jedi and is exactly the kind of thing that might push toward the pyright fallback the issue already anticipated.
- `ty` *does* do server-side prefix filtering correctly once positioned right.
- Completions need an absolute `file://` URI — a relative path silently degrades (no error, just empty/wrong results). Diagnostics need this even more than completions do, since they need a resolvable file. Caught a real bug this way: `get_lsp_completions` was resolving the node's path with `os.path.abspath(fileName)` against `goto.find_root`'s bare filename, which silently pointed outside `leo/core/`. Fixed with `g.fullPath(c, root)`.

## Verification

Verified two ways:

- Headlessly via `leoBridge` (null gui) against `LeoPyRef.leo`: completions, mid-line completions, and diagnostic-to-node-local-coordinate mapping all checked out against real code in `leoKeys.py` itself.
- In the real Qt UI: completion, the squiggly *rendering* (`QTextEdit.setExtraSelections`), and hover — both hovering a squiggle to see its diagnostic message and hovering a symbol/variable for its inferred type/documentation — all confirmed working.

## Explicitly out of scope for this spike

- Per-`@language` server selection (`@data language-servers`) — currently hardcoded to whatever `@string lsp-command` resolves to (`ty server` by default). Still open in #4877 too.
- Process crash/restart handling. **Addressed in #4877.**
- Async completion round-trip (currently blocks the caller; fine for a fast local server, not fine for higher-latency ones). **Addressed in #4877.**
- Settings UI, `LeoPyRef.leo` outline sync.

## Test plan

- [x] Enable `@bool use-lsp = True` in a test `.leo` file (needs `pip install ty`) and confirm completions work in the body pane, including mid-line
- [x] Confirm diagnostics show up as wavy red underlines while typing
- [x] Confirm hover works: a squiggle shows its diagnostic message, a symbol/variable shows its inferred type/documentation
- [ ] Confirm existing jedi-based completion (`use-lsp` unset/False) is unaffected

## Autocompletion acceptance behavior

During Qt testing, LSP completion exposed an existing Leo behavior that was too eager for semantic completions: `@bool auto-tab-complete = True` extends the body text to the longest common prefix after every typed character. With LSP's precise, context-aware results, the candidate list often narrows to one full symbol very quickly—for example, typing `s.to` could immediately insert `s.toPythonIndexRowCol`.

This is not fundamentally an LSP-specific problem; it comes from the legacy autocompleter's acceptance semantics. It is more visible with LSP because LSP results are usually narrower and contain full symbol names. For this spike, LSP completion is therefore filter-only while typing. Tab explicitly extends/accepts the current common completion.

The change is intentionally scoped to `use-lsp` so the spike does not silently alter long-standing Jedi/codewise behavior. A possible follow-up is to unify all completers around modern explicit acceptance (Tab/Enter/click) rather than inserting completions during ordinary typing.

