### PR TITLE
PR: run `ty leo` from full_test_leo.py

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -5317,7 +5317,7 @@ class Commands:
 
         # Run the command.
         try:
-            subprocess.Popen(command, shell=True).communicate()  # Wait for results.
+            subprocess.run(command)  # Wait for results.
             results = g.readFile(filename)
             if g.isWindows:
                 results = results.replace('\r', '')

--- a/leo/scripts/beautify_all_leo.py
+++ b/leo/scripts/beautify_all_leo.py
@@ -45,5 +45,5 @@ targets = (
 # Use -m so that __name__ == '__main__'.
 python = sys.executable
 command = f"{python} -m ruff format {args} {' '.join(targets)}"
-subprocess.Popen(command, shell=True).communicate()
+subprocess.run(command)
 # @-leo

--- a/leo/scripts/build_leo.py
+++ b/leo/scripts/build_leo.py
@@ -38,7 +38,7 @@ command = f"{python} -m build > build_log.txt"
 print('')
 print(command)
 print('')
-subprocess.Popen(command, shell=True).communicate()
+subprocess.run(command)
 
 print('See build_log.txt')
 # @-leo

--- a/leo/scripts/full_test_leo.py
+++ b/leo/scripts/full_test_leo.py
@@ -40,6 +40,7 @@ for command in [
     rf'{python} -m leo.scripts.mypy_leo',
     rf'{python} -m leo.scripts.ruff_leo',
     rf'{python} -m leo.scripts.check_leo',
+    rf'{python} -m leo.scripts.ty_leo',
 ]:
     subprocess.Popen(command, shell=True).communicate()
 # @-leo

--- a/leo/scripts/full_test_leo.py
+++ b/leo/scripts/full_test_leo.py
@@ -42,5 +42,5 @@ for command in [
     rf'{python} -m leo.scripts.check_leo',
     rf'{python} -m leo.scripts.ty_leo',
 ]:
-    subprocess.Popen(command, shell=True).communicate()
+    subprocess.run(command)
 # @-leo

--- a/leo/scripts/inspect_wheel.py
+++ b/leo/scripts/inspect_wheel.py
@@ -28,7 +28,7 @@ os.chdir(leo_editor_dir)
 python = sys.executable
 command = rf"{python} -m wheel_inspect dist\leo-6.8.9-py3-none-any.whl >inspect_wheel.txt"
 print(command)
-subprocess.Popen(command, shell=True).communicate()
+subprocess.run(command)
 
 print('See inspect_wheel.txt')
 # @-leo

--- a/leo/scripts/install_leo_from_pypi.py
+++ b/leo/scripts/install_leo_from_pypi.py
@@ -23,5 +23,5 @@ os.chdir(home_dir)
 python = sys.executable
 command = f"{python} -m pip install leo==6.8.9"
 print(command)
-subprocess.Popen(command, shell=True).communicate()
+subprocess.run(command)
 # @-leo

--- a/leo/scripts/install_leo_from_testpypi.py
+++ b/leo/scripts/install_leo_from_testpypi.py
@@ -24,5 +24,5 @@ os.chdir(home_dir)
 python = sys.executable
 command = f"{python} -m pip install -i https://test.pypi.org/simple/ leo==6.8.9"
 print(command)
-subprocess.Popen(command, shell=True).communicate()
+subprocess.run(command)
 # @-leo

--- a/leo/scripts/install_leo_locally.py
+++ b/leo/scripts/install_leo_locally.py
@@ -46,7 +46,7 @@ else:
     python = sys.executable
     command = rf"{python} -m pip install {dist_dir}{os.sep}{wheel_file}"
     print(command)
-    subprocess.Popen(command, shell=True).communicate()
+    subprocess.run(command)
 
     # List site-packages/leo*.
     python_dir = os.path.dirname(sys.executable)

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -27,7 +27,7 @@ os.chdir(leo_editor_dir)
 python = sys.executable
 args = ''.join(sys.argv[1:])
 command = rf"{python} -m mypy {args} leo"
-subprocess.Popen(command, shell=True).communicate()
+subprocess.run(command)
 
 # @@language python
 # @-leo

--- a/leo/scripts/pip_install_r.py
+++ b/leo/scripts/pip_install_r.py
@@ -28,5 +28,5 @@ for command in [
     f"{python} -m pip list",
 ]:
     print(command)
-    subprocess.Popen(command, shell=True).communicate()
+    subprocess.run(command)
 # @-leo

--- a/leo/scripts/pip_uninstall_all.py
+++ b/leo/scripts/pip_uninstall_all.py
@@ -31,7 +31,7 @@ for command in [
     print('')
     print(command)
     print('')
-    subprocess.Popen(command, shell=True).communicate()
+    subprocess.run(command)
 
 if os.path.exists('temp_requirements.txt'):
     print('')

--- a/leo/scripts/ruff_leo.py
+++ b/leo/scripts/ruff_leo.py
@@ -28,5 +28,5 @@ os.chdir(leo_editor_dir)
 args = ' '.join(sys.argv[1:])
 python = sys.executable
 command = rf'{python} -m ruff check leo'
-subprocess.Popen(command, shell=True).communicate()
+subprocess.run(command)
 # @-leo

--- a/leo/scripts/run_installed_leo.py
+++ b/leo/scripts/run_installed_leo.py
@@ -29,5 +29,5 @@ else:
     command = f"{python} -m leo.core.runLeo"
     print(command)
     print('')
-    subprocess.Popen(command, shell=True).communicate()
+    subprocess.run(command)
 # @-leo

--- a/leo/scripts/run_test_leo.py
+++ b/leo/scripts/run_test_leo.py
@@ -27,5 +27,5 @@ os.chdir(leo_editor_dir)
 args = ' '.join(sys.argv[1:])
 python = sys.executable
 command = rf'{python} -m unittest {args}'
-subprocess.Popen(command, shell=True).communicate()
+subprocess.run(command)
 # @-leo

--- a/leo/scripts/ty_leo.py
+++ b/leo/scripts/ty_leo.py
@@ -17,5 +17,5 @@ os.chdir(leo_editor_dir)
 args = ' '.join(sys.argv[1:])
 python = sys.executable
 command = rf'{python} -m ty check leo {args}'
-subprocess.Popen(command, shell=True).communicate()
+subprocess.run(command)
 # @-leo

--- a/leo/scripts/ty_leo.py
+++ b/leo/scripts/ty_leo.py
@@ -1,0 +1,21 @@
+# @+leo-ver=5-thin
+# @+node:ekr.20260809120840.1: * @file ../scripts/ty_leo.py
+"""
+ty_leo.py: Run ty on all of Leo.
+"""
+
+import os
+import subprocess
+import sys
+
+print(os.path.basename(__file__))
+
+# cd to leo-editor
+leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
+os.chdir(leo_editor_dir)
+
+args = ' '.join(sys.argv[1:])
+python = sys.executable
+command = rf'{python} -m ty check leo {args}'
+subprocess.Popen(command, shell=True).communicate()
+# @-leo

--- a/leo/scripts/uninstall_leo.py
+++ b/leo/scripts/uninstall_leo.py
@@ -37,7 +37,7 @@ else:
     python = sys.executable
     command = f"{python} -m pip uninstall leo"
     print(command)
-    subprocess.Popen(command, shell=True).communicate()
+    subprocess.run(command)
 
     if 0:  # This hack should no longer be necessary.
         # Delete the leo/leo.egg-info directory.

--- a/leo/scripts/update_leo_tools.py
+++ b/leo/scripts/update_leo_tools.py
@@ -28,5 +28,5 @@ for command in [
 ]:
     print('')
     print(command)
-    subprocess.Popen(command, shell=True).communicate()
+    subprocess.run(command)
 # @-leo

--- a/leo/scripts/upload_leo_to_pypi.py
+++ b/leo/scripts/upload_leo_to_pypi.py
@@ -28,7 +28,7 @@ command = f"{python} -m twine upload -r pypi dist/*.* --verbose"
 # Upload.
 if 1:  # Don't do this until we are ready to release.
     print(command)
-    subprocess.Popen(command, shell=True).communicate()
+    subprocess.run(command)
 else:
     print(f"Skipped: {command}")
 # @-leo

--- a/leo/scripts/upload_leo_to_testpypi.py
+++ b/leo/scripts/upload_leo_to_testpypi.py
@@ -28,7 +28,7 @@ command = f"{python} -m twine upload -r testpypi dist/*.* --verbose"
 # Upload
 if 1:  # Don't do this until we are ready to release.
     print(command)
-    subprocess.Popen(command, shell=True).communicate()
+    subprocess.run(command)
 else:
     print(f"Skipped: {command}")
 # @-leo


### PR DESCRIPTION
This PR seems necessary now that ty is a blocker for GitHub actions. The changes should be part of Leo 6.8.10.

- [x] Add leo/scripts/ty_leo.py.
- [x] Call ty_leo.py from leo/scripts/full_test_leo.py.
- [x] Replace all calls to `subprocess.Popen(command, shell=True).communicate()` by `subprocess.run(command)`.