### PR TITLE
PR fixes #4944 and #4945

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7650,6 +7650,8 @@ def getDocString(s: str) -> str:
 def getDocStringForFunction(func: Callable) -> str:
     """Return the docstring for a function that creates a Leo command."""
 
+    g.trace(g.callers())
+
     def name(func: Callable) -> str:
         return str(func.__name__) if hasattr(func, '__name__') else '<no __name__>'
 
@@ -7663,16 +7665,19 @@ def getDocStringForFunction(func: Callable) -> str:
 
     if name(func) == 'minibufferCallback':
         func = get_defaults(func, 0)
-        if s := getattr(func, '__doc__', '').strip():
+        s = getattr(func, '__doc__', None)
+        if s and s.strip():
             return s
     if name(func) == 'commonCommandCallback':
         script = get_defaults(func, 1)
         if s := g.getDocString(script):  # Do a text scan for the function.
             return s
     # Now the general cases.  Prefer __doc__ to docstring()
-    if s := getattr(func, '__doc__', '').strip():
+    s = getattr(func, '__doc__', None)
+    if s and s.strip():
         return s
-    if s := getattr(func, 'docstring', '').strip():
+    s = getattr(func, 'docstring', None)
+    if s and s.strip():
         return s
     return ''
 

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -4681,6 +4681,7 @@ def hideOutlinePane(event: LeoKeyEvent | None = None) -> None:
 # @+node:ekr.20231102130902.1: *4* 'hide-status-bar'
 @g.command('hide-status-bar')
 def hideStatusBar(event: LeoKeyEvent | None = None) -> None:
+    """Hide the status bar."""
     if c := event.get('c') if event else None:
         dw = c.frame.top
         dw.statusBar().hide()
@@ -4760,6 +4761,7 @@ def showQtWidgets(event: LeoKeyEvent | None = None) -> None:
 # @+node:ekr.20241027141138.1: *4* 'show-status-bar'
 @g.command('show-status-bar')
 def showStatusBar(event: LeoKeyEvent | None = None) -> None:
+    """Show the status bar"""
     if c := event.get('c') if event else None:
         dw = c.frame.top
         dw.statusBar().show()

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -4683,7 +4683,7 @@ def hideOutlinePane(event: LeoKeyEvent | None = None) -> None:
 def hideStatusBar(event: LeoKeyEvent | None = None) -> None:
     if c := event.get('c') if event else None:
         dw = c.frame.top
-        dw.statusBar.hide()
+        dw.statusBar().hide()
 
 
 # @+node:ekr.20241027140853.1: *3* show-* commands
@@ -4762,7 +4762,7 @@ def showQtWidgets(event: LeoKeyEvent | None = None) -> None:
 def showStatusBar(event: LeoKeyEvent | None = None) -> None:
     if c := event.get('c') if event else None:
         dw = c.frame.top
-        dw.statusBar.show()
+        dw.statusBar().show()
 
 
 # @+node:ekr.20241027140920.1: *3* toggle-* commands

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -4795,7 +4795,7 @@ def toggleMinibuffer(event: LeoKeyEvent | None = None) -> None:
 def toggleStatusBar(event: LeoKeyEvent | None = None) -> None:
     if c := event.get('c') if event else None:
         dw = c.frame.top
-        w = dw.statusBar
+        w = dw.statusBar()
         if w.isVisible():
             w.hide()
         else:

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -4645,6 +4645,7 @@ def hideBodyPane(event: LeoKeyEvent | None = None) -> None:
 # @+node:ekr.20231102130853.1: *4* 'hide-icon-bar'
 @g.command('hide-icon-bar')
 def hideIconBar(event: LeoKeyEvent | None = None) -> None:
+    """Hide the icon bar."""
     if c := event.get('c') if event else None:
         dw = c.frame.top
         dw.iconBar.hide()
@@ -4663,6 +4664,7 @@ def hideLogPane(event: LeoKeyEvent | None = None) -> None:
 # @+node:ekr.20231102131048.1: *4* 'hide-minibuffer'
 @g.command('hide-minibuffer')
 def hideMinibuffer(event: LeoKeyEvent | None = None) -> None:
