### PR TITLE
Fix ic.languageForExtension: empty-string default masked the extension_dict fallback

### DIFF
--- a/leo/core/LeoPyRef.leo
+++ b/leo/core/LeoPyRef.leo
@@ -971,7 +971,7 @@ c.backup_helper(sub_dir='leoPy')
 <t tx="ekr.20150514035207.1"></t>
 <t tx="ekr.20160122104332.1">@language python
 </t>
-<t tx="ekr.20160123142722.1" _mod_time="4741da9b69061c67b92e"># An example configuration file for make_stub_files.py.
+<t tx="ekr.20160123142722.1" _mod_time="4741da9ddfe1f8ea3d2e"># An example configuration file for make_stub_files.py.
 # By default, this is ~/stubs/make_stub_files.cfg.
 # Can be changed using the --config=path command-line option.
 
@@ -1055,9 +1055,9 @@ print('done! wrote %s' % fn)
 <t tx="ekr.20180225010913.1"></t>
 <t tx="ekr.20180504191650.36"></t>
 <t tx="ekr.20180504191650.42"></t>
-<t tx="ekr.20180504191650.68" _mod_time="4741da24cf053b9aa12e"></t>
+<t tx="ekr.20180504191650.68" _mod_time="4741da9ddfe1fbb0f42e"></t>
 <t tx="ekr.20180504192522.1"></t>
-<t tx="ekr.20180708145905.1" _mod_time="4741da24cf0b43cf212e">@language rest
+<t tx="ekr.20180708145905.1" _mod_time="4741da9ddfe1f8ea3d2e">@language rest
 @wrap
 
 This is the theory of operation document for py2cs.py. The most interesting aspect of this script is the TokenSync class. This class provides a reliable way of associating tokenizer tokens with ast nodes.
@@ -1601,7 +1601,7 @@ def do_sec(i, m, s):
     child.h = h.strip()
     parents.append(('@ ', child))
 </t>
-<t tx="ekr.20220222130955.1" _mod_time="4741da9b7bb18011332e"># Config file for mypy
+<t tx="ekr.20220222130955.1" _mod_time="4741da9ddfe1e3cea32e"># Config file for mypy
 
 # Note: Do not put comments after settings.
 
@@ -1912,7 +1912,7 @@ assert core_p and command_p and globals_p
     # 'toString', 'toUnicode', 'trace', 'translateString',
     # 'underline', 'undoHelper', 'unl', 'values', 'visit',
     # 'warn', 'warning', 'word',</t>
-<t tx="ekr.20220823195205.1" _mod_time="4741da9dcece3fe29c2e">"""
+<t tx="ekr.20220823195205.1" _mod_time="4741da9ddfe1f8cb5a2e">"""
 Stand alone GUI free index builder for Leo's full text search system::
 
   python leoftsindex.py &lt;file1&gt; &lt;file2&gt; &lt;file3&gt;...
@@ -2074,7 +2074,7 @@ writers = 'leo.unittests.plugins.test_writers'
 # f"{plugins}.test_plugins",
 # f"{plugins}.test_writers",
 </t>
-<t tx="ekr.20230624114517.1" _mod_time="4741da24cf053b9aa12e"></t>
+<t tx="ekr.20230624114517.1" _mod_time="4741da9ddfe1fb2db82e"></t>
 <t tx="ekr.20230720115916.1">g.cls()
 import leo.commands.editFileCommands as efc
 
@@ -2160,7 +2160,7 @@ print('done')</t>
 <t tx="ekr.20240107154430.1"></t>
 <t tx="ekr.20240204082420.1"></t>
 <t tx="ekr.20240204082924.1"></t>
-<t tx="ekr.20240206161713.1" _mod_time="4741da9dcecad33f0c2e">@language ini
+<t tx="ekr.20240206161713.1" _mod_time="4741da9de2eca964d12e">@language ini
 
 [bdist_wheel]
 
@@ -2172,7 +2172,7 @@ universal=0
 # Becomes the home-page in `pip show leo`.
 url = https://leo-editor.github.io/leo-editor/
 </t>
-<t tx="ekr.20240317061516.1" _mod_time="4741da5a5ae8fea4c22e">@language python
+<t tx="ekr.20240317061516.1" _mod_time="4741da9ddfe1e3cea32e">@language python
 
 # Order matters!
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -687,8 +687,8 @@ class LeoImportCommands:
         if ext.startswith('.'):
             ext = ext[1:]
         if ext:
