### PR TITLE
Allow leoBridge to run without Qt

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoNodes
 from leo.commands.baseCommands import BaseEditCommandsClass
-from leo.plugins.qt_text import QTextMixin
+from leo.core.leoAPI import TextMixin as QTextMixin
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr

--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -9,9 +9,9 @@ from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:  # pragma: no cover
+    from leo.core.leoAPI import TextMixin as QTextMixin
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
-    from leo.plugins.qt_text import QTextMixin
 
 # @-<< baseCommands imports & abbreviations >>
 

--- a/leo/commands/bufferCommands.py
+++ b/leo/commands/bufferCommands.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from typing import cast, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
-from leo.plugins.qt_text import QTextMixin
+from leo.core.leoAPI import TextMixin as QTextMixin
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -11,7 +11,7 @@ from typing import cast, Any, TYPE_CHECKING
 
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
-from leo.plugins.qt_text import QTextMixin
+from leo.core.leoAPI import TextMixin as QTextMixin
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr

--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position
-    from leo.plugins.qt_text import QTextMixin
+    from leo.core.leoAPI import TextMixin as QTextMixin
 
 # @-<< killBufferCommands imports & annotations >>
 

--- a/leo/commands/rectangleCommands.py
+++ b/leo/commands/rectangleCommands.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
-from leo.plugins.qt_text import QTextMixin
+from leo.core.leoAPI import TextMixin as QTextMixin
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -7,9 +7,8 @@ Abstract base classes and Protocol classes for Leo's gui.
 # @+<< leoAPI.py: imports and annotations >>
 # @+node:ekr.20250329041628.1: ** << leoAPI.py: imports and annotations >>
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
-from leo.plugins.qt_text import QTextMixin
 
 if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
@@ -17,8 +16,23 @@ if TYPE_CHECKING:
 
 
 # @+others
-# @+node:ekr.20070228074228.1: ** class StringTextWrapper(QTextMixin)
-class StringTextWrapper(QTextMixin):
+# @+node:ekr.20260811120000.1: ** class TextMixin
+class TextMixin:
+    """GUI-neutral base class for Leo's text wrappers."""
+
+    def __init__(self, c: Cmdr | None = None) -> None:
+        self.c = c
+        self.changingText = False
+        self.enabled = True
+        self.tags: dict[str, str] = {}
+        self.permanent = True
+        self.useScintilla = False
+        self.virtualInsertPoint: int | None = None
+        self.widget: Any | None = None
+
+
+# @+node:ekr.20070228074228.1: ** class StringTextWrapper (TextMixin)
+class StringTextWrapper(TextMixin):
     """A class that represents Leo's body pane as a Python string."""
 
     # @+others
@@ -26,7 +40,6 @@ class StringTextWrapper(QTextMixin):
     def __init__(self, c: Cmdr | None, name: str) -> None:
         """Ctor for the StringTextWrapper class."""
         super().__init__(c)
-        self.c = c
         self.name = name
         self.ins = 0
         self.sel = 0, 0

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -19,17 +19,6 @@ import platform
 from leo.core import leoGlobals as g
 from leo.core import leoExternalFiles
 from leo.core.leoCache import GlobalCacher
-from leo.core.leoQt import QCloseEvent
-
-# For casts
-from leo.core.leoBackground import BackgroundProcessManager
-from leo.core.leoCommands import Commands as Cmdr
-from leo.core.leoExternalFiles import ExternalFilesController
-from leo.core.leoNodes import NodeIndices, Position
-from leo.core.leoPlugins import LeoPluginsController
-from leo.core.leoSessions import SessionManager
-from leo.plugins.qt_events import LossageData
-from leo.plugins.qt_idle_time import IdleTime
 
 # @-<< leoApp imports >>
 # @+<< leoApp annotations >>
@@ -37,6 +26,15 @@ from leo.plugins.qt_idle_time import IdleTime
 if TYPE_CHECKING:  # pragma: no cover
     from subprocess import Popen
     from types import ModuleType
+
+    from leo.core.leoBackground import BackgroundProcessManager
+    from leo.core.leoCommands import Commands as Cmdr
+    from leo.core.leoExternalFiles import ExternalFilesController
+    from leo.core.leoNodes import NodeIndices, Position
+    from leo.core.leoPlugins import LeoPluginsController
+    from leo.core.leoSessions import SessionManager
+    from leo.plugins.qt_events import LossageData
+    from leo.plugins.qt_idle_time import IdleTime
 
     # Do not import these at the top level: they would cause circular imports.
     from leo.core.leoConfig import GlobalConfigManager