+    """Hide the minibuffer."""
     if c := event.get('c') if event else None:
         dw = c.frame.top
         dw.leo_minibuffer_frame.hide()
@@ -4691,6 +4693,7 @@ def hideStatusBar(event: LeoKeyEvent | None = None) -> None:
 # @+node:ekr.20241027140945.1: *4* 'show-icon-bar'
 @g.command('show-icon-bar')
 def showIconBar(event: LeoKeyEvent | None = None) -> None:
+    """Show the icon bar."""
     if c := event.get('c') if event else None:
         dw = c.frame.top
         dw.iconBar.show()
@@ -4699,6 +4702,7 @@ def showIconBar(event: LeoKeyEvent | None = None) -> None:
 # @+node:ekr.20241027141052.1: *4* 'show-minibuffer'
 @g.command('show-minibuffer')
 def showMinibuffer(event: LeoKeyEvent | None = None) -> None:
+    """Show the minibuffer."""
     if c := event.get('c') if event else None:
         dw = c.frame.top
         dw.leo_minibuffer_frame.show()
@@ -4771,6 +4775,7 @@ def showStatusBar(event: LeoKeyEvent | None = None) -> None:
 # @+node:ekr.20241027141012.1: *4* 'toggle-icon-bar'
 @g.command('toggle-icon-bar')
 def toggleIconBar(event: LeoKeyEvent | None = None) -> None:
+    """Toggle the visibility of the icon bar."""
     if c := event.get('c') if event else None:
         dw = c.frame.top
         w = dw.iconBar
@@ -4783,6 +4788,7 @@ def toggleIconBar(event: LeoKeyEvent | None = None) -> None:
 # @+node:ekr.20241027141108.1: *4* 'toggle-minibuffer'
 @g.command('toggle-minibuffer')
 def toggleMinibuffer(event: LeoKeyEvent | None = None) -> None:
+    """Toggle the visibility of the minibuffer."""
     if c := event.get('c') if event else None:
         dw = c.frame.top
         w = dw.leo_minibuffer_frame
@@ -4795,6 +4801,7 @@ def toggleMinibuffer(event: LeoKeyEvent | None = None) -> None:
 # @+node:ekr.20241027141155.1: *4* 'toggle-status-bar'
 @g.command('toggle-status-bar')
 def toggleStatusBar(event: LeoKeyEvent | None = None) -> None:
+    """Toggle the visibility of the status bar."""
     if c := event.get('c') if event else None:
         dw = c.frame.top
         w = dw.statusBar()
@@ -4807,6 +4814,7 @@ def toggleStatusBar(event: LeoKeyEvent | None = None) -> None:
 # @+node:ekr.20240505045118.1: *4* 'toggle-unl-view'
 @g.command('toggle-unl-view')
 def toggleUnlView(event: LeoKeyEvent | None = None) -> None:
+    """Toggle the unl view."""
     c = event.get('c') if event else None
     if c and c.frame.statusLine:
         # This is not a convenience method.

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -53,6 +53,7 @@ from leo.plugins.qt_text import QTextMixin
 
 assert Qt
 assert qt_commands
+QWidget = QtWidgets.QWidget
 # @-<< qt_gui imports  >>
 # @+<< qt_gui annotations >>
 # @+node:ekr.20220415183421.1: ** << qt_gui annotations >>
@@ -79,7 +80,6 @@ if TYPE_CHECKING:  # pragma: no cover
     QSplitter = QtWidgets.QSplitter
     QTabWidget = QtWidgets.QTabWidget
     QVBoxLayout = QtWidgets.QVBoxLayout
-    QWidget = QtWidgets.QWidget
 
 
 # @-<< qt_gui annotations >>


### PR DESCRIPTION
See #4944 (show-status-bar) and #4945 (expand-log-pane).

- [x] Fix crashers in g.getDocStringForFunction. These were blunders in using the walrus operators.
- [x] Fix crashers in top-level show/hide/toggle-status-bar commands.
- [x] qt_gui.py: define QWidget at the top level, for casts.
- [x] Add docstrings for show/hide/toggle commands in qt_frame.py.