### PR TITLE
Split pyproject.toml dependencies into optional-dependencies groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -281,9 +281,19 @@ readme = "README.md"
 #@+node:ekr.20240713074535.1: ** << pyproject.toml: dependencies >>
 # Warning: these dependencies should match those in requirements.txt.
 
-dependencies = [
+# `dependencies`: the minimum needed to launch Leo and edit outlines.
+# Everything else is optional: `pip install leo[plugins]`, `leo[dev]`, or `leo[full]` (both).
+# See #4891.
 
-  # For build devs.
+dependencies = [
+  "PyQt6>= 6.6",
+  "PyQt6-QScintilla",
+]
+
+[project.optional-dependencies]
+
+# For build/release devs, type-checking and the test suite.
+dev = [
   "build>=1.2.1",
   "twine>=5.1.0",
 
@@ -297,8 +307,7 @@ dependencies = [
   # "types-PyYAML",
   # "types-requests",
   # "types-six",
-  
-  # For testing.
+
   "asttokens",       # For unit tests.
   "beautifulsoup4",  # For link testing.
   "black",           # For unit tests.
@@ -306,9 +315,10 @@ dependencies = [
   "pytest-cov",      # For coverage testing.
   "ruff",
   "ty==0.0.73",
+]
 
-  # General packages for plugins, leoserver and commands...
-
+# Packages needed by specific plugins, leoserver and commands, but not to run Leo itself.
+plugins = [
   "docutils",        # For Sphinx and rST plugins.
   # "flexx",         # For --gui=browser (leoflexx.py plugin).
   "jedi",            # For autocompletion.
@@ -319,19 +329,20 @@ dependencies = [
   # "meta",          # livecode.py plugin.
   "numpy",           # VR3 plugin.
   "pyenchant",       # The spell tab.
+  "PyQt6-WebEngine", # Render-pane HTML/Markdown view; degrades to QTextBrowser without it.
   "PyYAML",          # auto_colorize2_0.py plugin.
+  "Send2Trash; platform_system == 'Windows'",  # For picture_viewer plugin.
 
   "sphinx",
   "sphinx-book-theme",
   "urllib3",
   "websockets",      # For leoserver.
+]
 
-  # Gui packages...
-
-  "PyQt6>= 6.6",
-  "PyQt6-QScintilla",
-  "PyQt6-WebEngine",
-  "Send2Trash; platform_system == 'Windows'",  # For picture_viewer plugin.
+# Everything: matches plain `pip install leo` before optional-dependencies existed.
+full = [
+  "leo[dev]",
+  "leo[plugins]",
 ]
 
 #@-<< pyproject.toml: dependencies >>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,19 @@
 # leo-editor/requirements.txt.
 
 # The dependencies here should match those in pyproject.toml.
+# This file installs everything: the equivalent of `pip install leo[full]`. See #4891.
 
 # @+<< requirements.txt: dependencies >>
 # @+node:ekr.20241022091142.1: ** << requirements.txt: dependencies >>
 # Warning: these dependencies should match those in pyproject.toml.
 
-# For build devs.
+# Gui packages: the minimum needed to launch Leo and edit outlines.
+
+PyQt6>= 6.6
+PyQt6-QScintilla
+
+# For build/release devs, type-checking and the test suite (pyproject.toml: [dev]).
+
 build>=1.2.1
 twine>=5.1.0
 setuptools>=80.4.0
@@ -24,7 +31,6 @@ setuptools>=80.4.0
 # types-requests
 # types-six
 
-# For testing.
 asttokens       # For unit tests.
 beautifulsoup4  # For link testing.
 black           # For unit tests.
@@ -33,7 +39,7 @@ pytest-cov      # For coverage testing.
 ruff
 ty==0.0.73
 
-# General packages for plugins, leoserver and commands...
+# Packages needed by specific plugins, leoserver and commands (pyproject.toml: [plugins]).
 
 docutils        # For Sphinx and rST plugins.
 # flexx           # leoflexx.py plugin.
@@ -45,18 +51,13 @@ matplotlib      # VR3 plugin.
 # meta          # livecode.py plugin.
 numpy           # VR3 plugin.
 pyenchant       # The spell tab.
+PyQt6-WebEngine # Render-pane HTML/Markdown view; degrades to QTextBrowser without it.
 PyYAML          # auto_colorize2_0.py plugin.
+Send2Trash; platform_system=="Windows"  # For picture_viewer plugin.
 sphinx          # For documentation.
 sphinx-book-theme
 urllib3
 websockets      # For leoserver.
-
-# Gui packages...
-
-PyQt6>= 6.6
-PyQt6-QScintilla
-PyQt6-WebEngine
-Send2Trash; platform_system=="Windows"  # For picture_viewer plugin.
 # @-<< requirements.txt: dependencies >>
 
 # @@language python


### PR DESCRIPTION
## Summary

- `dependencies` in `pyproject.toml` now lists only `PyQt6`/`PyQt6-QScintilla` — the minimum needed to launch Leo and edit outlines.
- Added `[project.optional-dependencies]`:
  - `dev` — build/release/type-checking/test tooling (build, twine, pytest, ruff, black, ty, commented-out mypy stubs, ...).
  - `plugins` — plugin/leoserver-only packages (docutils, jedi, jupytext, lxml, markdown, matplotlib, numpy, pyenchant, PyYAML, sphinx, sphinx-book-theme, urllib3, websockets, Send2Trash), plus `PyQt6-WebEngine` — confirmed only needed for the render pane, which already falls back to `QTextBrowser` without it.
  - `full = ["leo[dev]", "leo[plugins]"]` — restores exactly today's `pip install leo` behavior for anyone who wants everything.
- `requirements.txt` regrouped to match; it still installs everything (equivalent to `pip install leo[full]`), so no functional change there.

See #4891 for the full discussion/rationale, including package-count and install-size analysis, and the confirmation that `PyQt6-WebEngine` and `PyYAML` are both safe to make optional (the latter is used by exactly one non-default-enabled plugin, and Leo's plugin loader isolates per-plugin `ImportError`s without affecting startup).

Draft while this settles in for the next release round (not targeting the current one, per discussion on the issue).

## Test plan

- [x] `python -m tomllib` parses the updated `pyproject.toml`.
- [x] `setuptools.config.pyprojecttoml.read_configuration` reads the new `dependencies`/`optional-dependencies` structure correctly.
- [x] `pip install --dry-run --report` on the base package, and on `leo[dev]`, `leo[plugins]`, `leo[full]`, all resolve metadata successfully — `requires_dist` shows the right `extra ==` markers, including the `Send2Trash` Windows marker combined correctly with `extra == "plugins"`.
- [ ] CI (ruff/ty/tests) — pending