@@ -209,17 +207,17 @@ class LeoApp:
         # We can't always use a cast here because doing so would create circular imports.
         # In those two places we suppress the otherwise valid mypy complaints.
 
-        self.backgroundProcessManager = cast(BackgroundProcessManager, None)
+        self.backgroundProcessManager = cast('BackgroundProcessManager', None)
         self.config: GlobalConfigManager = None  # type:ignore  # g.app.config
-        self.externalFilesController = cast(ExternalFilesController, None)
+        self.externalFilesController = cast('ExternalFilesController', None)
         self.db: dict | SqlitePickleShare | g.NullObject = {}  # g.app.global_cacher.
         self.global_cacher: dict | GlobalCacher | g.NullObject = {}
         self.idleTimeManager = cast(IdleTimeManager, None)
         self.jupytextManager: JupytextManager = None  # type:ignore
         self.loadManager = cast(LoadManager, None)
-        self.nodeIndices = cast(NodeIndices, None)
-        self.pluginsController = cast(LeoPluginsController, None)
-        self.sessionManager = cast(SessionManager, None)
+        self.nodeIndices = cast('NodeIndices', None)
+        self.pluginsController = cast('LeoPluginsController', None)
+        self.sessionManager = cast('SessionManager', None)
 
         # Global status vars for the Commands class...
         self.commandName = ''  # The name of the command being executed.
@@ -1452,6 +1450,8 @@ class LeoApp:
             g.trace()
 
         # #2433 - use the same method as clicking on the close box.
+        from leo.core.leoQt import QCloseEvent
+
         g.app.gui.close_event(QCloseEvent())
 
     # @+node:ekr.20230703100758.1: *4* app.saveSession

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -144,7 +144,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoGui
     from leo.core.qt_frame import LeoQtMenu
     from leo.plugins.qt_gui import StyleSheetManager
-    from leo.plugins.qt_text import QTextMixin
+    from leo.core.leoAPI import TextMixin as QTextMixin
 
     Args = Any
     KWargs = Any

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -12,7 +12,6 @@ import time
 from typing import cast, Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 
-from leo.plugins.qt_frame import FindTabManager
 from leo.core.leoNodes import Position
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -21,7 +20,8 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoKeys import KeyHandlerClass as KeyHandler
     from leo.core.leoNodes import VNode
-    from leo.plugins.qt_text import QTextMixin
+    from leo.plugins.qt_frame import FindTabManager
+    from leo.core.leoAPI import TextMixin as QTextMixin
 # @-<< leoFind imports & annotations >>
 # @+<< Theory of operation of find/change >>
 # @+node:ekr.20031218072017.2414: ** << Theory of operation of find/change >>
@@ -97,7 +97,7 @@ class LeoFind:
         self.k: KeyHandler = c.k
 
         # Created by dw.createFindTab.
-        self.ftm = cast(FindTabManager, None)
+        self.ftm = cast('FindTabManager', None)
         self.re_obj = cast(re.Pattern, None)
 
         # The work "widget".

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -28,6 +28,7 @@ from leo.core.leoAPI import StringTextWrapper
 # @+node:ekr.20220415013957.1: ** << leoFrame annotations >>
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoColorizer import BaseColorizer
+    from leo.core.leoAPI import TextMixin as QTextMixin
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import (
         LeoKeyEvent,
@@ -51,7 +52,6 @@ if TYPE_CHECKING:  # pragma: no cover
         QMinibufferWrapper,
         QScintillaWrapper,
         QTextEditWrapper,
-        QTextMixin,
     )
 
     Widget = Any  # 'Any' is the correct annotation for base class widgets.

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -16,10 +16,7 @@ from collections.abc import Callable
 from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoFrame
-from leo.core.leoAPI import StringTextWrapper
-from leo.core.leoQt import QtWidgets
-from leo.plugins.qt_frame import LeoQTreeWidget
-from leo.plugins.qt_text import QLineEditWrapper, QTextEditWrapper, QTextMixin
+from leo.core.leoAPI import StringTextWrapper, TextMixin
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
@@ -92,7 +89,7 @@ class LeoGui:
         *,
         binding: str = '',
         char: str = '',
