### PR TITLE
Fix documentation navbar controls

### DIFF
--- a/leo/doc/html/conf.py
+++ b/leo/doc/html/conf.py
@@ -16,6 +16,12 @@ html_theme_options = {
     'use_repository_button': True,
     'home_page_in_toc': True,
     'show_navbar_depth': 2,
+    # Everything in the navbar is already available in the primary sidebar.
+    # Leaving all slots empty also lets the theme bind the visible sidebar toggle.
+    'navbar_start': [],
+    'navbar_center': [],
+    'navbar_end': [],
+    'navbar_persistent': [],
     'logo': {
         'image_light': '../_static/LeoLogo.svg',
         'image_dark': '../_static/LeoLogo-dark.svg',


### PR DESCRIPTION
## Summary

- remove the redundant top-level Search navbar
- restore the primary-sidebar toggle by leaving the unused navbar slots empty
- keep the theme’s native responsive behavior without custom CSS or JavaScript

## Verification

- `QT_QPA_PLATFORM=offscreen python -m leo.scripts.build_docs --out /tmp/leo-built-docs`
- checked the rendered site at 1440x900: no duplicate Search bar and the sidebar toggle collapses correctly
- checked at 390x844: the sidebar toggle opens the navigation drawer
- `git diff --check`