### PR TITLE
Add lxml and PyYAML as declared dependencies

### DIFF
--- a/leo/scripts/ty_leo.py
+++ b/leo/scripts/ty_leo.py
@@ -15,6 +15,7 @@ print(os.path.basename(__file__))
 leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
 os.chdir(leo_editor_dir)
 
+
 # @+others
 # @+node:ekr.20260823160000.1: ** check_optional_deps
 def check_optional_deps() -> bool:
@@ -39,13 +40,17 @@ def check_optional_deps() -> bool:
         except Exception:
             missing.append(pip_name)
     if missing:
-        print('ty_leo.py: missing packages that some `# type:ignore` comments assume are installed:')
+        print(
+            'ty_leo.py: missing packages that some `# type:ignore` comments assume are installed:'
+        )
         for name in missing:
             print(f'  {name}')
         print('Install them with: pip install -r requirements.txt')
         print('Without them, ty reports spurious unused-type-ignore-comment diagnostics.')
         return False
     return True
+
+
 # @-others
 
 if not check_optional_deps():

--- a/leo/scripts/ty_leo.py
+++ b/leo/scripts/ty_leo.py
@@ -4,6 +4,7 @@
 ty_leo.py: Run ty on all of Leo.
 """
 
+import importlib
 import os
 import subprocess
 import sys
@@ -13,6 +14,42 @@ print(os.path.basename(__file__))
 # cd to leo-editor
 leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
 os.chdir(leo_editor_dir)
+
+# @+others
+# @+node:ekr.20260823160000.1: ** check_optional_deps
+def check_optional_deps() -> bool:
+    """Return True if every package that a `# type:ignore` fallback assumes is present is importable. See #4952."""
+    # (pip package name, importable module name)
+    packages = [
+        ('docutils', 'docutils'),
+        ('lxml', 'lxml'),
+        ('mypy', 'mypy'),
+        ('nbformat', 'nbformat'),
+        ('Pygments', 'pygments'),
+        ('PyQt6', 'PyQt6.QtWidgets'),
+        ('PyQt6-QScintilla', 'PyQt6.Qsci'),
+        ('pyenchant', 'enchant'),
+        ('PyYAML', 'yaml'),
+        ('websockets', 'websockets'),
+    ]
+    missing = []
+    for pip_name, module_name in packages:
+        try:
+            importlib.import_module(module_name)
+        except Exception:
+            missing.append(pip_name)
+    if missing:
+        print('ty_leo.py: missing packages that some `# type:ignore` comments assume are installed:')
+        for name in missing:
+            print(f'  {name}')
+        print('Install them with: pip install -r requirements.txt')
+        print('Without them, ty reports spurious unused-type-ignore-comment diagnostics.')
+        return False
+    return True
+# @-others
+
+if not check_optional_deps():
+    sys.exit(1)
 
 args = ' '.join(sys.argv[1:])
 python = sys.executable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -313,12 +313,14 @@ dependencies = [
   # "flexx",         # For --gui=browser (leoflexx.py plugin).
   "jedi",            # For autocompletion.
   "jupytext",        # For paired .ipynb/.py files.
+  "lxml",            # For leoImport.py importers.
   "markdown",        # VR3 plugin.
   "matplotlib",      # VR3 plugin.
   # "meta",          # livecode.py plugin.
   "numpy",           # VR3 plugin.
   "pyenchant",       # The spell tab.
- 
+  "PyYAML",          # auto_colorize2_0.py plugin.
+
   "sphinx",
   "sphinx-book-theme",
   "urllib3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,11 +39,13 @@ docutils        # For Sphinx and rST plugins.
 # flexx           # leoflexx.py plugin.
 jedi            # For autocompletion.
 jupytext        # For paired .ipynb/.py files.
+lxml            # For leoImport.py importers.
 markdown        # VR3 plugin.
 matplotlib      # VR3 plugin.
 # meta          # livecode.py plugin.
 numpy           # VR3 plugin.
 pyenchant       # The spell tab.
+PyYAML          # auto_colorize2_0.py plugin.
 sphinx          # For documentation.
 sphinx-book-theme
 urllib3


### PR DESCRIPTION
## Summary
- `leo/core/leoImport.py` imports `lxml` and `leo/plugins/auto_colorize2_0.py` imports `yaml` (PyYAML), but neither package was ever listed in `requirements.txt`/`pyproject.toml`. Added both.
- `ty_leo.py` now checks up front that every package a `# type:ignore` fallback assumes is present (docutils, lxml, mypy, nbformat, Pygments, PyQt6, PyQt6-QScintilla, pyenchant, PyYAML, websockets) is actually importable, and exits with a clear "pip install -r requirements.txt" message if not — instead of letting `ty` silently resolve the missing imports as unresolved and flag the matching `# type:ignore` comments as "unused," which produces a wall of diagnostics that look like code bugs but are really just a missing dependency.

Fixes #4952. (The `mypy`/`lxml`/`PyYAML` diagnostics were a genuine gap in `requirements.txt`; the rest were most likely caused by the reporter's `ty_leo.py` run using a different/incomplete Python environment than the one `pip install -r requirements.txt` populated. The eager check should turn that class of problem into an immediate, clear message instead of a confusing diagnostic dump.)

## Test plan
- [x] `python3 -m leo.scripts.ty_leo` still reports "All checks passed!" with all deps installed.
- [x] Verified the missing-package detection and eager-exit path directly (simulated a missing package, confirmed the message and exit code).
- [x] `ruff check` and `ty check` pass on the modified `ty_leo.py`.
- [x] CI passes.