### PR TITLE
Bump version to 6.8.10.dev0 to test publish.yml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,7 +234,7 @@ packages = [
 
 [project]
 requires-python = ">= 3.10"
-version = "6.8.9"  # No space.
+version = "6.8.10.dev0"  # No space.
 name = "leo"
 
 #@+<< developer info >>


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` version to `6.8.10.dev0` so we can cut a pre-release and exercise the full `publish.yml` pipeline (build → GitHub release asset upload → PyPI trusted-publish) end to end, without touching the real `6.8.10` release.

Related to #4884.

## Test plan
- [ ] Merge this PR into `devel`
- [ ] Create a GitHub pre-release targeting `devel` with tag `v6.8.10.dev0` (this creates the tag and the release together), which fires `publish.yml`
- [ ] Confirm dist assets attach to the GitHub release
- [ ] Confirm `leo==6.8.10.dev0` appears on PyPI
- [ ] Once confirmed working, bump version to the real `6.8.10` for the actual release