### PR TITLE
PR fixes #4949: qt layout menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,4 @@ leo/plugins/temacs_ext/
 
 
 leo/test/scriptFile.py
+leo/test/beautify_node.py

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -2291,6 +2291,7 @@
 </v>
 <v t="ekr.20140915194122.23428"></v>
 <v t="ekr.20260111055007.1"></v>
+<v t="ekr.20070224073109.1"></v>
 </vnodes>
 <tnodes>
 <t tx="TL.20080702085131.2">If True: Save the Leo file and all modified derived files every time the external editor saves a modified file.
@@ -3712,6 +3713,7 @@ contextmenu.py      # Required by the vim.py and xemacs.py plugins.
 mod_scripting.py
 nav_qt.py           # Forward/back buttons &amp; goto-next/prev-history-node
 nodetags.py
+qt_layout.py        # Creates qt_layout menu in the Plugins menu.
 quicksearch.py      # Nav pane.
 viewrendered.py     # (Or viewrendered3.py) Plugins menu support.
 leo_to_html_outline_viewer.py  # Self-contained HTML Outline Viewer</t>

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -221,11 +221,11 @@ class LeoKeyEvent:
             # Inject the `leo_wrapper` ivar into the widget so that this method
             # will never reallocate another wrapper for this widget.
             self.w = w.leo_wrapper = QTextEditWrapper(widget=w, name=c.widget_name(w), c=c)
-            trace_always('new wrapper', f"{self.w.__class__.__name__} for {obj_name(w)}")
+            trace('New wrapper', f"{self.w.__class__.__name__} for {obj_name(w)}")
             return
         if isinstance(w, QtWidgets.QLineEdit):
             self.w = w.leo_wrapper = QLineEditWrapper(widget=w, name=c.widget_name(w), c=c)
-            trace_always('New wrapper', f"{self.w.__class__.__name__} for {obj_name(w)}")
+            trace('New wrapper', f"{self.w.__class__.__name__} for {obj_name(w)}")
             return
         if isinstance(w, LeoQTreeWidget):  # A very special case.
             self.w = w

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -299,6 +299,8 @@ class LeoMenu:
             return
         if not menu:
             return
+        if 'qt_layout' in repr(menu):  ###
+            g.trace(menu, len(table))  ###
         self.traceMenuTable(table)
         for data in table:
             label, command, done = self.getMenuEntryInfo(data, menu)

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -299,8 +299,6 @@ class LeoMenu:
             return
         if not menu:
             return
-        if 'qt_layout' in repr(menu):  ###
-            g.trace(menu, len(table))  ###
         self.traceMenuTable(table)
         for data in table:
             label, command, done = self.getMenuEntryInfo(data, menu)

--- a/leo/plugins/plugins_menu.py
+++ b/leo/plugins/plugins_menu.py
@@ -159,8 +159,6 @@ def createPluginsMenu(tag: str, keywords: KWargs) -> None:
     for group_name in PluginDatabase.getGroups():
         PluginDatabase.setMenu(group_name, c.frame.menu.createNewMenu(group_name, menu_name))
     for z in plugins_list:
-        if 'qt_layout' in repr(z):
-            g.trace(z)  ###
         addPluginMenuItem(z, c)
 
 
@@ -301,13 +299,8 @@ class PlugIn:
         The g.command decorator sets func.is_command & func.command_name.
         """
         self.othercmds = {}
-        trace = 'qt_layout' in repr(self)
-        # if 'qt_layout' in repr(self):  ###
-        #     g.printObj(list(self.mod.__dict__.keys()))
-        for key in self.mod.__dict__.keys():
+        for key in self.mod.__dict__.keys():  ###
             func = self.mod.__dict__[key]
-            if trace:
-                g.trace(key, getattr(func, 'is_command', 'None'))
             if getattr(func, 'is_command', None):
                 self.othercmds[func.command_name] = func
 

--- a/leo/plugins/plugins_menu.py
+++ b/leo/plugins/plugins_menu.py
@@ -299,8 +299,7 @@ class PlugIn:
         The g.command decorator sets func.is_command & func.command_name.
         """
         self.othercmds = {}
-        for key in self.mod.__dict__.keys():  ###
-            func = self.mod.__dict__[key]
+        for func in self.mod.__dict__.values():
             if getattr(func, 'is_command', None):
                 self.othercmds[func.command_name] = func
 

