### PR TITLE
Fix publish.yml duplicate-run trigger; bump to 6.8.10.dev1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   release:
-    types: [published, created]
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,7 +234,7 @@ packages = [
 
 [project]
 requires-python = ">= 3.10"
-version = "6.8.10.dev0"  # No space.
+version = "6.8.10.dev1"  # No space.
 name = "leo"
 
 #@+<< developer info >>


### PR DESCRIPTION
## Summary
- The `6.8.10.dev0` test release (#4885, see #4884) showed `publish.yml` runs **twice** per release: GitHub fires both `release.created` and `release.published` webhooks simultaneously for a non-draft release, and the workflow listened for both. The two concurrent runs raced on the PyPI upload — one succeeded, the other failed with `400 File already exists`. This also explains why both runs of the real `v6.8.9` release show as failed in the Actions history.
- Fix: restrict the trigger to `types: [published]` only, matching the pattern used in `~/zaira`'s own `publish.yml`.
- Bumps version to `6.8.10.dev1` to re-test the fix with a fresh pre-release.

Compared the `6.8.10.dev0` build artifacts (wheel + sdist) against the real `v6.8.9` release assets: same packaging structure and `dist-info` layout; the only content differences (new icons, removed `npyscreen`/`cursesGui2.py`, pruned doc sources) are real changes from the intervening two months of `devel` history, not build regressions.

Related to #4884.

## Test plan
- [ ] Merge this PR into `devel`
- [ ] Create a GitHub pre-release targeting `devel` with tag `v6.8.10.dev1`
- [ ] Confirm `publish.yml` runs exactly once
- [ ] Confirm dist assets attach to the GitHub release and `leo==6.8.10.dev1` appears on PyPI
- [ ] Once confirmed working, bump version to the real `6.8.10` for the actual release