### PR TITLE
Set the Qt application icon for terminal launches

### DIFF
--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -123,8 +123,15 @@ class LeoQtGui(leoGui.LeoGui):
         QtWidgets.QApplication.setDesktopSettingsAware(True)
         # Create objects...
         self.qtApp = QtWidgets.QApplication(sys.argv)
+        if sys.platform.startswith('linux'):
+            # Match packaging/linux/leo.desktop when Leo starts in a terminal.
+            self.qtApp.setDesktopFileName('leo')
         self.reloadSettings()
         self.appIcon = self.getIconImage('leoapp32.png')
+        if self.appIcon:
+            # Set the application icon as well as each window's icon. Desktop
+            # shells use QApplication.windowIcon() for terminal launches.
+            self.qtApp.setWindowIcon(self.appIcon)
 
         # Define various classes key stokes.
         # @+<< define FKeys >>


### PR DESCRIPTION
## Summary

- set Leo's loaded icon on the Qt application, not only individual windows
- identify Linux terminal launches with the shipped `leo.desktop` entry
- preserve the existing per-window icon behavior

## Why

Desktop shells can query application-level metadata or match a process to a desktop entry. Leo previously set its icon only on individual windows and did not identify terminal launches as the `leo` desktop application, which could leave a generic or missing icon.

## Verification

- `QT_QPA_PLATFORM=offscreen python -m pytest leo/unittests/plugins/test_plugins.py` (7 passed)
- `ruff check leo/plugins/qt_gui.py`
- refreshed `leo/plugins/qt_gui.py` in `LeoPyRef.leo` and XML-validated the outline