--- a/leo/plugins/plugins_menu.py
+++ b/leo/plugins/plugins_menu.py
@@ -159,7 +159,7 @@ def createPluginsMenu(tag: str, keywords: KWargs) -> None:
     for group_name in PluginDatabase.getGroups():
         PluginDatabase.setMenu(group_name, c.frame.menu.createNewMenu(group_name, menu_name))
     for z in plugins_list:
-        if 'qt_layout' in z.name:
+        if 'qt_layout' in repr(z):
             g.trace(z)  ###
         addPluginMenuItem(z, c)
 
@@ -255,14 +255,14 @@ class PlugIn:
     hastoplevel: Any
 
     # @+others
-    # @+node:EKR.20040517080555.4: *3* PlugIn.__init__ & helper
-    def __init__(self, plgMod: ModuleType, c: Cmdr | None = None) -> None:
+    # @+node:EKR.20040517080555.4: *3* PlugIn.__init__
+    def __init__(self, _module: ModuleType, c: Cmdr | None = None) -> None:
         """
-        @param plgMod: Module object for the plugin represented by this instance.
+        @param _module: Module object for the plugin represented by this instance.
         @param c:  Leo-editor "commander" for the current .leo file
         """
         self.c = c
-        self.mod = plgMod
+        self.mod = _module
         self.name = self.moduleName = None
         self.doc = self.version = None
         try:
@@ -280,13 +280,13 @@ class PlugIn:
         self.version = self.mod.__dict__.get("__version__", "<unknown>")
         # g.pr(self.version,g.shortFileName(filename))
         # Configuration...
-        assert plgMod.__file__
-        self.configfilename = "%s.ini" % os.path.splitext(plgMod.__file__)[0]
+        assert _module.__file__
+        self.configfilename = "%s.ini" % os.path.splitext(_module.__file__)[0]
         # True if this can be configured.
         self.hasconfig = os.path.isfile(self.configfilename)
         # Look for an applyConfiguration function in the module.
         # This is used to apply changes in configuration from the properties window
-        self.hasapply = hasattr(plgMod, "applyConfiguration")
+        self.hasapply = hasattr(_module, "applyConfiguration")
         self.create_menu()  # Create menu items from cmd_* functions.
         # Use a toplevel menu item instead of the default About.
         try:
@@ -294,15 +294,20 @@ class PlugIn:
         except KeyError:
             self.hastoplevel = False
 
-    # @+node:EKR.20040517080555.7: *4* create_menu (Plugin)
+    # @+node:EKR.20040517080555.7: *3* Plugin.create_menu
     def create_menu(self) -> None:
         """
         Add items in the main menu for each decorated command in this plugin.
         The g.command decorator sets func.is_command & func.command_name.
         """
         self.othercmds = {}
-        for item in self.mod.__dict__.keys():
-            func = self.mod.__dict__[item]
+        trace = 'qt_layout' in repr(self)
+        # if 'qt_layout' in repr(self):  ###
+        #     g.printObj(list(self.mod.__dict__.keys()))
+        for key in self.mod.__dict__.keys():
+            func = self.mod.__dict__[key]
+            if trace:
+                g.trace(key, getattr(func, 'is_command', 'None'))
             if getattr(func, 'is_command', None):
                 self.othercmds[func.command_name] = func
 

--- a/leo/plugins/plugins_menu.py
+++ b/leo/plugins/plugins_menu.py
@@ -140,26 +140,28 @@ def createPluginsMenu(tag: str, keywords: KWargs) -> None:
         return
     menu_name = keywords.get('menu_name', '&Plugins')
     pc = g.app.pluginsController
-    lmd = pc.loadedModules
-    if not lmd:
+    loaded_modules = pc.loadedModules
+    if not loaded_modules:
         return  # #4753
 
-    impModSpecList = list(lmd.keys())
+    keys = list(loaded_modules.keys())
 
     def key(s: str) -> str:
         return s.split('.')[-1].lower()
 
-    impModSpecList.sort(key=key)
-    plgObList: list[PlugIn] = [PlugIn(lmd[impModSpec], c) for impModSpec in impModSpecList]
+    keys.sort(key=key)
+    plugins_list: list[PlugIn] = [PlugIn(loaded_modules[key], c) for key in keys]
     c.pluginsMenu = pluginMenu = c.frame.menu.createNewMenu(menu_name)
-    # 2013/12/13: Add any items in @menu plugins
-    add_menu_from_settings(c)
+    add_menu_from_settings(c)  # Add any items in @menu plugins
     PluginDatabase.setMenu("Default", pluginMenu)
+
     # Add group menus
     for group_name in PluginDatabase.getGroups():
         PluginDatabase.setMenu(group_name, c.frame.menu.createNewMenu(group_name, menu_name))
