### PR TITLE
Keep documentation search visible while scrolling

### DIFF
--- a/leo/doc/_static/custom.css
+++ b/leo/doc/_static/custom.css
@@ -32,11 +32,19 @@ html[data-theme="dark"] {
     max-width: 85%;
 }
 
-.bd-sidebar-primary .sidebar-primary-items__start > .sidebar-primary-item:first-child {
-    background: var(--pst-color-background);
-    position: sticky;
-    top: 0;
-    z-index: 1;
+.bd-sidebar-primary {
+    overflow: hidden;
+}
+
+.bd-sidebar-primary .sidebar-primary-items__start {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.bd-sidebar-primary .sidebar-primary-items__start > .sidebar-primary-item:last-child {
+    overflow-y: auto;
 }
 
 .leo-hero {


### PR DESCRIPTION
## Summary

- keep the Leo logo and search field visible in the primary documentation sidebar
- limit scrolling to the sidebar navigation section

## Testing

- built the documentation with Sphinx
- verified the long Commands sidebar at 1440x800 with agent-browser
- confirmed navigation scrolls while the logo and search positions remain unchanged
- checked the mobile sidebar at 600x800
- ran `git diff --check`