### PR TITLE
Check mypy availability without importing it

### DIFF
--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -5,6 +5,7 @@
 # @+<< checkerCommands imports >>
 # @+node:ekr.20161021092038.1: ** << checkerCommands imports >>
 from __future__ import annotations
+import importlib.util
 import os
 import re
 import subprocess
@@ -13,12 +14,10 @@ import time
 from typing import TYPE_CHECKING
 
 # Third-party imports.
-try:
-    import mypy
-    from mypy import api as mypy_api
-except Exception:
-    mypy = None  # type:ignore
-    mypy_api = None
+# Mypy ships full type stubs, so importing it here (and reassigning the name if
+# missing) would need an ignore comment that ty only wants when mypy is absent.
+# Checking availability via importlib avoids the import -- and that ignore -- entirely.
+MYPY_AVAILABLE = importlib.util.find_spec('mypy') is not None
 
 try:
     import ruff
@@ -259,7 +258,7 @@ def mypy_command(event: LeoKeyEvent | None = None) -> None:
         return
     if c.isChanged():
         c.save()
-    if mypy_api:
+    if MYPY_AVAILABLE:
         MypyCommand(c).run(c.p)
     else:
         g.es_print('can not import mypy')
@@ -414,7 +413,7 @@ class MypyCommand:
     def check_all(self, roots: list[Position]) -> None:
         """Run mypy on all files in paths."""
         c = self.c
-        if not mypy:
+        if not MYPY_AVAILABLE:
             print('install mypy with `pip install mypy`')
             return
         self.unknown_path_names = []
@@ -426,7 +425,7 @@ class MypyCommand:
     def check_file(self, fn: str, root: Position) -> None:
         """Run mypy on one file."""
         c = self.c
-        if not mypy:
+        if not MYPY_AVAILABLE:
             print('install mypy with `pip install mypy`')
             return
         command = f"{sys.executable} -m mypy {fn}"
@@ -437,7 +436,7 @@ class MypyCommand:
     def run(self, p: Position) -> None:
         """Run mypy on all Python @<file> nodes in c.p's tree."""
         c = self.c
-        if not mypy:
+        if not MYPY_AVAILABLE:
             print('install mypy with `pip install mypy`')
             return
         root = p.copy()

--- a/leo/scripts/ty_leo.py
+++ b/leo/scripts/ty_leo.py
@@ -24,7 +24,6 @@ def check_optional_deps() -> bool:
     packages = [
         ('docutils', 'docutils'),
         ('lxml', 'lxml'),
-        ('mypy', 'mypy'),
         ('nbformat', 'nbformat'),
         ('Pygments', 'pygments'),
         ('PyQt6', 'PyQt6.QtWidgets'),


### PR DESCRIPTION
## Summary
- `leo/commands/checkerCommands.py`'s mypy fallback-import (`try: import mypy / except: mypy = None  # type:ignore`) needed the `# type:ignore` because mypy ships full type stubs, so `ty` can actually verify the reassignment when mypy is installed -- and flags the ignore as "unused" when it isn't (see #4952).
- But `mypy`/`mypy_api` were only ever used as truthy availability checks -- the actual `mypy` command shells out via subprocess (`python -m mypy ...`) -- so the import itself was never needed.
- Replaced it with `MYPY_AVAILABLE = importlib.util.find_spec('mypy') is not None`, which needs no ignore comment in any environment, and updated the 4 call sites.
- Dropped `mypy` from `ty_leo.py`'s `check_optional_deps` list, since the spurious "unused ignore" warning it guarded against is now impossible.
- Checked the codebase's other optional-dependency fallback imports (docutils, lxml, pygments, nbformat, websockets, enchant, yaml) -- none of them qualify for the same fix, since they all use the real module API at runtime (unlike mypy, which was only ever presence-checked). So `ty_leo.py`'s dependency check remains necessary for the rest of that list.

## Test plan
- [x] `ty check leo/commands/checkerCommands.py` is clean both with and without mypy installed (verified in a throwaway venv without mypy).
- [x] `ruff check leo`, `ruff format --check leo`, `python -m leo.scripts.ty_leo`, and `pytest leo/unittests/commands/test_checkerCommands.py` all pass.
- [x] `cub sync --dry-run` confirms both edited files (both `@file` derived nodes) match `leo/core/LeoPyRef.leo`, so no outline resync is needed.