### PR TITLE
PR fixes #4936: crash in show-settings-outline command

### DIFF
--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1252,6 +1252,8 @@ class ActiveSettingsOutline:
         result = {}
         for key in d.keys():
             gs = d.get(key)
+            if not gs:
+                continue
             assert isinstance(gs, g.GeneralSetting), repr(gs)
             if not gs.kind:
                 g.trace('OOPS: no kind', repr(gs))


### PR DESCRIPTION
See #4936.

- [x] Add a guard, bypassing the failed assert.