### PR TITLE
Keep documentation lion visible while scrolling

### DIFF
--- a/leo/doc/_static/custom.css
+++ b/leo/doc/_static/custom.css
@@ -32,6 +32,13 @@ html[data-theme="dark"] {
     max-width: 85%;
 }
 
+.bd-sidebar-primary .sidebar-primary-items__start > .sidebar-primary-item:first-child {
+    background: var(--pst-color-background);
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+
 .leo-hero {
     align-items: center;
     display: grid;


### PR DESCRIPTION
## Summary

- keep the documentation sidebar lion sticky while navigation scrolls
- preserve the theme-aware sidebar background beneath the logo

Closes #4912

## Verification

- built the documentation successfully with Sphinx
- verified with agent-browser at a 1000x500 viewport: the sidebar scrolled from 0 to 600 px while the lion remained 24 px from the viewport top
- ran git diff --check