### PR TITLE
ci.yml: use GitHub Actions output format for ruff and ty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
       - run: pip install ruff
-      - run: ruff check leo
+      - run: ruff check leo --output-format=github
       - run: ruff format --check leo
 
   test:
@@ -79,6 +79,8 @@ jobs:
 
   ty:
     runs-on: ubuntu-latest
+    env:
+      TY_OUTPUT_FORMAT: github
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7


### PR DESCRIPTION
## Summary
- `ruff check` now passes `--output-format=github`
- the `ty` job sets `TY_OUTPUT_FORMAT: github`

Both now emit GitHub Actions error annotations (inline on the Files changed tab / job summary) instead of only plain text in the raw log.

`ruff format --check` is left as-is since its `--output-format` flag is preview-only and emits a warning on stable.

## Test plan
- [x] Confirmed `ruff check --output-format=github` and `TY_OUTPUT_FORMAT=github ty check` are valid, stable flags locally
- [x] CI run on this PR shows annotations if any lint/type issues are introduced