### PR TITLE
Add CI check and manual publish workflow for docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,23 @@ jobs:
       - run: pip install "PyQt6>=6.6" PyQt6-QScintilla
       - run: python -m leo.scripts.check_leo_sync
 
+  docs:
+    # Catch LeoDocs.leo failing to build into Sphinx HTML.
+    # See leo/scripts/build_docs.py.
+    runs-on: ubuntu-latest
+    env:
+      QT_QPA_PLATFORM: offscreen
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends
+          libegl1 libgl1 libxkbcommon0 libdbus-1-3 libfontconfig1
+      - run: pip install "PyQt6>=6.6" PyQt6-QScintilla docutils sphinx
+      - run: python -m leo.scripts.build_docs
+
   mypy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,65 @@
+name: Publish docs
+
+# Manually rebuilds Leo's documentation from leo/doc/LeoDocs.leo (see
+# leo/scripts/build_docs.py). No generated HTML is ever committed to git:
+#
+# - Every run uploads the built site as a plain workflow artifact, so it
+#   can be downloaded and reviewed before anything goes live.
+# - Re-running with the "publish" input checked additionally deploys the
+#   same build straight to GitHub Pages via actions/deploy-pages.
+#
+# The "publish" path requires the repo's Pages source (Settings > Pages >
+# Build and deployment) to be set to "GitHub Actions" -- it will fail
+# clearly if that hasn't been switched from the legacy branch-based source.
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Deploy to GitHub Pages (requires Pages source = "GitHub Actions"). Leave unchecked to just build a reviewable artifact.'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      QT_QPA_PLATFORM: offscreen
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends
+          libegl1 libgl1 libxkbcommon0 libdbus-1-3 libfontconfig1
+      - run: pip install "PyQt6>=6.6" PyQt6-QScintilla docutils sphinx
+      - run: python -m leo.scripts.build_docs --out built-docs
+
+      - name: Upload reviewable artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: leo-docs-html
+          path: built-docs/
+
+      - name: Package for Pages
+        if: ${{ inputs.publish }}
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: built-docs/
+
+  deploy:
+    if: ${{ inputs.publish }}
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/leo/core/LeoPyRef.leo
+++ b/leo/core/LeoPyRef.leo
@@ -1573,7 +1573,7 @@ def do_sec(i, m, s):
     child.h = h.strip()
     parents.append(('@ ', child))
 </t>
-<t tx="ekr.20220222130955.1" _mod_time="4741da9b7bb18011332e"># Config file for mypy
+<t tx="ekr.20220222130955.1"># Config file for mypy
 
 # Note: Do not put comments after settings.
 

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -88,7 +88,7 @@ class RstCommands:
         self.encoding = 'utf-8'  # From any @encoding directive.
         self.path = ''  # The path from any @path directive.
         self.result_list: list[str] = []  # The intermediate results.
-        self.root: Position  # The @rst node being processed.
+        self.root: Position | None = None  # The @rst node being processed.
 
         # Default settings.
         self.default_underline_characters = '#=+*^~-:><'
@@ -467,7 +467,7 @@ class RstCommands:
         if changed := g.write_file_if_changed(fn, s, encoding=self.encoding):
             self.n_intermediate += 1
             self.report(fn)
-            assert self.root.v
+            assert self.root is not None and self.root.v
             if self.root.v not in self.changed_vnodes:
                 self.changed_positions.append(self.root.copy())
                 self.changed_vnodes.add(self.root.v)
@@ -761,7 +761,7 @@ class RstCommands:
 
     def rst_parents(self, p: Position) -> Generator[Position, None, None]:
         for p2 in p.parents():
-            if p2 == self.root:
+            if self.root is not None and p2 == self.root:
                 return
             yield p2
 
@@ -802,6 +802,7 @@ class RstCommands:
         # Never add the root's headline.
         if not s:
             return ''
+        assert self.root is not None
         encoded_s = g.toEncodedString(s, encoding=self.encoding, reportErrors=False)
         if self.at_auto_write:
             # We *might* generate overlines for top-level sections.

