### PR TITLE
Add 6.8.10 to leoVersion.py's version dates changelog

### DIFF
--- a/leo/core/leoVersion.py
+++ b/leo/core/leoVersion.py
@@ -64,6 +64,7 @@ leoVersion.version:     Leo's version number.
 # 6.8.7:  October 11, 2025.
 # 6.8.8:  April 14, 2026.
 # 6.8.9:  June 1, 2026.
+# 6.8.10: August 9, 2026.
 # @-<< version dates >>
 try:
     from importlib.metadata import version as _installed_version


### PR DESCRIPTION
## Summary
- Last remaining manual item from `leoDist.leo`'s "Update version files in release branch" checklist for `6.8.10`: adds the release-date entry to the `<< version dates >>` changelog section in `leo/core/leoVersion.py`. Everything else in that checklist is now either automated (version, static_date — see #4887) or dead weight tracked for deletion (#4888).

Related to #4884.

## Test plan
- [ ] Merge into `devel`
- [ ] Tag the real `v6.8.10` release from `devel`'s tip