### PR TITLE
Re-enable ty in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,11 +85,10 @@ jobs:
         with:
           python-version: "3.14"
           cache: pip
-      # Install optional packages that Leo's devs should have installed.
-      # - run: pip install "mypy<2" mypy-extensions typing_extensions
-      #     types-docutils types-Markdown types-paramiko types-PyYAML
-      #     types-requests types-six
+      # Install optional packages that Leo's devs should have installed,
+      # so ty resolves their imports the same way it does on devs' machines.
       - run: pip install "ty==0.0.73"
           "PyQt6>=6.6" PyQt6-QScintilla PyQt6-WebEngine
           black Jinja2 Pygments docutils pyenchant jedi nbformat nbconvert
+          "mypy<2" lxml PyYAML
       - run: ty check leo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,22 +77,19 @@ jobs:
       - run: pip install "PyQt6>=6.6" PyQt6-QScintilla docutils sphinx sphinx-book-theme
       - run: python -m leo.scripts.build_docs
 
-  # For now, do *not* require ty to pass.
-  # It's more important for ty to pass on EKR's machine!
-
-  # ty:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v7
-  #     - uses: actions/setup-python@v7
-  #       with:
-  #         python-version: "3.14"
-  #         cache: pip
-  #     # Install optional packages that Leo's devs should have installed.
-  #     # - run: pip install "mypy<2" mypy-extensions typing_extensions
-  #     #     types-docutils types-Markdown types-paramiko types-PyYAML
-  #     #     types-requests types-six
-  #     - run: pip install "ty==0.0.73"
-  #         "PyQt6>=6.6" PyQt6-QScintilla PyQt6-WebEngine 
-  #         black Jinja2 Pygments docutils pyenchant jedi nbformat nbconvert
-  #     - run: ty check leo
+  ty:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+          cache: pip
+      # Install optional packages that Leo's devs should have installed.
+      # - run: pip install "mypy<2" mypy-extensions typing_extensions
+      #     types-docutils types-Markdown types-paramiko types-PyYAML
+      #     types-requests types-six
+      - run: pip install "ty==0.0.73"
+          "PyQt6>=6.6" PyQt6-QScintilla PyQt6-WebEngine
+          black Jinja2 Pygments docutils pyenchant jedi nbformat nbconvert
+      - run: ty check leo

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -28,7 +28,7 @@ try:
     import lxml
     import lxml.html
 except ImportError:
-    lxml = None
+    lxml = None  # type:ignore
 
 # Leo imports...
 from leo.core import leoGlobals as g


### PR DESCRIPTION
## Summary

Re-enables the `ty` job in `.github/workflows/ci.yml`, which Edward commented out in c750fbde27 because `ty check leo` was failing in CI even though it passed on his machine.

**Why it differed between Edward's machine and CI:** the `ty` job's `pip install` line never installed `mypy`, `lxml`, or `PyYAML`, even though several files probe for them with an `ImportError` fallback (e.g. `leo/core/leoImport.py`, `leo/commands/checkerCommands.py`, `leo/plugins/auto_colorize2_0.py`). Edward has these packages installed locally, so `ty` resolves the real module types there and correctly requires `# type:ignore` on the `= None` fallback assignments. In CI those imports were unresolved, `ty.toml`'s `unresolved-import = "ignore"` treated them as `Unknown`, `= None` no longer conflicted with anything, and the existing `# type:ignore` comments became *unused* — which is itself a diagnostic under `unused-type-ignore-comment = "warn"` (re-enabled in 80a6705d22), and `ty check` exits non-zero whenever any diagnostics are reported, warnings included. So CI wasn't failing because the code was wrong; it was failing because CI's environment didn't match the environment the ty.toml rules assume.

**Fix:**
- Install `mypy`, `lxml`, and `PyYAML` in the `ty` CI job so it resolves imports the same way a dev machine does.
- Add the one genuinely missing `# type:ignore` on `leo/core/leoImport.py`'s `lxml = None` fallback (it was missing the comment that the equivalent `docutils` fallback right above it already has).
- Uncomment the `ty` job itself.

## Test plan
- [x] `ty check leo` passes locally with `ty==0.0.73` (the pinned CI version)
- [x] CI `ty` job passes on this PR: https://github.com/leo-editor/leo-editor/actions/runs/32628087401