-        w: QTextMixin | None = None,
+        w: Any = None,
         x: int | None = None,
         x_root: int | None = None,
         y: int | None = None,
@@ -118,7 +115,7 @@ class LeoGui:
         self.scriptFileName = scriptFileName
 
     # @+node:ekr.20110605121601.18845: *4* LeoGui.event_generate
-    def event_generate(self, c: Cmdr, char: str, shortcut: str, w: QTextMixin) -> None:
+    def event_generate(self, c: Cmdr, char: str, shortcut: str, w: Any) -> None:
         event = self.create_key_event(c, binding=shortcut, char=char, w=w)
         c.k.masterKeyHandler(event)
         c.outerUpdate()
@@ -199,15 +196,11 @@ class LeoKeyEvent:
             if w is None:
                 return
 
-        # trace(f" text? {isinstance(w, QTextMixin):1} w", info(w))
+        # trace(f" text? {isinstance(w, TextMixin):1} w", info(w))
 
         # Ensure that self.w is a wrapper for all key-related Qt widgets.
         if c.widget_name(w).startswith('log'):
             self.w = c.frame.log.logCtrl
-            return
-        if isinstance(w, QTextMixin):
-            trace('QTextMixin', info(w))
-            self.w = w
             return
         if wrapper := getattr(w, 'wrapper', None):
             trace('w.wrapper', info(wrapper))
@@ -217,19 +210,28 @@ class LeoKeyEvent:
             trace('w.leo_wrapper', info(wrapper))
             self.w = wrapper
             return
-        if isinstance(w, QtWidgets.QTextEdit):
-            # Inject the `leo_wrapper` ivar into the widget so that this method
-            # will never reallocate another wrapper for this widget.
-            self.w = w.leo_wrapper = QTextEditWrapper(widget=w, name=c.widget_name(w), c=c)
-            trace_always('new wrapper', f"{self.w.__class__.__name__} for {obj_name(w)}")
-            return
-        if isinstance(w, QtWidgets.QLineEdit):
-            self.w = w.leo_wrapper = QLineEditWrapper(widget=w, name=c.widget_name(w), c=c)
-            trace_always('New wrapper', f"{self.w.__class__.__name__} for {obj_name(w)}")
-            return
-        if isinstance(w, LeoQTreeWidget):  # A very special case.
-            self.w = w
-            return
+        if g.app.gui.guiName() == 'qt':
+            from leo.core.leoQt import QtWidgets
+            from leo.plugins.qt_frame import LeoQTreeWidget
+            from leo.plugins.qt_text import QLineEditWrapper, QTextEditWrapper
+
+            if isinstance(w, TextMixin):
+                trace('QTextMixin', info(w))
+                self.w = w
+                return
+            if isinstance(w, QtWidgets.QTextEdit):
+                # Inject the `leo_wrapper` ivar into the widget so that this method
+                # will never reallocate another wrapper for this widget.
+                self.w = w.leo_wrapper = QTextEditWrapper(widget=w, name=c.widget_name(w), c=c)
+                trace_always('new wrapper', f"{self.w.__class__.__name__} for {obj_name(w)}")
+                return
+            if isinstance(w, QtWidgets.QLineEdit):
+                self.w = w.leo_wrapper = QLineEditWrapper(widget=w, name=c.widget_name(w), c=c)
+                trace_always('New wrapper', f"{self.w.__class__.__name__} for {obj_name(w)}")
+                return
+            if isinstance(w, LeoQTreeWidget):  # A very special case.
+                self.w = w
+                return
 
         # Anything should be valid here: we don't expect the wrapper to do key handling.
         self.w = w

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -18,7 +18,6 @@ from typing import Any, cast, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.external import codewise
 from leo.core.leoFrame import NullLog
-from leo.core.leoQt import QtWidgets
 
 try:
     import jedi
@@ -28,14 +27,14 @@ except ImportError:
 # @+<< leoKeys annotations >>
 # @+node:ekr.20220414165644.1: ** << leoKeys annotations >>
 if TYPE_CHECKING:  # pragma: no cover
+    from leo.core.leoAPI import TextMixin as QTextMixin
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGlobals import BindingInfo
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position
     from leo.plugins.qt_frame import LeoQtLog
