### PR TITLE
Include home page in published docs

### DIFF
--- a/leo/scripts/build_docs.py
+++ b/leo/scripts/build_docs.py
@@ -19,6 +19,7 @@ Usage:
 import argparse
 import glob
 import os
+import shutil
 import subprocess
 import sys
 
@@ -60,6 +61,14 @@ def run_sphinx(out_dir: str) -> int:
     return subprocess.call(cmd)
 
 
+def copy_home_page(out_dir: str) -> str:
+    """Copy Leo's hand-maintained home page into the Sphinx output directory."""
+    source = os.path.join(leo_editor_dir, 'docs', 'index.html')
+    target = os.path.join(out_dir, 'index.html')
+    shutil.copy2(source, target)
+    return target
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -81,6 +90,10 @@ def main() -> int:
 
     rc = run_sphinx(args.out)
     if rc == 0:
+        home_page = copy_home_page(args.out)
+        if not os.path.isfile(home_page):
+            print(f"ERROR: home page was not created: {home_page}", file=sys.stderr)
+            return 1
         print(f"sphinx-build OK -> {args.out}")
     return rc
 


### PR DESCRIPTION
## Summary

- Copy the existing hand-maintained `docs/index.html` homepage into the Sphinx output directory after a successful build.
- Fail the build if the deployment root still has no `index.html`.

The previous branch-based Pages deployment published the whole `docs/` directory, so this homepage was included even though Sphinx generates `leo_toc.html` as its root document. The new Actions workflow publishes only the Sphinx output, which omitted the homepage and left the Pages root without an index document.

## Test plan

- [x] `python -m leo.scripts.build_docs --out /tmp/leo-docs-index-fix`
- [x] Generated `index.html` is byte-for-byte identical to `docs/index.html`
- [x] `ruff check leo/scripts/build_docs.py`
- [x] `ruff format --check leo/scripts/build_docs.py`
- [x] `python -m pytest leo/unittests/core/test_leoRst.py`
- [x] `python -m leo.scripts.check_leo_sync`