--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -380,7 +380,7 @@
 </v>
 </v>
 <v t="ekr.20050831195331.1"><vh>FAQ</vh>
-<v t="ekr.20050830115714"><vh>@rst html\FAQ.html</vh>
+<v t="ekr.20050830115714"><vh>@rst html/FAQ.html</vh>
 <v t="ekr.20050830120007"><vh>@rst-no-head Links (FAQ)</vh></v>
 <v t="ekr.20050830115714.1"><vh>Learning to use Leo</vh>
 <v t="ekr.20161207052511.1"><vh>How can I learn Leo, or python, or anything</vh></v>
@@ -522,8 +522,8 @@
 </v>
 </v>
 <v t="ekr.20091130111843.6787"><vh>Tutorials</vh>
-<v t="ekr.20091130111843.6788"><vh>@rst html\tutorial.html</vh></v>
-<v t="ekr.20131008041326.16203"><vh>@rst html\tutorial-basics.html</vh>
+<v t="ekr.20091130111843.6788"><vh>@rst html/tutorial.html</vh></v>
+<v t="ekr.20131008041326.16203"><vh>@rst html/tutorial-basics.html</vh>
 <v t="ekr.20131002055813.15973"><vh>Leo's main window</vh></v>
 <v t="ekr.20170215105125.1"><vh>Commands</vh></v>
 <v t="ekr.20170215031129.1"><vh>Outlines and clones</vh></v>
@@ -545,7 +545,7 @@
 </v>
 <v t="ekr.20131005214621.16090"><vh>Summary</vh></v>
 </v>
-<v t="ekr.20131008041326.16222"><vh>@rst html\tutorial-pim.html</vh>
+<v t="ekr.20131008041326.16222"><vh>@rst html/tutorial-pim.html</vh>
 <v t="ekr.20131004073415.16044"><vh>Clones</vh></v>
 <v t="ekr.20131018100353.16706"><vh>Clones create views</vh></v>
 <v t="ekr.20131009100732.16760"><vh>Using abbreviations and templates</vh></v>
@@ -553,7 +553,7 @@
 <v t="ekr.20170312083548.1"><vh>Using Chapters</vh></v>
 <v t="ekr.20131008041326.16066"><vh>Summary</vh></v>
 </v>
-<v t="ekr.20131008041326.16241"><vh>@rst html\tutorial-rst3.html</vh>
+<v t="ekr.20131008041326.16241"><vh>@rst html/tutorial-rst3.html</vh>
 <v t="ekr.20131102044158.16488"><vh>Install docutils and (optional) sphinx</vh></v>
 <v t="ekr.20131009100732.16748"><vh>Create the @rst node</vh></v>
 <v t="ekr.20131027064821.17144"><vh>The output and intermediate files</vh></v>
@@ -574,7 +574,7 @@
 <v t="ekr.20131005214621.16128"><vh>Summary</vh></v>
 <v t="ekr.20131009100732.16753"><vh>Further study</vh></v>
 </v>
-<v t="ekr.20040403171740"><vh>@rst html\tutorial-scripting.html</vh>
+<v t="ekr.20040403171740"><vh>@rst html/tutorial-scripting.html</vh>
 <v t="ekr.20131013060803.16852"><vh>Hello world</vh></v>
 <v t="ekr.20170313111502.1"><vh>Create outline nodes</vh></v>
 <v t="ekr.20170313111626.1"><vh>Generate an output file from nodes</vh></v>
@@ -588,7 +588,7 @@
 <v t="ekr.20131017051340.16735"><vh>Example position scripts</vh></v>
 </v>
 </v>
-<v t="ekr.20180126061923.1"><vh>@rst html\tutorial-tips.html</vh>
+<v t="ekr.20180126061923.1"><vh>@rst html/tutorial-tips.html</vh>
 <v t="ekr.20180126063015.1"><vh>The most important tips</vh>
 <v t="ekr.20180126061429.16"><vh>You don't have to remember command names</vh></v>
 <v t="ekr.20180126061429.15"><vh>Learn to use clones</vh></v>