-    for plgObj in plgObList:
-        addPluginMenuItem(plgObj, c)
+    for z in plugins_list:
+        if 'qt_layout' in z.name:
+            g.trace(z)  ###
+        addPluginMenuItem(z, c)
 
 
 # @+node:ekr.20131213072223.19531: *4* add_menu_from_settings
@@ -303,6 +305,10 @@ class PlugIn:
             func = self.mod.__dict__[item]
             if getattr(func, 'is_command', None):
                 self.othercmds[func.command_name] = func
+
+    # @+node:ekr.20260825054421.1: *3* Plugin.__repr__
+    def __repr__(self) -> str:
+        return f"<PlugIn {self.name=}>"
 
     # @+node:EKR.20040517080555.8: *3* PlugIn.about
     def about(self, event: Event | None = None) -> None:

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -73,6 +73,8 @@ def register_layout(name: str) -> Callable:
     def decorator(func: Callable) -> Callable:
         # Register the function's name and docstring in the dictionary
         LAYOUT_REGISTRY[name] = func.__doc__ or ''
+        # PR #4958: Inject the following into *this* callback for use
+        #           by Plugin.create_menu and ga.compute_tab_list.
         func.is_command = True  # PR #4958.
         func.command_name = func.__name__  # PR #4958
         return func  # Ensure the original function is returned

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -5,7 +5,8 @@ The basic machinery to support applying layouts of the main Leo panels.
 
 Leo always imports this module during startup when using the qt gui.
 
-If enabled explicitly, this plugin adds a menu item in the Plugins menu.
+If enabled explicitly in the `@enabled-plugins` setting, this plugin adds a
+menu item in the Plugins menu.
 """
 
 # @+<< qt_layout: imports & annotations >>

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -1,6 +1,12 @@
 # @+leo-ver=5-thin
 # @+node:tom.20240923194438.1: * @file ../plugins/qt_layout.py
-"""The basic machinery to support applying layouts of the main Leo panels."""
+"""
+The basic machinery to support applying layouts of the main Leo panels.
+
+This plugin is imported during Leo's startup.
+
+If enabled explicitly, it adds a menu item in the Plugins menu.
+"""
 
 # @+<< qt_layout: imports & annotations >>
 # @+node:tom.20240923194438.2: ** << qt_layout: imports & annotations >>
@@ -32,14 +38,20 @@ VR3_MODULE_NAME = 'viewrendered3.py'
 LAYOUT_REGISTRY: dict[str, str] = {}  # {layout_name: layout_docstring}
 # @-<< qt_layout: declarations >>
 
+__plugin_name__ = "qt_layout"
+
 
 # @+others
 # @+node:ekr.20241008174359.1: ** Top-level functions: qt_layout.py
 # @+node:ekr.20241008141246.1: *3* function: init (qt_layout.py)
 def init() -> bool:
     """
-    qt_layout is not a true plugin, but return True just in case.
+    Return True if this plugin is enabled.
+
+    Called only if the qt_layout.py plugin is explicitly enabled.
     """
+    g.registerHandler("create-optional-menus", create_layout_menu)
+    g.plugin_signon(__name__)
     return True
 
 
@@ -54,6 +66,11 @@ def is_module_loaded(module_name: str) -> bool:
     """Return True if the plugins controller has loaded the module."""
     controller = g.app.pluginsController
     return controller.isLoaded(module_name)
+
+
+# @+node:ekr.20260824080746.1: *3* function: create_layout_menu (qt_layout.py)
+def create_layout_menu(tag: str, kwargs: Any) -> None:
+    g.trace(f"{tag=}, {g.callers()=}")  ###
 
 
 # @+node:tom.20241015161609.1: *3* decorator:  register_layout (qt_layout.py)

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -3,9 +3,9 @@
 """
 The basic machinery to support applying layouts of the main Leo panels.
 
-This plugin is imported during Leo's startup.
+Leo always imports this module during startup when using the qt gui.
 
-If enabled explicitly, it adds a menu item in the Plugins menu.
+If enabled explicitly, this plugin adds a menu item in the Plugins menu.
 """
 
 # @+<< qt_layout: imports & annotations >>
@@ -37,8 +37,6 @@ VR3_MODULE_NAME = 'viewrendered3.py'
 
 LAYOUT_REGISTRY: dict[str, str] = {}  # {layout_name: layout_docstring}
 # @-<< qt_layout: declarations >>
-
-__plugin_name__ = "qt_layout"
 
 
 # @+others

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -1,14 +1,15 @@
 # @+leo-ver=5-thin
 # @+node:tom.20240923194438.1: * @file ../plugins/qt_layout.py
+# @+<< qt_layout: docstring>>
+# @+node:ekr.20260825062842.1: ** << qt_layout: docstring>>
 """
