### PR TITLE
Derive version from release tag in CI; stop manually bumping version strings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,12 +22,16 @@ jobs:
           python-version: '3.12'
           cache: pip
 
-      - name: Set version from release tag
+      - name: Set version and release date from release tag
         run: |
           VERSION="${{ github.event.inputs.tag || github.event.release.tag_name }}"
           VERSION="${VERSION#v}"
           sed -i "s/^version = .*/version = \"$VERSION\"/" pyproject.toml
           echo "Set version to $VERSION"
+
+          RELEASE_DATE="$(date -u +'%B %-d, %Y')"
+          sed -i "s/^static_date = .*/static_date = '$RELEASE_DATE'/" leo/core/leoVersion.py
+          echo "Set static_date to $RELEASE_DATE"
 
       - run: python -m pip install --upgrade build
       - run: python -m build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,13 @@ jobs:
           python-version: '3.12'
           cache: pip
 
+      - name: Set version from release tag
+        run: |
+          VERSION="${{ github.event.inputs.tag || github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          sed -i "s/^version = .*/version = \"$VERSION\"/" pyproject.toml
+          echo "Set version to $VERSION"
+
       - run: python -m pip install --upgrade build
       - run: python -m build
       - run: ls -la dist/

--- a/leo/core/leoVersion.py
+++ b/leo/core/leoVersion.py
@@ -65,7 +65,12 @@ leoVersion.version:     Leo's version number.
 # 6.8.8:  April 14, 2026.
 # 6.8.9:  June 1, 2026.
 # @-<< version dates >>
-version = '6.8.10-devel'
+try:
+    from importlib.metadata import version as _installed_version
+    version = _installed_version('leo')
+except Exception:
+    # Not pip-installed (e.g. running from a git checkout): version is unknown.
+    version = '0.0.0-devel'
 static_date = 'June 3, 2026'
 # @@language python
 # @@tabwidth -4

--- a/leo/core/leoVersion.py
+++ b/leo/core/leoVersion.py
@@ -67,6 +67,7 @@ leoVersion.version:     Leo's version number.
 # @-<< version dates >>
 try:
     from importlib.metadata import version as _installed_version
+
     version = _installed_version('leo')
 except Exception:
     # Not pip-installed (e.g. running from a git checkout): version is unknown.

--- a/leo/core/leoVersion.py
+++ b/leo/core/leoVersion.py
@@ -71,7 +71,7 @@ try:
     version = _installed_version('leo')
 except Exception:
     # Not pip-installed (e.g. running from a git checkout): version is unknown.
-    version = '0.0.0-devel'
+    version = '0.0.0.dev0'
 static_date = 'June 3, 2026'
 # @@language python
 # @@tabwidth -4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,7 +234,7 @@ packages = [
 
 [project]
 requires-python = ">= 3.10"
-version = "6.8.10.dev1"  # No space.
+version = "0.0.0"  # Placeholder: publish.yml stamps the real version from the release tag at build time.
 name = "leo"
 
 #@+<< developer info >>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,7 +234,7 @@ packages = [
 
 [project]
 requires-python = ">= 3.10"
-version = "0.0.0"  # Placeholder: publish.yml stamps the real version from the release tag at build time.
+version = "0.0.0.dev0"  # Placeholder: publish.yml stamps the real version from the release tag at build time.
 name = "leo"
 
 #@+<< developer info >>


### PR DESCRIPTION
## Summary
Since this is the first release cut through the new CI-based `publish.yml`, use it to also fix the underlying reason we've had to manually bump the version in two places (`pyproject.toml`, `leoVersion.py`) for every release:

- `publish.yml`'s `build` job now stamps the real version into `pyproject.toml` from the release tag right before `python -m build`, the same pattern `~/zaira`'s `publish.yml` uses.
- `pyproject.toml` keeps a fixed `0.0.0` placeholder in the repo — CI owns the real value at build time.
- `leo/core/leoVersion.py` now reads the installed package's version via `importlib.metadata.version('leo')`, falling back to a `0.0.0-devel` placeholder when Leo isn't pip-installed (e.g. running straight from a git checkout). `--version` from a raw checkout was never a meaningful value anyway, so a placeholder there is fine.

Net effect: future releases no longer require a manual version-bump commit/PR at all — just tag and publish. The `<< version dates >>` changelog section in `leoVersion.py` is unaffected (real release-notes content, not a mechanical version number).

Related to #4884. Builds on #4885 and #4886.

## Test plan
- [x] Merge this PR into `devel`
- [ ] Create a GitHub pre-release targeting `devel` with tag `v6.8.10.dev2`
- [ ] Confirm `publish.yml` runs once, builds `leo-6.8.10.dev2-*` artifacts (not `0.0.0`)
- [ ] Confirm `pip install leo==6.8.10.dev2` reports the correct version via `leo --version`
- [ ] Once confirmed working, tag the real `v6.8.10` release directly — no version-bump PR needed