### PR TITLE
Reduce documentation sidebar logo size

### DIFF
--- a/leo/doc/_static/custom.css
+++ b/leo/doc/_static/custom.css
@@ -28,6 +28,10 @@ html[data-theme="dark"] {
     letter-spacing: -0.02em;
 }
 
+.bd-sidebar-primary .navbar-brand .logo__image {
+    max-width: 85%;
+}
+
 .leo-hero {
     align-items: center;
     display: grid;


### PR DESCRIPTION
## Summary

- reduce the primary-sidebar lion logo to 85% of the available width
- leave more room for Search and documentation navigation
- complement the navbar fix from #4909

## Verification

- full documentation build succeeded
- checked the rendered landing page at 1440x900
- checked the rendered navigation drawer at 390x844
- `git diff --check`