@@ -933,7 +933,7 @@
 <v t="mhw.20191008134029.1"><vh>@rst html/leoandasciidoc.html</vh></v>
 </v>
 <v t="ekr.20061025065357"><vh>Leo and Emacs</vh>
-<v t="ekr.20061025065357.1"><vh>@rst html\emacs.html</vh>
+<v t="ekr.20061025065357.1"><vh>@rst html/emacs.html</vh>
 <v t="ekr.20170315072706.1"><vh>Leo vs org mode</vh></v>
 <v t="ekr.20140720203932.17747"><vh>Using org-mode (.org) files in Leo</vh></v>
 <v t="ekr.20061025081359"><vh>Controlling Leo from Emacs using Pymacs</vh></v>
@@ -942,7 +942,7 @@
 </v>
 </v>
 <v t="TL.20080804095315.1"><vh>Leo and Vim</vh>
-<v t="TL.20080804095315.2"><vh>@rst html\vimBindings.html</vh>
+<v t="TL.20080804095315.2"><vh>@rst html/vimBindings.html</vh>
 <v t="ekr.20140810085801.18230"><vh>Using Leo's native vim mode</vh>
 <v t="ekr.20140810153947.6747"><vh>Supported commands</vh></v>
 <v t="ekr.20140810153947.6752"><vh>Differences from the real vim</vh></v>
@@ -962,7 +962,7 @@
 </v>
 </v>
 <v t="ekr.20241027051721.1"><vh>Leo and Jupyter Notebooks</vh>
-<v t="ekr.20241027051739.1"><vh>@rst html\jupyternotebooks.html</vh>
+<v t="ekr.20241027051739.1"><vh>@rst html/jupyternotebooks.html</vh>
 <v t="ekr.20241107063856.1"><vh>Creating and populating @jupytext trees</vh></v>
 <v t="ekr.20241105100428.1"><vh>Reading @jupytext trees</vh></v>
 <v t="ekr.20241107070438.1"><vh>Editing @jupytext trees</vh></v>
@@ -972,7 +972,7 @@
 </v>
 </v>
 <v t="ekr.20070317033759"><vh>Embedding Leo with the leoBridge module</vh>
-<v t="ekr.20070317033759.1"><vh>@rst html\leoBridge.html</vh>
+<v t="ekr.20070317033759.1"><vh>@rst html/leoBridge.html</vh>
 <v t="ekr.20070317033759.3"><vh>Overview</vh></v>
 <v t="ekr.20071210094621"><vh>Running leoBridge from within Leo</vh></v>
 </v>
@@ -997,7 +997,7 @@
 <v t="ekr.20101025080245.5799"><vh>Advanced Topics</vh>
 <v t="ekr.20131008041326.16099"><vh>@rst html/intermediatetopics.html</vh></v>
 <v t="ekr.20060612102055"><vh>Writing Plugins</vh>
-<v t="ekr.20060612103240"><vh>@rst html\writingPlugins.html</vh>
+<v t="ekr.20060612103240"><vh>@rst html/writingPlugins.html</vh>
 <v t="ekr.20131008041326.16053"><vh>About Plugins</vh></v>
 <v t="EKR.20040524104904.224"><vh>Important security warnings</vh></v>
 <v t="peckj.20130813123907.6841"><vh>Documenting plugins</vh></v>
@@ -1009,7 +1009,7 @@
 </v>
 </v>
 <v t="ekr.20060527105211"><vh>Debugging with Leo</vh>
-<v t="ekr.20060527105617"><vh>@rst html\debuggers.html</vh>
+<v t="ekr.20060527105617"><vh>@rst html/debuggers.html</vh>
 <v t="ekr.20070116062405"><vh>Using g.trace and g.pdb</vh></v>
 <v t="ekr.20060527112801"><vh>Settings for winpdb</vh></v>
 <v t="ekr.20070115172724"><vh>Debugging scripts with winpdb</vh>
@@ -1020,7 +1020,7 @@
 </v>
 </v>
 <v t="ekr.20131015104133.16763"><vh>A scripting miscellany</vh>