-            z = g.app.extra_extension_dict.get(ext, '')
-            if z not in (None, 'none', 'None'):
+            z = g.app.extra_extension_dict.get(ext)
+            if z is not None and z not in ('none', 'None'):
                 language = z
             else:
                 language = g.app.extension_dict.get(ext, '')

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -229,6 +229,24 @@ class TestLeoImport(BaseTestImporter):
         u.redo()
         self.check_outline(target, expected_results)
 
+    # @+node:vv.20260808220000.1: *3* TestLeoImport.test_languageForExtension
+    def test_languageForExtension(self):
+        """
+        #4882: g.app.extra_extension_dict.get(ext, '') used '' as a default,
+        which incorrectly short-circuited the fallback to g.app.extension_dict,
+        since '' passes the `z not in (None, 'none', 'None')` check.
+        """
+        c = self.c
+        ic = c.importCommands
+        # Extensions known only to g.app.extension_dict must still resolve.
+        self.assertEqual(ic.languageForExtension('.py'), 'python')
+        self.assertEqual(ic.languageForExtension('.cfg'), 'config')
+        # Extensions in g.app.extra_extension_dict must still resolve.
+        self.assertEqual(ic.languageForExtension('.pod'), 'perl')
+        self.assertEqual(ic.languageForExtension('.w'), 'c')
+        # A genuinely unknown extension resolves to ''.
+        self.assertEqual(ic.languageForExtension('.zzz_no_such_ext'), '')
+
     # @-others
 
 


### PR DESCRIPTION
## Summary

Found this while double-checking PR #4881 (verifying `@language` directive behavior for `@edit` nodes converted from `@clean`).

`ic.languageForExtension` (`leo/core/leoImport.py`) is supposed to check `g.app.extra_extension_dict` first (a small 3-entry override table: `pod`/`unknown_language`/`w`), and fall back to the much larger `g.app.extension_dict` (which has the real entries -- `'py': 'python'`, `'cfg': 'config'`, etc.) when `extra_extension_dict` has nothing for that extension. The fallback check was broken:

```python
z = g.app.extra_extension_dict.get(ext, '')
if z not in (None, 'none', 'None'):
    language = z
else:
    language = g.app.extension_dict.get(ext, '')
```

`extra_extension_dict.get(ext, '')` returns `''` for every extension *not* in that 3-entry table -- i.e. nearly all of them. `''` passes the `z not in (None, 'none', 'None')` check, so `language` gets set to `''` right there, and the `extension_dict` fallback never runs. In practice, `languageForExtension('.py')` returned `''` instead of `'python'`, and likewise for basically every extension.

This silently breaks `@language`-directive detection everywhere `languageForExtension` is used:
- `at.readOneAtEditNode` (`leoAtFile.py`): every `@edit` node falls back to `@nocolor` on read instead of the correct `@language` line, regardless of its actual file type.
- `ic.scanUnknownFileType` (`leoImport.py`): the `@language` line is silently omitted when importing an unknown file type.

I confirmed this isn't specific to any file I'm working with -- it reproduces on pre-existing `@edit` nodes already in `LeoPyRef.leo` before any of my changes (`launchLeo.py`, `README.md`, `CONTRIBUTING.md`), so it's a real, previously-unnoticed bug, not something new.

**Fix**: use `.get(ext)` (defaulting to `None`) instead of `.get(ext, '')`, and check `z is not None` explicitly so the "value is `''`" vs "key is missing" distinction isn't lost.

## Test plan

- [x] Added `TestLeoImport.test_languageForExtension` -- confirmed it fails against the old code (`AssertionError: '' != 'python'`) and passes with the fix
- [x] `QT_QPA_PLATFORM=offscreen python -m pytest leo/unittests` -- 854 passed, 1 pre-existing unrelated flaky failure (`test_g_OptionsUtils`, a documented CLI-arg-parsing artifact of running under pytest)
- [x] `ruff check leo` -- clean
- [x] `python -m mypy leo` -- clean (hit the documented occasional `leoShadow.py` `has-type` flake on a couple of runs, unrelated to this change -- cleared `.mypy_cache` and reran until stable; also confirmed it doesn't reproduce at all on unmodified `devel`, then reproduced and cleared 3x on this branch, consistent with known mypy inference flakiness rather than a real issue)
- [x] `leo/scripts/check_leo_sync.py` -- outline stays in sync after resyncing the two touched files