### PR TITLE
PR: Require strict-equality-semantics

### DIFF
--- a/ty.toml
+++ b/ty.toml
@@ -32,6 +32,9 @@ exclude = [
     "leo/plugins/qt_main*",
 ]
 
+[analysis]
+strict-equality-semantics = true
+
 [rules]
 
 # Like `disable_error_code=attr-defined` in .mypy.ini.


### PR DESCRIPTION
- [x] Add this section to ty.toml to make ty formally as strict as mypy:
```ini
[analysis]
strict-equality-semantics = true
```

- [x] Ensure that ci.yml passes.