### PR TITLE
PR: Require ty

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -305,6 +305,7 @@ dependencies = [
   "pytest",
   "pytest-cov",      # For coverage testing.
   "ruff",
+  "ty",
 
   # General packages for plugins, leoserver and commands...
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ black           # For unit tests.
 pytest
 pytest-cov      # For coverage testing.
 ruff
+ty
 
 # General packages for plugins, leoserver and commands...
 


### PR DESCRIPTION
I see no reason not to require ty. Adding ty to the two requirements files should be less confusing for Leo's devs.