### PR TITLE
PR fixes #4956: all commands should have docstrings

### DIFF
--- a/leo/commands/commanderEditCommands.py
+++ b/leo/commands/commanderEditCommands.py
@@ -729,6 +729,7 @@ def insertBodyTime(self: Self, event: LeoKeyEvent | None = None) -> None:
 # @+node:ekr.20171123135625.52: ** c_ec.justify-toggle-auto
 @g.commander_command("justify-toggle-auto")
 def justify_toggle_auto(self: Self, event: LeoKeyEvent | None = None) -> None:
+    """Toggle justification per the @autojustify setting"""
     c = self
     if c.editCommands.autojustify == 0:
         c.editCommands.autojustify = abs(c.config.getInt("autojustify") or 0)

--- a/leo/commands/commanderHelpCommands.py
+++ b/leo/commands/commanderHelpCommands.py
@@ -67,6 +67,7 @@ def editOneSetting(self: Self, event: LeoKeyEvent | None = None) -> None:
 # @+node:vitalije.20170708172746.1: ** c_help.editShortcut
 @g.commander_command('edit-shortcut')
 def editShortcut(self: Self, event: LeoKeyEvent | None = None) -> None:
+    """Edit the shortcut of an @button or @command node"""
     k = self.k
     if k.isEditShortcutSensible():
         # k.setState('input-shortcut', 'input-shortcut')

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -265,6 +265,7 @@ def merge_node_with_prev_node(event: LeoKeyEvent | None = None) -> None:
 # @+node:ekr.20190926103245.1: *3* @g.command('next-or-end-of-line')
 @g.command('next-or-end-of-line')
 def nextOrEndOfLine(event: LeoKeyEvent | None = None) -> None:
+    """Do end-of-line or next-line"""
     # by Brian Theado.
     if c := event.get('c') if event else None:
         lineScrollHelper(c, 'next-', 'end-', '')
@@ -273,6 +274,7 @@ def nextOrEndOfLine(event: LeoKeyEvent | None = None) -> None:
 # @+node:ekr.20190926103246.2: *3* @g.command('next-or-end-of-line-extend-selection')
 @g.command('next-or-end-of-line-extend-selection')
 def nextOrEndOfLineExtendSelection(event: LeoKeyEvent | None = None) -> None:
+    """Do end-of-line-extend-selection or next-line-extend-selection"""
     # by Brian Theado.
     if c := event.get('c') if event else None:
         lineScrollHelper(c, 'next-', 'end-', '-extend-selection')
@@ -281,6 +283,7 @@ def nextOrEndOfLineExtendSelection(event: LeoKeyEvent | None = None) -> None:
 # @+node:ekr.20190926103246.1: *3* @g.command('previous-or-beginning-of-line')
 @g.command('previous-or-beginning-of-line')
 def previousOrBeginningOfLine(event: LeoKeyEvent | None = None) -> None:
+    """Do beginning-of-line or previous-line"""
     # by Brian Theado.
     if c := event.get('c') if event else None:
         lineScrollHelper(c, 'previous-', 'beginning-', '')
@@ -289,6 +292,7 @@ def previousOrBeginningOfLine(event: LeoKeyEvent | None = None) -> None:
 # @+node:ekr.20190926103246.3: *3* @g.command('previous-or-beginning-of-line-extend-selection')
 @g.command('previous-or-beginning-of-line-extend-selection')
 def previousOrBeginningOfLineExtendSelection(event: LeoKeyEvent | None = None) -> None:
+    """Do beginning-of-line-extend-selection or previous-line-extend-selection"""
     # by Brian Theado.
     if c := event.get('c') if event else None:
         lineScrollHelper(c, 'previous-', 'beginning-', '-extend-selection')
@@ -2765,6 +2769,7 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     @cmd('back-to-home-extend-selection')
     def backToHomeExtendSelection(self, event: LeoKeyEvent | None = None) -> None:
+        """Smart home, extending selection"""
         self.backToHome(event, extend=True)
 
     # @+node:ekr.20150514063305.291: *4* ec.backToIndentation

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -891,6 +891,7 @@ class SpellTabHandler:
 # @+node:ekr.20180209141207.1: ** @g.command('show-spell-info')
 @g.command('show-spell-info')
 def show_spell_info(event: LeoKeyEvent | None = None) -> None:
+    """Show the location of the main and user spelling dictionaries"""
     if c := event.get('c') if event else None:
         c.spellCommands.handler.spellController.show_info()
 

--- a/leo/core/leoBackground.py
+++ b/leo/core/leoBackground.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # @+node:ekr.20220415160700.1: ** bpm-status
 @g.command('bpm-status')
 def bpm_status(event: LeoKeyEvent | None = None) -> None:
+    """Show the status of the BackgroundProcessManager"""
     bpm = g.app.backgroundProcessManager
     bpm.show_status()
 

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -92,6 +92,7 @@ def make_colorizer(c: Cmdr, widget: QWidget) -> JEditColorizer | PygmentsColoriz
 # @+node:ekr.20260215050008.1: ** command: dump-last-colorizer-trace
 @g.command('dump-last-colorizer-trace')
 def dump_colorizer_last_colorizer_traces(event: LeoKeyEvent | None = None) -> None:
+    """Dump the last colorizer trace"""
     c = event['c'] if event else None
     if not c:
         return

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1481,6 +1481,7 @@ class Commands:
     # @+node:ekr.20260619021703.1: *4* @cmd redraw (c.redraw_command)
     @cmd('redraw')
     def redraw_command(self, event: LeoKeyEvent | None = None) -> None:
+        """Redraw the outline"""
         if c := event.get('c') if event else None:
             c.redraw()
 

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1002,7 +1002,7 @@ class LeoFind:
     # @+node:ekr.20141113094129.6: *4* find.focus-to-find
     @cmd('focus-to-find')
     def focus_to_find(self, event: LeoKeyEvent | None = None) -> None:
-        """Show the Find Tab and put the focus their or in the minibuffer"""
+        """Show the Find Tab and put the focus there or in the minibuffer"""
         c = self.c
         if c.config.getBool('use-find-dialog', default=True):
             g.app.gui.openFindDialog(c)

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1002,6 +1002,7 @@ class LeoFind:
     # @+node:ekr.20141113094129.6: *4* find.focus-to-find
     @cmd('focus-to-find')
     def focus_to_find(self, event: LeoKeyEvent | None = None) -> None:
+        """Show the Find Tab and put the focus their or in the minibuffer"""
         c = self.c
         if c.config.getBool('use-find-dialog', default=True):
             g.app.gui.openFindDialog(c)

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -479,12 +479,14 @@ class LeoFrame:
     # @+node:felix.20250313154127.1: *4* LeoFrame.Window Layouts
     @frame_cmd('horizontal-window-layout')
     def horizontalWindowLayout(self, event: LeoKeyEvent | None = None) -> None:
+        """Change the layout of Leo's window to the horizontal (legacy) layout"""
         c = self.c
         c.inCommand = False  # Allow inner command
         c.doCommandByName('layout-legacy')
 
     @frame_cmd('vertical-window-layout')
     def verticalWindowLayout(self, event: LeoKeyEvent | None = None) -> None:
+        """Change the layout of Leo's window to the vertical layout"""
         c = self.c
         c.inCommand = False  # Allow inner command
         c.doCommandByName('layout-vertical-thirds')

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7650,8 +7650,6 @@ def getDocString(s: str) -> str:
 def getDocStringForFunction(func: Callable) -> str:
     """Return the docstring for a function that creates a Leo command."""
 
-    g.trace(g.callers())
-
     def name(func: Callable) -> str:
         return str(func.__name__) if hasattr(func, '__name__') else '<no __name__>'
 

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -2147,10 +2147,12 @@ class VimCommands:
     # @+node:ekr.20150509050905.1: *4* vc.e_command & tabnew_command
     @cmd(':e')
     def e_command(self, event: LeoKeyEvent | None = None) -> None:
+        """Handle the vim :e command"""
         self.Tabnew(self)
 
     @cmd(':tabnew')
     def tabnew_command(self, event: LeoKeyEvent | None = None) -> None:
+        """Handle the vim :tabnew command"""
         self.Tabnew(self)
 
     # @+node:ekr.20140815160132.18824: *4* vc.print_dot (:print-dot)
