### PR TITLE
Check ty_leo.py's optional deps by resolvability, not import

### DIFF
--- a/leo/scripts/ty_leo.py
+++ b/leo/scripts/ty_leo.py
@@ -4,7 +4,7 @@
 ty_leo.py: Run ty on all of Leo.
 """
 
-import importlib
+import importlib.util
 import os
 import subprocess
 import sys
@@ -19,7 +19,12 @@ os.chdir(leo_editor_dir)
 # @+others
 # @+node:ekr.20260823160000.1: ** check_optional_deps
 def check_optional_deps() -> bool:
-    """Return True if every package that a `# type:ignore` fallback assumes is present is importable. See #4952."""
+    """Return True if every package that a `# type:ignore` fallback assumes is present is resolvable. See #4952."""
+    # ty resolves types from a package's on-disk source, it never actually runs the
+    # package's import machinery. So check resolvability with find_spec instead of
+    # actually importing: a package like pyenchant can be pip-installed and fully
+    # resolvable for typing purposes while still failing a real import because the
+    # unrelated native libenchant C library isn't present on the system. See #4961.
     # (pip package name, importable module name)
     packages = [
         ('docutils', 'docutils'),
@@ -35,8 +40,10 @@ def check_optional_deps() -> bool:
     missing = []
     for pip_name, module_name in packages:
         try:
-            importlib.import_module(module_name)
+            found = importlib.util.find_spec(module_name) is not None
         except Exception:
+            found = False
+        if not found:
             missing.append(pip_name)
     if missing:
         print(


### PR DESCRIPTION
Fixes the root cause reported in #4961.

`check_optional_deps()` used `importlib.import_module()`, which actually executes a module's import machinery. `ty` is a static type checker: it resolves types from a package's on-disk source and never runs that machinery itself, so this check was stricter than what `ty` actually needs.

This bit `pyenchant` on Linux: `pip install pyenchant` installs the Python bindings, but *importing* them also loads the native `libenchant` C library via ctypes — which isn't bundled by the PyPI wheel and may not be present as a system package. That runtime import failure got reported as "missing package" even though pyenchant was fully pip-installed and perfectly resolvable for typing purposes (confirmed: `ty` passes fine with pyenchant installed but `libenchant` unavailable).

Switched to `importlib.util.find_spec()`, which locates a module without running its import-time code — matching what `ty` itself actually relies on.

## Test plan
- [x] `python3 leo/scripts/ty_leo.py` passes the optional-deps check and runs `ty` successfully
- [x] `ruff check` / `ruff format --check` pass on the changed file
- [x] Verified `importlib.util.find_spec` resolves all 9 packages in the list without triggering their import-time side effects