### PR TITLE
fix @adoc command drops text when a node contains two or more @langua…

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7858,6 +7858,7 @@ def getScript(
     useSelectedText: bool = True,
     forcePythonSentinels: bool = True,
     useSentinels: bool = True,
+    useExtraction: bool = True,
 ) -> str:
     """
     Return the expansion of the selected text of node p.
@@ -7876,7 +7877,8 @@ def getScript(
             s = p.b
         # Remove extra leading whitespace so the user may execute indented code.
         s = textwrap.dedent(s)
-        s = g.extractExecutableString(c, p, s)
+        if useExtraction:
+            s = g.extractExecutableString(c, p, s)
         script = g.composeScript(
             c,
             p,

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -497,7 +497,7 @@ class MarkupCommands:
         """Write p.b"""
         # We no longer add newlines to the start of nodes because
         # we write a blank line after all sections.
-        script = g.getScript(self.c, p, useSentinels=False)
+        script = g.getScript(self.c, p, useSentinels=False, useExtraction=False)
         s = self.remove_directives(script)
         self.output_file.write(g.ensureTrailingNewlines(s, 2))
 

--- a/leo/unittests/core/test_leoMarkup.py
+++ b/leo/unittests/core/test_leoMarkup.py
@@ -1,0 +1,100 @@
+"""Tests of leoMarkup.py"""
+
+import io
+
+from leo.core import leoGlobals as g
+from leo.core import leoMarkup
+from leo.core.leoTest2 import LeoUnitTest
+
+
+class TestMarkup(LeoUnitTest):
+    """Test cases for leoMarkup.py"""
+
+    def test_adoc_preserves_body_with_multiple_language_directives(self):
+        """
+        The @adoc command must write the *entire* body of a node.
+
+        Regression test for a node that contains two or more @language
+        directives.  g.getScript() used to call g.extractExecutableString(),
+        which:
+
+        (a) discarded all text *before* the first @language directive, and
+        (b) discarded the text of every section whose @language does not match
+            the language in effect.
+
+        The @adoc command now calls g.getScript(..., useExtraction=False).
+        """
+        c, p = self.c, self.c.p
+        p.b = self.prep(
+            """
+            intro text
+
+            .App.svelte
+            [source,html]
+            ----
+            @language html
+            <script>let message = $state('hello');</script>
+            ----
+
+            .FancyInput.svelte
+            [source,html]
+            ----
+            @language html
+            <input bind:value={value} />
+            ----
+            """
+        )
+        m = leoMarkup.MarkupCommands(c)
+        m.kind = 'adoc'
+        m.output_file = io.StringIO()
+
+        # g.extractExecutableString is a no-op while g.unitTesting is True,
+        # so turn it off to exercise the real code path.
+        old_unit_testing = g.unitTesting
+        g.unitTesting = False
+        try:
+            m.write_body(p)
+        finally:
+            g.unitTesting = old_unit_testing
+
+        result = m.output_file.getvalue()
+        # Text before the first @language directive must be preserved.
+        self.assertIn('intro text', result)
+        self.assertIn('[source,html]', result)
+        # The first @language section must be preserved.
+        self.assertIn('let message', result)
+        # Text after the second @language directive must be preserved.
+        self.assertIn('.FancyInput.svelte', result)
+        self.assertIn('bind:value', result)
+        # The @language directives themselves must be removed.
+        self.assertNotIn('@language', result)
+
+    def test_getScript_useExtraction(self):
+        """
+        g.getScript(..., useExtraction=False) must not drop text that
+        g.getScript(..., useExtraction=True) would drop.
+        """
+        c, p = self.c, self.c.p
+        p.b = self.prep(
+            """
+            intro text
+            @language html
+            <script>one</script>
+            @language html
+            <script>two</script>
+            """
+        )
+        old_unit_testing = g.unitTesting
+        g.unitTesting = False
+        try:
+            with_extraction = g.getScript(c, p, useSentinels=False, useExtraction=True)
+            without_extraction = g.getScript(c, p, useSentinels=False, useExtraction=False)
+        finally:
+            g.unitTesting = old_unit_testing
+
+        # Without extraction, all of the text is kept.
+        self.assertIn('intro text', without_extraction)
+        self.assertIn('<script>one</script>', without_extraction)
+        self.assertIn('<script>two</script>', without_extraction)
+        # With extraction, the leading text is dropped.
+        self.assertNotIn('intro text', with_extraction)


### PR DESCRIPTION
Fixes #4979.

**Problem**
When a node body contains two or more `@language` directives, the `@adoc` command silently drops:
1. all text before the first `@language` directive, and
2. any section whose `@language` differs from the active language.

With a single `@language` the bug is masked because `extractExecutableString` short-circuits and returns the whole body unchanged.

**Root cause**
`MarkupCommands.write_body` renders the body via `g.getScript`, which calls `g.extractExecutableString`. That function is designed for *script execution* (extract only the section matching the current language) and is inappropriate for markup commands, where the entire body must be rendered as literal text.

**Fix**
Add a `useExtraction` flag to `g.getScript` (default `True`, preserving existing behavior) and call it with `useExtraction=False` from `write_body`. `@others`/`@<<section>>` expansion still works; `@language` directive lines are still removed by `remove_directives`. This also fixes `@pandoc`/`@sphinx`, which share `write_body`.

**Changes**
- `leo/core/leoGlobals.py`: `getScript` gains `useExtraction: bool = True`.
- `leo/core/leoMarkup.py`: `write_body` calls `g.getScript(..., useExtraction=False)`.

**Test**
`python -m unittest leo.unittests.core.test_leoMarkup` — includes `test_adoc_preserves_body_with_multiple_language_directives` and `test_getScript_useExtraction`.