-The basic machinery to support applying layouts of the main Leo panels.
+The basic machinery to support applying Qt layouts to Leo's outline.
 
-Leo always imports this module during startup when using the qt gui.
-
-If enabled explicitly in the `@enabled-plugins` setting, this plugin adds a
-menu item in the Plugins menu.
+This plugin adds the qt_layout menu (and submenus) to the Plugins menu
+*only* if enabled explictly via the `@enabled-plugins`
 """
 
+# @-<< qt_layout: docstring>>
 # @+<< qt_layout: imports & annotations >>
 # @+node:tom.20240923194438.2: ** << qt_layout: imports & annotations >>
 from __future__ import annotations

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -49,7 +49,6 @@ def init() -> bool:
 
     Called only if the `@enabled-plugins` setting explicitly enables this plugin.
     """
-    g.registerHandler("create-optional-menus", create_layout_menu)
     g.plugin_signon(__name__)
     return True
 
@@ -67,17 +66,14 @@ def is_module_loaded(module_name: str) -> bool:
     return controller.isLoaded(module_name)
 
 
-# @+node:ekr.20260824080746.1: *3* function: create_layout_menu (qt_layout.py)
-def create_layout_menu(tag: str, kwargs: Any) -> None:
-    g.trace(f"TO DO: {tag=}")  ###
-
-
 # @+node:tom.20241015161609.1: *3* decorator:  register_layout (qt_layout.py)
 def register_layout(name: str) -> Callable:
 
     def decorator(func: Callable) -> Callable:
         # Register the function's name and docstring in the dictionary
         LAYOUT_REGISTRY[name] = func.__doc__ or ''
+        func.is_command = True  # PR #4958.
+        func.command_name = func.__name__  # PR #4958
         return func  # Ensure the original function is returned
 
     return decorator
@@ -87,7 +83,7 @@ def register_layout(name: str) -> Callable:
 # Read Me or Suffer
 #
 # The help-for-layouts and show-layout commands use these docstrings,
-# so the following constraints apply to the following docstrings:
+# so the following constraints apply to them:
 #
 # - All docstrings must start with a newline.
 #

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -84,19 +84,18 @@ def register_layout(name: str) -> Callable:
 
 
 # @+node:ekr.20241008174351.1: ** Layout commands
-# @+at
 # Read Me or Suffer
 #
 # The help-for-layouts and show-layout commands use these docstrings,
 # so the following constraints apply to the following docstrings:
 #
-# 1. All docstrings must start with a newline.
-# 2. Use a *single* ':', followed by a blank line
-#    to denote the start of a layout diagram or
-#    any other verbatim text.
-# 3. All verbatim text must end with a blank line unless
-#    the verbatim text ends the docstring.
-# @@c
+# - All docstrings must start with a newline.
+#
+# - Use a *single* ':', followed by a blank line to denote
+#   the start of a layout diagram or any other verbatim text.
+#
+# - All verbatim text must end with a blank line unless
+#   the verbatim text ends the docstring.
 # @+node:tom.20240928171510.1: *3* command: 'layout-big-tree'
 @g.command('layout-big-tree')
 @register_layout('layout-big-tree')

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -622,7 +622,7 @@ class LayoutCacheWidget(QWidget):
 
         splitter: Any = self.find_widget(name)
         if is_splitter(splitter):
-            return splitter  # type:ignore  # We've just checked the type.
+            return splitter
         splitter = self.created_splitter_dict.get(name, None)
         if is_splitter(splitter):
             return splitter  # type:ignore  # We've just checked the type.

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -361,7 +361,7 @@ def showLayouts(event: LeoKeyEvent | None) -> None:
     g.es(listing_s, tabName='layouts')
 
 
-# @+node:tom.20250106123058.1: *3* command: show_layout_name
+# @+node:tom.20250106123058.1: *3* command: 'show-current-layout'
 @g.command('show-current-layout')
 def show_layout_name(event: LeoKeyEvent | None = None) -> None:
     """Show the name of the current layout of Leo's outline"""
@@ -620,8 +620,7 @@ class LayoutCacheWidget(QWidget):
         def is_splitter(obj: object) -> bool:
             return obj is not None and isinstance(obj, QSplitter)
 
