### PR TITLE
Fix #4919: pin ty and resolve new diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,9 @@ jobs:
       - run: pip install "mypy<2" mypy-extensions typing_extensions
           types-docutils types-Markdown types-paramiko types-PyYAML
           types-requests types-six
-          "PyQt6>=6.6" PyQt6-QScintilla PyQt6-WebEngine ty
+          "PyQt6>=6.6" PyQt6-QScintilla PyQt6-WebEngine "ty==0.0.71"
           black Jinja2 Pygments docutils pyenchant jedi nbformat nbconvert
       - run: python -m mypy leo
       # Require ty: https://github.com/astral-sh/ty to pass.
       # Run after mypy to reuse the checkout/Python/PyQt6 setup.
-      # - run: ty check --python "$(python -c 'import sys; print(sys.prefix)')" leo
-      # - run: ty check leo
+      - run: ty check leo

--- a/leo/core/LeoPyRef.leo
+++ b/leo/core/LeoPyRef.leo
@@ -3256,8 +3256,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -3275,8 +3275,8 @@ jobs:
       # No display in CI; run Qt headless instead of pulling in xvfb.
       QT_QPA_PLATFORM: offscreen
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -3292,8 +3292,8 @@ jobs:
     env:
       QT_QPA_PLATFORM: offscreen
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -3309,8 +3309,8 @@ jobs:
     env:
       QT_QPA_PLATFORM: offscreen
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -3322,8 +3322,8 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -3331,13 +3331,12 @@ jobs:
       - run: pip install "mypy&lt;2" mypy-extensions typing_extensions
           types-docutils types-Markdown types-paramiko types-PyYAML
           types-requests types-six
-          "PyQt6&gt;=6.6" PyQt6-QScintilla PyQt6-WebEngine ty
+          "PyQt6&gt;=6.6" PyQt6-QScintilla PyQt6-WebEngine "ty==0.0.71"
           black Jinja2 Pygments docutils pyenchant jedi nbformat nbconvert
       - run: python -m mypy leo
       # Require ty: https://github.com/astral-sh/ty to pass.
       # Run after mypy to reuse the checkout/Python/PyQt6 setup.
-      # - run: ty check --python "$(python -c 'import sys; print(sys.prefix)')" leo
-      # - run: ty check leo
+      - run: ty check leo
 </t>
 <t tx="ekr.20260806163514.1">g.cls()
 from leo.commands import editFileCommands as efc

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -4862,7 +4862,7 @@ class LeoServer:
                 try:
                     childIndex = int(childIndex_s)
                 except Exception:  # pragma: no cover.
-                    raise ServerError(f"{tag}: bad childIndex: {childIndex!r}")
+                    raise ServerError(f"{tag}: bad childIndex: {childIndex_s!r}")
                 gnx = d.get('gnx')
                 if gnx is None:  # pragma: no cover.
                     raise ServerError(f"{tag}: no gnx in {d}.")

--- a/leo/core/tracing_utils.py
+++ b/leo/core/tracing_utils.py
@@ -183,6 +183,7 @@ def to_unicode(s: Any, encoding: str = 'utf-8') -> str:
         trace(callers())
     except Exception:
         es_exception()
+        s2 = ''
         print(f"{tag}: unexpected error! encoding: {encoding!r}, s2:\n{s2!r}")
         trace(callers())
     return s2

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -216,7 +216,7 @@ class FreeLayoutController:
         w = top and top.find_child(QtWidgets.QWidget, 'outlineFrame')
         while w:
             w = w.parent()
-            if isinstance(w, NestedSplitter):
+            if NestedSplitter is not None and isinstance(w, NestedSplitter):
                 return w
         return None
 

--- a/leo/plugins/mod_http.py
+++ b/leo/plugins/mod_http.py
@@ -279,6 +279,7 @@ def init():
         return False
     getGlobalConfiguration()
     if config.http_active:
+        assert asyncore is not None
         try:
             Server(config.http_ip, config.http_port, RequestHandler)
         except OSError as e:
@@ -330,6 +331,7 @@ def plugin_wrapper(tag, keywords):
 
 # @+node:bwmulder.20050326191345.1: *3* onFileOpen (not used) (mod_http.py)
 def onFileOpen(tag, keywords):
+    assert asyncore is not None
     c = keywords.get("new_c")
     g.trace('c', repr(c))
     wasactive = config.http_active

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -1553,6 +1553,9 @@ class ViewRenderedController(QtWidgets.QWidget):
             )
             return
 
+        if Template is None:
+            g.es("Jinja2 is not installed.")
+            return
         tmpl = Template(Path(template_path).read_text())
         out = tmpl.render(template_data)
         w = self.get_base_text_widget()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -305,7 +305,7 @@ dependencies = [
   "pytest",
   "pytest-cov",      # For coverage testing.
   "ruff",
-  "ty",
+  "ty==0.0.71",
 
   # General packages for plugins, leoserver and commands...
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ black           # For unit tests.
 pytest
 pytest-cov      # For coverage testing.
 ruff
-ty
+ty==0.0.71
 
 # General packages for plugins, leoserver and commands...
 


### PR DESCRIPTION
Fixes #4919.

## Summary

- pin `ty==0.0.71` consistently in `pyproject.toml`, `requirements.txt`, and CI
- re-enable the required `ty check leo` CI step
- fix the seven diagnostics introduced by ty 0.0.71
- synchronize all changed files into `LeoPyRef.leo`

Two diagnostics exposed genuine unbound-variable paths in `leoserver.py` and `tracing_utils.py`. The remaining fixes make optional dependency handling explicit for `NestedSplitter`, `asyncore`, and Jinja2.

## Verification

- `uvx --from ty==0.0.71 ty check leo`
- `python -m mypy leo`
- `ruff check leo`
- `QT_QPA_PLATFORM=offscreen python -m pytest leo/unittests` (866 passed, 3 skipped)