-    from leo.plugins.qt_text import QTextMixin
 
-    QWidget = QtWidgets.QWidget
+    QWidget = Any
     Stroke = Any
     Widget = Any  # 'Any' is the correct annotation for base class widgets.
 

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -56,7 +56,7 @@ from leo.core.leoNodes import Position, VNode
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
-    from leo.plugins.qt_text import QTextMixin
+    from leo.core.leoAPI import TextMixin as QTextMixin
 
 
 # @-<< leoUndo imports & annotations >>

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -28,7 +28,7 @@ import string
 from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core.leoGui import LeoKeyEvent
-from leo.plugins.qt_text import QTextMixin
+from leo.core.leoAPI import TextMixin as QTextMixin
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, cast, TYPE_CHECKING
 from leo.core import leoGlobals as g
+from leo.core.leoAPI import TextMixin
 from leo.core.leoQt import QtCore, QtGui, Qsci, QtWidgets
 from leo.core.leoQt import ContextMenuPolicy, Key, KeyboardModifier
 from leo.core.leoQt import MouseButton, MoveMode, MoveOperation
@@ -145,7 +146,7 @@ def helpForRMarginGuides(self, event=None):
 
 
 # @+node:ekr.20140901062324.18719: **   class QTextMixin
-class QTextMixin:
+class QTextMixin(TextMixin):
     """
     A mixin class for StringTextWrapper, QTextEditWrapper and QScintillaWrapper classes.
 

--- a/leo/unittests/core/test_leoBridge.py
+++ b/leo/unittests/core/test_leoBridge.py
@@ -3,6 +3,9 @@
 """Tests of leoBridge.py"""
 
 import os
+import subprocess
+import sys
+import textwrap
 from leo.core import leoBridge
 from leo.core.leoTest2 import LeoUnitTest
 
@@ -31,6 +34,51 @@ class TestBridge(LeoUnitTest):
         self.assertTrue(os.path.exists(test_dot_leo), msg=test_dot_leo)
         c = controller.openLeoFile(test_dot_leo)
         self.assertTrue(c)
+
+    def test_null_bridge_does_not_import_qt(self):
+        """The null bridge must work when PyQt6 is not installed."""
+        repo_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+        test_dot_leo = os.path.join(repo_dir, 'leo', 'test', 'test.leo')
+        script = textwrap.dedent(
+            f"""
+            import importlib.abc
+            import sys
+
+            class BlockPyQt(importlib.abc.MetaPathFinder):
+                def find_spec(self, fullname, path=None, target=None):
+                    if fullname == 'PyQt6' or fullname.startswith('PyQt6.'):
+                        raise ImportError(f'Unexpected Qt import: {{fullname}}')
+                    return None
+
+            sys.meta_path.insert(0, BlockPyQt())
+
+            from leo.core import leoBridge
+
+            bridge = leoBridge.controller(
+                gui='nullGui',
+                loadPlugins=False,
+                readSettings=False,
+                silent=True,
+                useCaches=False,
+            )
+            assert bridge.isOpen()
+            assert bridge.globals().app.gui.guiName() == 'nullGui'
+            c = bridge.openLeoFile({test_dot_leo!r})
+            assert c
+            assert not any(
+                name == 'PyQt6' or name.startswith('PyQt6.')
+                for name in sys.modules
+            )
+            assert not any(name.startswith('leo.plugins.qt_') for name in sys.modules)
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, '-c', script],
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     # @-others
 


### PR DESCRIPTION
## Summary

- decouple GUI-neutral text wrappers and annotations from the Qt implementation
- lazily import Qt-only event and widget classes
- add a subprocess regression test that blocks PyQt6 imports and opens a real .leo file with nullGui

## Testing

- `python -m pytest leo/unittests/core/test_leoBridge.py ... leo/unittests/commands/test_editCommands.py` — 271 passed
- `python -m pytest leo/unittests/plugins/test_gui.py leo/unittests/plugins/test_plugins.py` — 13 passed, 1 skipped
- Ruff on all changed files — passed
- `git diff --check` — passed
- LeoPyRef.leo refreshed, XML validated, and reopened successfully

Mypy reports only the pre-existing `leoShadow.py` inference errors documented as a known repository quirk.