### PR TITLE
PR: print html links to console when using qt gui

### DIFF
--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -749,6 +749,8 @@ class LeoLog:
         Otherwise, return False.
         """
         c = self.c
+        if s.strip() and g.app.gui.guiName() == 'qt':
+            print(s)
         if not c:
             return False  # PR #4812
         assert c

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -749,8 +749,8 @@ class LeoLog:
         Otherwise, return False.
         """
         c = self.c
-        if s.strip() and g.app.gui.guiName() == 'qt':
-            print(s)
+        if s.strip() and g.app.gui.guiName() == 'qt' and not g.unitTesting:
+            print(s)  # PR #4906.
         if not c:
             return False  # PR #4812
         assert c


### PR DESCRIPTION
Some error messages are too long to be read comfortably in Leo's log.