@@ -2189,6 +2191,7 @@ class VimCommands:
     # @+node:ekr.20150509050918.1: *4* vc.r_command
     @cmd(':r')
     def r_command(self, event: LeoKeyEvent | None = None) -> None:
+        """Handle the vim :r (load-file-at-cursor) command."""
         self.LoadFileAtCursor(self)
 
     # @+node:ekr.20140815160132.18826: *4* vc.revert (:e!)
@@ -2200,10 +2203,12 @@ class VimCommands:
     # @+node:ekr.20150509050755.1: *4* vc.s_command & percent_s_command
     @cmd(':%s')
     def percent_s_command(self, event: LeoKeyEvent | None = None) -> None:
+        """Handle the Vim :%s command"""
         self.Substitution(self, all_lines=True)
 
     @cmd(':s')
     def s_command(self, event: LeoKeyEvent | None = None) -> None:
+        """Handle the Vim :s command"""
         self.Substitution(self, all_lines=False)
 
     # @+node:ekr.20140815160132.18827: *4* vc.shell_command (:!)

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -350,6 +350,7 @@ def showLayouts(event: LeoKeyEvent | None) -> None:
 # @+node:tom.20250106123058.1: *3* command: show_layout_name
 @g.command('show-current-layout')
 def show_layout_name(event: LeoKeyEvent | None = None) -> None:
+    """Show the name of the current layout of Leo's outline"""
     c = event.get('c') if event else None
     if not c:
         return

--- a/leo/plugins/testRegisterCommand.py
+++ b/leo/plugins/testRegisterCommand.py
@@ -35,6 +35,7 @@ def onCreate(tag, keys):
 
 @g.command('print-hello2')
 def hello_command2(event):
+    """The print-hello2 command (testing only)"""
     g.es_print('Hello 2 from %s' % (g.shortFileName(__file__)), color='red')
 
 

--- a/leo/unittests/misc_tests/test_design.py
+++ b/leo/unittests/misc_tests/test_design.py
@@ -265,6 +265,16 @@ class TestCommands(LeoUnitTest):
             params = sig.parameters
             assert 'event' in params, f"{func.__name__}{params}"
 
+    # @+node:ekr.20260824012333.1: *3* TestCommands.test_docstrings
+    def test_docstrings(self):
+        """Global test that all commands have a docstring"""
+        c = self.c
+        for command_name, func in c.commandsDict.items():
+            assert inspect.isfunction(func), (command_name, func.__name__)
+            # sig = inspect.signature(func)
+            # params = sig.parameters
+            # assert 'event' in params, f"{func.__name__}{params}"
+
     # @-others
 
 

--- a/leo/unittests/misc_tests/test_design.py
+++ b/leo/unittests/misc_tests/test_design.py
@@ -275,7 +275,7 @@ class TestCommands(LeoUnitTest):
             s = g.getDocStringForFunction(func)
             if not s.strip():
                 missing.append(func.__name__)
-        assert not missing, g.objToString(list(sorted(missing)), tag='Missing docstrings')
+        assert not missing, 'Missing docstrings...\n  ' + '\n  '.join(list(sorted(missing)))
 
     # @-others
 

--- a/leo/unittests/misc_tests/test_design.py
+++ b/leo/unittests/misc_tests/test_design.py
@@ -269,11 +269,13 @@ class TestCommands(LeoUnitTest):
     def test_docstrings(self):
         """Global test that all commands have a docstring"""
         c = self.c
+        missing: list[str] = []
         for command_name, func in c.commandsDict.items():
             assert inspect.isfunction(func), (command_name, func.__name__)
-            # sig = inspect.signature(func)
-            # params = sig.parameters
-            # assert 'event' in params, f"{func.__name__}{params}"
+            s = g.getDocStringForFunction(func)
+            if not s.strip():
+                missing.append(func.__name__)
+        assert not missing, g.objToString(list(sorted(missing)), tag='Missing docstrings')
 
     # @-others
 


### PR DESCRIPTION
See #4956.

- [x] Remove a trace.
- [x] Create a new unit test.
- [x] Add missing docstrings, and spell-check them.