### PR TITLE
PR: tracing_utils.py:to_unicode: fall back to reporting original string

### DIFF
--- a/leo/core/tracing_utils.py
+++ b/leo/core/tracing_utils.py
@@ -184,7 +184,7 @@ def to_unicode(s: Any, encoding: str = 'utf-8') -> str:
     except Exception:
         es_exception()
         s2 = ''
-        print(f"{tag}: unexpected error! encoding: {encoding!r}, s2:\n{s2!r}")
+        print(f"{tag}: unexpected error! encoding: {encoding!r}, s:\n{s!r}")
         trace(callers())
     return s2
 


### PR DESCRIPTION
There is no point in reporting a made-up empty string.