-<v t="ekr.20131015091948.16784"><vh>@rst html\scripting-miscellany.html</vh>
+<v t="ekr.20131015091948.16784"><vh>@rst html/scripting-miscellany.html</vh>
 <v t="ekr.20131014053720.16816"><vh>\@button example</vh></v>
 <v t="ekr.20150817125512.1"><vh>Comparing two similar outlines</vh></v>
 <v t="tom.20230107235603.1"><vh>Converting Body Text To Title Case</vh></v>
@@ -1100,10 +1100,10 @@
 </v>
 </v>
 <v t="ekr.20131019035402.17557"><vh>The Leonine world</vh>
-<v t="ekr.20131019035402.17573"><vh>@rst html\leonine-world.html</vh></v>
+<v t="ekr.20131019035402.17573"><vh>@rst html/leonine-world.html</vh></v>
 </v>
 <v t="ekr.20180505114327.1"><vh>Leo University</vh>
-<v t="ekr.20180509042555.1"><vh>@rst html\leo-university.html</vh>
+<v t="ekr.20180509042555.1"><vh>@rst html/leo-university.html</vh>
 <v t="ekr.20180505114327.5"><vh>Lesson 1: Think process, not knowledge</vh></v>
 <v t="ekr.20180505114327.7"><vh>Lesson 2: Learn Leo's debugging tools</vh></v>
 <v t="ekr.20180505114327.8"><vh>Lesson 3: Running unit tests</vh></v>
@@ -1118,7 +1118,7 @@
 </v>
 </v>
 <v t="ekr.20131008041326.16091"><vh>Cheat Sheet</vh>
-<v t="ekr.20131007143750.16070"><vh>@rst html\cheatsheet.html</vh>
+<v t="ekr.20131007143750.16070"><vh>@rst html/cheatsheet.html</vh>
 <v t="ekr.20131019061259.16693"><vh>Key bindings</vh>
 <v t="ekr.20131015035606.16778"><vh>Selecting outline nodes</vh></v>
 <v t="ekr.20131015035606.16800"><vh>Moving outline nodes</vh></v>
@@ -25448,7 +25448,7 @@ any change to one clone inevitably affects all other clones.
 <t tx="ekr.20230121061309.1"></t>
 <t tx="ekr.20230121061335.1"></t>
 <t tx="ekr.20230121061433.1"></t>
-<t tx="ekr.20230121110340.1" _mod_time="4741da464e3720be372e">@language batch
+<t tx="ekr.20230121110340.1">@language batch
 echo off
 echo off
 cd C:\Repos\leo-editor\leo\doc\html
@@ -25456,7 +25456,7 @@ echo make clean
 call make clean
 </t>
 <t tx="ekr.20230121110345.1"></t>
-<t tx="ekr.20230121110533.1" _mod_time="4741da464e3720ce992e">@language batch
+<t tx="ekr.20230121110533.1">@language batch
 echo off
 echo off
 cd C:\Repos\leo-editor\leo\doc\html