-        splitter: Any
-        splitter = self.find_widget(name)
+        splitter: Any = self.find_widget(name)
         if is_splitter(splitter):
             return splitter  # type:ignore  # We've just checked the type.
         splitter = self.created_splitter_dict.get(name, None)

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -69,7 +69,7 @@ def is_module_loaded(module_name: str) -> bool:
 
 # @+node:ekr.20260824080746.1: *3* function: create_layout_menu (qt_layout.py)
 def create_layout_menu(tag: str, kwargs: Any) -> None:
-    g.trace(f"{tag=}, {g.callers()=}")  ###
+    g.trace(f"TO DO: {tag=}")  ###
 
 
 # @+node:tom.20241015161609.1: *3* decorator:  register_layout (qt_layout.py)

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -47,7 +47,7 @@ def init() -> bool:
     """
     Return True if this plugin is enabled.
 
-    Called only if the qt_layout.py plugin is explicitly enabled.
+    Called only if the `@enabled-plugins` setting explicitly enables this plugin.
     """
     g.registerHandler("create-optional-menus", create_layout_menu)
     g.plugin_signon(__name__)

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -167,7 +167,7 @@ def big_tree(event: LeoKeyEvent | None = None) -> None:
 # @+node:ekr.20241008180407.1: *3* command: 'layout-legacy'
 @g.command('layout-legacy')
 @register_layout('layout-legacy')
-def quadrants(event: LeoKeyEvent | None = None) -> None:
+def legacy(event: LeoKeyEvent | None = None) -> None:
     """
     Create Leo's legacy layout:
 
@@ -236,7 +236,7 @@ def render_focused(event: LeoKeyEvent | None = None) -> None:
 # @+node:tom.20240930101515.1: *3* command: 'layout-restore-to-setting'
 @g.command('layout-restore-to-setting')
 @register_layout('layout-restore-to-setting')
-def restoreDefaultLayout(event: LeoKeyEvent | None = None) -> None:
+def restore_to_setting(event: LeoKeyEvent | None = None) -> None:
     """
     Select the layout specified by the `@string qt-layout-name` setting in effect
     for this outline. Use the **legacy** layout if the user's setting is erroneous.
@@ -257,7 +257,7 @@ def restoreDefaultLayout(event: LeoKeyEvent | None = None) -> None:
 # @+node:tom.20241005163724.1: *3* command: 'layout-swap-log-panel'
 @g.command('layout-swap-log-panel')
 @register_layout('layout-swap-log-panel')
-def swapLogPanel(event: LeoKeyEvent | None = None) -> None:
+def swap_log_panel(event: LeoKeyEvent | None = None) -> None:
     """
     Move the Log frame between main and secondary splitters.
 
@@ -341,7 +341,7 @@ def vertical_thirds2(event: LeoKeyEvent | None = None) -> None:
 # @+node:tom.20241022170042.1: *3* command: 'show-layouts'
 @g.command('layout-show-layouts')
 @g.command('show-layouts')
-def showLayouts(event: LeoKeyEvent | None) -> None:
+def show_layouts(event: LeoKeyEvent | None) -> None:
     """Show all layout diagrams in the Log Frame's `layouts` tab."""
     if not event:
         return
@@ -363,7 +363,7 @@ def showLayouts(event: LeoKeyEvent | None) -> None:
 
 # @+node:tom.20250106123058.1: *3* command: 'show-current-layout'
 @g.command('show-current-layout')
-def show_layout_name(event: LeoKeyEvent | None = None) -> None:
+def show_current_layout(event: LeoKeyEvent | None = None) -> None:
     """Show the name of the current layout of Leo's outline"""
     c = event.get('c') if event else None
     if not c:

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -140,7 +140,7 @@ class TestPlugins(LeoUnitTest):
             'mod_scripting.py',
             'nodetags.py',  # #2031: Qt imports are optional.
             'pyplot_backend.py',  # Not a real plugin.
-            'qt_layout.py',  # Not a real plugin.
+            'qt_layout.py',  # A special case.
         )
         pattern = re.compile(r'\b(QtCore|QtGui|QtWidgets)\b')  # Don't search for Qt.
         for fn in files:


### PR DESCRIPTION
See #4949.

- [x] Fix the bug: Inject ivars in the register_layout decorator.
- [x] qt_layout.py: Improve the docstrings for the module and the init function.
- [x] Add qt_layout.py to the official plugins in leoSettings.leo.
- [x] Fix a comment in test_plugins.py.

### Extras

- [x] Add PlugIn.__repr__.
- [x] Simplify code and var names in plugins_menu.py.
- [x] Suppress an unwanted trace in LeoKeyEvent.__init__.