--- a/leo/scripts/build_docs.py
+++ b/leo/scripts/build_docs.py
@@ -1,0 +1,89 @@
+"""
+build_docs.py: Regenerate Leo's documentation from leo/doc/LeoDocs.leo.
+
+Two-stage pipeline, both stages driven headlessly (no Leo GUI needed):
+
+1. Run Leo's rst3 command over the LeoDocs.leo outline. This writes the
+   reStructuredText intermediate files (leo/doc/html/*.html.txt and
+   leo/doc/html/slides/**/*.html.txt) from the bodies of its @rst nodes.
+   readSettings=True so the outline's own @settings tree is honored --
+   in particular @bool rst3_call_docutils = False, which keeps this stage
+   from invoking docutils itself; Sphinx does that in stage 2.
+2. Run sphinx-build over leo/doc/html (using its conf.py/Makefile config)
+   to turn those intermediates into final HTML.
+
+Usage:
+    python -m leo.scripts.build_docs [--out DIR]
+"""
+
+import argparse
+import glob
+import os
+import subprocess
+import sys
+
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
+os.chdir(leo_editor_dir)
+sys.path.insert(0, leo_editor_dir)
+
+from leo.core import leoBridge  # noqa: E402
+
+
+def run_rst3() -> int:
+    """Regenerate the .html.txt intermediates from LeoDocs.leo. Return the count written."""
+    leo_path = os.path.join(leo_editor_dir, 'leo', 'doc', 'LeoDocs.leo')
+    bridge = leoBridge.controller(
+        gui='nullGui',
+        loadPlugins=False,
+        readSettings=True,
+        silent=True,
+        verbose=False,
+    )
+    c = bridge.openLeoFile(leo_path)
+    # rst3() only searches the subtree of the current position (see
+    # g.findRootsWithPredicate), and @rst trees are scattered across many
+    # top-level nodes in LeoDocs.leo -- not gathered under one parent.
+    # Run it once per top-level tree so every @rst node gets picked up.
+    total = 0
+    for p in c.rootPosition().self_and_siblings(copy=False):
+        c.selectPosition(p)
+        total += c.rstCommands.rst3()
+    return total
+
+
+def run_sphinx(out_dir: str) -> int:
+    html_dir = os.path.join(leo_editor_dir, 'leo', 'doc', 'html')
+    cmd = ['sphinx-build', '-b', 'html', html_dir, out_dir]
+    print(' '.join(cmd))
+    return subprocess.call(cmd)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--out',
+        default=os.path.join(leo_editor_dir, 'leo', 'doc', 'html', '_build', 'html'),
+        help='Directory to write the built HTML to.',
+    )
+    args = parser.parse_args()
+
+    n = run_rst3()
+    print(f"rst3: wrote {n} changed intermediate file(s)")
+    # n only counts files that *changed*; on a no-op rebuild it's legitimately 0.
+    # Check existence instead, as a sanity gate before handing off to sphinx-build.
+    html_dir = os.path.join(leo_editor_dir, 'leo', 'doc', 'html')
+    existing = glob.glob(os.path.join(html_dir, '*.html.txt'))
+    if not existing:
+        print("ERROR: no .html.txt intermediates found -- check LeoDocs.leo", file=sys.stderr)
+        return 1
+
+    rc = run_sphinx(args.out)
+    if rc == 0:
+        print(f"sphinx-build OK -> {args.out}")
+    return rc
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds a `docs` job to CI (`leo/scripts/build_docs.py`) that runs `rst3` over `LeoDocs.leo` and then `sphinx-build`, so a broken documentation build fails CI.
- Adds `.github/workflows/publish-docs.yml`, a manual (`workflow_dispatch`) workflow that builds the documentation and uploads it as a reviewable artifact. When its `publish` input is enabled, it deploys the same build through `actions/deploy-pages`.
- See #4892 for the follow-up migration away from committing generated HTML to the `gh-pages` branch, which currently adds generated output to git history on every manual rebuild.

## Post-merge activation

1. In **Settings > Pages**, change **Build and deployment > Source** from the current branch-based source to **GitHub Actions**.
2. In **Actions > Publish docs**, run the workflow with **Deploy to GitHub Pages** enabled.

The deployment continues to use the repository's existing GitHub Pages URL and custom-domain configuration.

## Bugs fixed along the way

Running `rst3` headlessly in a fresh process surfaced two pre-existing bugs:

- `leoRst.py`: `RstCommands.root` was a bare type annotation and was never initialized. The first `@rst` node processed in a fresh session crashed with `AttributeError`. This was hidden in the GUI because a long-running session eventually sets it once and retains it.
- `LeoDocs.leo`: 17 `@rst` headlines used Windows-style backslashes (for example, `@rst html\FAQ.html`) instead of forward slashes. On Linux and macOS this wrote malformed filenames rather than files under `html/`, leaving pages missing from the built site.

## Test plan

- [x] `python -m leo.scripts.build_docs` succeeds from a clean checkout with zero Sphinx warnings and all documentation sources built.
- [x] `ruff check`, `ruff format --check`, `mypy leo`, `ty check`, and `leo/unittests/core/test_leoRst.py` pass.
- [x] `leo.scripts.check_leo_sync` confirms `LeoPyRef.leo` is synchronized after the `leoRst.py` edit.
- [x] GitHub CI passes after merging the latest `devel` into this branch.
